### PR TITLE
Fix Password Reset Token Bug for Looking Up Security Question Answers

### DIFF
--- a/src/main/java/com/tiernebre/zone_blitz/user/repository/UserSecurityQuestionsJooqRepository.java
+++ b/src/main/java/com/tiernebre/zone_blitz/user/repository/UserSecurityQuestionsJooqRepository.java
@@ -27,6 +27,7 @@ public class UserSecurityQuestionsJooqRepository implements UserSecurityQuestion
                 .join(PASSWORD_RESET_TOKENS)
                 .on(USERS.ID.eq(PASSWORD_RESET_TOKENS.USER_ID))
                 .where(USERS.EMAIL.eq(email))
+                .and(PASSWORD_RESET_TOKENS.TOKEN.eq(resetToken))
                 .and(utilities.passwordResetTokenIsNotExpired())
                 .fetchMap(USER_SECURITY_QUESTIONS.SECURITY_QUESTION_ID, USER_SECURITY_QUESTIONS.ANSWER);
     }

--- a/src/test/java/com/tiernebre/zone_blitz/user/repository/UserSecurityQuestionsJooqRepositoryIntegrationTests.java
+++ b/src/test/java/com/tiernebre/zone_blitz/user/repository/UserSecurityQuestionsJooqRepositoryIntegrationTests.java
@@ -62,9 +62,18 @@ public class UserSecurityQuestionsJooqRepositoryIntegrationTests extends Abstrac
         }
 
         @Test
+        @DisplayName("returns an empty set if the user has no password reset token tied to them")
+        void returnsAnEmptySetIfTheUserHasNoPasswordResetTokenTiedToThem() {
+            UsersRecord user = userRecordPool.createAndSaveOneWithSecurityQuestions();
+            Map<Long, String> answers = userSecurityQuestionsJooqRepository.getAnswersForEmailAndResetToken(user.getEmail(), UUID.randomUUID());
+            assertTrue(MapUtils.isEmpty(answers));
+        }
+
+        @Test
         @DisplayName("returns an empty set if the password reset token is not legit")
         void returnsAnEmptySetIfThePasswordResetTokenIsNotLegit() {
             UsersRecord user = userRecordPool.createAndSaveOneWithSecurityQuestions();
+            passwordResetTokenRecordPool.createAndSaveOneForUser(user);
             Map<Long, String> answers = userSecurityQuestionsJooqRepository.getAnswersForEmailAndResetToken(user.getEmail(), UUID.randomUUID());
             assertTrue(MapUtils.isEmpty(answers));
         }
@@ -72,7 +81,8 @@ public class UserSecurityQuestionsJooqRepositoryIntegrationTests extends Abstrac
         @Test
         @DisplayName("returns an empty set if the password reset token and email are not legit")
         void returnsAnEmptySetIfThePasswordResetTokenAndEmailAreNotLegit() {
-            userRecordPool.createAndSaveOneWithSecurityQuestions();
+            UsersRecord user = userRecordPool.createAndSaveOneWithSecurityQuestions();
+            passwordResetTokenRecordPool.createAndSaveOneForUser(user);
             Map<Long, String> answers = userSecurityQuestionsJooqRepository.getAnswersForEmailAndResetToken(UUID.randomUUID().toString(), UUID.randomUUID());
             assertTrue(MapUtils.isEmpty(answers));
         }


### PR DESCRIPTION
Forgot to originally include a `WHERE` clause to check a specific password reset token. This ensured that any user who had a tied to password reset token could attempt to get their security question answers as long as the email was correct.