### PR TITLE
Remove `.vscode` from being tracked in version control

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -176,3 +176,6 @@ buildNumber.properties
 src/main/resources/assets/styles.css
 src/main/resources/assets/reset.css
 src/main/resources/assets/htmx.js
+
+# visual studio code configuration
+.vscode

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,0 @@
-{
-  "java.configuration.updateBuildConfiguration": "automatic",
-  "java.compile.nullAnalysis.mode": "automatic",
-  "r.lsp.promptToInstall": false
-}


### PR DESCRIPTION
Noticed `.vscode` was accidentally being included. Since this project uses dev containers, it doesn't make sense to track this in code since we can set project configuration in `devcontainer.json`.