### PR TITLE
Fix cURL usage in the new E2E Staging Test Workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,7 +46,7 @@ jobs:
           ZONE_BLITZ_POSTGRES_PASSWORD: e2e_staging_test
           ZONE_BLITZ_POSTGRES_NAME: zone_blitz
           ZONE_BLITZ_POSTGRES_HOST: database:5432/zone_blitz
-        run: docker compose up
+        run: docker compose up -d --wait
       - name: Verify application is running and healthy
         run: |
           ${{ env.CURL }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -50,7 +50,7 @@ jobs:
         run: docker compose up -d --wait
       - name: Verify application is running and healthy
         run: |
-          ${{ env.CURL }} 
+          ${{ env.CURL }}
           ${{ env.CURL }}/api/health
           ${{ env.CURL }}/favicon.ico
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,7 +27,7 @@ jobs:
     env:
       ZONE_BLITZ_WEB_DOCKER_IMAGE: brendantierney/zone-blitz:staging
       ZONE_BLITZ_DOMAIN: localhost
-      CURL: curl --retry 10 --retry-delay 5 --retry-all-errors -fkv https://localhost
+      CURL: curl -fkv https://localhost
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -46,6 +46,7 @@ jobs:
           ZONE_BLITZ_POSTGRES_PASSWORD: e2e_staging_test
           ZONE_BLITZ_POSTGRES_NAME: zone_blitz
           ZONE_BLITZ_POSTGRES_HOST: database:5432/zone_blitz
+        continue-on-error: true
         run: docker compose up -d
       - name: Verify application is running and healthy
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -47,7 +47,7 @@ jobs:
           ZONE_BLITZ_POSTGRES_NAME: zone_blitz
           ZONE_BLITZ_POSTGRES_HOST: database:5432/zone_blitz
         continue-on-error: true
-        run: docker compose up -d
+        run: docker compose up -d --wait
       - name: Verify application is running and healthy
         run: |
           ${{ env.CURL }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,7 +46,7 @@ jobs:
           ZONE_BLITZ_POSTGRES_PASSWORD: e2e_staging_test
           ZONE_BLITZ_POSTGRES_NAME: zone_blitz
           ZONE_BLITZ_POSTGRES_HOST: database:5432/zone_blitz
-        run: docker compose up -d --wait
+        run: docker compose up
       - name: Verify application is running and healthy
         run: |
           ${{ env.CURL }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,7 +27,7 @@ jobs:
     env:
       ZONE_BLITZ_WEB_DOCKER_IMAGE: brendantierney/zone-blitz:staging
       ZONE_BLITZ_DOMAIN: localhost
-      CURL: curl -fkv https://localhost
+      CURL: curl --retry 15 --retry-delay 1 --retry-all-errors -fkv https://localhost
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,6 +27,8 @@ jobs:
     env:
       ZONE_BLITZ_WEB_DOCKER_IMAGE: brendantierney/zone-blitz:staging
       ZONE_BLITZ_DOMAIN: 0.0.0.0
+      ZONE_BLITZ_URL: https://$ZONE_BLITZ_DOMAIN
+      CURL: curl -fkv $ZONE_BLITZ_URL
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -48,9 +50,9 @@ jobs:
         run: docker compose up -d --wait
       - name: Verify application is running and healthy
         run: |
-          curl -fv https://${{ env.ZONE_BLITZ_DOMAIN }}
-          curl -fv https://${{ env.ZONE_BLITZ_DOMAIN }}/api/health
-          curl -fv https://${{ env.ZONE_BLITZ_DOMAIN }}/favicon.ico
+          ${{ env.CURL }} 
+          ${{ env.CURL }}/api/health
+          ${{ env.CURL }}/favicon.ico
 
   development-environment-smoke-test:
     name: Development Environment Smoke Test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,7 +27,7 @@ jobs:
     env:
       ZONE_BLITZ_WEB_DOCKER_IMAGE: brendantierney/zone-blitz:staging
       ZONE_BLITZ_DOMAIN: 0.0.0.0
-      CURL: curl --retry 10 --retry-delay 5 -fkv https://0.0.0.0
+      CURL: curl --retry 10 --retry-delay 5 --retry-all-errors -fkv https://0.0.0.0
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,8 +27,8 @@ jobs:
     env:
       ZONE_BLITZ_WEB_DOCKER_IMAGE: brendantierney/zone-blitz:staging
       ZONE_BLITZ_DOMAIN: 0.0.0.0
-      ZONE_BLITZ_URL: https://$ZONE_BLITZ_DOMAIN
-      CURL: curl -fkv $ZONE_BLITZ_URL
+      ZONE_BLITZ_URL: https://${ZONE_BLITZ_DOMAIN}
+      CURL: curl -fkv ${ZONE_BLITZ_URL}
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,8 +27,7 @@ jobs:
     env:
       ZONE_BLITZ_WEB_DOCKER_IMAGE: brendantierney/zone-blitz:staging
       ZONE_BLITZ_DOMAIN: 0.0.0.0
-      ZONE_BLITZ_URL: https://${ZONE_BLITZ_DOMAIN}
-      CURL: curl -fkv ${ZONE_BLITZ_URL}
+      CURL: curl -fkv https://0.0.0.0
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,7 +46,7 @@ jobs:
           ZONE_BLITZ_POSTGRES_PASSWORD: e2e_staging_test
           ZONE_BLITZ_POSTGRES_NAME: zone_blitz
           ZONE_BLITZ_POSTGRES_HOST: database:5432/zone_blitz
-        run: docker compose up -d --wait
+        run: docker compose up -d
       - name: Verify application is running and healthy
         run: |
           ${{ env.CURL }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,7 +27,7 @@ jobs:
     env:
       ZONE_BLITZ_WEB_DOCKER_IMAGE: brendantierney/zone-blitz:staging
       ZONE_BLITZ_DOMAIN: 0.0.0.0
-      CURL: curl -fkv https://0.0.0.0
+      CURL: curl --retry 10 --retry-delay 5 -fkv https://0.0.0.0
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,8 +26,8 @@ jobs:
     runs-on: ubuntu-latest
     env:
       ZONE_BLITZ_WEB_DOCKER_IMAGE: brendantierney/zone-blitz:staging
-      ZONE_BLITZ_DOMAIN: 0.0.0.0
-      CURL: curl --retry 10 --retry-delay 5 --retry-all-errors -fkv https://0.0.0.0
+      ZONE_BLITZ_DOMAIN: localhost
+      CURL: curl --retry 10 --retry-delay 5 --retry-all-errors -fkv https://localhost
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,7 @@ services:
       - "--api.insecure=false"
       - "--providers.docker=true"
       - "--providers.docker.exposedbydefault=false"
+      - "--log.level=DEBUG"
       - "--entrypoints.websecure.address=:443"
       - "--certificatesresolvers.myresolver.acme.tlschallenge=true"
       - "--certificatesresolvers.myresolver.acme.email=tiernebre@gmail.com"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,6 @@ services:
       - "--api.insecure=false"
       - "--providers.docker=true"
       - "--providers.docker.exposedbydefault=false"
-      - "--log.level=DEBUG"
       - "--entrypoints.websecure.address=:443"
       - "--certificatesresolvers.myresolver.acme.tlschallenge=true"
       - "--certificatesresolvers.myresolver.acme.email=tiernebre@gmail.com"


### PR DESCRIPTION
- `0.0.0.0` doesn't work on Github actions, needed to use `localhost` instead.
- Configured cURL to verify failure mode and allow self signed certs.