### PR TITLE
refactor(dev): use concurrently for parallel dev services

### DIFF
--- a/bin/dev
+++ b/bin/dev
@@ -1,11 +1,11 @@
 #!/usr/bin/env bash
 set -euo pipefail
+cd "$(dirname "$0")/.."
 
 deno task setup
 deno task db:start
 deno task db:migrate
 
-echo "Starting server and client..."
-deno run --env --watch --allow-net --allow-env --allow-read --allow-sys server/main.ts &
-cd client && deno run -A npm:vite &
-wait
+deno run -A npm:concurrently -n server,client -c blue,green \
+  "deno task dev:server" \
+  "deno task dev:client"

--- a/client/vite.config.ts
+++ b/client/vite.config.ts
@@ -1,9 +1,23 @@
-import { defineConfig } from "vite";
+import { createLogger, defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
 import tailwindcss from "@tailwindcss/vite";
 import { resolve } from "node:path";
 
+const logger = createLogger();
+const originalInfo = logger.info.bind(logger);
+logger.info = (msg, options) => {
+  // Suppress Vite's default startup banner — our server prints its own
+  if (
+    msg.includes("Local") || msg.includes("Network") ||
+    msg.includes("ready in") || msg.includes("VITE")
+  ) {
+    return;
+  }
+  originalInfo(msg, options);
+};
+
 export default defineConfig({
+  customLogger: logger,
   plugins: [react(), tailwindcss()],
   resolve: {
     alias: {

--- a/deno.json
+++ b/deno.json
@@ -14,6 +14,8 @@
   "tasks": {
     "setup": "./bin/setup",
     "dev": "./bin/dev",
+    "dev:server": "deno run --env --watch --allow-net --allow-env --allow-read --allow-sys server/main.ts",
+    "dev:client": "cd client && deno run -A npm:vite",
     "db:start": "docker compose up -d --wait",
     "db:stop": "docker compose down",
     "db:migrate": "cd server && deno run --env=../.env --allow-net --allow-env --allow-read --allow-sys db/migrate.ts",


### PR DESCRIPTION
## Summary
- Replace raw `&`/`wait` background processes in `bin/dev` with `npm:concurrently`, giving each service a named, color-coded log prefix (`server`=blue, `client`=green)
- Add `dev:server` and `dev:client` tasks to `deno.json` so they can be run independently
- Suppress Vite's default startup banner in `client/vite.config.ts` so the server's `onListen` banner is the single source of dev URLs

## Test plan
- [x] `deno task test:client` passes
- [ ] Run `deno task dev` and verify colored prefixed output and banner displays correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)