### PR TITLE
feat(league): add settings page with delete league

### DIFF
--- a/client/src/features/league/layout.test.tsx
+++ b/client/src/features/league/layout.test.tsx
@@ -54,4 +54,11 @@ describe("LeagueLayout", () => {
     const svgs = nav.querySelectorAll("svg");
     expect(svgs.length).toBeGreaterThanOrEqual(2);
   });
+
+  it("renders a Settings nav link", () => {
+    render(<LeagueLayout />);
+    const settingsLink = screen.getByRole("link", { name: /settings/i });
+    expect(settingsLink).toBeDefined();
+    expect(settingsLink.getAttribute("href")).toBe("/leagues/1/settings");
+  });
 });

--- a/client/src/features/league/layout.tsx
+++ b/client/src/features/league/layout.tsx
@@ -1,5 +1,5 @@
 import { Link, Outlet, useParams } from "@tanstack/react-router";
-import { ArrowLeft, Home } from "lucide-react";
+import { ArrowLeft, Home, Settings } from "lucide-react";
 
 export function LeagueLayout() {
   const { leagueId } = useParams({ strict: false });
@@ -22,6 +22,15 @@ export function LeagueLayout() {
             >
               <Home size={16} />
               Home
+            </Link>
+          </li>
+          <li>
+            <Link
+              to={`/leagues/${leagueId}/settings`}
+              className="flex items-center gap-2 rounded px-3 py-2 text-sm font-medium text-gray-300 hover:bg-gray-800 hover:text-gray-100"
+            >
+              <Settings size={16} />
+              Settings
             </Link>
           </li>
         </ul>

--- a/client/src/features/league/settings.test.tsx
+++ b/client/src/features/league/settings.test.tsx
@@ -1,0 +1,125 @@
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { LeagueSettings } from "./settings.tsx";
+
+const mockDelete = vi.fn();
+const mockNavigate = vi.fn();
+
+vi.mock("../../api.ts", () => ({
+  api: {
+    api: {
+      leagues: {
+        ":id": {
+          $delete: (...args: unknown[]) => mockDelete(...args),
+        },
+      },
+    },
+  },
+}));
+
+vi.mock("@tanstack/react-router", () => ({
+  useParams: () => ({ leagueId: "league-1" }),
+  useNavigate: () => mockNavigate,
+}));
+
+function renderWithProviders() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <LeagueSettings />
+    </QueryClientProvider>,
+  );
+}
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+describe("LeagueSettings", () => {
+  it("renders the Settings heading", () => {
+    renderWithProviders();
+    expect(
+      screen.getByRole("heading", { name: "Settings" }),
+    ).toBeDefined();
+  });
+
+  it("renders the Danger Zone section", () => {
+    renderWithProviders();
+    expect(
+      screen.getByRole("heading", { name: /danger zone/i }),
+    ).toBeDefined();
+  });
+
+  it("renders a Delete League button", () => {
+    renderWithProviders();
+    expect(
+      screen.getByRole("button", { name: "Delete League" }),
+    ).toBeDefined();
+  });
+
+  it("shows confirmation buttons after clicking Delete League", () => {
+    renderWithProviders();
+    fireEvent.click(screen.getByRole("button", { name: "Delete League" }));
+    expect(
+      screen.getByRole("button", { name: "Confirm Delete" }),
+    ).toBeDefined();
+    expect(
+      screen.getByRole("button", { name: "Cancel" }),
+    ).toBeDefined();
+  });
+
+  it("hides confirmation buttons when Cancel is clicked", () => {
+    renderWithProviders();
+    fireEvent.click(screen.getByRole("button", { name: "Delete League" }));
+    fireEvent.click(screen.getByRole("button", { name: "Cancel" }));
+    expect(
+      screen.getByRole("button", { name: "Delete League" }),
+    ).toBeDefined();
+  });
+
+  it("calls delete API when Confirm Delete is clicked", async () => {
+    mockDelete.mockReturnValue(Promise.resolve({ ok: true }));
+    renderWithProviders();
+
+    fireEvent.click(screen.getByRole("button", { name: "Delete League" }));
+    fireEvent.click(screen.getByRole("button", { name: "Confirm Delete" }));
+
+    await waitFor(() => {
+      expect(mockDelete).toHaveBeenCalledWith({ param: { id: "league-1" } });
+    });
+  });
+
+  it("navigates to home after successful deletion", async () => {
+    mockDelete.mockReturnValue(Promise.resolve({ ok: true }));
+    renderWithProviders();
+
+    fireEvent.click(screen.getByRole("button", { name: "Delete League" }));
+    fireEvent.click(screen.getByRole("button", { name: "Confirm Delete" }));
+
+    await waitFor(() => {
+      expect(mockNavigate).toHaveBeenCalledWith({ to: "/" });
+    });
+  });
+
+  it("shows Deleting... text while mutation is pending", async () => {
+    mockDelete.mockReturnValue(new Promise(() => {}));
+    renderWithProviders();
+
+    fireEvent.click(screen.getByRole("button", { name: "Delete League" }));
+    fireEvent.click(screen.getByRole("button", { name: "Confirm Delete" }));
+
+    await waitFor(() => {
+      expect(screen.getByText("Deleting...")).toBeDefined();
+    });
+  });
+});

