### PR TITLE
Move all static files into the root of the server instead of sub path `/assets`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Verify web server container runs and serves healthy responses
         uses: jtalk/url-health-check-action@v4
         with:
-          url: ${{ env.WEB_SERVER_URL }}/api/health|${{ env.WEB_SERVER_URL }}/assets/htmx.js|${{ env.WEB_SERVER_URL }}/assets/styles.css
+          url: ${{ env.WEB_SERVER_URL }}/api/health|${{ env.WEB_SERVER_URL }}/htmx.js|${{ env.WEB_SERVER_URL }}/styles.css|${{ env.WEB_SERVER_URL }}/robots.txt
           max-attempts: 1
 
   development-environment-smoke-test:

--- a/src/main/java/com/tiernebre/web/Server.java
+++ b/src/main/java/com/tiernebre/web/Server.java
@@ -16,7 +16,7 @@ public final class Server {
         Javalin.create(config -> {
           config.showJavalinBanner = false;
           config.staticFiles.add(staticFiles -> {
-            staticFiles.hostedPath = "/assets";
+            staticFiles.hostedPath = "/";
             staticFiles.directory = "/assets";
           });
         })

--- a/src/main/resources/templates/base_layout.mustache
+++ b/src/main/resources/templates/base_layout.mustache
@@ -9,26 +9,12 @@
       content="{{$description}}American football manager simulator{{/description}}"
     />
     <title>{{$title}}Zone Blitz{{/title}}</title>
-    <link
-      rel="apple-touch-icon"
-      sizes="180x180"
-      href="assets/apple-touch-icon.png"
-    />
-    <link
-      rel="icon"
-      type="image/png"
-      sizes="32x32"
-      href="assets/favicon-32x32.png"
-    />
-    <link
-      rel="icon"
-      type="image/png"
-      sizes="16x16"
-      href="assets/favicon-16x16.png"
-    />
-    <link rel="manifest" href="assets/site.webmanifest" />
-    <link rel="stylesheet" href="assets/reset.css" />
-    <link rel="stylesheet" href="assets/styles.css" />
+    <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png" />
+    <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png" />
+    <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png" />
+    <link rel="manifest" href="/site.webmanifest" />
+    <link rel="stylesheet" href="/reset.css" />
+    <link rel="stylesheet" href="/styles.css" />
     {{$head}}{{/head}}
   </head>
   <body class="flex flex-col grow">

--- a/src/main/resources/templates/interactive_layout.mustache
+++ b/src/main/resources/templates/interactive_layout.mustache
@@ -1,4 +1,4 @@
 {{! interactive layout adds in htmx for JS functionality }} {{< base_layout}}
 {{$head}}
-<script src="assets/htmx.js"></script>
+<script src="/htmx.js"></script>
 {{$head}}{{/head}} {{/head}} {{/base_layout}}


### PR DESCRIPTION
This will make `favicon.ico` support better across devices and also help with `robots.txt` parsing for search engines.