### PR TITLE
feat(league): add NFL default settings to league schema

### DIFF
--- a/packages/shared/types/league.ts
+++ b/packages/shared/types/league.ts
@@ -1,6 +1,12 @@
 export interface League {
   id: string;
   name: string;
+  numberOfTeams: number;
+  seasonLength: number;
+  salaryCap: number;
+  capFloorPercent: number;
+  capGrowthRate: number;
+  rosterSize: number;
   createdAt: Date;
   updatedAt: Date;
 }

--- a/server/db/migrations/0004_chunky_silver_fox.sql
+++ b/server/db/migrations/0004_chunky_silver_fox.sql
@@ -1,0 +1,6 @@
+ALTER TABLE "leagues" ADD COLUMN "number_of_teams" integer DEFAULT 32 NOT NULL;--> statement-breakpoint
+ALTER TABLE "leagues" ADD COLUMN "season_length" integer DEFAULT 17 NOT NULL;--> statement-breakpoint
+ALTER TABLE "leagues" ADD COLUMN "salary_cap" integer DEFAULT 255000000 NOT NULL;--> statement-breakpoint
+ALTER TABLE "leagues" ADD COLUMN "cap_floor_percent" integer DEFAULT 89 NOT NULL;--> statement-breakpoint
+ALTER TABLE "leagues" ADD COLUMN "cap_growth_rate" integer DEFAULT 5 NOT NULL;--> statement-breakpoint
+ALTER TABLE "leagues" ADD COLUMN "roster_size" integer DEFAULT 53 NOT NULL;

