### PR TITLE
fix(ci): add GHCR image source label to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
 FROM denoland/deno:2.7.11 AS base
+LABEL org.opencontainers.image.source=https://github.com/tiernebre/zone-blitz
 WORKDIR /app
 
 # Cache dependencies by copying config files first


### PR DESCRIPTION
## Summary
- Adds `org.opencontainers.image.source` label so GHCR links the package to this repo
- Without this, the workflow's `GITHUB_TOKEN` can't push to the container package

## Test plan
- [ ] CI passes
- [ ] Deploy workflow successfully pushes to GHCR and deploys to Droplet

🤖 Generated with [Claude Code](https://claude.com/claude-code)