### PR TITLE
docs: add PR description format guideline

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,3 +57,5 @@
      worktree's `main` ref catches up.
 - After a PR is pushed, immediately exit/delete the worktree and return to
   `main`.
+- PR descriptions should include a **Summary** section only. Do not add a test
+  plan section.


### PR DESCRIPTION
## Summary

- Adds guidance to CLAUDE.md that PR descriptions should include a Summary section only, with no test plan section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)