### PR TITLE
Clean up validators for Google Authentication Strategy and Registration Service

### DIFF
--- a/src/main/java/com/tiernebre/authentication/AuthenticationContext.java
+++ b/src/main/java/com/tiernebre/authentication/AuthenticationContext.java
@@ -2,13 +2,11 @@ package com.tiernebre.authentication;
 
 import com.tiernebre.authentication.google.GoogleAuthenticationStrategy;
 import com.tiernebre.authentication.registration.RegistrationService;
-import com.tiernebre.authentication.registration.RegistrationValidator;
 import com.tiernebre.authentication.session.SessionService;
 
 public record AuthenticationContext(
   AuthenticationConfiguration configuration,
   GoogleAuthenticationStrategy googleAuthenticationService,
   SessionService sessionService,
-  RegistrationService registrationService,
-  RegistrationValidator registrationValidator
+  RegistrationService registrationService
 ) {}

--- a/src/main/java/com/tiernebre/authentication/AuthenticationContextFactory.java
+++ b/src/main/java/com/tiernebre/authentication/AuthenticationContextFactory.java
@@ -4,6 +4,7 @@ import com.tiernebre.authentication.account.DefaultAccountService;
 import com.tiernebre.authentication.account.JooqAccountRepository;
 import com.tiernebre.authentication.google.GoogleAuthenticationStrategy;
 import com.tiernebre.authentication.google.GoogleIdTokenVerifierFactory;
+import com.tiernebre.authentication.google.VavrGoogleAuthenticationValidator;
 import com.tiernebre.authentication.registration.Argon2PasswordHasher;
 import com.tiernebre.authentication.registration.DefaultRegistrationService;
 import com.tiernebre.authentication.registration.JooqRegistrationRepository;
@@ -39,7 +40,8 @@ public final class AuthenticationContextFactory {
           AuthenticationConstants.CONFIGURATION.oauthGoogleClientId()
         ).create(),
         sessionService,
-        accountService
+        accountService,
+        new VavrGoogleAuthenticationValidator()
       ),
       sessionService,
       new DefaultRegistrationService(

--- a/src/main/java/com/tiernebre/authentication/AuthenticationContextFactory.java
+++ b/src/main/java/com/tiernebre/authentication/AuthenticationContextFactory.java
@@ -47,9 +47,9 @@ public final class AuthenticationContextFactory {
       new DefaultRegistrationService(
         new JooqRegistrationRepository(dsl),
         new Argon2PasswordHasher(),
-        accountService
-      ),
-      new VavrRegistrationValidator()
+        accountService,
+        new VavrRegistrationValidator()
+      )
     );
   }
 }

--- a/src/main/java/com/tiernebre/authentication/google/GoogleAuthenticationValidator.java
+++ b/src/main/java/com/tiernebre/authentication/google/GoogleAuthenticationValidator.java
@@ -1,0 +1,17 @@
+package com.tiernebre.authentication.google;
+
+import io.vavr.collection.Seq;
+import io.vavr.control.Either;
+
+public interface GoogleAuthenticationValidator {
+  /**
+   * For a given GoogleAuthenticationRequest, verifies that is a safe and valid request
+   * and parses the specific token credential.
+   *
+   * @param request The authentication request from Google.
+   * @return Either a list of validation errors or a valid credential token string.
+   */
+  public Either<Seq<String>, String> parseCredential(
+    GoogleAuthenticationRequest request
+  );
+}

--- a/src/main/java/com/tiernebre/authentication/google/GoogleAuthenticationValidator.java
+++ b/src/main/java/com/tiernebre/authentication/google/GoogleAuthenticationValidator.java
@@ -1,6 +1,5 @@
 package com.tiernebre.authentication.google;
 
