### PR TITLE
feat(client): add back-to-leagues link in league dashboard sidebar

### DIFF
--- a/client/src/features/league/layout.test.tsx
+++ b/client/src/features/league/layout.test.tsx
@@ -30,4 +30,11 @@ describe("LeagueLayout", () => {
     render(<LeagueLayout />);
     expect(screen.getByRole("navigation")).toBeDefined();
   });
+
+  it("renders a link back to the league select page", () => {
+    render(<LeagueLayout />);
+    const backLink = screen.getByRole("link", { name: /leagues/i });
+    expect(backLink).toBeDefined();
+    expect(backLink.getAttribute("href")).toBe("/");
+  });
 });

--- a/client/src/features/league/layout.tsx
+++ b/client/src/features/league/layout.tsx
@@ -6,6 +6,12 @@ export function LeagueLayout() {
   return (
     <div className="flex min-h-screen bg-gray-950 text-gray-100">
       <nav className="w-60 border-r border-gray-800 p-4">
+        <Link
+          to="/"
+          className="mb-4 block text-sm text-gray-400 hover:text-gray-200"
+        >
+          &larr; All Leagues
+        </Link>
         <ul>
           <li>
             <Link


### PR DESCRIPTION
## Summary

- Adds a "← All Leagues" link at the top of the league sidebar navigation that routes back to `/`, making it easy to switch between leagues.
- Includes test coverage for the new link.

🤖 Generated with [Claude Code](https://claude.com/claude-code)