### PR TITLE
Fix Web Assets in Docker Build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,8 @@ run:
 	java -jar target/zone-blitz-1.0-SNAPSHOT.jar
 
 .PHONY: compile
-compile: assets-build
+compile:
+	npm run build
 	mvn compile assembly:single -q
 
 .PHONY: test
@@ -22,10 +23,6 @@ clean:
 format:
 	npm run format
 
-.PHONY: assets-build
-assets-build:
-	npm run build
-	
 .PHONY: fmt
 fmt:
 	npm run format

--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,3 @@ clean:
 .PHONY: format
 format:
 	npm run format
-
-.PHONY: fmt
-fmt:
-	npm run format

--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,12 @@
 .PHONY: serve
-serve: compile assets-build run
+serve: compile run
 
 .PHONY: run
 run:
 	java -jar target/zone-blitz-1.0-SNAPSHOT.jar
 
 .PHONY: compile
-compile:
+compile: assets-build
 	mvn compile assembly:single -q
 
 .PHONY: test


### PR DESCRIPTION
Forgot to call `make build-assets` in the `make compile` script that the main Dockerfile uses.