### PR TITLE
Improve Lighthouse CI flakiness by leverage multiple runs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -53,6 +53,7 @@ jobs:
           urls: |
             ${{ env.WEB_SERVER_URL }}
           configPath: "./.lighthouserc.json"
+          runs: 5
 
   development-environment-smoke-test:
     name: Development Environment Smoke Test

--- a/.lighthouserc.json
+++ b/.lighthouserc.json
@@ -2,7 +2,7 @@
   "ci": {
     "assert": {
       "assertions": {
-        "categories:performance": ["error", {"minScore": 0.7}],
+        "categories:performance": ["error", {"minScore": 0.95}],
         "categories:accessibility": ["error", {"minScore": 1}],
         "categories:best-practices": ["error", {"minScore": 1}],
         "categories:seo": ["error", {"minScore": 1}]


### PR DESCRIPTION
Noticed inconsistent performance scores, following the [guidance](https://github.com/marketplace/actions/lighthouse-ci-action#runs-default-1) to increase the runs to `5`.