### PR TITLE
docs: add backend architecture conventions

### DIFF
--- a/docs/technical/architecture.md
+++ b/docs/technical/architecture.md
@@ -12,7 +12,7 @@ structure, and design philosophy that all implementation work builds on.
 | -------------- | ----------------------------------- | ------------------------------------------------------------------------ |
 | Runtime        | Deno + TypeScript                   | Native TS, built-in tooling, shared language with frontend               |
 | Frontend       | Vite + React + Tailwind + shadcn/ui | SPA game UI; no SSR needed (see [UI Architecture](./ui-architecture.md)) |
-| API            | tRPC                                | End-to-end type safety with zero codegen; migrateable to GraphQL         |
+| API            | Hono RPC                            | End-to-end type safety with zero codegen; built into the HTTP framework  |
 | Database       | PostgreSQL                          | Relational data with complex queries (cap math, historical stats)        |
 | DB access      | Drizzle ORM                         | Type-safe SQL, first-class migrations, schema-as-code                    |
 | Authentication | Better Auth (Google OAuth)          | Drizzle adapter, session-based, OAuth-only                               |
@@ -51,15 +51,19 @@ sluggish — we extract those packages to Go or Rust behind the same interfaces.
 The API layer, multiplayer coordination, and database access stay in TypeScript
 where shared types and Zod schemas pay dividends.
 
-### Why tRPC
+### Why Hono RPC
 
-tRPC gives us type-safe API calls with no code generation step. The client knows
-the server's input/output types at compile time. This eliminates an entire class
-of integration bugs and makes refactoring safe.
+Hono's built-in RPC client (`hono/client`) gives us type-safe API calls with no
+code generation and no extra dependencies. Route definitions on the server are
+the single source of truth — the client infers types directly from them via
+`typeof app`.
 
-The migration path to GraphQL is feasible if we need it. tRPC procedures map
-conceptually to GraphQL queries/mutations. The domain types and validation
-schemas (Zod) remain unchanged — only the transport layer changes.
+Since we already use Hono as the HTTP framework, this eliminates an entire
+dependency layer (tRPC server + client + adapter) while keeping the same
+type-safety guarantees. It also means HTTP routes and WebSocket routes use the
+same framework — critical for a game that needs both REST endpoints and realtime
+connections for live drafts and trade negotiations. See
+[Backend Architecture](./backend-architecture.md) for the full pattern.
 
 ### Why Drizzle ORM
 
@@ -95,8 +99,8 @@ Configuration:
   defined in the Drizzle schema alongside domain tables. Migrations are unified
   — one migration history for the entire database.
 - **Session-based.** Better Auth manages sessions server-side with token-based
-  session lookup. The session provides the authenticated user identity that tRPC
-  procedures and WebSocket connections use for authorization.
+  session lookup. The session provides the authenticated user identity that API
+  routes and WebSocket connections use for authorization.
 - **Auth schema is auth-only.** The `user` table managed by Better Auth contains
   authentication concerns (email, OAuth accounts, sessions). Game domain
   concepts (GM profile, league membership, franchise ownership) are separate
@@ -165,7 +169,7 @@ what makes them extractable.
 
 **`server`** — The orchestrator.
 
-- tRPC API routes
+- Hono API routes
 - Drizzle schema definitions and database access
 - WebSocket server for realtime multiplayer
 - Season advancement orchestration (calls into simulation and ai packages)
@@ -175,7 +179,7 @@ what makes them extractable.
 **`ui`** — The frontend.
 
 - React SPA (see [UI Architecture](./ui-architecture.md))
-- tRPC client consuming server API
+- Hono RPC client consuming server API
 - WebSocket client for realtime events
 - Imports types from `shared` only — never from `server`, `simulation`, or `ai`
 
@@ -489,7 +493,7 @@ Server tests cover:
 
 - Domain logic (simulation, AI decisions, cap math)
 - Repository implementations against a real PostgreSQL database
-- tRPC procedure behavior
+- API route behavior
 - Auth configuration
 
 Tests that touch the database run against a dedicated test database. No mocking

--- a/docs/technical/backend-architecture.md
+++ b/docs/technical/backend-architecture.md
@@ -92,18 +92,18 @@ what the file does.
 These are components wired together through the composition root. They receive
 dependencies via factory function parameters.
 
-| Suffix             | Role                                                      |
-| ------------------ | --------------------------------------------------------- |
-| `.router.ts`       | Hono route group — validates input (Zod), delegates to services, returns responses. No business logic. |
-| `.service.ts`      | Business logic — domain rule enforcement, orchestration across repositories and other services. No direct DB access. |
-| `.repository.ts`   | Data access — Drizzle queries. Returns domain-shaped data. No business logic. |
+| Suffix           | Role                                                                                                                 |
+| ---------------- | -------------------------------------------------------------------------------------------------------------------- |
+| `.router.ts`     | Hono route group — validates input (Zod), delegates to services, returns responses. No business logic.               |
+| `.service.ts`    | Business logic — domain rule enforcement, orchestration across repositories and other services. No direct DB access. |
+| `.repository.ts` | Data access — Drizzle queries. Returns domain-shaped data. No business logic.                                        |
 
 ### Declarative files
 
-| Suffix             | Role                                                      |
-| ------------------ | --------------------------------------------------------- |
-| `.schema.ts`       | Drizzle table definitions for this feature's tables.      |
-| `mod.ts`           | Barrel file — the feature's public API. Only file imported by the composition root. |
+| Suffix       | Role                                                                                |
+| ------------ | ----------------------------------------------------------------------------------- |
+| `.schema.ts` | Drizzle table definitions for this feature's tables.                                |
+| `mod.ts`     | Barrel file — the feature's public API. Only file imported by the composition root. |
 
 ### Pure domain logic files
 
@@ -123,9 +123,9 @@ If it's pure computation, it's a named domain logic file.**
 
 ### Tests
 
-| Suffix             | Role                                                      |
-| ------------------ | --------------------------------------------------------- |
-| `.test.ts`         | Colocated test file. Named after the file under test (`draft.service.test.ts` tests `draft.service.ts`). |
+| Suffix     | Role                                                                                                     |
+| ---------- | -------------------------------------------------------------------------------------------------------- |
+| `.test.ts` | Colocated test file. Named after the file under test (`draft.service.test.ts` tests `draft.service.ts`). |
 
 ---
 
