### PR TITLE
fix(db): add missing leagues migration and repository integration tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,14 @@ jobs:
         with:
           deno-version: v2.7.11
       - run: deno install
-      - run: deno task test
+      - name: Run migrations
+        run: deno task db:migrate
+        env:
+          DATABASE_URL: postgres://zone_blitz:zone_blitz@localhost:5432/zone_blitz
+      - name: Run tests
+        run: deno task test
+        env:
+          DATABASE_URL: postgres://zone_blitz:zone_blitz@localhost:5432/zone_blitz
 
   e2e:
     name: E2E Tests

--- a/deno.json
+++ b/deno.json
@@ -27,7 +27,7 @@
     "db:stop": "docker compose down",
     "db:migrate": "cd server && deno run --env=../.env --allow-net --allow-env --allow-read --allow-sys db/migrate.ts",
     "test": "deno task test:server && deno task test:packages && deno task test:client",
-    "test:server": "deno test server/ --allow-env --allow-net --allow-read --allow-sys",
+    "test:server": "deno test server/ --env=.env --allow-env --allow-net --allow-read --allow-sys",
     "test:packages": "deno test packages/simulation/ packages/ai/",
     "test:client": "cd client && deno run -A npm:vitest run",
     "test:e2e": "./bin/test-e2e",

--- a/server/db/migrations/0001_cheerful_tiger_shark.sql
+++ b/server/db/migrations/0001_cheerful_tiger_shark.sql
@@ -1,0 +1,6 @@
+CREATE TABLE "leagues" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"name" text NOT NULL,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"updated_at" timestamp DEFAULT now() NOT NULL
+);

--- a/server/db/migrations/meta/0001_snapshot.json
+++ b/server/db/migrations/meta/0001_snapshot.json
@@ -1,0 +1,91 @@
+{
+  "id": "ef97cc88-d0da-4e59-bc97-b55bdd67008d",
+  "prevId": "ac8708b8-82d0-4063-82cc-4b4fa603adc8",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.health_checks": {
+      "name": "health_checks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "checked_at": {
+          "name": "checked_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.leagues": {
+      "name": "leagues",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/server/db/migrations/meta/_journal.json
+++ b/server/db/migrations/meta/_journal.json
@@ -8,6 +8,13 @@
       "when": 1776022285405,
       "tag": "0000_new_crystal",
       "breakpoints": true
+    },
+    {
+      "idx": 1,
+      "version": "7",
+      "when": 1776030445499,
+      "tag": "0001_cheerful_tiger_shark",
+      "breakpoints": true
     }
   ]
 }

--- a/server/features/league/league.repository.test.ts
+++ b/server/features/league/league.repository.test.ts
@@ -1,0 +1,124 @@
+import { assertEquals } from "@std/assert";
+import { drizzle } from "drizzle-orm/postgres-js";
+import postgres from "postgres";
+import * as schema from "../../db/schema.ts";
+import { leagues } from "./league.schema.ts";
+import { createLeagueRepository } from "./league.repository.ts";
+import pino from "pino";
+import { eq } from "drizzle-orm";
+
+function createTestDb() {
+  const connectionString = Deno.env.get("DATABASE_URL");
+  if (!connectionString) {
+    throw new Error("DATABASE_URL is required for integration tests");
+  }
+  const client = postgres(connectionString);
+  const db = drizzle(client, { schema });
+  return { db, client };
+}
+
+function createTestLogger() {
+  return pino({ level: "silent" });
+}
+
+Deno.test({
+  name: "leagueRepository.getAll: returns all leagues",
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    const { db, client } = createTestDb();
+    const repo = createLeagueRepository({ db, log: createTestLogger() });
+    const inserted: string[] = [];
+
+    try {
+      const [a] = await db.insert(leagues).values({ name: "League A" })
+        .returning();
+      const [b] = await db.insert(leagues).values({ name: "League B" })
+        .returning();
+      inserted.push(a.id, b.id);
+
+      const result = await repo.getAll();
+      const names = result.map((l) => l.name);
+      assertEquals(names.includes("League A"), true);
+      assertEquals(names.includes("League B"), true);
+    } finally {
+      for (const id of inserted) {
+        await db.delete(leagues).where(eq(leagues.id, id));
+      }
+      await client.end();
+    }
+  },
+});
+
+Deno.test({
+  name: "leagueRepository.getById: returns the league when it exists",
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    const { db, client } = createTestDb();
+    const repo = createLeagueRepository({ db, log: createTestLogger() });
+    let leagueId: string | undefined;
+
+    try {
+      const [created] = await db.insert(leagues).values({
+        name: "Find Me",
+      }).returning();
+      leagueId = created.id;
+
+      const result = await repo.getById(leagueId);
+      assertEquals(result?.id, leagueId);
+      assertEquals(result?.name, "Find Me");
+    } finally {
+      if (leagueId) {
+        await db.delete(leagues).where(eq(leagues.id, leagueId));
+      }
+      await client.end();
+    }
+  },
+});
+
+Deno.test({
+  name: "leagueRepository.getById: returns undefined when not found",
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    const { db, client } = createTestDb();
+    const repo = createLeagueRepository({ db, log: createTestLogger() });
+
+    try {
+      const result = await repo.getById(crypto.randomUUID());
+      assertEquals(result, undefined);
+    } finally {
+      await client.end();
+    }
+  },
+});
+
+Deno.test({
+  name: "leagueRepository.create: inserts and returns the new league",
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    const { db, client } = createTestDb();
+    const repo = createLeagueRepository({ db, log: createTestLogger() });
+    let leagueId: string | undefined;
+
+    try {
+      const result = await repo.create({ name: "New League" });
+      leagueId = result.id;
+
+      assertEquals(result.name, "New League");
+      assertEquals(typeof result.id, "string");
+
+      const [row] = await db.select().from(leagues).where(
+        eq(leagues.id, leagueId),
+      );
+      assertEquals(row.name, "New League");
+    } finally {
+      if (leagueId) {
+        await db.delete(leagues).where(eq(leagues.id, leagueId));
+      }
+      await client.end();
+    }
+  },
+});


### PR DESCRIPTION
## Summary
- Adds the missing `leagues` table migration that was omitted from PR #15 — the schema was defined but `drizzle-kit generate` was never run, causing `relation "leagues" does not exist` at runtime.
- Adds repository integration tests (`league.repository.test.ts`) that run against a real Postgres database, covering `getAll`, `getById`, and `create`.
- Fixes `test:server` task to load `.env` so `DATABASE_URL` is available to integration tests.

## Test plan
- [x] `deno task db:migrate` applies the new migration without errors
- [x] `deno task test:server` — all 6 tests pass (4 new integration + 2 existing)
- [x] `GET /api/leagues` returns 200 instead of 500

🤖 Generated with [Claude Code](https://claude.com/claude-code)