### PR TITLE
chore: add Google OAuth dev credentials to .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,5 @@
 DATABASE_URL=postgres://zone_blitz:zone_blitz@localhost:5432/zone_blitz
 BETTER_AUTH_SECRET=your-secret-here
 BETTER_AUTH_URL=http://localhost:3000
-GOOGLE_CLIENT_ID=your-google-client-id
-GOOGLE_CLIENT_SECRET=your-google-client-secret
+GOOGLE_CLIENT_ID=826314607045-dis96deqtmh91vaqp676e8ag8tca0uas.apps.googleusercontent.com
+GOOGLE_CLIENT_SECRET=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


### PR DESCRIPTION
## Summary

- Populate Google OAuth client ID and secret for local development so new contributors can run the app without manual credential setup

Generated with [Claude Code](https://claude.ai/code)