### PR TITLE
Continue iterating on the Registration and Authentication strategy

### DIFF
--- a/.rest/registration.rest
+++ b/.rest/registration.rest
@@ -1,4 +1,4 @@
 POST http://0.0.0.0:8000/api/registration
 content-type: application/x-www-form-urlencoded
 
-username=tiernebre&password=password&confirmPassword=password
+username={{$guid}}&password=password&confirmPassword=password

--- a/src/main/java/com/tiernebre/authentication/AuthenticationContextFactory.java
+++ b/src/main/java/com/tiernebre/authentication/AuthenticationContextFactory.java
@@ -29,6 +29,9 @@ public final class AuthenticationContextFactory {
     var sessionService = new DefaultSessionService(
       new JooqSessionRepository(dsl)
     );
+    var accountService = new DefaultAccountService(
+      new JooqAccountRepository(dsl)
+    );
     return new AuthenticationContext(
       AuthenticationConstants.CONFIGURATION,
       new GoogleAuthenticationStrategy(
@@ -36,12 +39,13 @@ public final class AuthenticationContextFactory {
           AuthenticationConstants.CONFIGURATION.oauthGoogleClientId()
         ).create(),
         sessionService,
-        new DefaultAccountService(new JooqAccountRepository(dsl))
+        accountService
       ),
       sessionService,
       new DefaultRegistrationService(
         new JooqRegistrationRepository(dsl),
-        new Argon2PasswordHasher()
+        new Argon2PasswordHasher(),
+        accountService
       ),
       new VavrRegistrationValidator()
     );

--- a/src/main/java/com/tiernebre/authentication/account/AccountRepository.java
+++ b/src/main/java/com/tiernebre/authentication/account/AccountRepository.java
@@ -3,7 +3,7 @@ package com.tiernebre.authentication.account;
 import io.vavr.control.Option;
 
 public interface AccountRepository {
-  public Account insertOne(String googleAccountId);
+  public Account insertOne(String googleAccountId, Long registrationId);
 
   public Option<Account> selectOneByGoogleAccountId(String googleAccountId);
 

--- a/src/main/java/com/tiernebre/authentication/account/AccountRepository.java
+++ b/src/main/java/com/tiernebre/authentication/account/AccountRepository.java
@@ -6,4 +6,6 @@ public interface AccountRepository {
   public Account insertOne(String googleAccountId);
 
   public Option<Account> selectOneByGoogleAccountId(String googleAccountId);
+
+  public Option<Account> selectOneByRegistrationId(long registrationId);
 }

--- a/src/main/java/com/tiernebre/authentication/account/AccountService.java
+++ b/src/main/java/com/tiernebre/authentication/account/AccountService.java
@@ -1,6 +1,7 @@
 package com.tiernebre.authentication.account;
 
 import io.vavr.control.Either;
+import io.vavr.control.Option;
 
 public interface AccountService {
   /**
@@ -12,5 +13,13 @@ public interface AccountService {
    * @param googleAccountId The associated Google account id.
    * @return An error message if an error occurred, or the existing / created account.
    */
-  public Either<String, Account> getForGoogleAccountId(String googleAccountId);
+  public Either<String, Account> getForGoogleAccount(String googleAccountId);
+
+  /**
+   * Will get an existing Account by an associated registration id.
+   *
+   * @param googleAccountId The associated registration id.
+   * @return Empty if an account does not exist for the given registration id, or the existing account.
+   */
+  public Option<Account> getForRegistration(long registrationId);
 }

--- a/src/main/java/com/tiernebre/authentication/account/AccountService.java
+++ b/src/main/java/com/tiernebre/authentication/account/AccountService.java
@@ -1,5 +1,6 @@
 package com.tiernebre.authentication.account;
 
+import com.tiernebre.authentication.registration.Registration;
 import io.vavr.control.Either;
 import io.vavr.control.Option;
 
@@ -22,4 +23,12 @@ public interface AccountService {
    * @return Empty if an account does not exist for the given registration id, or the existing account.
    */
   public Option<Account> getForRegistration(long registrationId);
+
+  /**
+   * Creates an account that is tied to a given Registration.
+   *
+   * @param registration The registration to create the Account for.
+   * @return The created account.
+   */
+  public Account create(Registration registration);
 }

--- a/src/main/java/com/tiernebre/authentication/account/DefaultAccountService.java
+++ b/src/main/java/com/tiernebre/authentication/account/DefaultAccountService.java
@@ -26,8 +26,7 @@ public final class DefaultAccountService implements AccountService {
 
   @Override
   public Account create(Registration registration) {
-    // TODO Auto-generated method stub
-    throw new UnsupportedOperationException("Unimplemented method 'create'");
+    return repository.insertOne(null, registration.id());
   }
 
   private Account selectOrCreateByGoogleAccountId(String accountId) {

--- a/src/main/java/com/tiernebre/authentication/account/DefaultAccountService.java
+++ b/src/main/java/com/tiernebre/authentication/account/DefaultAccountService.java
@@ -12,10 +12,18 @@ public final class DefaultAccountService implements AccountService {
   }
 
   @Override
-  public Either<String, Account> getForGoogleAccountId(String googleAccountId) {
+  public Either<String, Account> getForGoogleAccount(String googleAccountId) {
     return Option.of(googleAccountId)
       .toEither("Given Google account id is null.")
       .map(this::selectOrCreateByGoogleAccountId);
+  }
+
+  @Override
+  public Option<Account> getForRegistration(long registrationId) {
+    // TODO Auto-generated method stub
+    throw new UnsupportedOperationException(
+      "Unimplemented method 'getForRegistration'"
+    );
   }
 
   private Account selectOrCreateByGoogleAccountId(String accountId) {

--- a/src/main/java/com/tiernebre/authentication/account/DefaultAccountService.java
+++ b/src/main/java/com/tiernebre/authentication/account/DefaultAccountService.java
@@ -1,5 +1,6 @@
 package com.tiernebre.authentication.account;
 
+import com.tiernebre.authentication.registration.Registration;
 import io.vavr.control.Either;
 import io.vavr.control.Option;
 
@@ -20,15 +21,18 @@ public final class DefaultAccountService implements AccountService {
 
   @Override
   public Option<Account> getForRegistration(long registrationId) {
+    return repository.selectOneByRegistrationId(registrationId);
+  }
+
+  @Override
+  public Account create(Registration registration) {
     // TODO Auto-generated method stub
-    throw new UnsupportedOperationException(
-      "Unimplemented method 'getForRegistration'"
-    );
+    throw new UnsupportedOperationException("Unimplemented method 'create'");
   }
 
   private Account selectOrCreateByGoogleAccountId(String accountId) {
     return repository
       .selectOneByGoogleAccountId(accountId)
-      .getOrElse(() -> repository.insertOne(accountId));
+      .getOrElse(() -> repository.insertOne(accountId, null));
   }
 }

--- a/src/main/java/com/tiernebre/authentication/account/JooqAccountRepository.java
+++ b/src/main/java/com/tiernebre/authentication/account/JooqAccountRepository.java
@@ -13,10 +13,14 @@ public final class JooqAccountRepository implements AccountRepository {
   }
 
   @Override
-  public Account insertOne(String googleAccountId) {
+  public Account insertOne(String googleAccountId, Long registrationId) {
     return dsl
-      .insertInto(Tables.ACCOUNT, Tables.ACCOUNT.GOOGLE_ACCOUNT_ID)
-      .values(googleAccountId)
+      .insertInto(
+        Tables.ACCOUNT,
+        Tables.ACCOUNT.GOOGLE_ACCOUNT_ID,
+        Tables.ACCOUNT.REGISTRATION_ID
+      )
+      .values(googleAccountId, registrationId)
       .returning()
       .fetchSingleInto(Account.class);
   }
@@ -27,6 +31,16 @@ public final class JooqAccountRepository implements AccountRepository {
       dsl.fetchOne(
         Tables.ACCOUNT,
         Tables.ACCOUNT.GOOGLE_ACCOUNT_ID.eq(googleAccountId)
+      )
+    ).map(result -> result.into(Account.class));
+  }
+
+  @Override
+  public Option<Account> selectOneByRegistrationId(long registrationId) {
+    return Option.of(
+      dsl.fetchOne(
+        Tables.ACCOUNT,
+        Tables.ACCOUNT.REGISTRATION_ID.eq(registrationId)
       )
     ).map(result -> result.into(Account.class));
   }

--- a/src/main/java/com/tiernebre/authentication/google/GoogleAuthenticationStrategy.java
+++ b/src/main/java/com/tiernebre/authentication/google/GoogleAuthenticationStrategy.java
@@ -41,7 +41,7 @@ public final class GoogleAuthenticationStrategy
       .flatMap(this::verifyAndParseCredential)
       .map(GoogleIdToken::getPayload)
       .map(Payload::getSubject)
-      .flatMap(accountService::getForGoogleAccountId)
+      .flatMap(accountService::getForGoogleAccount)
       .map(sessionService::create);
   }
 

--- a/src/main/java/com/tiernebre/authentication/registration/DefaultRegistrationService.java
+++ b/src/main/java/com/tiernebre/authentication/registration/DefaultRegistrationService.java
@@ -1,26 +1,32 @@
 package com.tiernebre.authentication.registration;
 
+import com.tiernebre.authentication.account.AccountService;
 import io.vavr.control.Option;
 
 public final class DefaultRegistrationService implements RegistrationService {
 
   private final RegistrationRepository repository;
   private final PasswordHasher passwordHasher;
+  private final AccountService accountService;
 
   public DefaultRegistrationService(
     RegistrationRepository repository,
-    PasswordHasher passwordHasher
+    PasswordHasher passwordHasher,
+    AccountService accountService
   ) {
     this.repository = repository;
     this.passwordHasher = passwordHasher;
+    this.accountService = accountService;
   }
 
   @Override
   public Registration create(RegistrationRequest request) {
-    return repository.insertOne(
+    var registration = repository.insertOne(
       request.username(),
       passwordHasher.hash(request.password())
     );
+    accountService.create(registration);
+    return registration;
   }
 
   @Override

--- a/src/main/java/com/tiernebre/authentication/registration/DefaultRegistrationService.java
+++ b/src/main/java/com/tiernebre/authentication/registration/DefaultRegistrationService.java
@@ -1,5 +1,7 @@
 package com.tiernebre.authentication.registration;
 
+import io.vavr.control.Option;
+
 public final class DefaultRegistrationService implements RegistrationService {
 
   private final RegistrationRepository repository;
@@ -19,5 +21,11 @@ public final class DefaultRegistrationService implements RegistrationService {
       request.username(),
       passwordHasher.hash(request.password())
     );
+  }
+
+  @Override
+  public Option<Registration> getOne(String username, String password) {
+    // TODO Auto-generated method stub
+    throw new UnsupportedOperationException("Unimplemented method 'getOne'");
   }
 }

--- a/src/main/java/com/tiernebre/authentication/registration/RegistrationAuthenticationRequest.java
+++ b/src/main/java/com/tiernebre/authentication/registration/RegistrationAuthenticationRequest.java
@@ -1,0 +1,6 @@
+package com.tiernebre.authentication.registration;
+
+public record RegistrationAuthenticationRequest(
+  String username,
+  String password
+) {}

--- a/src/main/java/com/tiernebre/authentication/registration/RegistrationAuthenticationStrategy.java
+++ b/src/main/java/com/tiernebre/authentication/registration/RegistrationAuthenticationStrategy.java
@@ -1,0 +1,33 @@
+package com.tiernebre.authentication.registration;
+
+import com.tiernebre.authentication.AuthenticationStrategy;
+import com.tiernebre.authentication.session.Session;
+import io.vavr.control.Either;
+import io.vavr.control.Option;
+
+public class RegistrationAuthenticationStrategy
+  implements AuthenticationStrategy<RegistrationAuthenticationRequest> {
+
+  private final RegistrationService service;
+
+  public RegistrationAuthenticationStrategy(RegistrationService service) {
+    this.service = service;
+  }
+
+  @Override
+  public Either<String, Session> authenticate(
+    RegistrationAuthenticationRequest request
+  ) {
+    return Option.of(request)
+      .toEither("Given registration authentication request was null.")
+      .flatMap(
+        value ->
+          service
+            .getOne(value.username(), value.password())
+            .toEither(
+              "Could not find a registration with the given username and password."
+            )
+      )
+      .map(registration -> new Session(null, 0));
+  }
+}

--- a/src/main/java/com/tiernebre/authentication/registration/RegistrationAuthenticationStrategy.java
+++ b/src/main/java/com/tiernebre/authentication/registration/RegistrationAuthenticationStrategy.java
@@ -1,7 +1,10 @@
 package com.tiernebre.authentication.registration;
 
 import com.tiernebre.authentication.AuthenticationStrategy;
+import com.tiernebre.authentication.account.Account;
+import com.tiernebre.authentication.account.AccountService;
 import com.tiernebre.authentication.session.Session;
+import com.tiernebre.authentication.session.SessionService;
 import io.vavr.control.Either;
 import io.vavr.control.Option;
 
@@ -9,9 +12,17 @@ public class RegistrationAuthenticationStrategy
   implements AuthenticationStrategy<RegistrationAuthenticationRequest> {
 
   private final RegistrationService service;
+  private final AccountService accountService;
+  private final SessionService sessionService;
 
-  public RegistrationAuthenticationStrategy(RegistrationService service) {
+  public RegistrationAuthenticationStrategy(
+    RegistrationService service,
+    AccountService accountService,
+    SessionService sessionService
+  ) {
     this.service = service;
+    this.accountService = accountService;
+    this.sessionService = sessionService;
   }
 
   @Override
@@ -20,14 +31,26 @@ public class RegistrationAuthenticationStrategy
   ) {
     return Option.of(request)
       .toEither("Given registration authentication request was null.")
-      .flatMap(
-        value ->
-          service
-            .getOne(value.username(), value.password())
-            .toEither(
-              "Could not find a registration with the given username and password."
-            )
-      )
-      .map(registration -> new Session(null, 0));
+      .flatMap(this::getRegistration)
+      .flatMap(this::getAccount)
+      .map(sessionService::create);
+  }
+
+  private Either<String, Registration> getRegistration(
+    RegistrationAuthenticationRequest request
+  ) {
+    return service
+      .getOne(request.username(), request.password())
+      .toEither(
+        "Could not find a registration with the given username and password."
+      );
+  }
+
+  private Either<String, Account> getAccount(Registration registration) {
+    return accountService
+      .getForRegistration(registration.id())
+      .toEither(
+        "Could not find an associated account for the provided registration."
+      );
   }
 }

--- a/src/main/java/com/tiernebre/authentication/registration/RegistrationService.java
+++ b/src/main/java/com/tiernebre/authentication/registration/RegistrationService.java
@@ -1,5 +1,9 @@
 package com.tiernebre.authentication.registration;
 
+import io.vavr.control.Option;
+
 public interface RegistrationService {
   public Registration create(RegistrationRequest request);
+
+  public Option<Registration> getOne(String username, String password);
 }

--- a/src/test/java/com/tiernebre/authentication/account/DefaultAccountServiceTest.java
+++ b/src/test/java/com/tiernebre/authentication/account/DefaultAccountServiceTest.java
@@ -52,7 +52,7 @@ public class DefaultAccountServiceTest {
       }
       assertEquals(
         test.expected(),
-        service.getForGoogleAccountId(test.googleAccountId())
+        service.getForGoogleAccount(test.googleAccountId())
       );
     }
   }

--- a/src/test/java/com/tiernebre/authentication/account/DefaultAccountServiceTest.java
+++ b/src/test/java/com/tiernebre/authentication/account/DefaultAccountServiceTest.java
@@ -43,7 +43,9 @@ public class DefaultAccountServiceTest {
           when(repository.selectOneByGoogleAccountId(accountId)).thenReturn(
             Option.none()
           );
-          when(repository.insertOne(accountId)).thenReturn(accountResult.get());
+          when(repository.insertOne(accountId, null)).thenReturn(
+            accountResult.get()
+          );
         }),
     };
     for (var test : cases) {

--- a/src/test/java/com/tiernebre/authentication/account/JooqAccountRepositoryTest.java
+++ b/src/test/java/com/tiernebre/authentication/account/JooqAccountRepositoryTest.java
@@ -20,7 +20,7 @@ public class JooqAccountRepositoryTest {
   @Test
   public void insertOne() {
     var id = UUID.randomUUID().toString();
-    var insertedAccount = repository.insertOne(id);
+    var insertedAccount = repository.insertOne(id, null);
     assertNotNull(insertedAccount);
     assertNotNull(insertedAccount.id());
     assertEquals(id, insertedAccount.googleAccountId());
@@ -29,7 +29,10 @@ public class JooqAccountRepositoryTest {
 
   @Test
   public void selectOneByGoogleAccountIdExists() {
-    var insertedAccount = repository.insertOne(UUID.randomUUID().toString());
+    var insertedAccount = repository.insertOne(
+      UUID.randomUUID().toString(),
+      null
+    );
     var foundAccount = repository.selectOneByGoogleAccountId(
       insertedAccount.googleAccountId()
     );

--- a/src/test/java/com/tiernebre/authentication/google/GoogleAuthenticationStrategyTest.java
+++ b/src/test/java/com/tiernebre/authentication/google/GoogleAuthenticationStrategyTest.java
@@ -98,7 +98,7 @@ public final class GoogleAuthenticationStrategyTest {
           var accountId = "accountId";
           when(payload.getSubject()).thenReturn(accountId);
           when(token.getPayload()).thenReturn(payload);
-          when(accountService.getForGoogleAccountId(accountId)).thenReturn(
+          when(accountService.getForGoogleAccount(accountId)).thenReturn(
             Either.left("Get account error")
           );
           try {
@@ -120,7 +120,7 @@ public final class GoogleAuthenticationStrategyTest {
           );
           when(payload.getSubject()).thenReturn(accountId);
           when(token.getPayload()).thenReturn(payload);
-          when(accountService.getForGoogleAccountId(accountId)).thenReturn(
+          when(accountService.getForGoogleAccount(accountId)).thenReturn(
             Either.right(expectedAccount)
           );
           when(sessionService.create(expectedAccount)).thenReturn(

--- a/src/test/java/com/tiernebre/authentication/registration/RegistrationAuthenticationStrategyTest.java
+++ b/src/test/java/com/tiernebre/authentication/registration/RegistrationAuthenticationStrategyTest.java
@@ -2,9 +2,11 @@ package com.tiernebre.authentication.registration;
 
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import com.tiernebre.authentication.session.Session;
 import io.vavr.control.Either;
+import io.vavr.control.Option;
 import java.util.function.BiConsumer;
 import org.junit.Test;
 
@@ -29,6 +31,18 @@ public final class RegistrationAuthenticationStrategyTest {
         null,
         Either.left("Given registration authentication request was null."),
         null
+      ),
+      new TestCase(
+        "registration not found",
+        new RegistrationAuthenticationRequest("username", "password"),
+        Either.left(
+          "Could not find a registration with the given username and password."
+        ),
+        (request, expected) -> {
+          when(
+            service.getOne(request.username(), request.password())
+          ).thenReturn(Option.none());
+        }
       ),
     };
     for (var testCase : cases) {

--- a/src/test/java/com/tiernebre/authentication/registration/RegistrationAuthenticationStrategyTest.java
+++ b/src/test/java/com/tiernebre/authentication/registration/RegistrationAuthenticationStrategyTest.java
@@ -4,7 +4,9 @@ import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import com.tiernebre.authentication.account.AccountService;
 import com.tiernebre.authentication.session.Session;
+import com.tiernebre.authentication.session.SessionService;
 import io.vavr.control.Either;
 import io.vavr.control.Option;
 import java.util.function.BiConsumer;
@@ -13,8 +15,14 @@ import org.junit.Test;
 public final class RegistrationAuthenticationStrategyTest {
 
   private final RegistrationService service = mock(RegistrationService.class);
+  private final AccountService accountService = mock(AccountService.class);
+  private final SessionService sessionService = mock(SessionService.class);
   private final RegistrationAuthenticationStrategy strategy =
-    new RegistrationAuthenticationStrategy(service);
+    new RegistrationAuthenticationStrategy(
+      service,
+      accountService,
+      sessionService
+    );
 
   private final record TestCase(
     String name,
@@ -34,6 +42,32 @@ public final class RegistrationAuthenticationStrategyTest {
       ),
       new TestCase(
         "registration not found",
+        new RegistrationAuthenticationRequest("username", "password"),
+        Either.left(
+          "Could not find a registration with the given username and password."
+        ),
+        (request, expected) -> {
+          when(
+            service.getOne(request.username(), request.password())
+          ).thenReturn(Option.none());
+        }
+      ),
+      new TestCase("account not found", new RegistrationAuthenticationRequest(
+          "username",
+          "password"
+        ), Either.left(
+          "Could not find an associated account for the provided registration."
+        ), (request, expected) -> {
+          var registration = new Registration(1, "username", "password");
+          when(
+            service.getOne(request.username(), request.password())
+          ).thenReturn(Option.of(registration));
+          when(accountService.getForRegistration(registration.id())).thenReturn(
+            Option.none()
+          );
+        }),
+      new TestCase(
+        "happy path created session for a valid registration",
         new RegistrationAuthenticationRequest("username", "password"),
         Either.left(
           "Could not find a registration with the given username and password."

--- a/src/test/java/com/tiernebre/authentication/registration/RegistrationAuthenticationStrategyTest.java
+++ b/src/test/java/com/tiernebre/authentication/registration/RegistrationAuthenticationStrategyTest.java
@@ -4,11 +4,13 @@ import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import com.tiernebre.authentication.account.Account;
 import com.tiernebre.authentication.account.AccountService;
 import com.tiernebre.authentication.session.Session;
 import com.tiernebre.authentication.session.SessionService;
 import io.vavr.control.Either;
 import io.vavr.control.Option;
+import java.util.UUID;
 import java.util.function.BiConsumer;
 import org.junit.Test;
 
@@ -69,13 +71,17 @@ public final class RegistrationAuthenticationStrategyTest {
       new TestCase(
         "happy path created session for a valid registration",
         new RegistrationAuthenticationRequest("username", "password"),
-        Either.left(
-          "Could not find a registration with the given username and password."
-        ),
+        Either.right(new Session(UUID.randomUUID(), 1)),
         (request, expected) -> {
+          var registration = new Registration(1, "username", "password");
+          var account = new Account(1, registration.id(), null);
           when(
             service.getOne(request.username(), request.password())
-          ).thenReturn(Option.none());
+          ).thenReturn(Option.of(registration));
+          when(accountService.getForRegistration(registration.id())).thenReturn(
+            Option.of(account)
+          );
+          when(sessionService.create(account)).thenReturn(expected.get());
         }
       ),
     };

--- a/src/test/java/com/tiernebre/authentication/registration/RegistrationAuthenticationStrategyTest.java
+++ b/src/test/java/com/tiernebre/authentication/registration/RegistrationAuthenticationStrategyTest.java
@@ -1,0 +1,44 @@
+package com.tiernebre.authentication.registration;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+
+import com.tiernebre.authentication.session.Session;
+import io.vavr.control.Either;
+import java.util.function.BiConsumer;
+import org.junit.Test;
+
+public final class RegistrationAuthenticationStrategyTest {
+
+  private final RegistrationService service = mock(RegistrationService.class);
+  private final RegistrationAuthenticationStrategy strategy =
+    new RegistrationAuthenticationStrategy(service);
+
+  private final record TestCase(
+    String name,
+    RegistrationAuthenticationRequest request,
+    Either<String, Session> expected,
+    BiConsumer<RegistrationAuthenticationRequest, Either<String, Session>> mock
+  ) {}
+
+  @Test
+  public void authenticate() {
+    var cases = new TestCase[] {
+      new TestCase(
+        "null request",
+        null,
+        Either.left("Given registration authentication request was null."),
+        null
+      ),
+    };
+    for (var testCase : cases) {
+      if (testCase.mock() != null) {
+        testCase.mock().accept(testCase.request(), testCase.expected());
+      }
+      assertEquals(
+        testCase.expected(),
+        strategy.authenticate(testCase.request())
+      );
+    }
+  }
+}

--- a/src/test/java/com/tiernebre/authentication/session/JooqSessionRepositoryTest.java
+++ b/src/test/java/com/tiernebre/authentication/session/JooqSessionRepositoryTest.java
@@ -25,7 +25,7 @@ public final class JooqSessionRepositoryTest {
   @Test
   public void insertOne() {
     var accountId = accountRepository
-      .insertOne(UUID.randomUUID().toString())
+      .insertOne(UUID.randomUUID().toString(), null)
       .id();
     var session = repository.insertOne(accountId);
     assertEquals(accountId, session.accountId());
@@ -35,7 +35,7 @@ public final class JooqSessionRepositoryTest {
   @Test
   public void selectOne() {
     var existingSession = repository.insertOne(
-      accountRepository.insertOne(UUID.randomUUID().toString()).id()
+      accountRepository.insertOne(UUID.randomUUID().toString(), null).id()
     );
     var selectedSession = repository.selectOne(existingSession.id());
     assertEquals(existingSession, selectedSession.get());


### PR DESCRIPTION
- Start to setup a linking between `Account` and `Registration.
- Setup the initial `RegistrationAuthenticationStrategy` for authenticating registrations.