--- a/server/db/migrations/meta/0004_snapshot.json
+++ b/server/db/migrations/meta/0004_snapshot.json
@@ -1,0 +1,532 @@
+{
+  "id": "bbd997e6-471a-4adb-a5af-dd00bbe9eddb",
+  "prevId": "5dbe98d3-2ac0-458a-8b58-7212ef2b754c",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.accounts": {
+      "name": "accounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "accounts_user_id_users_id_fk": {
+          "name": "accounts_user_id_users_id_fk",
+          "tableFrom": "accounts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.health_checks": {
+      "name": "health_checks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "checked_at": {
+          "name": "checked_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.leagues": {
+      "name": "leagues",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "number_of_teams": {
+          "name": "number_of_teams",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 32
+        },
+        "season_length": {
+          "name": "season_length",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 17
+        },
+        "salary_cap": {
+          "name": "salary_cap",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 255000000
+        },
+        "cap_floor_percent": {
+          "name": "cap_floor_percent",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 89
+        },
+        "cap_growth_rate": {
+          "name": "cap_growth_rate",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 5
+        },
+        "roster_size": {
+          "name": "roster_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 53
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "sessions_token_unique": {
+          "name": "sessions_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.teams": {
+      "name": "teams",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "city": {
+          "name": "city",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "abbreviation": {
+          "name": "abbreviation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "primary_color": {
+          "name": "primary_color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "secondary_color": {
+          "name": "secondary_color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "accent_color": {
+          "name": "accent_color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conference": {
+          "name": "conference",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "division": {
+          "name": "division",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "teams_abbreviation_unique": {
+          "name": "teams_abbreviation_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "abbreviation"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verifications": {
+      "name": "verifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/server/db/migrations/meta/_journal.json
+++ b/server/db/migrations/meta/_journal.json
@@ -29,6 +29,13 @@
       "when": 1776113752467,
       "tag": "0003_lame_iron_fist",
       "breakpoints": true
+    },
+    {
+      "idx": 4,
+      "version": "7",
+      "when": 1776114459832,
+      "tag": "0004_chunky_silver_fox",
+      "breakpoints": true
     }
   ]
 }

--- a/server/features/league/league.repository.test.ts
+++ b/server/features/league/league.repository.test.ts
@@ -109,11 +109,23 @@ Deno.test({
 
       assertEquals(result.name, "New League");
       assertEquals(typeof result.id, "string");
+      assertEquals(result.numberOfTeams, 32);
+      assertEquals(result.seasonLength, 17);
+      assertEquals(result.salaryCap, 255_000_000);
+      assertEquals(result.capFloorPercent, 89);
+      assertEquals(result.capGrowthRate, 5);
+      assertEquals(result.rosterSize, 53);
 
       const [row] = await db.select().from(leagues).where(
         eq(leagues.id, leagueId),
       );
       assertEquals(row.name, "New League");
+      assertEquals(row.numberOfTeams, 32);
+      assertEquals(row.seasonLength, 17);
+      assertEquals(row.salaryCap, 255_000_000);
+      assertEquals(row.capFloorPercent, 89);
+      assertEquals(row.capGrowthRate, 5);
+      assertEquals(row.rosterSize, 53);
     } finally {
       if (leagueId) {
         await db.delete(leagues).where(eq(leagues.id, leagueId));

--- a/server/features/league/league.router.test.ts
+++ b/server/features/league/league.router.test.ts
@@ -2,25 +2,29 @@ import { assertEquals } from "@std/assert";
 import { createLeagueRouter } from "./league.router.ts";
 import type { League, LeagueService } from "@zone-blitz/shared";
 
+function createMockLeague(overrides: Partial<League> = {}): League {
+  return {
+    id: "1",
+    name: "Test",
+    numberOfTeams: 32,
+    seasonLength: 17,
+    salaryCap: 255_000_000,
+    capFloorPercent: 89,
+    capGrowthRate: 5,
+    rosterSize: 53,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    ...overrides,
+  };
+}
+
 function createMockLeagueService(
   overrides: Partial<LeagueService> = {},
 ): LeagueService {
   return {
     getAll: () => Promise.resolve([]),
-    getById: () =>
-      Promise.resolve({
-        id: "1",
-        name: "Test",
-        createdAt: new Date(),
-        updatedAt: new Date(),
-      }),
-    create: () =>
-      Promise.resolve({
-        id: "new-id",
-        name: "Test",
-        createdAt: new Date(),
-        updatedAt: new Date(),
-      }),
+    getById: () => Promise.resolve(createMockLeague()),
+    create: () => Promise.resolve(createMockLeague({ id: "new-id" })),
     deleteById: () => Promise.resolve(),
     ...overrides,
   };
@@ -29,18 +33,8 @@ function createMockLeagueService(
 Deno.test("league.router", async (t) => {
   await t.step("GET / returns all leagues", async () => {
     const leagues: League[] = [
-      {
-        id: "1",
-        name: "League One",
-        createdAt: new Date(),
-        updatedAt: new Date(),
-      },
-      {
-        id: "2",
-        name: "League Two",
-        createdAt: new Date(),
-        updatedAt: new Date(),
-      },
+      createMockLeague({ id: "1", name: "League One" }),
+      createMockLeague({ id: "2", name: "League Two" }),
     ];
     const router = createLeagueRouter(
       createMockLeagueService({ getAll: () => Promise.resolve(leagues) }),
@@ -66,12 +60,7 @@ Deno.test("league.router", async (t) => {
   });
 
   await t.step("GET /:id returns a league by id", async () => {
-    const league: League = {
-      id: "42",
-      name: "Found League",
-      createdAt: new Date(),
-      updatedAt: new Date(),
-    };
+    const league = createMockLeague({ id: "42", name: "Found League" });
     const router = createLeagueRouter(
       createMockLeagueService({ getById: () => Promise.resolve(league) }),
     );
@@ -85,12 +74,7 @@ Deno.test("league.router", async (t) => {
   });
 
   await t.step("POST / creates a league and returns 201", async () => {
-    const created: League = {
-      id: "new-id",
-      name: "New League",
-      createdAt: new Date(),
-      updatedAt: new Date(),
-    };
+    const created = createMockLeague({ id: "new-id", name: "New League" });
     const router = createLeagueRouter(
       createMockLeagueService({ create: () => Promise.resolve(created) }),
     );

--- a/server/features/league/league.schema.ts
+++ b/server/features/league/league.schema.ts
@@ -1,8 +1,14 @@
-import { pgTable, text, timestamp, uuid } from "drizzle-orm/pg-core";
+import { integer, pgTable, text, timestamp, uuid } from "drizzle-orm/pg-core";
 
 export const leagues = pgTable("leagues", {
   id: uuid("id").defaultRandom().primaryKey(),
   name: text("name").notNull(),
+  numberOfTeams: integer("number_of_teams").notNull().default(32),
+  seasonLength: integer("season_length").notNull().default(17),
+  salaryCap: integer("salary_cap").notNull().default(255_000_000),
+  capFloorPercent: integer("cap_floor_percent").notNull().default(89),
+  capGrowthRate: integer("cap_growth_rate").notNull().default(5),
+  rosterSize: integer("roster_size").notNull().default(53),
   createdAt: timestamp("created_at").defaultNow().notNull(),
   updatedAt: timestamp("updated_at").defaultNow().notNull(),
 });

--- a/server/features/league/league.service.test.ts
+++ b/server/features/league/league.service.test.ts
@@ -8,19 +8,29 @@ function createTestLogger() {
   return pino({ level: "silent" });
 }
 
+function createMockLeague(overrides: Partial<League> = {}): League {
+  return {
+    id: "1",
+    name: "Test",
+    numberOfTeams: 32,
+    seasonLength: 17,
+    salaryCap: 255_000_000,
+    capFloorPercent: 89,
+    capGrowthRate: 5,
+    rosterSize: 53,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    ...overrides,
+  };
+}
+
 function createMockRepo(
   overrides: Partial<LeagueRepository> = {},
 ): LeagueRepository {
   return {
     getAll: () => Promise.resolve([]),
     getById: () => Promise.resolve(undefined),
-    create: () =>
-      Promise.resolve({
-        id: "new-id",
-        name: "Test",
-        createdAt: new Date(),
-        updatedAt: new Date(),
-      }),
+    create: () => Promise.resolve(createMockLeague({ id: "new-id" })),
     deleteById: () => Promise.resolve(),
     ...overrides,
   };
@@ -29,18 +39,8 @@ function createMockRepo(
 Deno.test("league.service", async (t) => {
   await t.step("getAll returns all leagues from repository", async () => {
     const leagues: League[] = [
-      {
-        id: "1",
-        name: "League One",
-        createdAt: new Date(),
-        updatedAt: new Date(),
-      },
-      {
-        id: "2",
-        name: "League Two",
-        createdAt: new Date(),
-        updatedAt: new Date(),
-      },
+      createMockLeague({ id: "1", name: "League One" }),
+      createMockLeague({ id: "2", name: "League Two" }),
     ];
     const service = createLeagueService({
       leagueRepo: createMockRepo({ getAll: () => Promise.resolve(leagues) }),
@@ -53,12 +53,7 @@ Deno.test("league.service", async (t) => {
   });
 
   await t.step("getById returns league when found", async () => {
-    const league: League = {
-      id: "1",
-      name: "Found League",
-      createdAt: new Date(),
-      updatedAt: new Date(),
-    };
+    const league = createMockLeague({ id: "1", name: "Found League" });
     const service = createLeagueService({
       leagueRepo: createMockRepo({ getById: () => Promise.resolve(league) }),
       log: createTestLogger(),
@@ -84,12 +79,7 @@ Deno.test("league.service", async (t) => {
   await t.step(
     "create delegates to repository and returns league",
     async () => {
-      const created: League = {
-        id: "new-id",
-        name: "New League",
-        createdAt: new Date(),
-        updatedAt: new Date(),
-      };
+      const created = createMockLeague({ id: "new-id", name: "New League" });
       const service = createLeagueService({
         leagueRepo: createMockRepo({ create: () => Promise.resolve(created) }),
         log: createTestLogger(),
@@ -105,12 +95,7 @@ Deno.test("league.service", async (t) => {
     "deleteById delegates to repository when league exists",
     async () => {
       let deletedId: string | undefined;
-      const league: League = {
-        id: "delete-me",
-        name: "Delete Me",
-        createdAt: new Date(),
-        updatedAt: new Date(),
-      };
+      const league = createMockLeague({ id: "delete-me", name: "Delete Me" });
       const service = createLeagueService({
         leagueRepo: createMockRepo({
           getById: () => Promise.resolve(league),


### PR DESCRIPTION
## Summary

- Adds 6 settings columns to the `leagues` table: `numberOfTeams`, `seasonLength`, `salaryCap`, `capFloorPercent`, `capGrowthRate`, `rosterSize`
- All columns have DB-level defaults matching NFL values (32 teams, 17-game season, $255M cap, 89% floor, 5% growth, 53-man roster)
- Updates `League` shared type with the new fields
- League creation still only accepts a `name` — defaults are applied automatically (MVP: no user override)
- Updates all test mocks with a `createMockLeague()` helper for the expanded type

🤖 Generated with [Claude Code](https://claude.com/claude-code)