### PR TITLE
fix(ci): use production domain for deploy smoke test

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -85,7 +85,7 @@ jobs:
         run: |
           expected="${{ github.sha }}"
           for i in $(seq 1 10); do
-            body=$(curl -s http://${{ secrets.DROPLET_IP }}/api/health || echo "")
+            body=$(curl -s https://zoneblitz.app/api/health || echo "")
             commit=$(printf '%s' "$body" | jq -r '.commit // empty' 2>/dev/null || echo "")
             if [ "$commit" = "$expected" ]; then
               echo "Health check passed: /api/health.commit = $commit"


### PR DESCRIPTION
## Summary
- Updates deploy smoke test to use `https://zoneblitz.app` instead of raw Droplet IP
- Verifies the full request path through Cloudflare

## Test plan
- [ ] CI passes
- [ ] Deploy smoke test hits `https://zoneblitz.app/api/health`

🤖 Generated with [Claude Code](https://claude.com/claude-code)