### PR TITLE
test(e2e): update smoke test for auth-gated homepage

### DIFF
--- a/e2e/tests/smoke.spec.ts
+++ b/e2e/tests/smoke.spec.ts
@@ -1,0 +1,22 @@
+import { expect, test } from "@playwright/test";
+
+test("health endpoint returns ok", async ({ request }) => {
+  const response = await request.get("/api/health");
+  expect(response.status()).toBe(200);
+  const body = await response.json();
+  expect(body.status).toBe("ok");
+});
+
+test("homepage renders Zone Blitz heading", async ({ page }) => {
+  await page.goto("/");
+  await expect(
+    page.getByRole("heading", { name: "Zone Blitz" }),
+  ).toBeVisible();
+});
+
+test("homepage shows sign in button when unauthenticated", async ({ page }) => {
+  await page.goto("/");
+  await expect(
+    page.getByRole("button", { name: /sign in with google/i }),
+  ).toBeVisible();
+});


### PR DESCRIPTION
## Summary

- Update the E2E smoke test to expect the "Sign in with Google" button on the homepage instead of the "Leagues" heading, since unauthenticated users are now redirected to the login page after #28

Generated with [Claude Code](https://claude.ai/code)