### PR TITLE
test(router): add unit tests for health and league routers

### DIFF
--- a/server/features/health/health.router.test.ts
+++ b/server/features/health/health.router.test.ts
@@ -1,0 +1,43 @@
+import { assertEquals } from "@std/assert";
+import { createHealthRouter } from "./health.router.ts";
+import type { HealthService } from "@zone-blitz/shared";
+
+function createMockHealthService(
+  overrides: Partial<HealthService> = {},
+): HealthService {
+  return {
+    check: () => Promise.resolve({ status: "ok", commit: "test-sha" }),
+    ...overrides,
+  };
+}
+
+Deno.test("health.router", async (t) => {
+  await t.step("GET / returns 200 when health check is ok", async () => {
+    const router = createHealthRouter(
+      createMockHealthService({
+        check: () => Promise.resolve({ status: "ok", commit: "abc123" }),
+      }),
+    );
+
+    const res = await router.request("/");
+    assertEquals(res.status, 200);
+
+    const body = await res.json();
+    assertEquals(body.status, "ok");
+    assertEquals(body.commit, "abc123");
+  });
+
+  await t.step("GET / returns 500 when health check is error", async () => {
+    const router = createHealthRouter(
+      createMockHealthService({
+        check: () => Promise.resolve({ status: "error", commit: "abc123" }),
+      }),
+    );
+
+    const res = await router.request("/");
+    assertEquals(res.status, 500);
+
+    const body = await res.json();
+    assertEquals(body.status, "error");
+  });
+});

--- a/server/features/league/league.router.test.ts
+++ b/server/features/league/league.router.test.ts
@@ -1,0 +1,144 @@
+import { assertEquals } from "@std/assert";
+import { createLeagueRouter } from "./league.router.ts";
+import type { League, LeagueService } from "@zone-blitz/shared";
+
+function createMockLeagueService(
+  overrides: Partial<LeagueService> = {},
+): LeagueService {
+  return {
+    getAll: () => Promise.resolve([]),
+    getById: () =>
+      Promise.resolve({
+        id: "1",
+        name: "Test",
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      }),
+    create: () =>
+      Promise.resolve({
+        id: "new-id",
+        name: "Test",
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      }),
+    ...overrides,
+  };
+}
+
+Deno.test("league.router", async (t) => {
+  await t.step("GET / returns all leagues", async () => {
+    const leagues: League[] = [
+      {
+        id: "1",
+        name: "League One",
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      },
+      {
+        id: "2",
+        name: "League Two",
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      },
+    ];
+    const router = createLeagueRouter(
+      createMockLeagueService({ getAll: () => Promise.resolve(leagues) }),
+    );
+
+    const res = await router.request("/");
+    assertEquals(res.status, 200);
+
+    const body = await res.json();
+    assertEquals(body.length, 2);
+    assertEquals(body[0].name, "League One");
+    assertEquals(body[1].name, "League Two");
+  });
+
+  await t.step("GET / returns empty array when no leagues", async () => {
+    const router = createLeagueRouter(createMockLeagueService());
+
+    const res = await router.request("/");
+    assertEquals(res.status, 200);
+
+    const body = await res.json();
+    assertEquals(body.length, 0);
+  });
+
+  await t.step("GET /:id returns a league by id", async () => {
+    const league: League = {
+      id: "42",
+      name: "Found League",
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    };
+    const router = createLeagueRouter(
+      createMockLeagueService({ getById: () => Promise.resolve(league) }),
+    );
+
+    const res = await router.request("/42");
+    assertEquals(res.status, 200);
+
+    const body = await res.json();
+    assertEquals(body.id, "42");
+    assertEquals(body.name, "Found League");
+  });
+
+  await t.step("POST / creates a league and returns 201", async () => {
+    const created: League = {
+      id: "new-id",
+      name: "New League",
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    };
+    const router = createLeagueRouter(
+      createMockLeagueService({ create: () => Promise.resolve(created) }),
+    );
+
+    const res = await router.request("/", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ name: "New League" }),
+    });
+    assertEquals(res.status, 201);
+
+    const body = await res.json();
+    assertEquals(body.id, "new-id");
+    assertEquals(body.name, "New League");
+  });
+
+  await t.step("POST / returns 400 when name is missing", async () => {
+    const router = createLeagueRouter(createMockLeagueService());
+
+    const res = await router.request("/", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({}),
+    });
+    assertEquals(res.status, 400);
+  });
+
+  await t.step("POST / returns 400 when name is empty string", async () => {
+    const router = createLeagueRouter(createMockLeagueService());
+
+    const res = await router.request("/", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ name: "" }),
+    });
+    assertEquals(res.status, 400);
+  });
+
+  await t.step(
+    "POST / returns 400 when name exceeds 100 characters",
+    async () => {
+      const router = createLeagueRouter(createMockLeagueService());
+
+      const res = await router.request("/", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ name: "a".repeat(101) }),
+      });
+      assertEquals(res.status, 400);
+    },
+  );
+});


### PR DESCRIPTION
## Summary

- Adds unit tests for `health.router.ts` — verifies 200 on healthy check and 500 on error status.
- Adds unit tests for `league.router.ts` — covers GET all, GET by id, POST create (201), and zod validation rejections (missing name, empty name, name over 100 chars).
- Tests mock the service layer and use Hono's built-in `router.request()` to exercise HTTP handling in isolation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)