### PR TITLE
docs(product): split Composure into Composure and Clutch attributes

### DIFF
--- a/docs/product/coaches.md
+++ b/docs/product/coaches.md
@@ -236,7 +236,7 @@ effectiveness. All of these are hidden from the user.
 - **Physical development** — ability to design training programs that maximize
   players' physical tools without increasing injury risk
 - **Mental development** — ability to improve players' football IQ, decision-
-  making, and composure; the "teaching" dimension
+  making, composure, and clutch; the "teaching" dimension
 - **Youth development** — specific aptitude for developing young, raw players;
   some coaches are great with veterans but can't develop rookies, and vice
   versa

--- a/docs/product/player-attributes.md
+++ b/docs/product/player-attributes.md
@@ -184,8 +184,13 @@ surprise you — positively or negatively — once a player is on your roster.
   to throw it away, when to take the sack, when to force a throw
 - **Anticipation** — reading plays before they develop; throwing to where the
   receiver will be, jumping a route for an interception
-- **Composure** — performance under pressure; clutch moments, hostile
-  environments, playoff intensity; resistance to rattling
+- **Composure** — emotional control and discipline; resistance to drawing
+  penalties, unsportsmanlike conduct, off-field behavioral issues; how a player
+  handles adversity, frustration, and public scrutiny without it affecting his
+  game or the locker room
+- **Clutch** — performance in high-leverage game situations; the last two
+  minutes, 4th-quarter comebacks, playoff games, prime-time moments; some
+  players elevate when the stakes rise, others shrink
 - **Consistency** — how much variance there is game-to-game; a consistent
   player's floor is close to his ceiling; an inconsistent player has brilliant
   games and terrible ones
@@ -329,8 +334,12 @@ Mental attributes follow their own trajectory:
   better than rookies
 - **Decision-making** improves with reps and game experience but has a ceiling
   tied to the player's natural cognitive ability
