### PR TITLE
feat: backend architecture PoC with feature slices, logging, and Hono RPC

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,8 @@ COPY deno.json deno.lock ./
 COPY server/deno.json ./server/
 COPY client/deno.json client/package.json ./client/
 COPY packages/shared/deno.json ./packages/shared/
+COPY packages/simulation/deno.json ./packages/simulation/
+COPY packages/ai/deno.json ./packages/ai/
 COPY e2e/deno.json ./e2e/
 RUN deno install
 

--- a/client/package.json
+++ b/client/package.json
@@ -4,7 +4,9 @@
   "type": "module",
   "dependencies": {
     "react": "^19",
-    "react-dom": "^19"
+    "react-dom": "^19",
+    "hono": "^4",
+    "@tanstack/react-query": "^5"
   },
   "devDependencies": {
     "@testing-library/dom": "^10",

--- a/client/src/api.ts
+++ b/client/src/api.ts
@@ -1,0 +1,4 @@
+import { hc } from "hono/client";
+import type { AppType } from "@zone-blitz/server";
+
+export const api = hc<AppType>("/");

--- a/client/src/app.test.tsx
+++ b/client/src/app.test.tsx
@@ -1,19 +1,31 @@
 import { cleanup, render, screen } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { afterEach, describe, expect, it } from "vitest";
 import { App } from "./app.tsx";
+
+function renderWithProviders() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <App />
+    </QueryClientProvider>,
+  );
+}
 
 afterEach(cleanup);
 
 describe("App", () => {
   it("renders the Zone Blitz heading", () => {
-    render(<App />);
+    renderWithProviders();
     expect(
       screen.getByRole("heading", { name: "Zone Blitz" }),
     ).toBeDefined();
   });
 
   it("renders the tagline", () => {
-    render(<App />);
+    renderWithProviders();
     expect(screen.getByText(/football franchise simulation/i)).toBeDefined();
   });
 });

--- a/client/src/app.tsx
+++ b/client/src/app.tsx
@@ -1,40 +1,74 @@
-import { useEffect, useState } from "react";
+import { useState } from "react";
+import { useCreateLeague, useLeagues } from "./hooks/use-leagues.ts";
 
 export function App() {
-  const [health, setHealth] = useState<
-    {
-      status: string;
-      commit: string;
-    } | null
-  >(null);
-
-  useEffect(() => {
-    fetch("/api/health")
-      .then((res) => res.json())
-      .then(setHealth)
-      .catch(() => setHealth(null));
-  }, []);
+  const { data: leagues, isLoading, error } = useLeagues();
+  const createLeague = useCreateLeague();
+  const [newName, setNewName] = useState("");
 
   return (
     <div className="min-h-screen bg-gray-950 text-gray-100 flex items-center justify-center">
-      <div className="text-center space-y-6">
+      <div className="text-center space-y-6 max-w-lg w-full px-4">
         <h1 className="text-5xl font-bold tracking-tight">Zone Blitz</h1>
         <p className="text-lg text-gray-400 max-w-md mx-auto">
           Football franchise simulation. Scout, draft, trade, and build your
           dynasty.
         </p>
-        {health && (
-          <div className="inline-flex items-center gap-2 text-sm text-gray-500">
-            <span
-              className={`size-2 rounded-full ${
-                health.status === "ok" ? "bg-green-500" : "bg-red-500"
-              }`}
+
+        <div className="space-y-4 text-left">
+          <h2 className="text-xl font-semibold text-gray-200">Leagues</h2>
+
+          <form
+            className="flex gap-2"
+            onSubmit={(e) => {
+              e.preventDefault();
+              if (!newName.trim()) return;
+              createLeague.mutate({ name: newName.trim() });
+              setNewName("");
+            }}
+          >
+            <input
+              type="text"
+              value={newName}
+              onChange={(e) => setNewName(e.target.value)}
+              placeholder="League name..."
+              className="flex-1 rounded bg-gray-800 px-3 py-2 text-sm text-gray-100 placeholder-gray-500 border border-gray-700 focus:border-blue-500 focus:outline-none"
             />
-            <span>
-              {health.status === "ok" ? "Connected" : "Disconnected"}
-            </span>
-          </div>
-        )}
+            <button
+              type="submit"
+              disabled={createLeague.isPending || !newName.trim()}
+              className="rounded bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-500 disabled:opacity-50 disabled:cursor-not-allowed"
+            >
+              {createLeague.isPending ? "Creating..." : "Create"}
+            </button>
+          </form>
+
+          {isLoading && (
+            <p className="text-sm text-gray-500">Loading leagues...</p>
+          )}
+          {error && (
+            <p className="text-sm text-red-400">
+              Failed to load leagues
+            </p>
+          )}
+          {leagues && leagues.length === 0 && (
+            <p className="text-sm text-gray-500">
+              No leagues yet. Create one to get started.
+            </p>
+          )}
+          {leagues && leagues.length > 0 && (
+            <ul className="space-y-2">
+              {leagues.map((league) => (
+                <li
+                  key={league.id}
+                  className="rounded bg-gray-800 border border-gray-700 px-4 py-3"
+                >
+                  <span className="font-medium">{league.name}</span>
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
       </div>
     </div>
   );

--- a/client/src/hooks/use-leagues.ts
+++ b/client/src/hooks/use-leagues.ts
@@ -1,0 +1,25 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { api } from "../api.ts";
+
+export function useLeagues() {
+  return useQuery({
+    queryKey: ["leagues"],
+    queryFn: async () => {
+      const res = await api.api.leagues.$get();
+      return res.json();
+    },
+  });
+}
+
+export function useCreateLeague() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async (input: { name: string }) => {
+      const res = await api.api.leagues.$post({ json: input });
+      return res.json();
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["leagues"] });
+    },
+  });
+}

--- a/client/src/main.tsx
+++ b/client/src/main.tsx
@@ -1,5 +1,12 @@
 import { createRoot } from "react-dom/client";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { App } from "./app.tsx";
 import "./index.css";
 
-createRoot(document.getElementById("root")!).render(<App />);
+const queryClient = new QueryClient();
+
+createRoot(document.getElementById("root")!).render(
+  <QueryClientProvider client={queryClient}>
+    <App />
+  </QueryClientProvider>,
+);

--- a/client/tsconfig.json
+++ b/client/tsconfig.json
@@ -8,7 +8,8 @@
     "esModuleInterop": true,
     "skipLibCheck": true,
     "paths": {
-      "@zone-blitz/shared": ["../packages/shared/mod.ts"]
+      "@zone-blitz/shared": ["../packages/shared/mod.ts"],
+      "@zone-blitz/server": ["../server/main.ts"]
     }
   },
   "include": ["src"]