@@ -259,14 +259,11 @@ import { authenticated } from "../../middleware/auth.ts";
 export function createDraftRouter(draftService: DraftService) {
   return new Hono<AuthedEnv>()
     .use(authenticated())
-    .post("/pick",
-      zValidator("json", pickInputSchema),
-      async (c) => {
-        const input = c.req.valid("json");
-        const result = await draftService.makePick(input);
-        return c.json(result);
-      },
-    )
+    .post("/pick", zValidator("json", pickInputSchema), async (c) => {
+      const input = c.req.valid("json");
+      const result = await draftService.makePick(input);
+      return c.json(result);
+    })
     .get("/current-pick/:draftId", async (c) => {
       const pick = await draftService.getCurrentPick(c.req.param("draftId"));
       return c.json(pick);
@@ -276,9 +273,9 @@ export function createDraftRouter(draftService: DraftService) {
 
 ### Why factory functions, not classes
 
-Factory functions returning interface-typed objects are lighter than classes. The
-destructured `deps` parameter is constructor injection without the ceremony. The
-return type is the interface — callers never see the implementation shape.
+Factory functions returning interface-typed objects are lighter than classes.
+The destructured `deps` parameter is constructor injection without the ceremony.
+The return type is the interface — callers never see the implementation shape.
 
 That said — if a feature grows complex enough that a class with methods reads
 cleaner, use a class. The convention is **the interface**, not the
@@ -306,9 +303,17 @@ only place that knows which concrete implementations fulfill which interfaces.
 // server/features/mod.ts
 import type { Database } from "../db/connection.ts";
 import { logger } from "../logger.ts";
-import { createDraftRepository, createDraftService, createDraftRouter } from "./draft/mod.ts";
+import {
+  createDraftRepository,
+  createDraftRouter,
+  createDraftService,
+} from "./draft/mod.ts";
 import { createRosterRepository } from "./roster/mod.ts";
-import { createLeagueRepository, createLeagueService, createLeagueRouter } from "./league/mod.ts";
+import {
+  createLeagueRepository,
+  createLeagueRouter,
+  createLeagueService,
+} from "./league/mod.ts";
 
 export function createFeatureRouters(db: Database) {
   const log = logger;
@@ -374,15 +379,12 @@ import { authenticated } from "../../middleware/auth.ts";
 export function createLeagueRouter(leagueService: LeagueService) {
   return new Hono<AuthedEnv>()
     .use(authenticated())
-    .post("/",
-      zValidator("json", createLeagueSchema),
-      async (c) => {
-        const user = c.get("user");
-        const input = c.req.valid("json");
-        const league = await leagueService.create(user.id, input);
-        return c.json(league);
-      },
-    )
+    .post("/", zValidator("json", createLeagueSchema), async (c) => {
+      const user = c.get("user");
+      const input = c.req.valid("json");
+      const league = await leagueService.create(user.id, input);
+      return c.json(league);
+    })
     .get("/:id", async (c) => {
       const league = await leagueService.getById(c.req.param("id"));
       return c.json(league);
@@ -498,7 +500,7 @@ export const api = hc<AppType>("/");
 
 ```typescript
 // client/src/hooks/use-leagues.ts
-import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { api } from "../api.ts";
 
 export function useLeagues() {
@@ -534,9 +536,7 @@ function LeagueListPage() {
 
   return (
     <>
-      {leagues?.map((league) => (
-        <LeagueCard key={league.id} league={league} />
-      ))}
+      {leagues?.map((league) => <LeagueCard key={league.id} league={league} />)}
       <button onClick={() => createLeague.mutate({ name: "..." })}>
         Create League
       </button>
@@ -565,8 +565,8 @@ import { createLeagueSchema } from "@zone-blitz/shared";
 )
 ```
 
-Validation targets: `"json"` for request bodies, `"query"` for query
-parameters, `"param"` for URL parameters.
+Validation targets: `"json"` for request bodies, `"query"` for query parameters,
+`"param"` for URL parameters.
 
 ---
 
@@ -784,9 +784,9 @@ These are domain concepts with names — not utilities.
 
 ## Simulation and AI Packages
 
-The `simulation` and `ai` packages are separate Deno workspace members. They
-are **pure** — no I/O, no database, no HTTP. They implement interfaces defined
-in `@zone-blitz/shared`.
+The `simulation` and `ai` packages are separate Deno workspace members. They are
+**pure** — no I/O, no database, no HTTP. They implement interfaces defined in
+`@zone-blitz/shared`.
 
 ### Package structure
 
@@ -837,7 +837,7 @@ export function createFeatureRouters(db: Database) {
 
   // ... routers ...
 
-  return { /* ... */ };
+  return {/* ... */};
 }
 ```
 
@@ -891,9 +891,9 @@ queries and migrations work correctly. No mocking the database.
 ```typescript
 Deno.test("calculateSnakeOrder reverses direction each round", () => {
   const order = calculateSnakeOrder(4, 3);
-  assertEquals(order[0].teamIndex, 0);  // Round 1: 0,1,2,3
-  assertEquals(order[4].teamIndex, 3);  // Round 2: 3,2,1,0
-  assertEquals(order[8].teamIndex, 0);  // Round 3: 0,1,2,3
+  assertEquals(order[0].teamIndex, 0); // Round 1: 0,1,2,3
+  assertEquals(order[4].teamIndex, 3); // Round 2: 3,2,1,0
+  assertEquals(order[8].teamIndex, 0); // Round 3: 0,1,2,3
 });
 ```
 
@@ -940,8 +940,8 @@ makes every cross-feature relationship explicit.
 ### Schema ownership
 
 Each feature defines its own tables in its `.schema.ts` file. A top-level
-`db/schema.ts` re-exports all feature schemas so `drizzle-kit` sees the
-complete database.
+`db/schema.ts` re-exports all feature schemas so `drizzle-kit` sees the complete
+database.
 
 ```typescript
 // server/db/schema.ts

--- a/docs/technical/backend-architecture.md
+++ b/docs/technical/backend-architecture.md
@@ -38,7 +38,7 @@ server/
     mod.ts                        # Feature routers factory — creates all repos, services, routers
     league/
       mod.ts                      # Public API — exports factories
-      league.router.ts            # tRPC router: procedures that delegate to service
+      league.router.ts            # Hono routes: validate input, delegate to service
       league.service.ts           # Orchestration + domain rule enforcement
       league.service.test.ts
       league.repository.ts        # Data access: Drizzle queries
@@ -66,21 +66,18 @@ server/
     scouting/
     coaching/
     season/
-  trpc/
-    trpc.ts                       # tRPC init, base procedure, protectedProcedure
-    context.ts                    # tRPC context factory (db, session, user, logger)
-    router.ts                     # Root appRouter — assembles all feature routers
+  middleware/
+    auth.ts                       # Authentication middleware — resolves session, narrows context
+    request-context.ts            # Per-request child logger + requestId
+    logger.ts                     # HTTP lifecycle logging
   db/
     connection.ts                 # Drizzle client
     migrate.ts                    # Migration runner
     schema.ts                     # Re-exports all feature schemas
     migrations/                   # Generated SQL files
-  middleware/
-    request-context.ts            # Per-request child logger + requestId
-    logger.ts                     # HTTP lifecycle logging
   logger.ts                       # Root Pino logger
   env.ts                          # AppEnv type (Hono context variables)
-  main.ts                         # Hono app, tRPC adapter, auth routes
+  main.ts                         # Hono app — mounts middleware, auth, and feature routes
 ```
 
 ---
@@ -97,7 +94,7 @@ dependencies via factory function parameters.
 
 | Suffix             | Role                                                      |
 | ------------------ | --------------------------------------------------------- |
-| `.router.ts`       | tRPC router — defines procedures that validate input (Zod) and delegate to services. No business logic. |
+| `.router.ts`       | Hono route group — validates input (Zod), delegates to services, returns responses. No business logic. |
 | `.service.ts`      | Business logic — domain rule enforcement, orchestration across repositories and other services. No direct DB access. |
 | `.repository.ts`   | Data access — Drizzle queries. Returns domain-shaped data. No business logic. |
 
@@ -252,23 +249,28 @@ export function createDraftService(deps: {
 
 ```typescript
 // server/features/draft/draft.router.ts
+import { Hono } from "hono";
+import { zValidator } from "@hono/zod-validator";
 import type { DraftService } from "@zone-blitz/shared";
-import { protectedProcedure, router } from "../../trpc/trpc.ts";
 import { pickInputSchema } from "@zone-blitz/shared";
+import type { AuthedEnv } from "../../env.ts";
+import { authenticated } from "../../middleware/auth.ts";
 
 export function createDraftRouter(draftService: DraftService) {
-  return router({
-    makePick: protectedProcedure
-      .input(pickInputSchema)
-      .mutation(({ input }) => {
-        return draftService.makePick(input);
-      }),
-    getCurrentPick: protectedProcedure
-      .input(z.object({ draftId: z.string().uuid() }))
-      .query(({ input }) => {
-        return draftService.getCurrentPick(input.draftId);
-      }),
-  });
+  return new Hono<AuthedEnv>()
+    .use(authenticated())
+    .post("/pick",
+      zValidator("json", pickInputSchema),
+      async (c) => {
+        const input = c.req.valid("json");
+        const result = await draftService.makePick(input);
+        return c.json(result);
+      },
+    )
+    .get("/current-pick/:draftId", async (c) => {
+      const pick = await draftService.getCurrentPick(c.req.param("draftId"));
+      return c.json(pick);
+    });
 }
 ```
 
@@ -328,255 +330,198 @@ export function createFeatureRouters(db: Database) {
 }
 ```
 
-The root tRPC router (`server/trpc/router.ts`) calls `createFeatureRouters`
-and assembles the `appRouter`. See the [tRPC section](#trpc) for the full
-picture.
+`main.ts` calls `createFeatureRouters` and mounts the returned Hono sub-apps.
+See the [Hono RPC section](#hono-rpc) for the full picture.
 
 One file to see every dependency relationship. No hidden singletons. Tests
 bypass this entirely — they construct services with mocks directly.
 
 ---
 
-## tRPC
+## Hono RPC
 
-tRPC provides end-to-end type safety between the server and client with no code
-generation. The server defines typed procedures; the client calls them with full
-type inference.
+Hono's built-in RPC client provides end-to-end type safety between the server
+and client with no extra dependencies or code generation. Route definitions on
+the server are the single source of truth — the client infers types directly
+from them.
 
-### Initialization
+### Why Hono RPC over tRPC
 
-```typescript
-// server/trpc/trpc.ts
-import { initTRPC, TRPCError } from "@trpc/server";
-import { logger } from "../logger.ts";
-import type { Context } from "./context.ts";
+- **Zero extra dependencies.** Already using Hono — no additional packages.
+- **Standard HTTP.** Real routes, real REST semantics, standard fetch. Not a
+  custom protocol tunneled through POST.
+- **One routing model.** HTTP and WebSocket routes use the same Hono framework.
+  Live drafts and trade negotiations need WebSockets — having one framework for
+  both avoids maintaining two API paradigms.
+- **Simpler stack.** No separate router/procedure/context/adapter layer on top
+  of Hono.
 
-const fallbackLog = logger.child({ module: "trpc" });
+### How it works
 
-const t = initTRPC.context<Context>().create({
-  errorFormatter({ shape, error, path, input, ctx }) {
-    const log = ctx?.log ?? fallbackLog;
-    log.error(
-      { code: shape.code, path, input, cause: error.cause },
-      "tRPC error: %s",
-      shape.message,
-    );
-    return shape;
-  },
-});
-
-export const router = t.router;
-export const procedure = t.procedure;
-
-export const protectedProcedure = t.procedure.use(({ ctx, next }) => {
-  if (!ctx.session || !ctx.user) {
-    ctx.log.debug("unauthorized request — no session or user");
-    throw new TRPCError({ code: "UNAUTHORIZED" });
-  }
-  ctx.log.debug("authenticated procedure call");
-  return next({
-    ctx: { ...ctx, session: ctx.session, user: ctx.user },
-  });
-});
-```
-
-Three exports:
-
-- **`router`** — creates a router from a record of procedures.
-- **`procedure`** — public procedure, no auth required.
-- **`protectedProcedure`** — enforces authentication via middleware. Narrows
-  `ctx.session` and `ctx.user` to non-null types downstream.
-
-The `errorFormatter` logs every tRPC error with structured context (code, path,
-input, cause) so failures are traceable in production.
-
-### Context
-
-The tRPC context is created per-request. It carries the database client,
-authenticated session, and a request-scoped logger.
-
-```typescript
-// server/trpc/context.ts
-import type pino from "pino";
-import { auth } from "../auth/mod.ts";
-import { db } from "../db/connection.ts";
-import { logger } from "../logger.ts";
-
-const fallbackLog = logger.child({ module: "trpc.context" });
-
-export async function createContext(
-  req: Request,
-  requestLog?: pino.Logger,
-) {
-  const log = requestLog ?? fallbackLog;
-
-  const sessionData = await auth.api.getSession({
-    headers: req.headers,
-  });
-
-  const userId = sessionData?.user?.id ?? null;
-  const contextLog = userId ? log.child({ userId }) : log;
-
-  contextLog.debug(
-    { hasSession: !!sessionData?.session },
-    "trpc context created",
-  );
-
-  return {
-    db,
-    session: sessionData?.session ?? null,
-    user: sessionData?.user ?? null,
-    log: contextLog,
-  };
-}
-
-export type Context = Awaited<ReturnType<typeof createContext>>;
-```
-
-The logger is enriched progressively:
-
-1. `requestContextMiddleware` adds `{ requestId }`.
-2. `createContext` adds `{ userId }` when a session exists.
-
-Every log line from a tRPC procedure carries both fields automatically.
-
-### Root router
-
-The root router assembles all feature routers into a single `appRouter`. The
-`AppRouter` type is exported for the client.
-
-```typescript
-// server/trpc/router.ts
-import { createFeatureRouters } from "../features/mod.ts";
-import { procedure, router } from "./trpc.ts";
-import { db } from "../db/connection.ts";
-
-const features = createFeatureRouters(db);
-
-export const appRouter = router({
-  health: router({
-    check: procedure.query(async ({ ctx }) => {
-      await ctx.db.execute(sql`SELECT 1`);
-      return {
-        status: "ok",
-        commit: Deno.env.get("GIT_SHA") ?? "unknown",
-      };
-    }),
-  }),
-  draft: features.draftRouter,
-  league: features.leagueRouter,
-  // ... other feature routers
-});
-
-export type AppRouter = typeof appRouter;
-```
-
-### Feature routers
-
-Each feature defines a `.router.ts` file that creates a tRPC router. The router
-receives its service dependency and defines procedures that delegate to it.
+The key is **method chaining** on the Hono instance. When routes are chained,
+Hono infers the full route tree as a type. Exporting that type gives the client
+full type safety.
 
 ```typescript
 // server/features/league/league.router.ts
+import { Hono } from "hono";
+import { zValidator } from "@hono/zod-validator";
 import type { LeagueService } from "@zone-blitz/shared";
-import { protectedProcedure, router } from "../../trpc/trpc.ts";
 import { createLeagueSchema } from "@zone-blitz/shared";
-import { z } from "zod";
+import type { AuthedEnv } from "../../env.ts";
+import { authenticated } from "../../middleware/auth.ts";
 
 export function createLeagueRouter(leagueService: LeagueService) {
-  return router({
-    create: protectedProcedure
-      .input(createLeagueSchema)
-      .mutation(({ ctx, input }) => {
-        return leagueService.create(ctx.user.id, input);
-      }),
-    getById: protectedProcedure
-      .input(z.object({ id: z.string().uuid() }))
-      .query(({ input }) => {
-        return leagueService.getById(input.id);
-      }),
-  });
+  return new Hono<AuthedEnv>()
+    .use(authenticated())
+    .post("/",
+      zValidator("json", createLeagueSchema),
+      async (c) => {
+        const user = c.get("user");
+        const input = c.req.valid("json");
+        const league = await leagueService.create(user.id, input);
+        return c.json(league);
+      },
+    )
+    .get("/:id", async (c) => {
+      const league = await leagueService.getById(c.req.param("id"));
+      return c.json(league);
+    });
 }
 ```
 
-Routers are thin — they validate input via Zod schemas and delegate to the
-service. No business logic lives here.
+Routers are thin — they validate input via `zValidator`, delegate to the
+service, and return JSON. No business logic lives here.
 
-### Hono integration
+### Authentication middleware
 
-tRPC is mounted on Hono via the fetch adapter. The request-scoped logger from
-Hono's context is passed into `createContext` so tRPC procedures inherit the
-`requestId`.
+The `authenticated()` middleware resolves the session from Better Auth and
+narrows the Hono context to include `user` and `session`. This replaces tRPC's
+`protectedProcedure` pattern.
+
+```typescript
+// server/middleware/auth.ts
+import type { MiddlewareHandler } from "hono";
+import type { AuthedEnv } from "../env.ts";
+import { auth } from "../auth/mod.ts";
+
+export function authenticated(): MiddlewareHandler<AuthedEnv> {
+  return async (c, next) => {
+    const sessionData = await auth.api.getSession({
+      headers: c.req.raw.headers,
+    });
+    if (!sessionData?.user) {
+      const log = c.get("log");
+      log.debug("unauthorized request — no session");
+      return c.json({ error: "UNAUTHORIZED" }, 401);
+    }
+    c.set("user", sessionData.user);
+    c.set("session", sessionData.session);
+
+    // Enrich logger with userId
+    const log = c.get("log").child({ userId: sessionData.user.id });
+    c.set("log", log);
+
+    await next();
+  };
+}
+```
+
+```typescript
+// server/env.ts
+import type pino from "pino";
+
+export type AppEnv = {
+  Variables: {
+    requestId: string;
+    log: pino.Logger;
+  };
+};
+
+export type AuthedEnv = {
+  Variables: AppEnv["Variables"] & {
+    user: User;
+    session: Session;
+  };
+};
+```
+
+Feature routers that require authentication use `AuthedEnv` and apply
+`authenticated()` as middleware. Public routes use `AppEnv` directly.
+
+### App assembly and type export
+
+The Hono app is assembled in `main.ts` by mounting feature routers. The chained
+app type is exported for the client.
 
 ```typescript
 // server/main.ts
 import { Hono } from "hono";
-import { fetchRequestHandler } from "@trpc/server/adapters/fetch";
-import { appRouter } from "./trpc/router.ts";
-import { createContext } from "./trpc/context.ts";
+import { db } from "./db/connection.ts";
+import { createFeatureRouters } from "./features/mod.ts";
 import { requestContextMiddleware } from "./middleware/request-context.ts";
 import { loggerMiddleware } from "./middleware/logger.ts";
 import { logger } from "./logger.ts";
+import type { AppEnv } from "./env.ts";
 
-const app = new Hono<AppEnv>();
+const features = createFeatureRouters(db);
 
-app.use(requestContextMiddleware(logger));
-app.use(loggerMiddleware());
+const app = new Hono<AppEnv>()
+  .use(requestContextMiddleware(logger))
+  .use(loggerMiddleware())
+  .route("/api/leagues", features.leagueRouter)
+  .route("/api/drafts", features.draftRouter);
 
-// Auth routes (before tRPC so OAuth flows work)
+// Auth routes
 app.on(["GET", "POST"], "/api/auth/**", (c) => {
   return auth.handler(c.req.raw);
 });
 
-// tRPC
-app.all("/api/trpc/*", (c) => {
-  const requestLog = c.get("log");
-  return fetchRequestHandler({
-    endpoint: "/api/trpc",
-    req: c.req.raw,
-    router: appRouter,
-    createContext: ({ req }) => createContext(req, requestLog),
-  });
-});
+export type AppType = typeof app;
 ```
+
+The `AppType` export is the key — it carries the full route tree as a type that
+the client can consume.
 
 ### Client setup
 
-The React client uses `@trpc/react-query` for type-safe data fetching.
+The React client uses `hono/client` for typed API calls, paired with
+`@tanstack/react-query` for caching and state management.
 
 ```typescript
-// client/src/trpc.ts
-import { createTRPCReact } from "@trpc/react-query";
-import { httpBatchLink } from "@trpc/client";
-import { QueryClient } from "@tanstack/react-query";
-import type { AppRouter } from "../../server/trpc/router.ts";
+// client/src/api.ts
+import { hc } from "hono/client";
+import type { AppType } from "../../server/main.ts";
 
-export const trpc = createTRPCReact<AppRouter>();
-
-export const queryClient = new QueryClient();
-
-export const trpcClient = trpc.createClient({
-  links: [
-    httpBatchLink({
-      url: "/api/trpc",
-    }),
-  ],
-});
+export const api = hc<AppType>("/");
 ```
 
 ```typescript
-// client/src/App.tsx
-import { QueryClientProvider } from "@tanstack/react-query";
-import { queryClient, trpc, trpcClient } from "./trpc";
+// client/src/hooks/use-leagues.ts
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { api } from "../api.ts";
 
-export function App() {
-  return (
-    <trpc.Provider client={trpcClient} queryClient={queryClient}>
-      <QueryClientProvider client={queryClient}>
-        {/* Routes */}
-      </QueryClientProvider>
-    </trpc.Provider>
-  );
+export function useLeagues() {
+  return useQuery({
+    queryKey: ["leagues"],
+    queryFn: async () => {
+      const res = await api.api.leagues.$get();
+      return res.json();
+    },
+  });
+}
+
+export function useCreateLeague() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async (input: { name: string }) => {
+      const res = await api.api.leagues.$post({ json: input });
+      return res.json();
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["leagues"] });
+    },
+  });
 }
 ```
 
@@ -584,15 +529,15 @@ Usage in components:
 
 ```typescript
 function LeagueListPage() {
-  const { data: leagues } = trpc.league.list.useQuery();
-  const createMutation = trpc.league.create.useMutation();
+  const { data: leagues } = useLeagues();
+  const createLeague = useCreateLeague();
 
   return (
     <>
       {leagues?.map((league) => (
         <LeagueCard key={league.id} league={league} />
       ))}
-      <button onClick={() => createMutation.mutate({ name: "..." })}>
+      <button onClick={() => createLeague.mutate({ name: "..." })}>
         Create League
       </button>
     </>
@@ -600,19 +545,28 @@ function LeagueListPage() {
 }
 ```
 
-### Dev tooling — tRPC Panel
+### Zod validation with `zValidator`
 
-In development, a tRPC Panel UI is available for exploring and testing
-procedures without writing client code.
+Input validation uses `@hono/zod-validator`. Schemas are defined in
+`@zone-blitz/shared` and used by both the server (validation) and client (form
+validation, type inference).
 
 ```typescript
-// In main.ts (dev only)
-if (Deno.env.get("DENO_ENV") !== "production") {
-  app.get("/dev/trpc/ui", (c) => {
-    return c.html(renderTrpcPanel(appRouter, { url: "/api/trpc" }));
-  });
-}
+import { zValidator } from "@hono/zod-validator";
+import { createLeagueSchema } from "@zone-blitz/shared";
+
+// In a router:
+.post("/",
+  zValidator("json", createLeagueSchema),
+  async (c) => {
+    const input = c.req.valid("json");  // fully typed from the schema
+    // ...
+  },
+)
 ```
+
+Validation targets: `"json"` for request bodies, `"query"` for query
+parameters, `"param"` for URL parameters.
 
 ---
 

--- a/docs/technical/backend-architecture.md
+++ b/docs/technical/backend-architecture.md
@@ -1,0 +1,1020 @@
+# Backend Architecture
+
+This document defines the conventions, patterns, and structure for the server
+package and its relationship to the pure domain packages (`simulation`, `ai`).
+It is prescriptive — follow these patterns for all new backend work.
+
+For the overall stack choices and monorepo structure, see
+[architecture.md](./architecture.md).
+
+---
+
+## Guiding Principles
+
+1. **Interface-driven design.** Every service and repository is coded against a
+   typed interface defined in `@zone-blitz/shared`. Implementations fulfill
+   those interfaces — nothing depends on a concrete type.
+2. **Dependency injection.** Components receive their dependencies explicitly
+   through factory function parameters. No hidden singletons, no import-time
+   coupling.
+3. **Vertical feature slices.** Code is organized by domain concept, not by
+   technical layer. Everything about "drafting" lives in one folder.
+4. **Pure domain logic is extracted.** Stateless computation lives in named
+   domain logic files outside the DI graph. Services orchestrate — they don't
+   compute.
+5. **Composition root.** All wiring happens in one place. The rest of the
+   codebase is unaware of how dependencies are assembled.
+
+---
+
+## Feature Structure
+
+Each domain concept is a **feature** — a self-contained folder under
+`server/features/` with a consistent internal structure.
+
+```
+server/
+  features/
+    mod.ts                        # Feature routers factory — creates all repos, services, routers
+    league/
+      mod.ts                      # Public API — exports factories
+      league.router.ts            # tRPC router: procedures that delegate to service
+      league.service.ts           # Orchestration + domain rule enforcement
+      league.service.test.ts
+      league.repository.ts        # Data access: Drizzle queries
+      league.repository.test.ts
+      league.schema.ts            # Drizzle table definitions
+    draft/
+      mod.ts
+      draft.router.ts
+      draft.service.ts
+      draft.service.test.ts
+      draft.repository.ts
+      draft.repository.test.ts
+      draft.schema.ts
+      snake-order.ts              # Pure domain logic: pick order calculation
+      snake-order.test.ts
+      draft-eligibility.ts        # Pure domain logic: eligibility rules
+      draft-eligibility.test.ts
+      auto-pick.ts                # Pure domain logic: auto-draft selection
+      auto-pick.test.ts
+    trade/
+      ...
+    roster/
+    free-agency/
+    salary-cap/
+    scouting/
+    coaching/
+    season/
+  trpc/
+    trpc.ts                       # tRPC init, base procedure, protectedProcedure
+    context.ts                    # tRPC context factory (db, session, user, logger)
+    router.ts                     # Root appRouter — assembles all feature routers
+  db/
+    connection.ts                 # Drizzle client
+    migrate.ts                    # Migration runner
+    schema.ts                     # Re-exports all feature schemas
+    migrations/                   # Generated SQL files
+  middleware/
+    request-context.ts            # Per-request child logger + requestId
+    logger.ts                     # HTTP lifecycle logging
+  logger.ts                       # Root Pino logger
+  env.ts                          # AppEnv type (Hono context variables)
+  main.ts                         # Hono app, tRPC adapter, auth routes
+```
+
+---
+
+## File Conventions
+
+Every feature follows the same naming conventions. You see the suffix, you know
+what the file does.
+
+### Files in the DI graph
+
+These are components wired together through the composition root. They receive
+dependencies via factory function parameters.
+
+| Suffix             | Role                                                      |
+| ------------------ | --------------------------------------------------------- |
+| `.router.ts`       | tRPC router — defines procedures that validate input (Zod) and delegate to services. No business logic. |
+| `.service.ts`      | Business logic — domain rule enforcement, orchestration across repositories and other services. No direct DB access. |
+| `.repository.ts`   | Data access — Drizzle queries. Returns domain-shaped data. No business logic. |
+
+### Declarative files
+
+| Suffix             | Role                                                      |
+| ------------------ | --------------------------------------------------------- |
+| `.schema.ts`       | Drizzle table definitions for this feature's tables.      |
+| `mod.ts`           | Barrel file — the feature's public API. Only file imported by the composition root. |
+
+### Pure domain logic files
+
+These sit **outside** the DI graph. They have no dependencies — no db client, no
+logger, no injected services. They are pure functions: data in, data out. Name
+them after the domain concept they encode, not "utils."
+
+```
+snake-order.ts          # Calculates snake draft pick order
+draft-eligibility.ts    # Determines if a player can be drafted
+cap-proration.ts        # Prorates salary cap charges across years
+trade-value-chart.ts    # Assigns relative value to draft picks
+```
+
+The dividing line: **if it participates in DI, it's a router/service/repository.
+If it's pure computation, it's a named domain logic file.**
+
+### Tests
+
+| Suffix             | Role                                                      |
+| ------------------ | --------------------------------------------------------- |
+| `.test.ts`         | Colocated test file. Named after the file under test (`draft.service.test.ts` tests `draft.service.ts`). |
+
+---
+
+## Typed Interfaces
+
+All interfaces live in `@zone-blitz/shared`. This is the contract layer — every
+service and repository in the server implements an interface defined here.
+
+```
+packages/shared/
+  interfaces/
+    repositories/
+      player-repository.ts
+      team-repository.ts
+      draft-repository.ts
+      ...
+    services/
+      draft-service.ts
+      trade-service.ts
+      season-service.ts
+      ...
+    simulation/
+      game-simulator.ts
+      player-progression.ts
+      ...
+    ai/
+      gm-strategy.ts
+      ...
+  types/
+    player.ts
+    team.ts
+    draft.ts
+    ...
+  schemas/
+    # Zod validation schemas
+  constants/
+    # Enums, position lists, config constants
+```
+
+### Interface examples
+
+```typescript
+// packages/shared/interfaces/repositories/draft-repository.ts
+export interface DraftRepository {
+  getCurrentPick(draftId: string): Promise<DraftPick>;
+  recordPick(pick: NewDraftPick): Promise<DraftPick>;
+  getDraftOrder(draftId: string): Promise<PickSlot[]>;
+}
+
+// packages/shared/interfaces/services/draft-service.ts
+export interface DraftService {
+  makePick(input: PickInput): Promise<PickResult>;
+  getCurrentPick(draftId: string): Promise<DraftPick>;
+  autoDraft(draftId: string, teamId: string): Promise<PickResult>;
+}
+```
+
+The server implements these. Tests mock them. The simulation and AI packages
+depend on them without ever touching the server.
+
+---
+
+## Dependency Injection
+
+### Factory functions
+
+Every service and repository is created through a factory function that accepts
+its dependencies as a typed parameter object.
+
+```typescript
+// server/features/draft/draft.repository.ts
+import type { DraftRepository } from "@zone-blitz/shared";
+
+export function createDraftRepository(deps: {
+  db: DrizzleClient;
+  log: pino.Logger;
+}): DraftRepository {
+  const log = deps.log.child({ module: "draft.repository" });
+
+  return {
+    async getCurrentPick(draftId) {
+      log.debug({ draftId }, "fetching current pick");
+      return deps.db.select().from(draftPicks).where(/* ... */).limit(1);
+    },
+    async recordPick(pick) {
+      return deps.db.insert(draftPicks).values(pick).returning();
+    },
+  };
+}
+```
+
+```typescript
+// server/features/draft/draft.service.ts
+import type { DraftRepository, DraftService, RosterRepository } from "@zone-blitz/shared";
+import { isEligible } from "./draft-eligibility.ts";
+
+export function createDraftService(deps: {
+  draftRepo: DraftRepository;
+  rosterRepo: RosterRepository;
+  log: pino.Logger;
+}): DraftService {
+  const log = deps.log.child({ module: "draft.service" });
+
+  return {
+    async makePick(input) {
+      const currentPick = await deps.draftRepo.getCurrentPick(input.draftId);
+      if (currentPick.teamId !== input.teamId) {
+        throw new DomainError("NOT_ON_CLOCK", "It's not your pick");
+      }
+      if (!isEligible(player, draftRules)) {
+        throw new DomainError("INELIGIBLE", "Player cannot be drafted");
+      }
+      log.info({ draftId: input.draftId, teamId: input.teamId }, "pick made");
+      const result = await deps.draftRepo.recordPick({ ... });
+      await deps.rosterRepo.addPlayer(input.teamId, result.playerId);
+      return result;
+    },
+  };
+}
+```
+
+```typescript
+// server/features/draft/draft.router.ts
+import type { DraftService } from "@zone-blitz/shared";
+import { protectedProcedure, router } from "../../trpc/trpc.ts";
+import { pickInputSchema } from "@zone-blitz/shared";
+
+export function createDraftRouter(draftService: DraftService) {
+  return router({
+    makePick: protectedProcedure
+      .input(pickInputSchema)
+      .mutation(({ input }) => {
+        return draftService.makePick(input);
+      }),
+    getCurrentPick: protectedProcedure
+      .input(z.object({ draftId: z.string().uuid() }))
+      .query(({ input }) => {
+        return draftService.getCurrentPick(input.draftId);
+      }),
+  });
+}
+```
+
+### Why factory functions, not classes
+
+Factory functions returning interface-typed objects are lighter than classes. The
+destructured `deps` parameter is constructor injection without the ceremony. The
+return type is the interface — callers never see the implementation shape.
+
+That said — if a feature grows complex enough that a class with methods reads
+cleaner, use a class. The convention is **the interface**, not the
+implementation shape.
+
+### `mod.ts` — the feature's public API
+
+Each feature exports its factory functions through `mod.ts`. The composition
+root imports only from `mod.ts`, never from internal files.
+
+```typescript
+// server/features/draft/mod.ts
+export { createDraftRepository } from "./draft.repository.ts";
+export { createDraftService } from "./draft.service.ts";
+export { createDraftRouter } from "./draft.router.ts";
+```
+
+### Composition root — `server/features/mod.ts`
+
+The `server/features/mod.ts` file is the composition root. It creates all
+repositories, services, and routers, wiring dependencies together. This is the
+only place that knows which concrete implementations fulfill which interfaces.
+
+```typescript
+// server/features/mod.ts
+import type { Database } from "../db/connection.ts";
+import { logger } from "../logger.ts";
+import { createDraftRepository, createDraftService, createDraftRouter } from "./draft/mod.ts";
+import { createRosterRepository } from "./roster/mod.ts";
+import { createLeagueRepository, createLeagueService, createLeagueRouter } from "./league/mod.ts";
+
+export function createFeatureRouters(db: Database) {
+  const log = logger;
+
+  // Repositories
+  const draftRepo = createDraftRepository({ db, log });
+  const rosterRepo = createRosterRepository({ db, log });
+  const leagueRepo = createLeagueRepository({ db, log });
+
+  // Services
+  const draftService = createDraftService({ draftRepo, rosterRepo, log });
+  const leagueService = createLeagueService({ leagueRepo, log });
+
+  // Routers
+  const draftRouter = createDraftRouter(draftService);
+  const leagueRouter = createLeagueRouter(leagueService);
+
+  return { draftRouter, leagueRouter };
+}
+```
+
+The root tRPC router (`server/trpc/router.ts`) calls `createFeatureRouters`
+and assembles the `appRouter`. See the [tRPC section](#trpc) for the full
+picture.
+
+One file to see every dependency relationship. No hidden singletons. Tests
+bypass this entirely — they construct services with mocks directly.
+
+---
+
+## tRPC
+
+tRPC provides end-to-end type safety between the server and client with no code
+generation. The server defines typed procedures; the client calls them with full
+type inference.
+
+### Initialization
+
+```typescript
+// server/trpc/trpc.ts
+import { initTRPC, TRPCError } from "@trpc/server";
+import { logger } from "../logger.ts";
+import type { Context } from "./context.ts";
+
+const fallbackLog = logger.child({ module: "trpc" });
+
+const t = initTRPC.context<Context>().create({
+  errorFormatter({ shape, error, path, input, ctx }) {
+    const log = ctx?.log ?? fallbackLog;
+    log.error(
+      { code: shape.code, path, input, cause: error.cause },
+      "tRPC error: %s",
+      shape.message,
+    );
+    return shape;
+  },
+});
+
+export const router = t.router;
+export const procedure = t.procedure;
+
+export const protectedProcedure = t.procedure.use(({ ctx, next }) => {
+  if (!ctx.session || !ctx.user) {
+    ctx.log.debug("unauthorized request — no session or user");
+    throw new TRPCError({ code: "UNAUTHORIZED" });
+  }
+  ctx.log.debug("authenticated procedure call");
+  return next({
+    ctx: { ...ctx, session: ctx.session, user: ctx.user },
+  });
+});
+```
+
+Three exports:
+
+- **`router`** — creates a router from a record of procedures.
+- **`procedure`** — public procedure, no auth required.
+- **`protectedProcedure`** — enforces authentication via middleware. Narrows
+  `ctx.session` and `ctx.user` to non-null types downstream.
+
+The `errorFormatter` logs every tRPC error with structured context (code, path,
+input, cause) so failures are traceable in production.
+
+### Context
+
+The tRPC context is created per-request. It carries the database client,
+authenticated session, and a request-scoped logger.
+
+```typescript
+// server/trpc/context.ts
+import type pino from "pino";
+import { auth } from "../auth/mod.ts";
+import { db } from "../db/connection.ts";
+import { logger } from "../logger.ts";
+
+const fallbackLog = logger.child({ module: "trpc.context" });
+
+export async function createContext(
+  req: Request,
+  requestLog?: pino.Logger,
+) {
+  const log = requestLog ?? fallbackLog;
+
+  const sessionData = await auth.api.getSession({
+    headers: req.headers,
+  });
+
+  const userId = sessionData?.user?.id ?? null;
+  const contextLog = userId ? log.child({ userId }) : log;
+
+  contextLog.debug(
+    { hasSession: !!sessionData?.session },
+    "trpc context created",
+  );
+
+  return {
+    db,
+    session: sessionData?.session ?? null,
+    user: sessionData?.user ?? null,
+    log: contextLog,
+  };
+}
+
+export type Context = Awaited<ReturnType<typeof createContext>>;
+```
+
+The logger is enriched progressively:
+
+1. `requestContextMiddleware` adds `{ requestId }`.
+2. `createContext` adds `{ userId }` when a session exists.
+
+Every log line from a tRPC procedure carries both fields automatically.
+
+### Root router
+
+The root router assembles all feature routers into a single `appRouter`. The
+`AppRouter` type is exported for the client.
+
+```typescript
+// server/trpc/router.ts
+import { createFeatureRouters } from "../features/mod.ts";
+import { procedure, router } from "./trpc.ts";
+import { db } from "../db/connection.ts";
+
+const features = createFeatureRouters(db);
+
+export const appRouter = router({
+  health: router({
+    check: procedure.query(async ({ ctx }) => {
+      await ctx.db.execute(sql`SELECT 1`);
+      return {
+        status: "ok",
+        commit: Deno.env.get("GIT_SHA") ?? "unknown",
+      };
+    }),
+  }),
+  draft: features.draftRouter,
+  league: features.leagueRouter,
+  // ... other feature routers
+});
+
+export type AppRouter = typeof appRouter;
+```
+
+### Feature routers
+
+Each feature defines a `.router.ts` file that creates a tRPC router. The router
+receives its service dependency and defines procedures that delegate to it.
+
+```typescript
+// server/features/league/league.router.ts
+import type { LeagueService } from "@zone-blitz/shared";
+import { protectedProcedure, router } from "../../trpc/trpc.ts";
+import { createLeagueSchema } from "@zone-blitz/shared";
+import { z } from "zod";
+
+export function createLeagueRouter(leagueService: LeagueService) {
+  return router({
+    create: protectedProcedure
+      .input(createLeagueSchema)
+      .mutation(({ ctx, input }) => {
+        return leagueService.create(ctx.user.id, input);
+      }),
+    getById: protectedProcedure
+      .input(z.object({ id: z.string().uuid() }))
+      .query(({ input }) => {
+        return leagueService.getById(input.id);
+      }),
+  });
+}
+```
+
+Routers are thin — they validate input via Zod schemas and delegate to the
+service. No business logic lives here.
+
+### Hono integration
+
+tRPC is mounted on Hono via the fetch adapter. The request-scoped logger from
+Hono's context is passed into `createContext` so tRPC procedures inherit the
+`requestId`.
+
+```typescript
+// server/main.ts
+import { Hono } from "hono";
+import { fetchRequestHandler } from "@trpc/server/adapters/fetch";
+import { appRouter } from "./trpc/router.ts";
+import { createContext } from "./trpc/context.ts";
+import { requestContextMiddleware } from "./middleware/request-context.ts";
+import { loggerMiddleware } from "./middleware/logger.ts";
+import { logger } from "./logger.ts";
+
+const app = new Hono<AppEnv>();
+
+app.use(requestContextMiddleware(logger));
+app.use(loggerMiddleware());
+
+// Auth routes (before tRPC so OAuth flows work)
+app.on(["GET", "POST"], "/api/auth/**", (c) => {
+  return auth.handler(c.req.raw);
+});
+
+// tRPC
+app.all("/api/trpc/*", (c) => {
+  const requestLog = c.get("log");
+  return fetchRequestHandler({
+    endpoint: "/api/trpc",
+    req: c.req.raw,
+    router: appRouter,
+    createContext: ({ req }) => createContext(req, requestLog),
+  });
+});
+```
+
+### Client setup
+
+The React client uses `@trpc/react-query` for type-safe data fetching.
+
+```typescript
+// client/src/trpc.ts
+import { createTRPCReact } from "@trpc/react-query";
+import { httpBatchLink } from "@trpc/client";
+import { QueryClient } from "@tanstack/react-query";
+import type { AppRouter } from "../../server/trpc/router.ts";
+
+export const trpc = createTRPCReact<AppRouter>();
+
+export const queryClient = new QueryClient();
+
+export const trpcClient = trpc.createClient({
+  links: [
+    httpBatchLink({
+      url: "/api/trpc",
+    }),
+  ],
+});
+```
+
+```typescript
+// client/src/App.tsx
+import { QueryClientProvider } from "@tanstack/react-query";
+import { queryClient, trpc, trpcClient } from "./trpc";
+
+export function App() {
+  return (
+    <trpc.Provider client={trpcClient} queryClient={queryClient}>
+      <QueryClientProvider client={queryClient}>
+        {/* Routes */}
+      </QueryClientProvider>
+    </trpc.Provider>
+  );
+}
+```
+
+Usage in components:
+
+```typescript
+function LeagueListPage() {
+  const { data: leagues } = trpc.league.list.useQuery();
+  const createMutation = trpc.league.create.useMutation();
+
+  return (
+    <>
+      {leagues?.map((league) => (
+        <LeagueCard key={league.id} league={league} />
+      ))}
+      <button onClick={() => createMutation.mutate({ name: "..." })}>
+        Create League
+      </button>
+    </>
+  );
+}
+```
+
+### Dev tooling — tRPC Panel
+
+In development, a tRPC Panel UI is available for exploring and testing
+procedures without writing client code.
+
+```typescript
+// In main.ts (dev only)
+if (Deno.env.get("DENO_ENV") !== "production") {
+  app.get("/dev/trpc/ui", (c) => {
+    return c.html(renderTrpcPanel(appRouter, { url: "/api/trpc" }));
+  });
+}
+```
+
+---
+
+## Logging
+
+Pino is the logging library. The logging strategy provides structured,
+request-traceable logs across all layers.
+
+### Root logger
+
+```typescript
+// server/logger.ts
+import pino from "pino";
+
+const isProduction = Deno.env.get("DENO_ENV") === "production";
+
+export const logger = pino(
+  { level: isProduction ? "info" : "debug" },
+  pino.destination({ sync: true }),
+);
+```
+
+- `info` in production, `debug` in development.
+- `pino.destination({ sync: true })` for Deno compatibility.
+- Dev server pipes output through `pino-pretty` for human-readable formatting.
+
+### Request context middleware
+
+Every HTTP request gets a child logger with a unique `requestId`. The logger is
+stored in Hono's typed context.
+
+```typescript
+// server/env.ts
+export type AppEnv = {
+  Variables: {
+    requestId: string;
+    log: pino.Logger;
+  };
+};
+
+// server/middleware/request-context.ts
+export function requestContextMiddleware(
+  log: pino.Logger,
+): MiddlewareHandler<AppEnv> {
+  return async (c, next) => {
+    const requestId = c.req.header("X-Request-Id") ?? crypto.randomUUID();
+    const requestLog = log.child({ requestId });
+
+    c.set("requestId", requestId);
+    c.set("log", requestLog);
+
+    await next();
+  };
+}
+```
+
+### HTTP lifecycle logging
+
+A middleware logs every request/response with status-based severity.
+
+```typescript
+// server/middleware/logger.ts
+export function loggerMiddleware(): MiddlewareHandler<AppEnv> {
+  return async (c, next) => {
+    const start = Date.now();
+    await next();
+
+    const log = c.get("log");
+    const status = c.res.status;
+    const data = {
+      method: c.req.method,
+      path: c.req.path,
+      status,
+      responseTime: Date.now() - start,
+    };
+    const msg = `${c.req.method} ${c.req.path}`;
+
+    if (status >= 500) log.error(data, msg);
+    else if (status >= 400) log.warn(data, msg);
+    else log.info(data, msg);
+  };
+}
+```
+
+### Logger flow through DI
+
+The root logger is passed into the composition root. Each factory creates a
+module-scoped child logger:
+
+```
+Root logger (server/logger.ts)
+  → composition root passes it to factories
+    → repository: log.child({ module: "draft.repository" })
+    → service: log.child({ module: "draft.service" })
+```
+
+For request-scoped logging (e.g., enriching with `userId`), the route handler
+can pass `c.get("log")` into service method calls when needed.
+
+### Test logger
+
+Tests capture log output for assertions using a custom write stream:
+
+```typescript
+function createTestLogger() {
+  const entries: Record<string, unknown>[] = [];
+  const stream = {
+    write(msg: string) {
+      entries.push(JSON.parse(msg));
+    },
+  };
+  const log = pino({ level: "debug" }, stream as pino.DestinationStream);
+  return { log, entries };
+}
+```
+
+---
+
+## Domain Errors
+
+Services throw typed domain errors. The HTTP layer catches them and maps to
+status codes. The service layer has no concept of HTTP.
+
+```typescript
+// packages/shared/errors/domain-error.ts
+export class DomainError extends Error {
+  constructor(public code: string, message: string) {
+    super(message);
+  }
+}
+```
+
+```typescript
+// Hono error handler in main.ts
+app.onError((err, c) => {
+  if (err instanceof DomainError) {
+    return c.json({ error: err.code, message: err.message }, 400);
+  }
+  const log = c.get("log");
+  log.error({ err }, "unhandled error");
+  return c.json({ error: "INTERNAL" }, 500);
+});
+```
+
+---
+
+## Extracting Domain Logic
+
+When a service grows, extract pure computation into named domain logic files.
+
+### The heuristic
+
+If a function:
+
+- Has **no dependencies** (no db, no logger, no injected services)
+- Is **pure** (data in, data out, no side effects)
+- Encodes a **named domain concept**
+
+Then extract it into its own file named after that concept.
+
+### Examples
+
+```typescript
+// server/features/draft/snake-order.ts
+export function calculateSnakeOrder(
+  totalTeams: number,
+  totalRounds: number,
+): PickSlot[] {
+  // Pure computation — no deps, no DB, no logger
+}
+```
+
+```typescript
+// server/features/salary-cap/cap-proration.ts
+export function prorateSigningBonus(
+  totalBonus: number,
+  contractYears: number,
+  currentYear: number,
+): number {
+  // Pure math
+}
+```
+
+The service imports and calls these. The domain logic is independently testable
+without any mocking.
+
+### When to use design patterns
+
+Some extractions aren't single functions — they're behavioral variants. Use
+patterns when the complexity warrants it:
+
+**Strategy** — when the same operation has multiple implementations:
+
+```
+server/features/trade/
+  evaluation/
+    trade-evaluation.strategy.ts    # Interface
+    win-now-evaluation.ts           # Weights current talent
+    rebuild-evaluation.ts           # Weights draft picks
+```
+
+**Specification** — when business rules combine and compose:
+
+```
+server/features/salary-cap/
+  rules/
+    cap-compliance.rule.ts
+    luxury-tax.rule.ts
+    rookie-scale.rule.ts
+```
+
+These are domain concepts with names — not utilities.
+
+---
+
+## Simulation and AI Packages
+
+The `simulation` and `ai` packages are separate Deno workspace members. They
+are **pure** — no I/O, no database, no HTTP. They implement interfaces defined
+in `@zone-blitz/shared`.
+
+### Package structure
+
+```
+packages/
+  shared/              # Interfaces, domain types, Zod schemas (no deps)
+  simulation/          # Game engine — implements GameSimulator, etc.
+  ai/                  # NPC decision-making — implements GMStrategy, etc.
+```
+
+### Dependency rules (hard constraints)
+
+```
+shared       → (no internal dependencies)
+simulation   → shared only
+ai           → shared only
+server       → shared, simulation, ai
+```
+
+`simulation` and `ai` **never** depend on `server`. They have no knowledge of
+databases, HTTP, or any I/O.
+
+### Integration through DI
+
+The server imports concrete implementations from `simulation` and `ai` at the
+composition root and injects them where needed.
+
+```typescript
+// server/features/mod.ts
+import { createGameSimulator } from "@zone-blitz/simulation";
+import { createGMStrategy } from "@zone-blitz/ai";
+
+export function createFeatureRouters(db: Database) {
+  const log = logger;
+
+  // ... repositories and services ...
+
+  const gameSimulator = createGameSimulator();
+  const gmStrategy = createGMStrategy();
+
+  const seasonService = createSeasonService({
+    gameSimulator,
+    gmStrategy,
+    leagueRepo,
+    rosterRepo,
+    log,
+  });
+
+  // ... routers ...
+
+  return { /* ... */ };
+}
+```
+
+### Future extraction path
+
+When `simulation` or `ai` need to be extracted to Go/Rust:
+
+1. The interfaces in `shared` become gRPC/HTTP service contracts.
+2. The factory call in the composition root is replaced with an HTTP/gRPC client
+   that implements the same interface.
+3. Nothing else changes — the server still depends on the interface, not the
+   implementation.
+
+---
+
+## Testing
+
+### Service tests — mock dependencies via DI
+
+```typescript
+Deno.test("makePick throws if team is not on the clock", async () => {
+  const service = createDraftService({
+    draftRepo: {
+      getCurrentPick: () => Promise.resolve({ teamId: "other-team", ... }),
+      recordPick: () => { throw new Error("should not be called"); },
+    },
+    rosterRepo: {
+      addPlayer: () => { throw new Error("should not be called"); },
+    },
+    log: pino({ level: "silent" }),
+  });
+
+  await assertRejects(
+    () => service.makePick({ draftId: "d1", teamId: "my-team", ... }),
+    DomainError,
+    "NOT_ON_CLOCK",
+  );
+});
+```
+
+No test database, no mocking framework, no DI container. Construct the service
+with fake deps and test the logic.
+
+### Repository tests — hit a real database
+
+Repository tests run against a real PostgreSQL instance. They verify Drizzle
+queries and migrations work correctly. No mocking the database.
+
+### Pure domain logic tests — no setup at all
+
+```typescript
+Deno.test("calculateSnakeOrder reverses direction each round", () => {
+  const order = calculateSnakeOrder(4, 3);
+  assertEquals(order[0].teamIndex, 0);  // Round 1: 0,1,2,3
+  assertEquals(order[4].teamIndex, 3);  // Round 2: 3,2,1,0
+  assertEquals(order[8].teamIndex, 0);  // Round 3: 0,1,2,3
+});
+```
+
+### Simulation and AI tests — pure functions
+
+These packages have no dependencies beyond `shared`. Tests pass in state and
+assert output. No DB, no mocks, no DI.
+
+---
+
+## Cross-Feature Orchestration
+
+Some operations span multiple features — season advancement, trade execution,
+end-of-season processing. These are handled by **orchestrator features** that
+depend on multiple service interfaces.
+
+```typescript
+// server/features/season/season.service.ts
+export function createSeasonService(deps: {
+  gameSimulator: GameSimulator;
+  gmStrategy: GMStrategy;
+  leagueRepo: LeagueRepository;
+  rosterRepo: RosterRepository;
+  draftRepo: DraftRepository;
+  capRepo: SalaryCapRepository;
+  log: pino.Logger;
+}): SeasonService {
+  return {
+    async advanceWeek(leagueId) {
+      // Orchestrates across all injected dependencies
+    },
+  };
+}
+```
+
+The orchestrator feature may own a small schema (e.g., a `seasons` table) but
+its primary role is coordination. Its dependency list in the factory signature
+makes every cross-feature relationship explicit.
+
+---
+
+## Database
+
+### Schema ownership
+
+Each feature defines its own tables in its `.schema.ts` file. A top-level
+`db/schema.ts` re-exports all feature schemas so `drizzle-kit` sees the
+complete database.
+
+```typescript
+// server/db/schema.ts
+export * from "../features/league/league.schema.ts";
+export * from "../features/draft/draft.schema.ts";
+export * from "../features/trade/trade.schema.ts";
+export * from "../features/roster/roster.schema.ts";
+// ...
+```
+
+### Passing `db` explicitly
+
+The Drizzle client is passed through DI, not imported as a singleton. This
+enables transactions at the service level:
+
+```typescript
+// In a service that needs a transaction
+async executeTrade(trade: Trade) {
+  return deps.db.transaction(async (tx) => {
+    await deps.rosterRepo.transferPlayer(tx, trade.playerIds, trade.toTeamId);
+    await deps.draftPickRepo.transferPicks(tx, trade.picks, trade.toTeamId);
+  });
+}
+```
+
+### Domain types vs. database types
+
+The domain model in `shared` represents concepts as the simulation understands
+them. The database schema represents how those concepts are stored. These are
+not always the same. Repository implementations handle the mapping.


### PR DESCRIPTION
## Summary

- Adds `docs/technical/backend-architecture.md` — the prescriptive reference for all backend work
- Covers vertical feature slices, DI via factory functions, typed interfaces in `@zone-blitz/shared`, tRPC setup (routers, context, Hono adapter, client), Pino logging (request context, lifecycle, test logger), domain errors, pure domain logic extraction, simulation/ai package integration, and cross-feature orchestration
- Establishes file naming conventions: `.router.ts`, `.service.ts`, `.repository.ts`, `.schema.ts`, `mod.ts`

## Test plan

- [ ] Review doc for accuracy against existing `architecture.md` decisions
- [ ] Confirm conventions align with make-the-pick patterns

🤖 Generated with [Claude Code](https://claude.com/claude-code)