### PR TITLE
fix(e2e): use process.env in Playwright config

### DIFF
--- a/e2e/deno.json
+++ b/e2e/deno.json
@@ -4,5 +4,8 @@
   "imports": {
     "@playwright/test": "npm:@playwright/test@^1.52",
     "postgres": "npm:postgres@^3"
+  },
+  "lint": {
+    "exclude": ["playwright.config.ts", "tests/"]
   }
 }

--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -1,6 +1,6 @@
 import { defineConfig, devices } from "@playwright/test";
 
-const isCI = !!Deno.env.get("CI");
+const isCI = !!process.env.CI;
 
 export default defineConfig({
   testDir: "./tests",
@@ -26,7 +26,7 @@ export default defineConfig({
     reuseExistingServer: !isCI,
     env: {
       DENO_ENV: "production",
-      DATABASE_URL: Deno.env.get("DATABASE_URL_E2E") ??
+      DATABASE_URL: process.env.DATABASE_URL_E2E ??
         "postgres://zone_blitz:zone_blitz@localhost:5432/zone_blitz_e2e",
     },
   },


### PR DESCRIPTION
## Summary
- Switches Playwright config from `Deno.env.get()` to `process.env` since Playwright runs under Node.js
- Excludes Playwright files from Deno lint (they run in Node.js context)

## Test plan
- [ ] E2E CI job passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)