--- a/client/vite.config.ts
+++ b/client/vite.config.ts
@@ -22,6 +22,7 @@ export default defineConfig({
   resolve: {
     alias: {
       "@zone-blitz/shared": resolve(__dirname, "../packages/shared/mod.ts"),
+      "@zone-blitz/server": resolve(__dirname, "../server/main.ts"),
     },
   },
   server: {

--- a/deno.json
+++ b/deno.json
@@ -1,5 +1,12 @@
 {
-  "workspace": ["./packages/shared", "./server", "./client", "./e2e"],
+  "workspace": [
+    "./packages/shared",
+    "./packages/simulation",
+    "./packages/ai",
+    "./server",
+    "./client",
+    "./e2e"
+  ],
   "nodeModulesDir": "auto",
   "fmt": {
     "indentWidth": 2,
@@ -19,8 +26,9 @@
     "db:start": "docker compose up -d --wait",
     "db:stop": "docker compose down",
     "db:migrate": "cd server && deno run --env=../.env --allow-net --allow-env --allow-read --allow-sys db/migrate.ts",
-    "test": "deno task test:server && deno task test:client",
+    "test": "deno task test:server && deno task test:packages && deno task test:client",
     "test:server": "deno test server/ --allow-env --allow-net --allow-read --allow-sys",
+    "test:packages": "deno test packages/simulation/ packages/ai/",
     "test:client": "cd client && deno run -A npm:vitest run",
     "test:e2e": "./bin/test-e2e",
     "build": "cd client && deno task build",

--- a/deno.lock
+++ b/deno.lock
@@ -1,12 +1,13 @@
 {
   "version": "5",
   "specifiers": {
-    "jsr:@hono/hono@4": "4.12.12",
     "jsr:@std/assert@*": "1.0.19",
     "jsr:@std/assert@1": "1.0.19",
     "jsr:@std/internal@^1.0.12": "1.0.12",
+    "npm:@hono/zod-validator@0.4": "0.4.3_hono@4.12.12_zod@3.25.76",
     "npm:@playwright/test@^1.52.0": "1.59.1",
     "npm:@tailwindcss/vite@4": "4.2.2_vite@6.4.2",
+    "npm:@tanstack/react-query@5": "5.96.2_react@19.2.4",
     "npm:@testing-library/dom@10": "10.4.1",
     "npm:@testing-library/react@16": "16.3.2_@testing-library+dom@10.4.1_@types+react@19.2.14_@types+react-dom@19.2.3__@types+react@19.2.14_react@19.2.4_react-dom@19.2.4__react@19.2.4",
     "npm:@types/react-dom@19": "19.2.3_@types+react@19.2.14",
@@ -16,6 +17,8 @@
     "npm:drizzle-kit@0.31": "0.31.10",
     "npm:drizzle-orm@0.44": "0.44.7_postgres@3.4.9",
     "npm:happy-dom@18": "18.0.1",
+    "npm:hono@4": "4.12.12",
+    "npm:pino-pretty@13": "13.1.3",
     "npm:pino@9": "9.14.0",
     "npm:postgres@3": "3.4.9",
     "npm:react-dom@19": "19.2.4_react@19.2.4",
@@ -25,12 +28,10 @@
     "npm:vite@*": "6.4.2",
     "npm:vite@6": "6.4.2",
     "npm:vitest@*": "3.2.4_happy-dom@18.0.1",
-    "npm:vitest@3": "3.2.4_happy-dom@18.0.1"
+    "npm:vitest@3": "3.2.4_happy-dom@18.0.1",
+    "npm:zod@3": "3.25.76"
   },
   "jsr": {
-    "@hono/hono@4.12.12": {
-      "integrity": "dc765178d38b5c4619b358062f6aa5514f7205bb0530b2823ff6265bec69c535"
-    },
     "@std/assert@1.0.19": {
       "integrity": "eaada96ee120cb980bc47e040f82814d786fe8162ecc53c91d8df60b8755991e",
       "dependencies": [
@@ -571,6 +572,13 @@
       "os": ["win32"],
       "cpu": ["x64"]
     },
+    "@hono/zod-validator@0.4.3_hono@4.12.12_zod@3.25.76": {
+      "integrity": "sha512-xIgMYXDyJ4Hj6ekm9T9Y27s080Nl9NXHcJkOvkXPhubOLj8hZkOL8pDnnXfvCf5xEE8Q4oMFenQUZZREUY2gqQ==",
+      "dependencies": [
+        "hono",
+        "zod"
+      ]
+    },
     "@jridgewell/gen-mapping@0.3.13": {
       "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
       "dependencies": [
@@ -833,6 +841,16 @@
         "vite"
       ]
     },
+    "@tanstack/query-core@5.96.2": {
+      "integrity": "sha512-hzI6cTVh4KNRk8UtoIBS7Lv9g6BnJPXvBKsvYH1aGWvv0347jT3BnSvztOE+kD76XGvZnRC/t6qdW1CaIfwCeA=="
+    },
+    "@tanstack/react-query@5.96.2_react@19.2.4": {
+      "integrity": "sha512-sYyzzJT4G0g02azzJ8o55VFFV31XvFpdUpG+unxS0vSaYsJnSPKGoI6WdPwUucJL1wpgGfwfmntNX/Ub1uOViA==",
+      "dependencies": [
+        "@tanstack/query-core",
+        "react"
+      ]
+    },
     "@testing-library/dom@10.4.1": {
       "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
       "dependencies": [
@@ -1052,11 +1070,17 @@
     "check-error@2.1.3": {
       "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA=="
     },
+    "colorette@2.0.20": {
+      "integrity": "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w=="
+    },
     "convert-source-map@2.0.0": {
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg=="
     },
     "csstype@3.2.3": {
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ=="
+    },
+    "dateformat@4.6.3": {
+      "integrity": "sha512-2P0p0pFGzHS5EMnhdxQi7aJN+iMheud0UhG4dlE1DLAlvL8JHjJJTX/CSm4JXwV0Ka5nGk3zC5mcb5bUQUxxMA=="
     },
     "debug@4.4.3": {
       "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
@@ -1097,6 +1121,12 @@
     },
     "electron-to-chromium@1.5.332": {
       "integrity": "sha512-7OOtytmh/rINMLwaFTbcMVvYXO3AUm029X0LcyfYk0B557RlPkdpTpnH9+htMlfu5dKwOmT0+Zs2Aw+lnn6TeQ=="
+    },
+    "end-of-stream@1.4.5": {
+      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "dependencies": [
+        "once"
+      ]
     },
     "enhanced-resolve@5.20.1": {
       "integrity": "sha512-Qohcme7V1inbAfvjItgw0EaxVX5q2rdVEZHRBrEQdRZTssLDGsL8Lwrznl8oQ/6kuTJONLaDcGjkNP247XEhcA==",
@@ -1215,6 +1245,12 @@
     "expect-type@1.3.0": {
       "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA=="
     },
+    "fast-copy@4.0.2": {
+      "integrity": "sha512-ybA6PDXIXOXivLJK/z9e+Otk7ve13I4ckBvGO5I2RRmBU1gMHLVDJYEuJYhGwez7YNlYji2M2DvVU+a9mSFDlw=="
+    },
+    "fast-safe-stringify@2.1.1": {
+      "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA=="
+    },
     "fdir@6.5.0_picomatch@4.0.4": {
       "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
       "dependencies": [
@@ -1254,9 +1290,18 @@
         "whatwg-mimetype"
       ]
     },
+    "help-me@5.0.0": {
+      "integrity": "sha512-7xgomUX6ADmcYzFik0HzAxh/73YlKR9bmFzf51CZwR+b6YtzU2m0u49hQCqV6SvlqIqsaxovfwdvbnsw3b/zpg=="
+    },
+    "hono@4.12.12": {
+      "integrity": "sha512-p1JfQMKaceuCbpJKAPKVqyqviZdS0eUxH9v82oWo1kb9xjQ5wA6iP3FNVAPDFlz5/p7d45lO+BpSk1tuSZMF4Q=="
+    },
     "jiti@2.6.1": {
       "integrity": "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==",
       "bin": true
+    },
+    "joycon@3.1.1": {
+      "integrity": "sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw=="
     },
     "js-tokens@4.0.0": {
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
@@ -1365,6 +1410,9 @@
         "@jridgewell/sourcemap-codec"
       ]
     },
+    "minimist@1.2.8": {
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA=="
+    },
     "ms@2.1.3": {
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
     },
@@ -1377,6 +1425,12 @@
     },
     "on-exit-leak-free@2.1.2": {
       "integrity": "sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA=="
+    },
+    "once@1.4.0": {
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "dependencies": [
+        "wrappy"
+      ]
     },
     "pathe@2.0.3": {
       "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w=="
@@ -1396,6 +1450,31 @@
         "split2"
       ]
     },
+    "pino-abstract-transport@3.0.0": {
+      "integrity": "sha512-wlfUczU+n7Hy/Ha5j9a/gZNy7We5+cXp8YL+X+PG8S0KXxw7n/JXA3c46Y0zQznIJ83URJiwy7Lh56WLokNuxg==",
+      "dependencies": [
+        "split2"
+      ]
+    },
+    "pino-pretty@13.1.3": {
+      "integrity": "sha512-ttXRkkOz6WWC95KeY9+xxWL6AtImwbyMHrL1mSwqwW9u+vLp/WIElvHvCSDg0xO/Dzrggz1zv3rN5ovTRVowKg==",
+      "dependencies": [
+        "colorette",
+        "dateformat",
+        "fast-copy",
+        "fast-safe-stringify",
+        "help-me",
+        "joycon",
+        "minimist",
+        "on-exit-leak-free",
+        "pino-abstract-transport@3.0.0",
+        "pump",
+        "secure-json-parse",
+        "sonic-boom",
+        "strip-json-comments"
+      ],
+      "bin": true
+    },
     "pino-std-serializers@7.1.0": {
       "integrity": "sha512-BndPH67/JxGExRgiX1dX0w1FvZck5Wa4aal9198SrRhZjH3GxKQUKIBnYJTdj2HDN3UQAS06HlfcSbQj2OHmaw=="
     },
@@ -1405,7 +1484,7 @@
         "@pinojs/redact",
         "atomic-sleep",
         "on-exit-leak-free",
-        "pino-abstract-transport",
+        "pino-abstract-transport@2.0.0",
         "pino-std-serializers",
         "process-warning",
         "quick-format-unescaped",
@@ -1451,6 +1530,13 @@
     },
     "process-warning@5.0.0": {
       "integrity": "sha512-a39t9ApHNx2L4+HBnQKqxxHNs1r7KF+Intd8Q/g1bUh6q0WIp9voPXJ/x0j+ZL45KF1pJd9+q2jLIRMfvEshkA=="
+    },
+    "pump@3.0.3": {
+      "integrity": "sha512-todwxLMY7/heScKmntwQG8CXVkWUOdYxIvY2s0VWAAMh/nd8SoYiRaKjlr7+iCs984f2P8zvrfWcDDYVb73NfA==",
+      "dependencies": [
+        "end-of-stream",
+        "once"
+      ]
     },
     "quick-format-unescaped@4.0.4": {
       "integrity": "sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg=="
@@ -1518,6 +1604,9 @@
     "scheduler@0.27.0": {
       "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q=="
     },
+    "secure-json-parse@4.1.0": {
+      "integrity": "sha512-l4KnYfEyqYJxDwlNVyRfO2E4NTHfMKAWdUuA8J0yve2Dz/E/PdBepY03RvyJpssIpRFwJoCD55wA+mEDs6ByWA=="
+    },
     "semver@6.3.1": {
       "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
       "bin": true
@@ -1552,6 +1641,9 @@
     },
     "std-env@3.10.0": {
       "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg=="
+    },
+    "strip-json-comments@5.0.3": {
+      "integrity": "sha512-1tB5mhVo7U+ETBKNf92xT4hrQa3pm0MZ0PQvuDnWgAAGHDsfp4lPSpiS6psrSiet87wyGPh9ft6wmhOMQ0hDiw=="
     },
     "strip-literal@3.1.0": {
       "integrity": "sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==",
@@ -1690,8 +1782,14 @@
       ],
       "bin": true
     },
+    "wrappy@1.0.2": {
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
+    },
     "yallist@3.1.1": {
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="
+    },
+    "zod@3.25.76": {
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="
     }
   },
   "workspace": {
@@ -1700,12 +1798,14 @@
         "packageJson": {
           "dependencies": [
             "npm:@tailwindcss/vite@4",
+            "npm:@tanstack/react-query@5",
             "npm:@testing-library/dom@10",
             "npm:@testing-library/react@16",
             "npm:@types/react-dom@19",
             "npm:@types/react@19",
             "npm:@vitejs/plugin-react@4",
             "npm:happy-dom@18",
+            "npm:hono@4",
             "npm:react-dom@19",
             "npm:react@19",
             "npm:tailwindcss@4",
@@ -1721,12 +1821,29 @@
           "npm:postgres@3"
         ]
       },
+      "packages/ai": {
+        "dependencies": [
+          "jsr:@std/assert@1"
+        ]
+      },
+      "packages/shared": {
+        "dependencies": [
+          "npm:zod@3"
+        ]
+      },
+      "packages/simulation": {
+        "dependencies": [
+          "jsr:@std/assert@1"
+        ]
+      },
       "server": {
         "dependencies": [
-          "jsr:@hono/hono@4",
           "jsr:@std/assert@1",
+          "npm:@hono/zod-validator@0.4",
           "npm:drizzle-kit@0.31",
           "npm:drizzle-orm@0.44",
+          "npm:hono@4",
+          "npm:pino-pretty@13",
           "npm:pino@9",
           "npm:postgres@3"
         ]

--- a/e2e/tests/smoke.spec.ts
+++ b/e2e/tests/smoke.spec.ts
@@ -9,10 +9,14 @@ test("health endpoint returns ok", async ({ request }) => {
 
 test("homepage renders Zone Blitz heading", async ({ page }) => {
   await page.goto("/");
-  await expect(page.getByRole("heading", { name: "Zone Blitz" })).toBeVisible();
+  await expect(
+    page.getByRole("heading", { name: "Zone Blitz" }),
+  ).toBeVisible();
 });
 
-test("homepage shows health status", async ({ page }) => {
+test("homepage shows leagues section", async ({ page }) => {
   await page.goto("/");
-  await expect(page.getByText("Connected")).toBeVisible();
+  await expect(
+    page.getByRole("heading", { name: "Leagues" }),
+  ).toBeVisible();
 });

--- a/packages/ai/deno.json
+++ b/packages/ai/deno.json
@@ -1,8 +1,8 @@
 {
-  "name": "@zone-blitz/shared",
+  "name": "@zone-blitz/ai",
   "version": "0.0.1",
   "exports": "./mod.ts",
   "imports": {
-    "zod": "npm:zod@^3"
+    "@std/assert": "jsr:@std/assert@^1"
   }
 }

--- a/packages/ai/gm-strategy.test.ts
+++ b/packages/ai/gm-strategy.test.ts
@@ -1,0 +1,52 @@
+import { assertEquals } from "@std/assert";
+import { createGMStrategy } from "./gm-strategy.ts";
+
+Deno.test("gm strategy", async (t) => {
+  const gm = createGMStrategy();
+
+  await t.step("evaluateTrade accepts favorable trades", () => {
+    const decision = gm.evaluateTrade({
+      offeredPlayerIds: ["p1", "p2"],
+      requestedPlayerIds: ["p3"],
+      offeredPickIds: [],
+      requestedPickIds: [],
+    });
+    assertEquals(decision.accept, true);
+  });
+
+  await t.step("evaluateTrade rejects unfavorable trades", () => {
+    const decision = gm.evaluateTrade({
+      offeredPlayerIds: [],
+      requestedPlayerIds: ["p1", "p2"],
+      offeredPickIds: [],
+      requestedPickIds: [],
+    });
+    assertEquals(decision.accept, false);
+  });
+
+  await t.step("selectDraftPick picks highest-rated need position", () => {
+    const selection = gm.selectDraftPick(
+      [
+        { playerId: "a", position: "WR", rating: 90 },
+        { playerId: "b", position: "QB", rating: 95 },
+        { playerId: "c", position: "QB", rating: 85 },
+      ],
+      { positions: ["QB"], strategy: "win-now" },
+    );
+    assertEquals(selection.playerId, "b");
+  });
+
+  await t.step(
+    "selectDraftPick falls back to best available",
+    () => {
+      const selection = gm.selectDraftPick(
+        [
+          { playerId: "a", position: "WR", rating: 90 },
+          { playerId: "b", position: "RB", rating: 95 },
+        ],
+        { positions: ["QB"], strategy: "rebuild" },
+      );
+      assertEquals(selection.playerId, "b");
+    },
+  );
+});

--- a/packages/ai/gm-strategy.ts
+++ b/packages/ai/gm-strategy.ts
@@ -1,0 +1,43 @@
+import type {
+  DraftCandidate,
+  DraftSelection,
+  GMStrategy,
+  TeamNeeds,
+  TradeDecision,
+  TradeOffer,
+} from "@zone-blitz/shared";
+
+export function createGMStrategy(): GMStrategy {
+  return {
+    evaluateTrade(offer: TradeOffer): TradeDecision {
+      // Placeholder — real AI logic will replace this
+      const netValue = offer.offeredPlayerIds.length -
+        offer.requestedPlayerIds.length;
+      return {
+        accept: netValue >= 0,
+        reasoning: netValue >= 0
+          ? "Trade looks favorable"
+          : "Giving up too much",
+      };
+    },
+
+    selectDraftPick(
+      available: DraftCandidate[],
+      needs: TeamNeeds,
+    ): DraftSelection {
+      // Placeholder — pick the highest-rated player at a need position
+      const needPick = available
+        .filter((p) => needs.positions.includes(p.position))
+        .sort((a, b) => b.rating - a.rating)[0];
+
+      const pick = needPick ?? available.sort((a, b) => b.rating - a.rating)[0];
+
+      return {
+        playerId: pick.playerId,
+        reasoning: needPick
+          ? `Filling need at ${pick.position}`
+          : `Best player available: ${pick.position}`,
+      };
+    },
+  };
+}

--- a/packages/ai/mod.ts
+++ b/packages/ai/mod.ts
@@ -1,0 +1,1 @@
+export { createGMStrategy } from "./gm-strategy.ts";

--- a/packages/shared/errors/domain-error.ts
+++ b/packages/shared/errors/domain-error.ts
@@ -1,0 +1,9 @@
+export class DomainError extends Error {
+  constructor(
+    public code: string,
+    message: string,
+  ) {
+    super(message);
+    this.name = "DomainError";
+  }
+}

--- a/packages/shared/interfaces/ai/gm-strategy.ts
+++ b/packages/shared/interfaces/ai/gm-strategy.ts
@@ -1,0 +1,35 @@
+export interface GMStrategy {
+  evaluateTrade(offer: TradeOffer): TradeDecision;
+  selectDraftPick(
+    available: DraftCandidate[],
+    needs: TeamNeeds,
+  ): DraftSelection;
+}
+
+export interface TradeOffer {
+  offeredPlayerIds: string[];
+  requestedPlayerIds: string[];
+  offeredPickIds: string[];
+  requestedPickIds: string[];
+}
+
+export interface TradeDecision {
+  accept: boolean;
+  reasoning: string;
+}
+
+export interface DraftCandidate {
+  playerId: string;
+  position: string;
+  rating: number;
+}
+
+export interface TeamNeeds {
+  positions: string[];
+  strategy: "win-now" | "rebuild";
+}
+
+export interface DraftSelection {
+  playerId: string;
+  reasoning: string;
+}

--- a/packages/shared/interfaces/repositories/league-repository.ts
+++ b/packages/shared/interfaces/repositories/league-repository.ts
@@ -1,0 +1,7 @@
+import type { League, NewLeague } from "../../types/league.ts";
+
+export interface LeagueRepository {
+  getAll(): Promise<League[]>;
+  getById(id: string): Promise<League | undefined>;
+  create(league: NewLeague): Promise<League>;
+}

--- a/packages/shared/interfaces/services/league-service.ts
+++ b/packages/shared/interfaces/services/league-service.ts
@@ -1,0 +1,7 @@
+import type { League, NewLeague } from "../../types/league.ts";
+
+export interface LeagueService {
+  getAll(): Promise<League[]>;
+  getById(id: string): Promise<League>;
+  create(input: NewLeague): Promise<League>;
+}

--- a/packages/shared/interfaces/simulation/game-simulator.ts
+++ b/packages/shared/interfaces/simulation/game-simulator.ts
@@ -1,0 +1,15 @@
+export interface GameSimulator {
+  simulate(homeTeamId: string, awayTeamId: string): GameResult;
+}
+
+export interface GameResult {
+  homeScore: number;
+  awayScore: number;
+  events: GameEvent[];
+}
+
+export interface GameEvent {
+  quarter: number;
+  timestamp: number;
+  description: string;
+}

--- a/packages/shared/mod.ts
+++ b/packages/shared/mod.ts
@@ -1,2 +1,31 @@
-// Zone Blitz shared types, schemas, and interfaces.
-// This package is the vocabulary of the system — no logic, no side effects.
+// Types
+export type { League, NewLeague } from "./types/league.ts";
+
+// Interfaces — repositories
+export type { LeagueRepository } from "./interfaces/repositories/league-repository.ts";
+
+// Interfaces — services
+export type { LeagueService } from "./interfaces/services/league-service.ts";
+
+// Interfaces — simulation
+export type {
+  GameEvent,
+  GameResult,
+  GameSimulator,
+} from "./interfaces/simulation/game-simulator.ts";
+
+// Interfaces — AI
+export type {
+  DraftCandidate,
+  DraftSelection,
+  GMStrategy,
+  TeamNeeds,
+  TradeDecision,
+  TradeOffer,
+} from "./interfaces/ai/gm-strategy.ts";
+
+// Schemas
+export { createLeagueSchema } from "./schemas/league.ts";
+
+// Errors
+export { DomainError } from "./errors/domain-error.ts";

--- a/packages/shared/schemas/league.ts
+++ b/packages/shared/schemas/league.ts
@@ -1,5 +1,6 @@
 import { z } from "zod";
+import type { ZodObject, ZodString } from "zod";
 
-export const createLeagueSchema = z.object({
+export const createLeagueSchema: ZodObject<{ name: ZodString }> = z.object({
   name: z.string().min(1).max(100),
 });

--- a/packages/shared/schemas/league.ts
+++ b/packages/shared/schemas/league.ts
@@ -1,0 +1,5 @@
+import { z } from "zod";
+
+export const createLeagueSchema = z.object({
+  name: z.string().min(1).max(100),
+});

--- a/packages/shared/types/league.ts
+++ b/packages/shared/types/league.ts
@@ -1,0 +1,10 @@
+export interface League {
+  id: string;
+  name: string;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+export interface NewLeague {
+  name: string;
+}

--- a/packages/simulation/deno.json
+++ b/packages/simulation/deno.json
@@ -1,0 +1,8 @@
+{
+  "name": "@zone-blitz/simulation",
+  "version": "0.0.1",
+  "exports": "./mod.ts",
+  "imports": {
+    "@std/assert": "jsr:@std/assert@^1"
+  }
+}

--- a/packages/simulation/game-simulator.test.ts
+++ b/packages/simulation/game-simulator.test.ts
@@ -1,0 +1,14 @@
+import { assertEquals } from "@std/assert";
+import { createGameSimulator } from "./game-simulator.ts";
+
+Deno.test("game simulator", async (t) => {
+  await t.step("simulate returns a result with scores and events", () => {
+    const sim = createGameSimulator();
+    const result = sim.simulate("team-a", "team-b");
+
+    assertEquals(typeof result.homeScore, "number");
+    assertEquals(typeof result.awayScore, "number");
+    assertEquals(result.events.length > 0, true);
+    assertEquals(result.events[0].quarter, 1);
+  });
+});

--- a/packages/simulation/game-simulator.ts
+++ b/packages/simulation/game-simulator.ts
@@ -1,0 +1,26 @@
+import type { GameResult, GameSimulator } from "@zone-blitz/shared";
+
+export function createGameSimulator(): GameSimulator {
+  return {
+    simulate(homeTeamId, awayTeamId) {
+      // Placeholder — real simulation engine will replace this
+      const homeScore = Math.floor(Math.random() * 42);
+      const awayScore = Math.floor(Math.random() * 42);
+
+      const result: GameResult = {
+        homeScore,
+        awayScore,
+        events: [
+          {
+            quarter: 1,
+            timestamp: 0,
+            description:
+              `Game between ${homeTeamId} and ${awayTeamId} simulated`,
+          },
+        ],
+      };
+
+      return result;
+    },
+  };
+}

--- a/packages/simulation/mod.ts
+++ b/packages/simulation/mod.ts
@@ -1,0 +1,1 @@
+export { createGameSimulator } from "./game-simulator.ts";

--- a/server/db/connection.ts
+++ b/server/db/connection.ts
@@ -9,3 +9,5 @@ if (!databaseUrl) {
 
 const client = postgres(databaseUrl);
 export const db = drizzle(client, { schema });
+
+export type Database = typeof db;

--- a/server/db/schema.ts
+++ b/server/db/schema.ts
@@ -5,3 +5,6 @@ export const healthChecks = pgTable("health_checks", {
   status: text("status").notNull(),
   checkedAt: timestamp("checked_at").defaultNow().notNull(),
 });
+
+// Feature schemas
+export { leagues } from "../features/league/league.schema.ts";

--- a/server/deno.json
+++ b/server/deno.json
@@ -1,6 +1,11 @@
 {
   "name": "@zone-blitz/server",
   "exports": "./main.ts",
+  "lint": {
+    "rules": {
+      "exclude": ["no-slow-types"]
+    }
+  },
   "imports": {
     "hono": "npm:hono@^4",
     "hono/": "npm:/hono@^4/",

--- a/server/deno.json
+++ b/server/deno.json
@@ -2,12 +2,15 @@
   "name": "@zone-blitz/server",
   "exports": "./main.ts",
   "imports": {
-    "hono": "jsr:@hono/hono@^4",
+    "hono": "npm:hono@^4",
+    "hono/": "npm:/hono@^4/",
+    "@hono/zod-validator": "npm:@hono/zod-validator@^0.4",
     "drizzle-orm": "npm:drizzle-orm@^0.44",
     "drizzle-orm/": "npm:/drizzle-orm@^0.44/",
     "postgres": "npm:postgres@^3",
     "drizzle-kit": "npm:drizzle-kit@^0.31",
     "pino": "npm:pino@^9",
+    "pino-pretty": "npm:pino-pretty@^13",
     "@std/assert": "jsr:@std/assert@^1"
   }
 }

--- a/server/env.ts
+++ b/server/env.ts
@@ -1,0 +1,9 @@
+import type { Env } from "hono";
+import type pino from "pino";
+
+export type AppEnv = Env & {
+  Variables: {
+    requestId: string;
+    log: pino.Logger;
+  };
+};

--- a/server/features/league/league.repository.ts
+++ b/server/features/league/league.repository.ts
@@ -1,0 +1,38 @@
+import type { LeagueRepository } from "@zone-blitz/shared";
+import type pino from "pino";
+import { eq } from "drizzle-orm";
+import type { Database } from "../../db/connection.ts";
+import { leagues } from "./league.schema.ts";
+
+export function createLeagueRepository(deps: {
+  db: Database;
+  log: pino.Logger;
+}): LeagueRepository {
+  const log = deps.log.child({ module: "league.repository" });
+
+  return {
+    async getAll() {
+      log.debug("fetching all leagues");
+      return deps.db.select().from(leagues);
+    },
+
+    async getById(id) {
+      log.debug({ id }, "fetching league by id");
+      const [league] = await deps.db
+        .select()
+        .from(leagues)
+        .where(eq(leagues.id, id))
+        .limit(1);
+      return league;
+    },
+
+    async create(input) {
+      log.debug({ name: input.name }, "creating league");
+      const [league] = await deps.db
+        .insert(leagues)
+        .values({ name: input.name })
+        .returning();
+      return league;
+    },
+  };
+}

--- a/server/features/league/league.repository.ts
+++ b/server/features/league/league.repository.ts
@@ -13,7 +13,7 @@ export function createLeagueRepository(deps: {
   return {
     async getAll() {
       log.debug("fetching all leagues");
-      return deps.db.select().from(leagues);
+      return await deps.db.select().from(leagues);
     },
 
     async getById(id) {

--- a/server/features/league/league.router.ts
+++ b/server/features/league/league.router.ts
@@ -1,0 +1,22 @@
+import { Hono } from "hono";
+import { zValidator } from "@hono/zod-validator";
+import type { LeagueService } from "@zone-blitz/shared";
+import { createLeagueSchema } from "@zone-blitz/shared";
+import type { AppEnv } from "../../env.ts";
+
+export function createLeagueRouter(leagueService: LeagueService) {
+  return new Hono<AppEnv>()
+    .get("/", async (c) => {
+      const leagues = await leagueService.getAll();
+      return c.json(leagues);
+    })
+    .get("/:id", async (c) => {
+      const league = await leagueService.getById(c.req.param("id"));
+      return c.json(league);
+    })
+    .post("/", zValidator("json", createLeagueSchema), async (c) => {
+      const input = c.req.valid("json");
+      const league = await leagueService.create(input);
+      return c.json(league, 201);
+    });
+}

--- a/server/features/league/league.schema.ts
+++ b/server/features/league/league.schema.ts
@@ -1,0 +1,8 @@
+import { pgTable, text, timestamp, uuid } from "drizzle-orm/pg-core";
+
+export const leagues = pgTable("leagues", {
+  id: uuid("id").defaultRandom().primaryKey(),
+  name: text("name").notNull(),
+  createdAt: timestamp("created_at").defaultNow().notNull(),
+  updatedAt: timestamp("updated_at").defaultNow().notNull(),
+});

--- a/server/features/league/league.service.test.ts
+++ b/server/features/league/league.service.test.ts
@@ -1,0 +1,102 @@
+import { assertEquals, assertRejects } from "@std/assert";
+import { createLeagueService } from "./league.service.ts";
+import { DomainError } from "@zone-blitz/shared";
+import pino from "pino";
+import type { League, LeagueRepository } from "@zone-blitz/shared";
+
+function createTestLogger() {
+  return pino({ level: "silent" });
+}
+
+function createMockRepo(
+  overrides: Partial<LeagueRepository> = {},
+): LeagueRepository {
+  return {
+    getAll: () => Promise.resolve([]),
+    getById: () => Promise.resolve(undefined),
+    create: () =>
+      Promise.resolve({
+        id: "new-id",
+        name: "Test",
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      }),
+    ...overrides,
+  };
+}
+
+Deno.test("league.service", async (t) => {
+  await t.step("getAll returns all leagues from repository", async () => {
+    const leagues: League[] = [
+      {
+        id: "1",
+        name: "League One",
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      },
+      {
+        id: "2",
+        name: "League Two",
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      },
+    ];
+    const service = createLeagueService({
+      leagueRepo: createMockRepo({ getAll: () => Promise.resolve(leagues) }),
+      log: createTestLogger(),
+    });
+
+    const result = await service.getAll();
+    assertEquals(result.length, 2);
+    assertEquals(result[0].name, "League One");
+  });
+
+  await t.step("getById returns league when found", async () => {
+    const league: League = {
+      id: "1",
+      name: "Found League",
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    };
+    const service = createLeagueService({
+      leagueRepo: createMockRepo({ getById: () => Promise.resolve(league) }),
+      log: createTestLogger(),
+    });
+
+    const result = await service.getById("1");
+    assertEquals(result.name, "Found League");
+  });
+
+  await t.step("getById throws NOT_FOUND when league missing", async () => {
+    const service = createLeagueService({
+      leagueRepo: createMockRepo({ getById: () => Promise.resolve(undefined) }),
+      log: createTestLogger(),
+    });
+
+    await assertRejects(
+      () => service.getById("missing"),
+      DomainError,
+      "not found",
+    );
+  });
+
+  await t.step(
+    "create delegates to repository and returns league",
+    async () => {
+      const created: League = {
+        id: "new-id",
+        name: "New League",
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      };
+      const service = createLeagueService({
+        leagueRepo: createMockRepo({ create: () => Promise.resolve(created) }),
+        log: createTestLogger(),
+      });
+
+      const result = await service.create({ name: "New League" });
+      assertEquals(result.id, "new-id");
+      assertEquals(result.name, "New League");
+    },
+  );
+});

--- a/server/features/league/league.service.ts
+++ b/server/features/league/league.service.ts
@@ -11,7 +11,7 @@ export function createLeagueService(deps: {
   return {
     async getAll() {
       log.debug("fetching all leagues");
-      return deps.leagueRepo.getAll();
+      return await deps.leagueRepo.getAll();
     },
 
     async getById(id) {
@@ -25,7 +25,7 @@ export function createLeagueService(deps: {
 
     async create(input) {
       log.info({ name: input.name }, "creating league");
-      return deps.leagueRepo.create(input);
+      return await deps.leagueRepo.create(input);
     },
   };
 }

--- a/server/features/league/league.service.ts
+++ b/server/features/league/league.service.ts
@@ -1,0 +1,31 @@
+import type { LeagueRepository, LeagueService } from "@zone-blitz/shared";
+import { DomainError } from "@zone-blitz/shared";
+import type pino from "pino";
+
+export function createLeagueService(deps: {
+  leagueRepo: LeagueRepository;
+  log: pino.Logger;
+}): LeagueService {
+  const log = deps.log.child({ module: "league.service" });
+
+  return {
+    async getAll() {
+      log.debug("fetching all leagues");
+      return deps.leagueRepo.getAll();
+    },
+
+    async getById(id) {
+      log.debug({ id }, "fetching league by id");
+      const league = await deps.leagueRepo.getById(id);
+      if (!league) {
+        throw new DomainError("NOT_FOUND", `League ${id} not found`);
+      }
+      return league;
+    },
+
+    async create(input) {
+      log.info({ name: input.name }, "creating league");
+      return deps.leagueRepo.create(input);
+    },
+  };
+}

--- a/server/features/league/mod.ts
+++ b/server/features/league/mod.ts
@@ -1,0 +1,3 @@
+export { createLeagueRepository } from "./league.repository.ts";
+export { createLeagueService } from "./league.service.ts";
+export { createLeagueRouter } from "./league.router.ts";

--- a/server/features/mod.ts
+++ b/server/features/mod.ts
@@ -1,0 +1,22 @@
+import type { Database } from "../db/connection.ts";
+import type pino from "pino";
+import {
+  createLeagueRepository,
+  createLeagueRouter,
+  createLeagueService,
+} from "./league/mod.ts";
+
+export function createFeatureRouters(deps: { db: Database; log: pino.Logger }) {
+  const { db, log } = deps;
+
+  // Repositories
+  const leagueRepo = createLeagueRepository({ db, log });
+
+  // Services
+  const leagueService = createLeagueService({ leagueRepo, log });
+
+  // Routers
+  const leagueRouter = createLeagueRouter(leagueService);
+
+  return { leagueRouter };
+}

--- a/server/logger.ts
+++ b/server/logger.ts
@@ -1,0 +1,8 @@
+import pino from "pino";
+
+const isProduction = Deno.env.get("DENO_ENV") === "production";
+
+export const logger = pino(
+  { level: isProduction ? "info" : "debug" },
+  pino.destination({ sync: true }),
+);

--- a/server/main.ts
+++ b/server/main.ts
@@ -1,5 +1,5 @@
 import { Hono } from "hono";
-import { serveStatic } from "hono/adapter/deno";
+import { serveStatic } from "hono/deno";
 import { db } from "./db/connection.ts";
 import { sql } from "drizzle-orm";
 import { DomainError } from "@zone-blitz/shared";

--- a/server/main.ts
+++ b/server/main.ts
@@ -1,41 +1,60 @@
 import { Hono } from "hono";
-import { serveStatic } from "hono/deno";
+import { serveStatic } from "hono/adapter/deno";
 import { db } from "./db/connection.ts";
 import { sql } from "drizzle-orm";
+import { DomainError } from "@zone-blitz/shared";
+import { logger } from "./logger.ts";
+import { requestContextMiddleware } from "./middleware/request-context.ts";
+import { loggerMiddleware } from "./middleware/logger.ts";
 import { spaRouteGuard } from "./middleware/spa-fallback.ts";
-
-const app = new Hono();
+import { createFeatureRouters } from "./features/mod.ts";
+import type { AppEnv } from "./env.ts";
 
 const GIT_SHA = Deno.env.get("GIT_SHA") ?? "unknown";
+const isProduction = Deno.env.get("DENO_ENV") === "production";
 
-app.get("/api/health", async (c) => {
-  try {
-    await db.execute(sql`SELECT 1`);
-    return c.json({ status: "ok", commit: GIT_SHA });
-  } catch {
-    return c.json({ status: "error", commit: GIT_SHA }, 500);
+const features = createFeatureRouters({ db, log: logger });
+
+const app = new Hono<AppEnv>()
+  .use(requestContextMiddleware(logger))
+  .use(loggerMiddleware())
+  .get("/api/health", async (c) => {
+    try {
+      await db.execute(sql`SELECT 1`);
+      return c.json({ status: "ok", commit: GIT_SHA });
+    } catch {
+      return c.json({ status: "error", commit: GIT_SHA }, 500);
+    }
+  })
+  .route("/api/leagues", features.leagueRouter);
+
+// Domain error handler
+app.onError((err, c) => {
+  if (err instanceof DomainError) {
+    return c.json({ error: err.code, message: err.message }, 400);
   }
+  const log = c.get("log");
+  log.error({ err }, "unhandled error");
+  return c.json({ error: "INTERNAL" }, 500);
 });
 
-// In production, serve the built client assets
-if (Deno.env.get("DENO_ENV") === "production") {
+// Production static asset serving
+if (isProduction) {
   app.use("/*", serveStatic({ root: "../client/dist" }));
 }
-
 app.get("/*", spaRouteGuard());
-
-if (Deno.env.get("DENO_ENV") === "production") {
+if (isProduction) {
   app.get("/*", serveStatic({ root: "../client/dist", path: "index.html" }));
 }
 
-if (import.meta.main) {
-  const isProduction = Deno.env.get("DENO_ENV") === "production";
+export type AppType = typeof app;
 
+if (import.meta.main) {
   Deno.serve({
     port: 3000,
     onListen: ({ hostname, port }) => {
       if (isProduction) {
-        console.log(`Listening on http://${hostname}:${port}/`);
+        logger.info({ hostname, port }, "server started");
       } else {
         const bold = (s: string) => `\x1b[1m${s}\x1b[0m`;
         const cyan = (s: string) => `\x1b[36m${s}\x1b[0m`;

--- a/server/middleware/logger.ts
+++ b/server/middleware/logger.ts
@@ -1,0 +1,23 @@
+import type { MiddlewareHandler } from "hono";
+import type { AppEnv } from "../env.ts";
+
+export function loggerMiddleware(): MiddlewareHandler<AppEnv> {
+  return async (c, next) => {
+    const start = Date.now();
+    await next();
+
+    const log = c.get("log");
+    const status = c.res.status;
+    const data = {
+      method: c.req.method,
+      path: c.req.path,
+      status,
+      responseTime: Date.now() - start,
+    };
+    const msg = `${c.req.method} ${c.req.path}`;
+
+    if (status >= 500) log.error(data, msg);
+    else if (status >= 400) log.warn(data, msg);
+    else log.info(data, msg);
+  };
+}

--- a/server/middleware/request-context.ts
+++ b/server/middleware/request-context.ts
@@ -1,0 +1,17 @@
+import type { MiddlewareHandler } from "hono";
+import type pino from "pino";
+import type { AppEnv } from "../env.ts";
+
+export function requestContextMiddleware(
+  log: pino.Logger,
+): MiddlewareHandler<AppEnv> {
+  return async (c, next) => {
+    const requestId = c.req.header("X-Request-Id") ?? crypto.randomUUID();
+    const requestLog = log.child({ requestId });
+
+    c.set("requestId", requestId);
+    c.set("log", requestLog);
+
+    await next();
+  };
+}


### PR DESCRIPTION
## Summary

- Implements the full backend architecture from `docs/technical/backend-architecture.md` as an end-to-end proof-of-concept
- Builds a complete league feature vertical slice (schema → repository → service → router) with DI composition root, pino structured logging, and Hono RPC type export
- Scaffolds `@zone-blitz/simulation` and `@zone-blitz/ai` packages with placeholder implementations and tests
- Wires up the client with Hono RPC typed client (`hc<AppType>`) and TanStack Query for a league list + create form

## What changed

**Server:** pino logging middleware, `AppEnv` types, feature composition root, league vertical slice, `DomainError` handling, slimmed-down `main.ts`, npm hono (for zod-validator compat)

**Shared:** interfaces for repos/services/simulation/AI, League types, Zod schemas, DomainError

**Client:** typed API client, TanStack Query provider, `useLeagues`/`useCreateLeague` hooks, updated App component

**New packages:** `@zone-blitz/simulation` (GameSimulator), `@zone-blitz/ai` (GMStrategy) — both with tests

## Test plan

- [x] Server tests pass (`deno test server/`)
- [x] Package tests pass (`deno test packages/simulation/ packages/ai/`)
- [x] Client tests pass (`vitest run`)
- [x] Server type-checks clean (`deno check server/main.ts`)
- [ ] Verify league CRUD works E2E with dev server + database

🤖 Generated with [Claude Code](https://claude.com/claude-code)