### PR TITLE
fix: load .env file in deno run commands

### DIFF
--- a/bin/dev
+++ b/bin/dev
@@ -6,6 +6,6 @@ deno task db:start
 deno task db:migrate
 
 echo "Starting server and client..."
-deno run --watch --allow-net --allow-env --allow-read --allow-sys server/main.ts &
+deno run --env --watch --allow-net --allow-env --allow-read --allow-sys server/main.ts &
 cd client && deno run -A npm:vite &
 wait

--- a/deno.json
+++ b/deno.json
@@ -16,12 +16,12 @@
     "dev": "./bin/dev",
     "db:start": "docker compose up -d --wait",
     "db:stop": "docker compose down",
-    "db:migrate": "cd server && deno run --allow-net --allow-env --allow-read --allow-sys db/migrate.ts",
+    "db:migrate": "cd server && deno run --env=../.env --allow-net --allow-env --allow-read --allow-sys db/migrate.ts",
     "test": "deno task test:server && deno task test:client",
     "test:server": "deno test server/ --allow-env --allow-net --allow-read --allow-sys",
     "test:client": "cd client && deno run -A npm:vitest run",
     "test:e2e": "./bin/test-e2e",
     "build": "cd client && deno task build",
-    "start": "cd server && deno run --allow-net --allow-env --allow-read --allow-sys main.ts"
+    "start": "cd server && deno run --env=../.env --allow-net --allow-env --allow-read --allow-sys main.ts"
   }
 }


### PR DESCRIPTION
## Summary
- `deno task dev` (and `deno task db:migrate` / `deno task start`) failed with `DATABASE_URL environment variable is required` because Deno does not auto-load `.env` files.
- Added the `--env` flag to the dev server command in `bin/dev` and `--env=../.env` to the `db:migrate` and `start` tasks in `deno.json` (which `cd` into `server/` first).

## Test plan
- [x] Verified `deno task db:migrate` succeeds with the fix
- [ ] Run `deno task dev` end-to-end and confirm server + client start without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)