### PR TITLE
Fix production docker build by installing `npm` + add CI job for testing docker build

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,5 +1,8 @@
 FROM alpine:3.19
 
+WORKDIR /usr/app
+COPY . .
+
 RUN apk add openjdk21 fish make git openssh-client maven nodejs npm R bash
 
 # shell setup

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -6,7 +6,6 @@
   "forwardPorts": [
     8000
   ],
-  "postCreateCommand": ".devcontainer/post-create-command.sh",
   "customizations": {
     "vscode": {
       "extensions": [

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -6,6 +6,7 @@
   "forwardPorts": [
     8000
   ],
+  "postCreateCommand": "make compile",
   "customizations": {
     "vscode": {
       "extensions": [

--- a/.devcontainer/post-create-command.sh
+++ b/.devcontainer/post-create-command.sh
@@ -1,4 +1,0 @@
-#!/bin/sh
-
-npm ci
-mvn dependency:resolve

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -38,7 +38,6 @@ jobs:
         uses: jtalk/url-health-check-action@v4
         with:
           url: http://${{ secrets.HOST_IP }}
-          max-attempts: 3 # Optional, defaults to 1
-          retry-delay: 5s # Optional, only applicable to max-attempts > 1
-          retry-all: false # Optional, defaults to "false"
+          max-attempts: 3
+          retry-delay: 5s
         

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,3 +30,4 @@ jobs:
           url: http://127.0.0.1:8000|http://127.0.0.1:8000/assets/htmx.js|http://127.0.0.1:8000/assets/styles.css
           max-attempts: 10
           retry-delay: 5s
+          retry-all: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,4 +21,13 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Build Docker image
-        run: docker build .
+        run: docker build -t brendantierney/zone-blitz:latest .
+      - name: Run Docker image
+        run: docker run -d -p 8000:8000 brendantierney/zone-blitz:latest
+      - name: Verify image runs with correct assets
+        uses: jtalk/url-health-check-action@v4
+        with:
+          url: http://localhost:8000|http://localhost:8000/assets/htmx.js|http://localhost:8000/assets/styles.css
+          max-attempts: 3 # Optional, defaults to 1
+          retry-delay: 5s # Optional, only applicable to max-attempts > 1
+          retry-all: false # Optional, defaults to "false"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,6 +27,6 @@ jobs:
       - name: Verify image runs with correct assets
         uses: jtalk/url-health-check-action@v4
         with:
-          url: http://localhost:8000|http://localhost:8000/assets/htmx.js|http://localhost:8000/assets/styles.css
+          url: http://127.0.0.1:8000|http://127.0.0.1:8000/assets/htmx.js|http://127.0.0.1:8000/assets/styles.css
           max-attempts: 10
           retry-delay: 5s

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,6 +28,5 @@ jobs:
         uses: jtalk/url-health-check-action@v4
         with:
           url: http://localhost:8000|http://localhost:8000/assets/htmx.js|http://localhost:8000/assets/styles.css
-          max-attempts: 3 # Optional, defaults to 1
-          retry-delay: 5s # Optional, only applicable to max-attempts > 1
-          retry-all: false # Optional, defaults to "false"
+          max-attempts: 10
+          retry-delay: 5s

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,3 +13,12 @@ jobs:
         uses: devcontainers/ci@v0.3
         with:
           runCmd: make test
+
+  test-docker:
+    name: Test Docker Build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Build Docker image
+        run: docker build .

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ COPY . .
 
 RUN apk add openjdk21 maven make npm
 RUN make compile
-RUN apk remove make npm
+RUN apk remove npm
 
 EXPOSE 8000
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,9 @@ FROM alpine:3.19
 
 COPY . .
 
-RUN apk add openjdk21 maven make
+RUN apk add openjdk21 maven make npm
 RUN make compile
+RUN apk remove make npm
 
 EXPOSE 8000
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ COPY . .
 
 RUN apk add openjdk21 maven make npm
 RUN make compile
-RUN apk remove npm
+RUN apk del npm
 
 EXPOSE 8000
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
 FROM alpine:3.19
 
+WORKDIR /usr/app
 COPY . .
 
 RUN apk add openjdk21 maven make npm

--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,8 @@ run:
 
 .PHONY: compile
 compile:
+	npm ci
+	mvn dependency:resolve
 	npm run build
 	mvn compile assembly:single -q
 


### PR DESCRIPTION
Forgot to verify the production docker build works, this PR adds the verification and fixes the current issue (`npm` is not installed).