-- **Composure** can improve (players get used to pressure) or decline (a
-  player who's been benched or booed might lose confidence)
+- **Composure** can improve (a player matures, learns to control his emotions)
+  or decline (frustration builds from losing, benchings, or off-field issues;
+  penalties and outbursts become more frequent)
+- **Clutch** can improve (players learn to thrive in big moments through
+  experience) or decline (a player who's been burned in late-game situations
+  might start playing tight when the stakes rise)
 - **Consistency** is relatively stable but can shift — a player who cleans up
   his lifestyle might become more consistent; one dealing with off-field
   issues might become less so
@@ -372,8 +381,8 @@ reps** for development purposes.
   doesn't test mental attributes the way a live game does.
 - **Game reps** accelerate development dramatically. The speed, pressure,
   unpredictability, and consequences of real games force adaptation that
-  practice can't replicate. A player's decision-making, composure, and
-  anticipation grow under fire in ways they never will holding a clipboard.
+  practice can't replicate. A player's decision-making, composure, clutch,
+  and anticipation grow under fire in ways they never will holding a clipboard.
 - The gap between practice and game development is largest for **mental
   attributes**. You can drill route running in practice. You can't drill
   reading a disguised Cover-2 with 70,000 fans screaming while the play clock
@@ -486,7 +495,8 @@ Key interactions:
 - Scouts **cannot see hidden potential** — they can guess at "ceiling" based on
   physical tools and age, but it's a guess
 - Mental attributes are the **hardest to scout** — a few interviews and film
-  sessions aren't enough to truly know a player's football IQ or composure
+  sessions aren't enough to truly know a player's football IQ, composure,
+  or clutch
 - Physical attributes are the **easiest to scout** — combine numbers and film
   give a relatively clear picture
 
@@ -504,7 +514,7 @@ system.
 The simulation engine consumes individual attributes — never an aggregate
 overall rating. On every play, the relevant attributes for each player in that
 context are what determine the outcome. A quarterback's deep accuracy matters
-on a go route. His composure matters when the pocket collapses. His football
+on a go route. His clutch matters in the final two minutes of a close game. His football
 IQ matters when reading a disguised coverage.
 
 This means a player can be dominant in one context and mediocre in another —

--- a/docs/product/schemes-and-strategy.md
+++ b/docs/product/schemes-and-strategy.md
@@ -313,7 +313,7 @@ Lives in the pocket, wins with arm talent, accuracy, anticipation, and
 pre-snap reads. The classic NFL QB model.
 
 - **Primary attributes**: Accuracy (short, medium, deep), arm strength,
-  football IQ, decision-making, anticipation, composure
+  football IQ, decision-making, anticipation, clutch
 - **Secondary attributes**: Touch, release, pocket awareness
 - **Physical profile**: Size matters (taller QBs see the field better), speed
   is irrelevant
@@ -356,8 +356,8 @@ ball to playmakers, protects possession, and executes the scheme reliably.
 High-risk, high-reward arm talent. Launches bombs, throws into tight
 windows, makes jaw-dropping plays — and backbreaking turnovers.
 
-- **Primary attributes**: Arm strength, accuracy (deep), composure (or lack
-  thereof — a gunslinger with low composure is a disaster in big moments)
+- **Primary attributes**: Arm strength, accuracy (deep), clutch (or lack
+  thereof — a gunslinger with low clutch is a disaster in big moments)
 - **Secondary attributes**: Touch (often lacking), decision-making (the key
   variable — a gunslinger with elite decision-making is a franchise QB; one
   with poor decision-making is a turnover machine)
@@ -449,7 +449,7 @@ running, catches in traffic, creates yards after the catch in space.
 
 - **Primary attributes**: Route running, catching, run after catch, agility,
   acceleration
-- **Secondary attributes**: Composure (catching over the middle with a safety
+- **Secondary attributes**: Clutch (catching over the middle with a safety
   coming), toughness
 - **Physical profile**: 5'9"-6'0", 180-200 lbs typically; quickness over
   size
@@ -697,7 +697,7 @@ offense's best receiver). Plays press or off coverage, tracks a single
 receiver, and is responsible for his man or his deep third depending on the
 call.
 
-- **Primary attributes**: Man coverage, speed, agility, composure
+- **Primary attributes**: Man coverage, speed, agility, clutch
 - **Secondary attributes**: Jumping, anticipation
 - **Physical profile**: 5'11"-6'2", 185-200 lbs; length and speed matter;
   long arms and fluid hips are the physical hallmarks
@@ -727,7 +727,7 @@ eyes, and makes plays on the ball. The last line of defense.
 
 - **Primary attributes**: Zone coverage, speed, anticipation, football IQ,
   catching
-- **Secondary attributes**: Jumping, composure
+- **Secondary attributes**: Jumping, clutch
 - **Physical profile**: 5'11"-6'2", 195-210 lbs; range and ball skills
   matter more than size
 - **Scheme fit**: Single-high defenses (Cover 1, Cover 3) that ask the free
@@ -773,7 +773,7 @@ Big leg. Makes 55-yarders. Might miss the 38-yarder because accuracy isn't
 his thing.
 
 - **Primary attributes**: Kicking power
-- **Secondary attributes**: Kicking accuracy, composure
+- **Secondary attributes**: Kicking accuracy, clutch
 - **Scheme fit**: Teams that play in domes or warm weather, offenses that
   stall in the red zone (more long FG attempts), aggressive coaches who
   want the option to kick from 55+
@@ -782,7 +782,7 @@ his thing.
 Won't miss inside 45. Won't attempt from 55. Reliable, consistent, boring
 in the best possible way.
 
-- **Primary attributes**: Kicking accuracy, composure, consistency
+- **Primary attributes**: Kicking accuracy, clutch, consistency
 - **Secondary attributes**: Kicking power
 - **Scheme fit**: Any team, but particularly valuable for conservative
   coaches and playoff-caliber teams where a missed kick is the difference
@@ -793,7 +793,7 @@ Pins opponents inside the 10. Varies hang time, direction, and distance
 to control field position. Doesn't just kick it far — kicks it smart.
 
 - **Primary attributes**: Punting accuracy, punting power, football IQ
-- **Secondary attributes**: Composure (coffin corner punts under pressure)
+- **Secondary attributes**: Clutch (coffin corner punts under pressure)
 - **Scheme fit**: Teams with elite defenses that win the field position
   battle; a great punter on a great defense is a cheat code because every
   opponent drive starts with a long field
@@ -802,7 +802,7 @@ to control field position. Doesn't just kick it far — kicks it smart.
 You don't notice him when he's good. You absolutely notice him when he's
 bad. A botched snap loses games.
 
-- **Primary attributes**: Snap accuracy, consistency, composure
+- **Primary attributes**: Snap accuracy, consistency, clutch
 - **Scheme fit**: Every team. The long snapper is the ultimate "you don't
   know what you have until it's gone" position.
 
@@ -814,7 +814,7 @@ roster spot dedicated purely to the return game.
 
 - **Primary attributes**: Speed, acceleration, elusiveness, agility, ball
   carrying
-- **Secondary attributes**: Composure (fielding a punt with a gunner in
+- **Secondary attributes**: Clutch (fielding a punt with a gunner in
   your face), football IQ (knowing when to fair catch, when to let it go,
   when to take it out of the end zone)
 - **Physical profile**: Fast and elusive; size is irrelevant — what matters
@@ -885,7 +885,7 @@ those attributes or he doesn't. The degree of alignment IS the fit.
 ### How it works
 
 A West Coast OC's system weights short accuracy, touch, decision-making,
-and composure heavily. A QB with 85 short accuracy, 80 touch, and 75
+and clutch heavily. A QB with 85 short accuracy, 80 touch, and 75
 decision-making will perform well in this system. The same QB in an Air
 Raid system — which weights quick release, deep accuracy, and arm strength
 more heavily — might perform worse because the system is asking for


### PR DESCRIPTION
## Summary
- Splits the single "Composure" mental attribute into two distinct attributes: **Composure** (emotional control, discipline, penalties, off-field behavior) and **Clutch** (performance in high-leverage game situations — last 2 minutes, playoffs, prime time)
- Updates all archetype attribute lists in schemes-and-strategy.md to use the correct term based on context
- Adds Clutch to coaches.md mental development dimension

## Test plan
- [ ] Read through player-attributes.md and confirm both definitions are clear and non-overlapping
- [ ] Spot-check schemes-and-strategy.md archetypes to verify each usage fits the correct attribute

🤖 Generated with [Claude Code](https://claude.com/claude-code)