### PR TITLE
docs(product): add Gambler NPC archetype across all system docs

### DIFF
--- a/docs/product/free-agency-and-contracts.md
+++ b/docs/product/free-agency-and-contracts.md
@@ -218,6 +218,10 @@ AI GMs approach free agency according to their personality:
   in free agency. Let expensive veterans walk and collect comp picks.
 - **"Old School" GMs**: Value toughness and character. Overpay for "their type"
   of player. Avoid paying premium for finesse positions.
+- **"Gambler" GMs** *(rare)*: Make the biggest splashes in the opening frenzy.
+  Outbid everyone for the marquee free agent, overpay dramatically, hand out
+  massive guaranteed money. They inflate the market for everyone — when a
+  Gambler is bidding, every other team's offers look cheap by comparison.
 
 NPC teams get into bidding wars with each other. The market should feel alive —
 you're not the only one trying to sign the top corner.

--- a/docs/product/npc-ai.md
+++ b/docs/product/npc-ai.md
@@ -82,10 +82,13 @@ offenses. Overpays for "football players" — big linemen, physical backs, tough
 linebackers. Dismissive of smaller, faster players regardless of production.
 Hires coaches who share the philosophy.
 
-**"The Gambler"**
-High risk tolerance, loves trades, always in motion. Will trade three firsts
-to move up for "their guy." Makes splashy free agent signings. The roster is
-always in flux. Exciting to watch, inconsistent results.
+**"The Gambler"** *(rare)*
+The rarest archetype — most leagues will have one or two at most. High risk
+tolerance, loves trades, always in motion. Will trade three firsts to move up
+for "their guy." Makes splashy free agent signings. The roster is always in
+flux. Exciting to watch, inconsistent results. When a Gambler GM lands in your
+league, everyone notices — he warps the trade market, overpays in free agency,
+and creates chaos that other GMs can exploit or get burned by.
 
 ## Front Office Decision-Making
 

--- a/docs/product/salary-cap.md
+++ b/docs/product/salary-cap.md
@@ -452,6 +452,12 @@ feeling authentic.
 - **"Old School" GMs**: Pay "their guys" — sometimes overpay for loyalty.
   Less sophisticated with contract structure. Occasionally get into cap
   trouble through emotional decisions rather than strategic ones.
+- **"Gambler" GMs** *(rare)*: The most reckless cap managers in the league.
+  Restructure everything, use void years liberally, and hand out massive
+  guaranteed deals to chase a championship *right now*. They cycle between
+  championship windows and brutal cap hell faster than any other archetype.
+  When a Gambler hits cap hell, they become a fire sale — other GMs can
+  scoop up talent shed for cap reasons.
 
 ### NPC cap mistakes
 

--- a/docs/product/trading.md
+++ b/docs/product/trading.md
@@ -134,6 +134,11 @@ Different AI archetypes approach trades differently:
   contracts that other teams want to dump, exploit desperation
 - **"Old School" GMs** prefer to build through the draft, skeptical of
   blockbuster trades, value "their guys"
+- **"Gambler" GMs** *(rare)* the most active traders in the league; initiate
+  blockbuster offers constantly, trade up aggressively in the draft, always
+  willing to mortgage future picks for the player they're convinced about;
+  they warp the trade market when they're in your league — other GMs can
+  exploit their impulsiveness or get outbid when they drive up the price
 
 ### NPC trade evaluation
 


### PR DESCRIPTION
## Summary
- Marks The Gambler as a **rare** archetype in npc-ai.md (1-2 per league)
- Adds Gambler-specific behaviors to trading.md (most active trader, drives up prices)
- Adds Gambler-specific behaviors to free-agency-and-contracts.md (biggest splashes, inflates market)
- Adds Gambler-specific behaviors to salary-cap.md (reckless cap management, cycles between windows and cap hell)

All five NPC GM archetypes are now consistently represented across every doc that describes archetype-specific behavior.

## Test plan
- [ ] Verify all five archetypes (Moneyball, Win Now, Developer, Old School, Gambler) appear in npc-ai, trading, free-agency, and salary-cap docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)