### PR TITLE
Move health check behind `/api/` prefix + setup initial `robots.txt` with a disallow of `/api` routes for SEO indexing.

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -40,5 +40,5 @@ jobs:
       - name: Verify deployment was successful
         uses: jtalk/url-health-check-action@v4
         with:
-          url: https://zoneblitz.app
+          url: https://zoneblitz.app/api/health
           max-attempts: 1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Verify web server container runs and serves healthy responses
         uses: jtalk/url-health-check-action@v4
         with:
-          url: ${{ env.WEB_SERVER_URL }}|${{ env.WEB_SERVER_URL }}/assets/htmx.js|${{ env.WEB_SERVER_URL }}/assets/styles.css
+          url: ${{ env.WEB_SERVER_URL }}/api/health|${{ env.WEB_SERVER_URL }}/assets/htmx.js|${{ env.WEB_SERVER_URL }}/assets/styles.css
           max-attempts: 1
 
   development-environment-smoke-test:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,6 +2,10 @@ name: Test
 
 on: push
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 env:
   PORT: 8000
   WEB_SERVER_URL: http://127.0.0.1:8000

--- a/src/main/java/com/tiernebre/web/Router.java
+++ b/src/main/java/com/tiernebre/web/Router.java
@@ -20,6 +20,6 @@ public final class Router {
   public Javalin register(Javalin app) {
     return app
       .get("/", frontPageController::render)
-      .get("/health", healthController::health);
+      .get("/api/health", healthController::health);
   }
 }

--- a/src/main/resources/assets/robots.txt
+++ b/src/main/resources/assets/robots.txt
@@ -1,0 +1,3 @@
+User-agent: *
+Allow: /
+Disallow: /api/


### PR DESCRIPTION
Also adds in a concurrency optimization for new commits pushed to a pull request to cancel previously running CI jobs.