### PR TITLE
refactor(health): extract health check into its own feature slice

### DIFF
--- a/packages/shared/interfaces/services/health-service.ts
+++ b/packages/shared/interfaces/services/health-service.ts
@@ -1,0 +1,5 @@
+import type { HealthStatus } from "../../types/health.ts";
+
+export interface HealthService {
+  check(): Promise<HealthStatus>;
+}

--- a/packages/shared/mod.ts
+++ b/packages/shared/mod.ts
@@ -1,10 +1,12 @@
 // Types
+export type { HealthStatus } from "./types/health.ts";
 export type { League, NewLeague } from "./types/league.ts";
 
 // Interfaces — repositories
 export type { LeagueRepository } from "./interfaces/repositories/league-repository.ts";
 
 // Interfaces — services
+export type { HealthService } from "./interfaces/services/health-service.ts";
 export type { LeagueService } from "./interfaces/services/league-service.ts";
 
 // Interfaces — simulation

--- a/packages/shared/types/health.ts
+++ b/packages/shared/types/health.ts
@@ -1,0 +1,4 @@
+export interface HealthStatus {
+  status: "ok" | "error";
+  commit: string;
+}

--- a/server/features/health/health.router.ts
+++ b/server/features/health/health.router.ts
@@ -1,0 +1,12 @@
+import { Hono } from "hono";
+import type { HealthService } from "@zone-blitz/shared";
+import type { AppEnv } from "../../env.ts";
+
+export function createHealthRouter(healthService: HealthService) {
+  return new Hono<AppEnv>()
+    .get("/", async (c) => {
+      const result = await healthService.check();
+      const status = result.status === "ok" ? 200 : 500;
+      return c.json(result, status);
+    });
+}

--- a/server/features/health/health.service.test.ts
+++ b/server/features/health/health.service.test.ts
@@ -1,0 +1,34 @@
+import { assertEquals } from "@std/assert";
+import { createHealthService } from "./health.service.ts";
+import type { HealthStatus } from "@zone-blitz/shared";
+import pino from "pino";
+
+function createTestLogger() {
+  return pino({ level: "silent" });
+}
+
+Deno.test("health.service", async (t) => {
+  await t.step("check returns ok when database is reachable", async () => {
+    const service = createHealthService({
+      ping: () => Promise.resolve(),
+      commit: "abc123",
+      log: createTestLogger(),
+    });
+
+    const result: HealthStatus = await service.check();
+    assertEquals(result.status, "ok");
+    assertEquals(result.commit, "abc123");
+  });
+
+  await t.step("check returns error when database is unreachable", async () => {
+    const service = createHealthService({
+      ping: () => Promise.reject(new Error("connection refused")),
+      commit: "abc123",
+      log: createTestLogger(),
+    });
+
+    const result: HealthStatus = await service.check();
+    assertEquals(result.status, "error");
+    assertEquals(result.commit, "abc123");
+  });
+});

--- a/server/features/health/health.service.ts
+++ b/server/features/health/health.service.ts
@@ -1,0 +1,22 @@
+import type { HealthService } from "@zone-blitz/shared";
+import type pino from "pino";
+
+export function createHealthService(deps: {
+  ping: () => Promise<void>;
+  commit: string;
+  log: pino.Logger;
+}): HealthService {
+  const log = deps.log.child({ module: "health.service" });
+
+  return {
+    async check() {
+      try {
+        await deps.ping();
+        return { status: "ok", commit: deps.commit };
+      } catch (error) {
+        log.error({ err: error }, "database health check failed");
+        return { status: "error", commit: deps.commit };
+      }
+    },
+  };
+}

--- a/server/features/health/mod.ts
+++ b/server/features/health/mod.ts
@@ -1,0 +1,2 @@
+export { createHealthService } from "./health.service.ts";
+export { createHealthRouter } from "./health.router.ts";

--- a/server/features/mod.ts
+++ b/server/features/mod.ts
@@ -1,13 +1,27 @@
+import { sql } from "drizzle-orm";
 import type { Database } from "../db/connection.ts";
 import type pino from "pino";
+import { createHealthRouter, createHealthService } from "./health/mod.ts";
 import {
   createLeagueRepository,
   createLeagueRouter,
   createLeagueService,
 } from "./league/mod.ts";
 
-export function createFeatureRouters(deps: { db: Database; log: pino.Logger }) {
-  const { db, log } = deps;
+export function createFeatureRouters(
+  deps: { db: Database; commit: string; log: pino.Logger },
+) {
+  const { db, commit, log } = deps;
+
+  // Health
+  const healthService = createHealthService({
+    ping: async () => {
+      await db.execute(sql`SELECT 1`);
+    },
+    commit,
+    log,
+  });
+  const healthRouter = createHealthRouter(healthService);
 
   // Repositories
   const leagueRepo = createLeagueRepository({ db, log });
@@ -18,5 +32,5 @@ export function createFeatureRouters(deps: { db: Database; log: pino.Logger }) {
   // Routers
   const leagueRouter = createLeagueRouter(leagueService);
 
-  return { leagueRouter };
+  return { healthRouter, leagueRouter };
 }

--- a/server/main.ts
+++ b/server/main.ts
@@ -1,7 +1,6 @@
 import { Hono } from "hono";
 import { serveStatic } from "hono/deno";
 import { db } from "./db/connection.ts";
-import { sql } from "drizzle-orm";
 import { DomainError } from "@zone-blitz/shared";
 import { logger } from "./logger.ts";
 import { requestContextMiddleware } from "./middleware/request-context.ts";
@@ -13,19 +12,12 @@ import type { AppEnv } from "./env.ts";
 const GIT_SHA = Deno.env.get("GIT_SHA") ?? "unknown";
 const isProduction = Deno.env.get("DENO_ENV") === "production";
 
-const features = createFeatureRouters({ db, log: logger });
+const features = createFeatureRouters({ db, commit: GIT_SHA, log: logger });
 
 const app = new Hono<AppEnv>()
   .use(requestContextMiddleware(logger))
   .use(loggerMiddleware())
-  .get("/api/health", async (c) => {
-    try {
-      await db.execute(sql`SELECT 1`);
-      return c.json({ status: "ok", commit: GIT_SHA });
-    } catch {
-      return c.json({ status: "error", commit: GIT_SHA }, 500);
-    }
-  })
+  .route("/api/health", features.healthRouter)
   .route("/api/leagues", features.leagueRouter);
 
 // Domain error handler


### PR DESCRIPTION
## Summary

- Extracts the inline health check route from `server/main.ts` into a proper feature slice at `server/features/health/`
- Adds shared `HealthService` interface and `HealthStatus` type in `packages/shared`
- Service uses a `ping` dependency for testability — no DB coupling in unit tests

## Test plan

- [x] Unit tests for service: ok status when DB reachable, error status when unreachable
- [x] Existing `main.test.ts` health check test still passes
- [x] `deno lint` clean
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)