### PR TITLE
docs(product): add Personality traits as fourth attribute category

### DIFF
--- a/docs/product/free-agency-and-contracts.md
+++ b/docs/product/free-agency-and-contracts.md
@@ -101,13 +101,18 @@ Players aren't just chasing dollars. Their decision weighs multiple factors:
 
 ### Player personality
 
-Players have personality traits that bias their decisions:
+Every player has hidden personality traits — greed, loyalty, ambition, vanity,
+scheme attachment, and media sensitivity — that bias their free agency
+decisions. See [Player Attributes — Personality](./player-attributes.md#personality-traits)
+for the full trait definitions.
 
-- **Money-motivated**: Will almost always go to the highest bidder
-- **Ring chaser**: Prioritizes competitiveness, especially later in career
-- **Loyalty-driven**: Gives a discount to re-sign with their current team
-- **Market-driven**: Values the "brand" of playing for a big-market team
-- **Scheme-loyal**: Strongly prefers familiar systems
+The key traits for free agency:
+
+- **Greed** drives how heavily money weighs against other factors
+- **Loyalty** determines whether a player gives a discount to re-sign
+- **Ambition** makes veterans chase contenders, even for less money
+- **Vanity** pulls players toward big-market teams and the spotlight
+- **Scheme attachment** biases players toward teams running familiar systems
 
 This means you can "win" a free agent without the highest bid — if your team,
 scheme, and situation are attractive. That makes team-building holistic, not
@@ -173,9 +178,8 @@ than market value to stay requires a specific combination of factors:
   players well — good coaching, honest front office, player-friendly culture
 - **Personal fit**: The player feels valued in their role and believes the
   scheme maximizes their ability
-- **Loyalty personality**: Only players with the loyalty-driven personality
-  trait are even candidates for a meaningful discount. Most players take
-  the best offer.
+- **High loyalty trait**: Only players with high loyalty are even candidates
+  for a meaningful discount. Most players take the best offer.
 
 Even when all conditions are met, the discount is modest — a few percent off
 market value, not a dramatic pay cut. Players have short careers and agents

--- a/docs/product/player-attributes.md
+++ b/docs/product/player-attributes.md
@@ -94,11 +94,13 @@ staff where the right answers emerge naturally.
 
 ## Attribute Categories
 
-Every player has attributes across three categories: **Physical**, **Technical**,
-and **Mental**. Each attribute is an independent value on the 0-100 scale.
-Attributes are position-agnostic in structure but position-specific in
-relevance — every player has an arm strength rating, but it only matters for
-quarterbacks.
+Every player has attributes across four categories: **Physical**, **Technical**,
+**Mental**, and **Personality**. Physical, technical, and mental attributes are
+each an independent value on the 0-100 scale. Personality traits use the same
+scale but affect off-field decisions and relationships rather than on-field
+performance. All attributes are position-agnostic in structure but
+position-specific in relevance — every player has an arm strength rating, but
+it only matters for quarterbacks.
 
 ### Physical attributes
 
@@ -200,6 +202,61 @@ surprise you — positively or negatively — once a player is on your roster.
   receptiveness to scheme changes and technique adjustments
 - **Leadership** — impact on teammates' performance and morale; locker room
   presence
+
+### Personality traits
+
+Personality traits represent who a player is off the field — his motivations,
+priorities, and psychological makeup. Unlike physical, technical, and mental
+attributes, personality traits don't directly affect on-field play outcomes.
+Instead, they drive decisions and relationships: how a player evaluates
+contract offers, how he responds to media pressure, whether he'll take a
+discount to stay, and how he reacts to being benched or tagged.
+
+Personality traits are **hidden** and **hard to scout**. You get signals
+through interviews, agent behavior, and a player's history of decisions —
+but the true values are never visible. A player who *says* he wants to stay
+might leave for more money. A player who seems like a mercenary might
+surprise you with loyalty after years of winning together.
+
+- **Greed** — how heavily money weighs in the player's decisions; high-greed
+  players almost always go to the highest bidder in free agency; low-greed
+  players weigh other factors more heavily and are candidates for discounts
+- **Loyalty** — attachment to his current team and organization; a loyal player
+  gives a meaningful discount to re-sign and values relationships with
+  coaches and teammates; disloyalty doesn't mean the player is selfish — it
+  means he treats free agency as a purely professional transaction
+- **Ambition** — drive to win championships; high-ambition players take
+  discounts to join contenders, especially later in their careers when
+  they've already been paid; low-ambition players don't factor team
+  competitiveness into their decisions as heavily
+- **Vanity** — desire for the spotlight and big-market prestige; high-vanity
+  players prefer large media markets, nationally televised games, and
+  franchise-player status; low-vanity players don't care whether they play
+  in New York or Jacksonville
+- **Scheme attachment** — how strongly a player prefers to stay in a familiar
+  system; high scheme attachment means he'll weigh scheme fit heavily in free
+  agency and may resist transitions to new systems; low scheme attachment
+  means he's adaptable and treats scheme as a secondary consideration
+- **Media sensitivity** — how much media coverage affects the player's morale
+  and behavior; a media-sensitive player who gets praised plays with
+  confidence, but one who gets criticized may spiral; a media-insensitive
+  player tunes it all out — praise doesn't lift him, criticism doesn't
+  bother him
+
+These traits interact with each other and with game context. A player with
+high loyalty and high ambition faces a genuine internal conflict when his
+team is rebuilding — does he stay out of loyalty, or chase a ring elsewhere?
+A player with high greed but high scheme attachment might take the money even
+if the new team's scheme is a terrible fit — and then underperform because
+of it. The combinations create realistic, distinct personalities that drive
+the off-field drama of franchise management.
+
+Personality traits are mostly stable but can shift in response to major
+career events. A player who wins a championship might see his ambition
+decrease — he got his ring. A player who's been franchise-tagged twice
+might see his loyalty erode. A player who's been burned by media narratives
+might become more media-sensitive over time, or might harden and become
+less sensitive. These shifts are gradual and rare, not dramatic swings.
 
 ---
 

--- a/docs/product/salary-cap.md
+++ b/docs/product/salary-cap.md
@@ -179,8 +179,8 @@ Managing the cap is an active, ongoing skill — not something you set and forge
 - Ask a player to take a reduced salary
 - Players may agree if the alternative is being cut, especially veterans who
   want to stay with a contender
-- Player personality affects willingness: loyalty-driven players are more
-  likely to accept; money-motivated players almost never will
+- Player personality affects willingness: players with high loyalty are more
+  likely to accept; players with high greed almost never will
 - Success rate depends on the player's market — if they'd get more elsewhere,
   why would they take less?
 


### PR DESCRIPTION
## Summary
- Adds a **Personality** section to player-attributes.md as a fourth attribute category (alongside Physical, Technical, Mental)
- Defines six personality traits on the 0-100 scale: greed, loyalty, ambition, vanity, scheme attachment, media sensitivity
- These traits drive off-field decisions (free agency, contracts, morale, media response) rather than on-field play
- Updates free-agency-and-contracts.md to reference the canonical definitions instead of its own inline list
- Updates salary-cap.md to use the new trait names (loyalty, greed)

## Test plan
- [ ] Read the new Personality section in player-attributes.md for clarity and completeness
- [ ] Verify free-agency-and-contracts.md references align with the new trait names
- [ ] Check salary-cap.md pay-cut section uses consistent terminology

🤖 Generated with [Claude Code](https://claude.com/claude-code)