### PR TITLE
chore: add deno lint pre-push hook

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -10,6 +10,13 @@
             "command": "deno fmt && git add -u",
             "timeout": 30,
             "statusMessage": "Formatting with deno fmt..."
+          },
+          {
+            "type": "command",
+            "if": "Bash(git push:*)",
+            "command": "deno lint",
+            "timeout": 60,
+            "statusMessage": "Running deno lint..."
           }
         ]
       }


### PR DESCRIPTION
## Summary
- Adds a PreToolUse hook that runs `deno lint` before any `git push` command
- If lint fails, the push is blocked, catching issues before CI

## Test plan
- [x] Verified `deno lint` passes on current codebase
- [x] Validated JSON structure with `jq`

🤖 Generated with [Claude Code](https://claude.com/claude-code)