### PR TITLE
fix(team): rename Detroit Pistons to Detroit Motors

### DIFF
--- a/server/features/team/default-teams.ts
+++ b/server/features/team/default-teams.ts
@@ -260,7 +260,7 @@ export const DEFAULT_TEAMS: DefaultTeam[] = [
     division: "NFC North",
   },
   {
-    name: "Pistons",
+    name: "Motors",
     city: "Detroit",
     abbreviation: "DET",
     primaryColor: "#0076B6",


### PR DESCRIPTION
## Summary

- Renames Detroit Pistons to Detroit Motors to avoid collision with the NBA team name

🤖 Generated with [Claude Code](https://claude.com/claude-code)