### PR TITLE
chore(db): use pino-pretty for migration logs and suppress notices

### DIFF
--- a/deno.lock
+++ b/deno.lock
@@ -22,6 +22,7 @@
     "npm:drizzle-orm@0.44": "0.44.7_@opentelemetry+api@1.9.1_kysely@0.28.15_postgres@3.4.9",
     "npm:happy-dom@18": "18.0.1",
     "npm:hono@4": "4.12.12",
+    "npm:lucide-react@^1.8.0": "1.8.0_react@19.2.4",
     "npm:pino-pretty@13": "13.1.3",
     "npm:pino@9": "9.14.0",
     "npm:postgres@3": "3.4.9",
@@ -1809,6 +1810,12 @@
         "yallist"
       ]
     },
+    "lucide-react@1.8.0_react@19.2.4": {
+      "integrity": "sha512-WuvlsjngSk7TnTBJ1hsCy3ql9V9VOdcPkd3PKcSmM34vJD8KG6molxz7m7zbYFgICwsanQWmJ13JlYs4Zp7Arw==",
+      "dependencies": [
+        "react"
+      ]
+    },
     "lz-string@1.5.0": {
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
       "bin": true
@@ -2411,6 +2418,7 @@
             "npm:better-auth@1",
             "npm:happy-dom@18",
             "npm:hono@4",
+            "npm:lucide-react@^1.8.0",
             "npm:react-dom@19",
             "npm:react@19",
             "npm:tailwindcss@4",

--- a/server/db/migrate.ts
+++ b/server/db/migrate.ts
@@ -1,16 +1,24 @@
 import { drizzle } from "drizzle-orm/postgres-js";
 import { migrate } from "drizzle-orm/postgres-js/migrator";
 import postgres from "postgres";
+import pino from "pino";
+
+const log = pino({
+  transport: { target: "pino-pretty" },
+});
 
 const databaseUrl = Deno.env.get("DATABASE_URL");
 if (!databaseUrl) {
   throw new Error("DATABASE_URL environment variable is required");
 }
 
-const client = postgres(databaseUrl, { max: 1 });
+const client = postgres(databaseUrl, {
+  max: 1,
+  onnotice: () => {},
+});
 const db = drizzle(client);
 
 await migrate(db, { migrationsFolder: "./db/migrations" });
 await client.end();
 
-console.log("Migrations complete.");
+log.info("Migrations complete.");


### PR DESCRIPTION
## Summary

- Use pino with pino-pretty for migration script output instead of raw `console.log`
- Suppress PostgreSQL NOTICE messages (schema/table already exists) that add noise during migrations

Generated with [Claude Code](https://claude.ai/code)