--- a/client/src/features/league/settings.tsx
+++ b/client/src/features/league/settings.tsx
@@ -1,0 +1,65 @@
+import { useNavigate, useParams } from "@tanstack/react-router";
+import { useState } from "react";
+import { useDeleteLeague } from "../../hooks/use-leagues.ts";
+
+export function LeagueSettings() {
+  const { leagueId } = useParams({ strict: false });
+  const navigate = useNavigate();
+  const deleteLeague = useDeleteLeague();
+  const [showConfirm, setShowConfirm] = useState(false);
+
+  const handleDelete = () => {
+    if (!leagueId) return;
+    deleteLeague.mutate(leagueId, {
+      onSuccess: () => {
+        navigate({ to: "/" });
+      },
+    });
+  };
+
+  return (
+    <div>
+      <h1 className="mb-6 text-2xl font-bold">Settings</h1>
+
+      <section className="rounded border border-red-900 bg-red-950/30 p-6">
+        <h2 className="mb-2 text-lg font-semibold text-red-400">
+          Danger Zone
+        </h2>
+        <p className="mb-4 text-sm text-gray-400">
+          Deleting a league is permanent and cannot be undone. All league data
+          will be lost.
+        </p>
+
+        {!showConfirm
+          ? (
+            <button
+              type="button"
+              onClick={() => setShowConfirm(true)}
+              className="rounded border border-red-700 bg-red-900/50 px-4 py-2 text-sm font-medium text-red-300 hover:bg-red-900"
+            >
+              Delete League
+            </button>
+          )
+          : (
+            <div className="flex items-center gap-3">
+              <button
+                type="button"
+                onClick={handleDelete}
+                disabled={deleteLeague.isPending}
+                className="rounded bg-red-700 px-4 py-2 text-sm font-medium text-white hover:bg-red-600 disabled:opacity-50"
+              >
+                {deleteLeague.isPending ? "Deleting..." : "Confirm Delete"}
+              </button>
+              <button
+                type="button"
+                onClick={() => setShowConfirm(false)}
+                className="rounded px-4 py-2 text-sm font-medium text-gray-400 hover:text-gray-200"
+              >
+                Cancel
+              </button>
+            </div>
+          )}
+      </section>
+    </div>
+  );
+}

--- a/client/src/hooks/use-leagues.ts
+++ b/client/src/hooks/use-leagues.ts
@@ -23,3 +23,15 @@ export function useCreateLeague() {
     },
   });
 }
+
+export function useDeleteLeague() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async (id: string) => {
+      await api.api.leagues[":id"].$delete({ param: { id } });
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["leagues"] });
+    },
+  });
+}

--- a/client/src/router.tsx
+++ b/client/src/router.tsx
@@ -11,6 +11,7 @@ import { LoginPage } from "./features/login/index.tsx";
 import { LeagueSelect } from "./features/league-select/index.tsx";
 import { LeagueLayout } from "./features/league/layout.tsx";
 import { LeagueHome } from "./features/league/index.tsx";
+import { LeagueSettings } from "./features/league/settings.tsx";
 
 const rootRoute = createRootRoute();
 
@@ -62,11 +63,17 @@ const leagueHomeRoute = createRoute({
   component: LeagueHome,
 });
 
+const leagueSettingsRoute = createRoute({
+  getParentRoute: () => leagueLayoutRoute,
+  path: "settings",
+  component: LeagueSettings,
+});
+
 const routeTree = rootRoute.addChildren([
   loginRoute,
   authenticatedRoute.addChildren([
     leagueSelectRoute,
-    leagueLayoutRoute.addChildren([leagueHomeRoute]),
+    leagueLayoutRoute.addChildren([leagueHomeRoute, leagueSettingsRoute]),
   ]),
 ]);
 

--- a/packages/shared/interfaces/repositories/league-repository.ts
+++ b/packages/shared/interfaces/repositories/league-repository.ts
@@ -4,4 +4,5 @@ export interface LeagueRepository {
   getAll(): Promise<League[]>;
   getById(id: string): Promise<League | undefined>;
   create(league: NewLeague): Promise<League>;
+  deleteById(id: string): Promise<void>;
 }

--- a/packages/shared/interfaces/services/league-service.ts
+++ b/packages/shared/interfaces/services/league-service.ts
@@ -4,4 +4,5 @@ export interface LeagueService {
   getAll(): Promise<League[]>;
   getById(id: string): Promise<League>;
   create(input: NewLeague): Promise<League>;
+  deleteById(id: string): Promise<void>;
 }

--- a/server/features/league/league.repository.test.ts
+++ b/server/features/league/league.repository.test.ts
@@ -122,3 +122,28 @@ Deno.test({
     }
   },
 });
