### PR TITLE
Fix template compilation issues due to non deterministic incremental compilation on dev script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,20 +1,17 @@
 .PHONY: serve
 serve: compile run
 
-.PHONY: dev
-dev: clean build run
-
 .PHONY: run
 run:
 	mvn exec:java
 
 .PHONY: compile
-compile: clean install build
+compile: install build
 
 .PHONY: build
 build:
 	npm run build
-	mvn compile
+	mvn clean package -DskipTests=true
 
 .PHONY: install
 install:
@@ -25,10 +22,6 @@ test:
 	npm run lint
 	mvn test
 	
-.PHONY: clean
-clean:
-	mvn clean -q
-
 .PHONY: format
 format:
 	npm run format

--- a/bin/dev.sh
+++ b/bin/dev.sh
@@ -1,10 +1,8 @@
 #!/bin/sh
 
-make install
-
 while true
 do
-  make dev &
+  make &
   inotifywait -r -e modify src/main/java/com/tiernebre src/main/resources/templates
   killall make
   kill $(pgrep -f "java -jar")

--- a/pom.xml
+++ b/pom.xml
@@ -72,6 +72,7 @@
             <configuration>
                 <source>21</source>
                 <target>21</target>
+                <useIncrementalCompilation>false</useIncrementalCompilation>
                 <annotationProcessorPaths>
                     <path>
                         <groupId>io.jstach</groupId>


### PR DESCRIPTION
Using the guidance at https://jstach.io/doc/jstachio/current/apidocs/#faq_template_not_found

> If the templates are generated but JStachio.render is not working a reflection exception will be thrown. This may happen if the generated class is not available because of incremental compiling and particularly a problem with Maven. Try a full rebuild (e.g. mvn clean package).

