### PR TITLE
feat(logger): pretty print logs in development

### DIFF
--- a/server/logger.ts
+++ b/server/logger.ts
@@ -2,7 +2,11 @@ import pino from "pino";
 
 const isProduction = Deno.env.get("DENO_ENV") === "production";
 
-export const logger = pino(
-  { level: isProduction ? "info" : "debug" },
-  pino.destination({ sync: true }),
-);
+export const logger = pino({
+  level: isProduction ? "info" : "debug",
+  ...(!isProduction && {
+    transport: {
+      target: "pino-pretty",
+    },
+  }),
+});


### PR DESCRIPTION
## Summary

- Configures Pino to use `pino-pretty` transport in non-production environments so dev logs are human-readable.
- Production keeps the default JSON output for structured log ingestion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)