+
+Deno.test({
+  name: "leagueRepository.deleteById: deletes the league from the database",
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    const { db, client } = createTestDb();
+    const repo = createLeagueRepository({ db, log: createTestLogger() });
+
+    try {
+      const [created] = await db.insert(leagues).values({
+        name: "Delete Me",
+      }).returning();
+
+      await repo.deleteById(created.id);
+
+      const [row] = await db.select().from(leagues).where(
+        eq(leagues.id, created.id),
+      );
+      assertEquals(row, undefined);
+    } finally {
+      await client.end();
+    }
+  },
+});

--- a/server/features/league/league.repository.ts
+++ b/server/features/league/league.repository.ts
@@ -34,5 +34,10 @@ export function createLeagueRepository(deps: {
         .returning();
       return league;
     },
+
+    async deleteById(id) {
+      log.debug({ id }, "deleting league by id");
+      await deps.db.delete(leagues).where(eq(leagues.id, id));
+    },
   };
 }

--- a/server/features/league/league.router.test.ts
+++ b/server/features/league/league.router.test.ts
@@ -21,6 +21,7 @@ function createMockLeagueService(
         createdAt: new Date(),
         updatedAt: new Date(),
       }),
+    deleteById: () => Promise.resolve(),
     ...overrides,
   };
 }
@@ -141,4 +142,20 @@ Deno.test("league.router", async (t) => {
       assertEquals(res.status, 400);
     },
   );
+
+  await t.step("DELETE /:id deletes a league and returns 204", async () => {
+    let deletedId: string | undefined;
+    const router = createLeagueRouter(
+      createMockLeagueService({
+        deleteById: (id) => {
+          deletedId = id;
+          return Promise.resolve();
+        },
+      }),
+    );
+
+    const res = await router.request("/some-uuid", { method: "DELETE" });
+    assertEquals(res.status, 204);
+    assertEquals(deletedId, "some-uuid");
+  });
 });

--- a/server/features/league/league.router.ts
+++ b/server/features/league/league.router.ts
@@ -18,5 +18,9 @@ export function createLeagueRouter(leagueService: LeagueService) {
       const input = c.req.valid("json");
       const league = await leagueService.create(input);
       return c.json(league, 201);
+    })
+    .delete("/:id", async (c) => {
+      await leagueService.deleteById(c.req.param("id"));
+      return c.body(null, 204);
     });
 }

--- a/server/features/league/league.service.test.ts
+++ b/server/features/league/league.service.test.ts
@@ -21,6 +21,7 @@ function createMockRepo(
         createdAt: new Date(),
         updatedAt: new Date(),
       }),
+    deleteById: () => Promise.resolve(),
     ...overrides,
   };
 }
@@ -97,6 +98,50 @@ Deno.test("league.service", async (t) => {
       const result = await service.create({ name: "New League" });
       assertEquals(result.id, "new-id");
       assertEquals(result.name, "New League");
+    },
+  );
+
+  await t.step(
+    "deleteById delegates to repository when league exists",
+    async () => {
+      let deletedId: string | undefined;
+      const league: League = {
+        id: "delete-me",
+        name: "Delete Me",
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      };
+      const service = createLeagueService({
+        leagueRepo: createMockRepo({
+          getById: () => Promise.resolve(league),
+          deleteById: (id) => {
+            deletedId = id;
+            return Promise.resolve();
+          },
+        }),
+        log: createTestLogger(),
+      });
+
+      await service.deleteById("delete-me");
+      assertEquals(deletedId, "delete-me");
+    },
+  );
+
+  await t.step(
+    "deleteById throws NOT_FOUND when league does not exist",
+    async () => {
+      const service = createLeagueService({
+        leagueRepo: createMockRepo({
+          getById: () => Promise.resolve(undefined),
+        }),
+        log: createTestLogger(),
+      });
+
+      await assertRejects(
+        () => service.deleteById("missing"),
+        DomainError,
+        "not found",
+      );
     },
   );
 });

--- a/server/features/league/league.service.ts
+++ b/server/features/league/league.service.ts
@@ -27,5 +27,14 @@ export function createLeagueService(deps: {
       log.info({ name: input.name }, "creating league");
       return await deps.leagueRepo.create(input);
     },
+
+    async deleteById(id) {
+      log.info({ id }, "deleting league");
+      const league = await deps.leagueRepo.getById(id);
+      if (!league) {
+        throw new DomainError("NOT_FOUND", `League ${id} not found`);
+      }
+      await deps.leagueRepo.deleteById(id);
+    },
   };
 }


### PR DESCRIPTION
## Summary

- Adds a **Settings** page to the league dashboard, accessible via a new sidebar navigation link
- The settings page includes a **Danger Zone** section with a two-step confirmation flow to delete a league
- Full-stack implementation: shared interfaces, server DELETE endpoint with existence validation, client mutation hook and UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)