-import io.vavr.collection.Seq;
 import io.vavr.control.Either;
 
 public interface GoogleAuthenticationValidator {
@@ -9,9 +8,9 @@ public interface GoogleAuthenticationValidator {
    * and parses the specific token credential.
    *
    * @param request The authentication request from Google.
-   * @return Either a list of validation errors or a valid credential token string.
+   * @return Either the validation error or a valid credential token string.
    */
-  public Either<Seq<String>, String> parseCredential(
+  public Either<String, String> parseCredential(
     GoogleAuthenticationRequest request
   );
 }

--- a/src/main/java/com/tiernebre/authentication/google/VavrGoogleAuthenticationValidator.java
+++ b/src/main/java/com/tiernebre/authentication/google/VavrGoogleAuthenticationValidator.java
@@ -1,0 +1,47 @@
+package com.tiernebre.authentication.google;
+
+import io.vavr.collection.List;
+import io.vavr.collection.Seq;
+import io.vavr.control.Either;
+import io.vavr.control.Option;
+import io.vavr.control.Validation;
+import org.apache.commons.lang3.StringUtils;
+
+public class VavrGoogleAuthenticationValidator
+  implements GoogleAuthenticationValidator {
+
+  @Override
+  public Either<Seq<String>, String> parseCredential(
+    GoogleAuthenticationRequest request
+  ) {
+    return Option.of(request)
+      .toValidation(
+        (Seq<String>) List.of(
+          "Google Authentication Request received was null."
+        )
+      )
+      .flatMap(req -> this.validateNonNull(req))
+      .toEither();
+  }
+
+  public Validation<Seq<String>, String> validateNonNull(
+    GoogleAuthenticationRequest request
+  ) {
+    return Validation.combine(
+      validateCredential(request.credential()),
+      validateCsrfToken(request.cookieCsrfToken())
+    ).ap((credential, __) -> credential);
+  }
+
+  private Validation<String, String> validateCredential(String credential) {
+    return StringUtils.isBlank(credential)
+      ? Validation.invalid("Google Credential received was an empty string.")
+      : Validation.valid(credential);
+  }
+
+  private Validation<String, String> validateCsrfToken(String csrfToken) {
+    return StringUtils.isBlank(csrfToken)
+      ? Validation.invalid("Google CRSF token received was an empty string.")
+      : Validation.valid(csrfToken);
+  }
+}

--- a/src/main/java/com/tiernebre/authentication/google/VavrGoogleAuthenticationValidator.java
+++ b/src/main/java/com/tiernebre/authentication/google/VavrGoogleAuthenticationValidator.java
@@ -5,13 +5,14 @@ import io.vavr.collection.Seq;
 import io.vavr.control.Either;
 import io.vavr.control.Option;
 import io.vavr.control.Validation;
+import java.util.stream.Collectors;
 import org.apache.commons.lang3.StringUtils;
 
 public class VavrGoogleAuthenticationValidator
   implements GoogleAuthenticationValidator {
 
   @Override
-  public Either<Seq<String>, String> parseCredential(
+  public Either<String, String> parseCredential(
     GoogleAuthenticationRequest request
   ) {
     return Option.of(request)
@@ -21,6 +22,7 @@ public class VavrGoogleAuthenticationValidator
         )
       )
       .flatMap(req -> this.validateNonNull(req))
+      .mapError(errors -> errors.collect(Collectors.joining("\n")))
       .toEither();
   }
 

--- a/src/main/java/com/tiernebre/authentication/registration/CreateRegistrationRequest.java
+++ b/src/main/java/com/tiernebre/authentication/registration/CreateRegistrationRequest.java
@@ -1,0 +1,7 @@
+package com.tiernebre.authentication.registration;
+
+public record CreateRegistrationRequest(
+  String username,
+  String password,
+  String confirmPassword
+) {}

--- a/src/main/java/com/tiernebre/authentication/registration/DefaultRegistrationService.java
+++ b/src/main/java/com/tiernebre/authentication/registration/DefaultRegistrationService.java
@@ -1,6 +1,8 @@
 package com.tiernebre.authentication.registration;
 
 import com.tiernebre.authentication.account.AccountService;
+import io.vavr.collection.Seq;
+import io.vavr.control.Either;
 import io.vavr.control.Option;
 
 public final class DefaultRegistrationService implements RegistrationService {
@@ -8,25 +10,34 @@ public final class DefaultRegistrationService implements RegistrationService {
   private final RegistrationRepository repository;
   private final PasswordHasher passwordHasher;
   private final AccountService accountService;
+  private final RegistrationValidator validator;
 
   public DefaultRegistrationService(
     RegistrationRepository repository,
     PasswordHasher passwordHasher,
-    AccountService accountService
+    AccountService accountService,
+    RegistrationValidator validator
   ) {
     this.repository = repository;
     this.passwordHasher = passwordHasher;
     this.accountService = accountService;
+    this.validator = validator;
   }
 
   @Override
-  public Registration create(RegistrationRequest request) {
-    var registration = repository.insertOne(
-      request.username(),
-      passwordHasher.hash(request.password())
-    );
-    accountService.create(registration);
-    return registration;
+  public Either<Seq<String>, Registration> create(
+    CreateRegistrationRequest request
+  ) {
+    return validator
+      .parse(request)
+      .map(
+        req ->
+          repository.insertOne(
+            req.username(),
+            passwordHasher.hash(req.password())
+          )
+      )
+      .peek(accountService::create);
   }
 
   @Override

--- a/src/main/java/com/tiernebre/authentication/registration/RegistrationService.java
+++ b/src/main/java/com/tiernebre/authentication/registration/RegistrationService.java
@@ -1,9 +1,13 @@
 package com.tiernebre.authentication.registration;
 
+import io.vavr.collection.Seq;
+import io.vavr.control.Either;
 import io.vavr.control.Option;
 
 public interface RegistrationService {
-  public Registration create(RegistrationRequest request);
+  public Either<Seq<String>, Registration> create(
+    CreateRegistrationRequest request
+  );
 
   public Option<Registration> getOne(String username, String password);
 }

--- a/src/main/java/com/tiernebre/authentication/registration/RegistrationValidator.java
+++ b/src/main/java/com/tiernebre/authentication/registration/RegistrationValidator.java
@@ -4,9 +4,11 @@ import io.vavr.collection.Seq;
 import io.vavr.control.Either;
 
 public interface RegistrationValidator {
-  public Either<Seq<String>, RegistrationRequest> validate(
-    String username,
-    String password,
-    String confirmPassword
+  public Either<Seq<String>, RegistrationRequest> parse(
+    CreateRegistrationRequest request
+  );
+
+  public Either<Seq<String>, RegistrationAuthenticationRequest> parse(
+    RegistrationAuthenticationRequest request
   );
 }

--- a/src/main/java/com/tiernebre/authentication/registration/VavrRegistrationValidator.java
+++ b/src/main/java/com/tiernebre/authentication/registration/VavrRegistrationValidator.java
@@ -8,14 +8,12 @@ import org.apache.commons.lang3.StringUtils;
 public final class VavrRegistrationValidator implements RegistrationValidator {
 
   @Override
-  public Either<Seq<String>, RegistrationRequest> validate(
-    String username,
-    String password,
-    String confirmPassword
+  public Either<Seq<String>, RegistrationRequest> parse(
+    CreateRegistrationRequest request
   ) {
     return Validation.combine(
-      validateUsername(username),
-      validatePassword(password, confirmPassword)
+      validateUsername(request.username()),
+      validatePassword(request.password(), request.confirmPassword())
     )
       .ap(RegistrationRequest::new)
       .toEither();
@@ -77,5 +75,13 @@ public final class VavrRegistrationValidator implements RegistrationValidator {
           RegistrationConstants.MAXIMUM_PASSWORD_LENGTH
         )
       );
+  }
+
+  @Override
+  public Either<Seq<String>, RegistrationAuthenticationRequest> parse(
+    RegistrationAuthenticationRequest request
+  ) {
+    // TODO Auto-generated method stub
+    throw new UnsupportedOperationException("Unimplemented method 'parse'");
   }
 }

--- a/src/main/java/com/tiernebre/authentication/registration/VavrRegistrationValidator.java
+++ b/src/main/java/com/tiernebre/authentication/registration/VavrRegistrationValidator.java
@@ -1,7 +1,9 @@
 package com.tiernebre.authentication.registration;
 
+import io.vavr.collection.List;
 import io.vavr.collection.Seq;
 import io.vavr.control.Either;
+import io.vavr.control.Option;
 import io.vavr.control.Validation;
 import org.apache.commons.lang3.StringUtils;
 
@@ -11,11 +13,17 @@ public final class VavrRegistrationValidator implements RegistrationValidator {
   public Either<Seq<String>, RegistrationRequest> parse(
     CreateRegistrationRequest request
   ) {
-    return Validation.combine(
-      validateUsername(request.username()),
-      validatePassword(request.password(), request.confirmPassword())
-    )
-      .ap(RegistrationRequest::new)
+    return Option.of(request)
+      .toValidation(
+        (Seq<String>) List.of("Create registration request is null.")
+      )
+      .flatMap(
+        req ->
+          Validation.combine(
+            validateUsername(req.username()),
+            validatePassword(req.password(), req.confirmPassword())
+          ).ap(RegistrationRequest::new)
+      )
       .toEither();
   }
 

--- a/src/main/java/com/tiernebre/web/controllers/authentication/RegistrationController.java
+++ b/src/main/java/com/tiernebre/web/controllers/authentication/RegistrationController.java
@@ -1,34 +1,34 @@
 package com.tiernebre.web.controllers.authentication;
 
+import com.tiernebre.authentication.registration.CreateRegistrationRequest;
 import com.tiernebre.authentication.registration.RegistrationService;
-import com.tiernebre.authentication.registration.RegistrationValidator;
 import com.tiernebre.web.constants.WebConstants;
 import io.javalin.http.Context;
 import io.javalin.http.HttpStatus;
 
 public final class RegistrationController {
 
-  private final RegistrationValidator validator;
   private final RegistrationService service;
 
-  public RegistrationController(
-    RegistrationValidator validator,
-    RegistrationService service
-  ) {
-    this.validator = validator;
+  public RegistrationController(RegistrationService service) {
     this.service = service;
   }
 
   public void handle(Context ctx) {
-    validator
-      .validate(
-        ctx.formParam(WebConstants.Authentication.REGISTRATION_USERNAME_PARAM),
-        ctx.formParam(WebConstants.Authentication.REGISTRATION_PASSWORD_PARAM),
-        ctx.formParam(
-          WebConstants.Authentication.REGISTRATION_CONFIRM_PASSWORD_PARAM
+    service
+      .create(
+        new CreateRegistrationRequest(
+          ctx.formParam(
+            WebConstants.Authentication.REGISTRATION_USERNAME_PARAM
+          ),
+          ctx.formParam(
+            WebConstants.Authentication.REGISTRATION_PASSWORD_PARAM
+          ),
+          ctx.formParam(
+            WebConstants.Authentication.REGISTRATION_CONFIRM_PASSWORD_PARAM
+          )
         )
       )
-      .map(service::create)
       .peek(registration -> {
         ctx.status(HttpStatus.CREATED);
       })

--- a/src/main/java/com/tiernebre/web/routes/RoutesFactory.java
+++ b/src/main/java/com/tiernebre/web/routes/RoutesFactory.java
@@ -31,10 +31,7 @@ public final class RoutesFactory {
         ),
         new HealthRoutes(new HealthController()),
         new RegistrationRoutes(
-          new RegistrationController(
-            authentication.registrationValidator(),
-            authentication.registrationService()
-          )
+          new RegistrationController(authentication.registrationService())
         )
       ),
       new PageRoutes(

--- a/src/test/java/com/tiernebre/authentication/google/GoogleAuthenticationStrategyTest.java
+++ b/src/test/java/com/tiernebre/authentication/google/GoogleAuthenticationStrategyTest.java
@@ -39,44 +39,6 @@ public final class GoogleAuthenticationStrategyTest {
   public void cases() throws GeneralSecurityException, IOException {
     var cases = new Case[] {
       new Case(
-        "Null request",
-        null,
-        Either.left("Request received was null."),
-        null
-      ),
-      new Case(
-        "No Body CSRF Token",
-        new GoogleAuthenticationRequest("creds", null, "csrf"),
-        Either.left("Request has invalid CSRF tokens."),
-        null
-      ),
-      new Case(
-        "No Cookie CSRF Token",
-        new GoogleAuthenticationRequest("creds", "csrf", null),
-        Either.left("Request has invalid CSRF tokens."),
-        null
-      ),
-      new Case(
-        "No Body and Cookie CSRF Token",
-        new GoogleAuthenticationRequest("creds", null, null),
-        Either.left("Request has invalid CSRF tokens."),
-        null
-      ),
-      new Case(
-        "Body and Cookie CSRF Tokens are not equal",
-        new GoogleAuthenticationRequest("creds", "body", "cookie"),
-        Either.left("Request has invalid CSRF tokens."),
-        null
-      ),
-      new Case(
-        "No Credential",
-        new GoogleAuthenticationRequest(null, "csrf", "csrf"),
-        Either.left(
-          "Could not verify and parse given Google authentication credential."
-        ),
-        null
-      ),
-      new Case(
         "Google token verifier returns null",
         new GoogleAuthenticationRequest("creds", "csrf", "csrf"),
         Either.left(

--- a/src/test/java/com/tiernebre/authentication/google/GoogleAuthenticationStrategyTest.java
+++ b/src/test/java/com/tiernebre/authentication/google/GoogleAuthenticationStrategyTest.java
@@ -25,8 +25,16 @@ public final class GoogleAuthenticationStrategyTest {
   );
   private final SessionService sessionService = mock(SessionService.class);
   private final AccountService accountService = mock(AccountService.class);
+  private final GoogleAuthenticationValidator validator = mock(
+    GoogleAuthenticationValidator.class
+  );
   private final GoogleAuthenticationStrategy googleAuthenticationStrategy =
-    new GoogleAuthenticationStrategy(verifier, sessionService, accountService);
+    new GoogleAuthenticationStrategy(
+      verifier,
+      sessionService,
+      accountService,
+      validator
+    );
 
   private final record Case(
     String name,
@@ -38,6 +46,15 @@ public final class GoogleAuthenticationStrategyTest {
   @Test
   public void cases() throws GeneralSecurityException, IOException {
     var cases = new Case[] {
+      new Case("Invalid request", new GoogleAuthenticationRequest(
+          "creds",
+          "csrf",
+          "csrf"
+        ), Either.left("Invalid request"), request -> {
+          when(validator.parseCredential(request)).thenReturn(
+            Either.left("Invalid request")
+          );
+        }),
       new Case(
         "Google token verifier returns null",
         new GoogleAuthenticationRequest("creds", "csrf", "csrf"),
@@ -45,6 +62,9 @@ public final class GoogleAuthenticationStrategyTest {
           "Could not verify and parse given Google authentication credential."
         ),
         request -> {
+          when(validator.parseCredential(request)).thenReturn(
+            Either.right(request.credential())
+          );
           try {
             when(verifier.verify(request.credential())).thenReturn(null);
           } catch (Exception e) {}
@@ -55,6 +75,9 @@ public final class GoogleAuthenticationStrategyTest {
           "csrf",
           "csrf"
         ), Either.left("Get account error"), request -> {
+          when(validator.parseCredential(request)).thenReturn(
+            Either.right(request.credential())
+          );
           var token = mock(GoogleIdToken.class);
           var payload = mock(Payload.class);
           var accountId = "accountId";
@@ -67,11 +90,14 @@ public final class GoogleAuthenticationStrategyTest {
             when(verifier.verify(request.credential())).thenReturn(token);
           } catch (Exception e) {}
         }),
-      new Case("Created happy path session", new GoogleAuthenticationRequest(
-          "creds",
-          "csrf",
-          "csrf"
-        ), Either.right(new Session(new UUID(0, 0), 1L)), request -> {
+      new Case(
+        "Happy path valid request and created session",
+        new GoogleAuthenticationRequest("creds", "csrf", "csrf"),
+        Either.right(new Session(new UUID(0, 0), 1L)),
+        request -> {
+          when(validator.parseCredential(request)).thenReturn(
+            Either.right(request.credential())
+          );
           var token = mock(GoogleIdToken.class);
           var payload = mock(Payload.class);
           var accountId = "accountId";
@@ -91,7 +117,8 @@ public final class GoogleAuthenticationStrategyTest {
           try {
             when(verifier.verify(request.credential())).thenReturn(token);
           } catch (Exception e) {}
-        }),
+        }
+      ),
     };
     for (var test : cases) {
       if (test.mock() != null) {

--- a/src/test/java/com/tiernebre/authentication/google/VavrGoogleAuthenticationValidatorTest.java
+++ b/src/test/java/com/tiernebre/authentication/google/VavrGoogleAuthenticationValidatorTest.java
@@ -26,6 +26,31 @@ public final class VavrGoogleAuthenticationValidatorTest {
         null,
         Either.left(List.of("Google Authentication Request received was null."))
       ),
+      new Case(
+        "No Body CSRF Token",
+        new GoogleAuthenticationRequest("creds", null, "csrf"),
+        Either.left(List.of("Google CSRF token received was an empty string."))
+      ),
+      new Case(
+        "No Cookie CSRF Token",
+        new GoogleAuthenticationRequest("creds", "csrf", null),
+        Either.left(List.of("Google CSRF token received was an empty string."))
+      ),
+      new Case(
+        "No Body and Cookie CSRF Token",
+        new GoogleAuthenticationRequest("creds", null, null),
+        Either.left(List.of("Google CSRF token received was an empty string."))
+      ),
+      new Case(
+        "Body and Cookie CSRF Tokens are not equal",
+        new GoogleAuthenticationRequest("creds", "body", "cookie"),
+        Either.left(List.of("Google CSRF tokens do not match each other."))
+      ),
+      new Case(
+        "No Credential",
+        new GoogleAuthenticationRequest(null, "csrf", "csrf"),
+        Either.left(List.of("Google Credential received was an empty string."))
+      ),
     };
     for (var test : cases) {
       assertEquals(test.expected(), validator.parseCredential(test.request()));

--- a/src/test/java/com/tiernebre/authentication/google/VavrGoogleAuthenticationValidatorTest.java
+++ b/src/test/java/com/tiernebre/authentication/google/VavrGoogleAuthenticationValidatorTest.java
@@ -2,8 +2,6 @@ package com.tiernebre.authentication.google;
 
 import static org.junit.Assert.assertEquals;
 
-import io.vavr.collection.List;
-import io.vavr.collection.Seq;
 import io.vavr.control.Either;
 import org.junit.Test;
 
@@ -15,7 +13,7 @@ public final class VavrGoogleAuthenticationValidatorTest {
   private final record Case(
     String name,
     GoogleAuthenticationRequest request,
-    Either<Seq<String>, String> expected
+    Either<String, String> expected
   ) {}
 
   @Test
@@ -24,32 +22,32 @@ public final class VavrGoogleAuthenticationValidatorTest {
       new Case(
         "Null request",
         null,
-        Either.left(List.of("Google Authentication Request received was null."))
+        Either.left("Google Authentication Request received was null.")
       ),
       new Case(
         "No Body CSRF Token",
         new GoogleAuthenticationRequest("creds", null, "csrf"),
-        Either.left(List.of("Google CSRF token received was an empty string."))
+        Either.left("Google CSRF token received was an empty string.")
       ),
       new Case(
         "No Cookie CSRF Token",
         new GoogleAuthenticationRequest("creds", "csrf", null),
-        Either.left(List.of("Google CSRF token received was an empty string."))
+        Either.left("Google CSRF token received was an empty string.")
       ),
       new Case(
         "No Body and Cookie CSRF Token",
         new GoogleAuthenticationRequest("creds", null, null),
-        Either.left(List.of("Google CSRF token received was an empty string."))
+        Either.left("Google CSRF token received was an empty string.")
       ),
       new Case(
         "Body and Cookie CSRF Tokens are not equal",
         new GoogleAuthenticationRequest("creds", "body", "cookie"),
-        Either.left(List.of("Google CSRF tokens do not match each other."))
+        Either.left("Google CSRF tokens do not match each other.")
       ),
       new Case(
         "No Credential",
         new GoogleAuthenticationRequest(null, "csrf", "csrf"),
-        Either.left(List.of("Google Credential received was an empty string."))
+        Either.left("Google Credential received was an empty string.")
       ),
       new Case(
         "Valid request",

--- a/src/test/java/com/tiernebre/authentication/google/VavrGoogleAuthenticationValidatorTest.java
+++ b/src/test/java/com/tiernebre/authentication/google/VavrGoogleAuthenticationValidatorTest.java
@@ -51,6 +51,11 @@ public final class VavrGoogleAuthenticationValidatorTest {
         new GoogleAuthenticationRequest(null, "csrf", "csrf"),
         Either.left(List.of("Google Credential received was an empty string."))
       ),
+      new Case(
+        "Valid request",
+        new GoogleAuthenticationRequest("credential", "csrf", "csrf"),
+        Either.right("credential")
+      ),
     };
     for (var test : cases) {
       assertEquals(test.expected(), validator.parseCredential(test.request()));

--- a/src/test/java/com/tiernebre/authentication/google/VavrGoogleAuthenticationValidatorTest.java
+++ b/src/test/java/com/tiernebre/authentication/google/VavrGoogleAuthenticationValidatorTest.java
@@ -1,0 +1,34 @@
+package com.tiernebre.authentication.google;
+
+import static org.junit.Assert.assertEquals;
+
+import io.vavr.collection.List;
+import io.vavr.collection.Seq;
+import io.vavr.control.Either;
+import org.junit.Test;
+
+public final class VavrGoogleAuthenticationValidatorTest {
+
+  private final VavrGoogleAuthenticationValidator validator =
+    new VavrGoogleAuthenticationValidator();
+
+  private final record Case(
+    String name,
+    GoogleAuthenticationRequest request,
+    Either<Seq<String>, String> expected
+  ) {}
+
+  @Test
+  public void cases() throws Exception {
+    var cases = new Case[] {
+      new Case(
+        "Null request",
+        null,
+        Either.left(List.of("Google Authentication Request received was null."))
+      ),
+    };
+    for (var test : cases) {
+      assertEquals(test.expected(), validator.parseCredential(test.request()));
+    }
+  }
+}

--- a/src/test/java/com/tiernebre/authentication/registration/VavrRegistrationValidatorTest.java
+++ b/src/test/java/com/tiernebre/authentication/registration/VavrRegistrationValidatorTest.java
@@ -14,95 +14,74 @@ public final class VavrRegistrationValidatorTest {
 
   private final record Case(
     String name,
-    String username,
-    String password,
-    String confirmPassword,
+    CreateRegistrationRequest request,
     Either<Seq<String>, RegistrationRequest> expected
   ) {}
 
   @Test
-  public void validate() {
+  public void parseCreate() {
     var cases = new Case[] {
       new Case(
         "null username",
-        null,
-        "password",
-        "password",
+        new CreateRegistrationRequest(null, "password", "password"),
         Either.left(List.of("Username is a required field."))
       ),
       new Case(
         "empty string username",
-        "",
-        "password",
-        "password",
+        new CreateRegistrationRequest("", "password", "password"),
         Either.left(List.of("Username is a required field."))
       ),
       new Case(
         "blank string username",
-        " ",
-        "password",
-        "password",
+        new CreateRegistrationRequest(" ", "password", "password"),
         Either.left(List.of("Username is a required field."))
       ),
       new Case(
         "null password",
-        "username",
-        null,
-        null,
+        new CreateRegistrationRequest("username", null, "password"),
         Either.left(List.of("Password is a required field."))
       ),
       new Case(
         "empty string password",
-        "username",
-        "",
-        "",
+        new CreateRegistrationRequest("username", "", "password"),
         Either.left(List.of("Password is a required field."))
       ),
       new Case(
         "blank string password",
-        "username",
-        " ",
-        "password",
+        new CreateRegistrationRequest("username", " ", "password"),
         Either.left(List.of("Password is a required field."))
       ),
       new Case(
         "too short of a password",
-        "username",
-        "a".repeat(RegistrationConstants.MINIMUM_PASSWORD_LENGTH - 1),
-        "a".repeat(RegistrationConstants.MINIMUM_PASSWORD_LENGTH - 1),
+        new CreateRegistrationRequest(
+          "username",
+          "a".repeat(RegistrationConstants.MINIMUM_PASSWORD_LENGTH - 1),
+          "a".repeat(RegistrationConstants.MINIMUM_PASSWORD_LENGTH - 1)
+        ),
         Either.left(List.of("Password must be at least 8 characters long."))
       ),
       new Case(
         "too long of a password",
-        "username",
-        "a".repeat(RegistrationConstants.MAXIMUM_PASSWORD_LENGTH + 1),
-        "a".repeat(RegistrationConstants.MAXIMUM_PASSWORD_LENGTH + 1),
+        new CreateRegistrationRequest(
+          "username",
+          "a".repeat(RegistrationConstants.MAXIMUM_PASSWORD_LENGTH + 1),
+          "a".repeat(RegistrationConstants.MAXIMUM_PASSWORD_LENGTH + 1)
+        ),
         Either.left(List.of("Password must be at most 64 characters long."))
       ),
       new Case(
         "confirm password is not equal",
-        "username",
-        "passwordA",
-        "passwordB",
+        new CreateRegistrationRequest("username", "passwordA", "passwordB"),
         Either.left(List.of("Confirm password must match password."))
       ),
       new Case(
         "valid happy path",
-        "username",
-        "password",
-        "password",
+        new CreateRegistrationRequest("username", "password", "password"),
         Either.right(new RegistrationRequest("username", "password"))
       ),
     };
     for (var test : cases) {
-      assertEquals(
-        test.expected(),
-        validator.validate(
-          test.username(),
-          test.password(),
-          test.confirmPassword()
-        )
-      );
+      assertEquals(test.expected(), validator.parse(test.request()));
     }
   }
 }

--- a/src/test/java/com/tiernebre/authentication/registration/VavrRegistrationValidatorTest.java
+++ b/src/test/java/com/tiernebre/authentication/registration/VavrRegistrationValidatorTest.java
@@ -22,6 +22,11 @@ public final class VavrRegistrationValidatorTest {
   public void parseCreate() {
     var cases = new Case[] {
       new Case(
+        "null request",
+        null,
+        Either.left(List.of("Create registration request is null."))
+      ),
+      new Case(
         "null username",
         new CreateRegistrationRequest(null, "password", "password"),
         Either.left(List.of("Username is a required field."))


### PR DESCRIPTION
Validators were being used in the controllers, when they should instead be used within the services to not be coupled to web.