### PR TITLE
feat(auth): add user profile menu with sign out and account deletion

### DIFF
--- a/client/src/components/user-menu.test.tsx
+++ b/client/src/components/user-menu.test.tsx
@@ -1,0 +1,134 @@
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { UserMenu } from "./user-menu.tsx";
+
+const mockSignOut = vi.fn();
+const mockDelete = vi.fn();
+
+vi.mock("../lib/auth-client.ts", () => ({
+  authClient: {
+    useSession: () => ({
+      data: {
+        user: {
+          id: "u1",
+          name: "Jane Doe",
+          email: "jane@example.com",
+          image: null,
+        },
+        session: { id: "s1" },
+      },
+      isPending: false,
+    }),
+    signOut: (...args: unknown[]) => mockSignOut(...args),
+  },
+}));
+
+vi.mock("../api.ts", () => ({
+  api: {
+    api: {
+      users: {
+        me: {
+          $delete: (...args: unknown[]) => mockDelete(...args),
+        },
+      },
+    },
+  },
+}));
+
+function renderWithProviders() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <UserMenu />
+    </QueryClientProvider>,
+  );
+}
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+describe("UserMenu", () => {
+  it("renders a button to open the menu", () => {
+    renderWithProviders();
+    expect(screen.getByRole("button", { name: /profile/i })).toBeDefined();
+  });
+
+  it("shows user name and email when menu is open", async () => {
+    renderWithProviders();
+    fireEvent.click(screen.getByRole("button", { name: /profile/i }));
+    expect(screen.getByText("Jane Doe")).toBeDefined();
+    expect(screen.getByText("jane@example.com")).toBeDefined();
+  });
+
+  it("shows sign out button when menu is open", () => {
+    renderWithProviders();
+    fireEvent.click(screen.getByRole("button", { name: /profile/i }));
+    expect(screen.getByRole("button", { name: /sign out/i })).toBeDefined();
+  });
+
+  it("shows delete account button when menu is open", () => {
+    renderWithProviders();
+    fireEvent.click(screen.getByRole("button", { name: /profile/i }));
+    expect(screen.getByRole("button", { name: /delete account/i }))
+      .toBeDefined();
+  });
+
+  it("calls signOut when sign out button is clicked", async () => {
+    mockSignOut.mockResolvedValue({});
+    renderWithProviders();
+    fireEvent.click(screen.getByRole("button", { name: /profile/i }));
+    fireEvent.click(screen.getByRole("button", { name: /sign out/i }));
+    expect(mockSignOut).toHaveBeenCalled();
+  });
+
+  it("shows a confirmation before deleting account", () => {
+    renderWithProviders();
+    fireEvent.click(screen.getByRole("button", { name: /profile/i }));
+    fireEvent.click(screen.getByRole("button", { name: /delete account/i }));
+    expect(screen.getByText(/are you sure/i)).toBeDefined();
+  });
+
+  it("calls delete endpoint when deletion is confirmed", async () => {
+    mockDelete.mockResolvedValue({ ok: true });
+    mockSignOut.mockResolvedValue({});
+    renderWithProviders();
+    fireEvent.click(screen.getByRole("button", { name: /profile/i }));
+    fireEvent.click(screen.getByRole("button", { name: /delete account/i }));
+    fireEvent.click(screen.getByRole("button", { name: /yes, delete/i }));
+
+    await waitFor(() => {
+      expect(mockDelete).toHaveBeenCalled();
+    });
+  });
+
+  it("closes confirmation when cancel is clicked", () => {
+    renderWithProviders();
+    fireEvent.click(screen.getByRole("button", { name: /profile/i }));
+    fireEvent.click(screen.getByRole("button", { name: /delete account/i }));
+    expect(screen.getByText(/are you sure/i)).toBeDefined();
+
+    fireEvent.click(screen.getByRole("button", { name: /cancel/i }));
+    expect(screen.queryByText(/are you sure/i)).toBeNull();
+  });
+
+  it("closes the menu when clicking the profile button again", () => {
+    renderWithProviders();
+    const btn = screen.getByRole("button", { name: /profile/i });
+    fireEvent.click(btn);
+    expect(screen.getByText("Jane Doe")).toBeDefined();
+
+    fireEvent.click(btn);
+    expect(screen.queryByText("Jane Doe")).toBeNull();
+  });
+});

--- a/client/src/components/user-menu.test.tsx
+++ b/client/src/components/user-menu.test.tsx
@@ -64,7 +64,7 @@ describe("UserMenu", () => {
     expect(screen.getByRole("button", { name: /profile/i })).toBeDefined();
   });
 
-  it("shows user name and email when menu is open", async () => {
+  it("shows user name and email when menu is open", () => {
     renderWithProviders();
     fireEvent.click(screen.getByRole("button", { name: /profile/i }));
     expect(screen.getByText("Jane Doe")).toBeDefined();
@@ -84,7 +84,7 @@ describe("UserMenu", () => {
       .toBeDefined();
   });
 
-  it("calls signOut when sign out button is clicked", async () => {
+  it("calls signOut when sign out button is clicked", () => {
     mockSignOut.mockResolvedValue({});
     renderWithProviders();
     fireEvent.click(screen.getByRole("button", { name: /profile/i }));

--- a/client/src/components/user-menu.tsx
+++ b/client/src/components/user-menu.tsx
@@ -1,0 +1,89 @@
+import { useState } from "react";
+import { User } from "lucide-react";
+import { authClient } from "../lib/auth-client.ts";
+import { useDeleteAccount } from "../hooks/use-delete-account.ts";
+
+export function UserMenu({ dropDown = false }: { dropDown?: boolean } = {}) {
+  const { data: session } = authClient.useSession();
+  const deleteAccount = useDeleteAccount();
+  const [isOpen, setIsOpen] = useState(false);
+  const [showConfirm, setShowConfirm] = useState(false);
+
+  const user = session?.user;
+
+  return (
+    <div className="relative">
+      <button
+        type="button"
+        aria-label="Profile"
+        onClick={() => {
+          setIsOpen(!isOpen);
+          if (isOpen) setShowConfirm(false);
+        }}
+        className="flex items-center gap-2 rounded px-3 py-2 text-sm font-medium text-gray-300 hover:bg-gray-800 hover:text-gray-100"
+      >
+        <User size={16} />
+        Profile
+      </button>
+
+      {isOpen && (
+        <div
+          className={`absolute ${
+            dropDown ? "top-full right-0 mt-2" : "bottom-full left-0 mb-2"
+          } w-64 rounded border border-gray-700 bg-gray-900 p-4 shadow-lg`}
+        >
+          {user && (
+            <div className="mb-3 border-b border-gray-700 pb-3">
+              <p className="text-sm font-medium text-gray-100">{user.name}</p>
+              <p className="text-xs text-gray-400">{user.email}</p>
+            </div>
+          )}
+
+          <div className="space-y-2">
+            <button
+              type="button"
+              onClick={() => authClient.signOut()}
+              className="w-full rounded px-3 py-2 text-left text-sm text-gray-300 hover:bg-gray-800 hover:text-gray-100"
+            >
+              Sign out
+            </button>
+
+            {!showConfirm
+              ? (
+                <button
+                  type="button"
+                  onClick={() => setShowConfirm(true)}
+                  className="w-full rounded px-3 py-2 text-left text-sm text-red-400 hover:bg-gray-800 hover:text-red-300"
+                >
+                  Delete account
+                </button>
+              )
+              : (
+                <div className="rounded border border-red-800 bg-red-950 p-3">
+                  <p className="mb-2 text-xs text-red-300">
+                    Are you sure? This cannot be undone.
+                  </p>
+                  <div className="flex gap-2">
+                    <button
+                      type="button"
+                      onClick={() => deleteAccount.mutate()}
+                      className="rounded bg-red-600 px-3 py-1 text-xs font-medium text-white hover:bg-red-500"
+                    >
+                      Yes, delete
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => setShowConfirm(false)}
+                      className="rounded px-3 py-1 text-xs text-gray-400 hover:text-gray-200"
+                    >
+                      Cancel
+                    </button>
+                  </div>
+                </div>
+              )}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/client/src/features/league-select/index.test.tsx
+++ b/client/src/features/league-select/index.test.tsx
@@ -20,7 +20,30 @@ vi.mock("../../api.ts", () => ({
         $get: (...args: unknown[]) => mockGet(...args),
         $post: (...args: unknown[]) => mockPost(...args),
       },
+      users: {
+        me: {
+          $delete: vi.fn(),
+        },
+      },
     },
+  },
+}));
+
+vi.mock("../../lib/auth-client.ts", () => ({
+  authClient: {
+    useSession: () => ({
+      data: {
+        user: {
+          id: "u1",
+          name: "Test User",
+          email: "test@example.com",
+          image: null,
+        },
+        session: { id: "s1" },
+      },
+      isPending: false,
+    }),
+    signOut: vi.fn(),
   },
 }));
 
@@ -183,6 +206,14 @@ describe("LeagueSelect", () => {
     fireEvent.submit(screen.getByRole("button", { name: "Create" }));
 
     expect(mockPost).not.toHaveBeenCalled();
+  });
+
+  it("renders a profile button in the top right", () => {
+    mockGet.mockReturnValue(
+      Promise.resolve({ json: () => Promise.resolve([]) }),
+    );
+    renderWithProviders();
+    expect(screen.getByRole("button", { name: /profile/i })).toBeDefined();
   });
 
   it("shows Creating... text while mutation is pending", async () => {

--- a/client/src/features/league-select/index.tsx
+++ b/client/src/features/league-select/index.tsx
@@ -1,6 +1,7 @@
 import { useState } from "react";
 import { useNavigate } from "@tanstack/react-router";
 import { useCreateLeague, useLeagues } from "../../hooks/use-leagues.ts";
+import { UserMenu } from "../../components/user-menu.tsx";
 
 export function LeagueSelect() {
   const { data: leagues, isLoading, error } = useLeagues();
@@ -9,7 +10,10 @@ export function LeagueSelect() {
   const [newName, setNewName] = useState("");
 
   return (
-    <div className="min-h-screen bg-gray-950 text-gray-100 flex items-center justify-center">
+    <div className="relative min-h-screen bg-gray-950 text-gray-100 flex items-center justify-center">
+      <div className="absolute top-4 right-4">
+        <UserMenu dropDown />
+      </div>
       <div className="text-center space-y-6 max-w-lg w-full px-4">
         <h1 className="text-5xl font-bold tracking-tight">Zone Blitz</h1>
         <p className="text-lg text-gray-400 max-w-md mx-auto">

--- a/client/src/features/league/layout.test.tsx
+++ b/client/src/features/league/layout.test.tsx
@@ -1,4 +1,5 @@
 import { cleanup, render, screen } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { LeagueLayout } from "./layout.tsx";
 
@@ -20,45 +21,91 @@ vi.mock("@tanstack/react-router", () => ({
   useParams: () => ({ leagueId: "1" }),
 }));
 
+vi.mock("../../lib/auth-client.ts", () => ({
+  authClient: {
+    useSession: () => ({
+      data: {
+        user: {
+          id: "u1",
+          name: "Test User",
+          email: "test@example.com",
+          image: null,
+        },
+        session: { id: "s1" },
+      },
+      isPending: false,
+    }),
+    signOut: vi.fn(),
+  },
+}));
+
+vi.mock("../../api.ts", () => ({
+  api: {
+    api: {
+      users: {
+        me: {
+          $delete: vi.fn(),
+        },
+      },
+    },
+  },
+}));
+
+function renderWithProviders() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <LeagueLayout />
+    </QueryClientProvider>,
+  );
+}
+
 afterEach(() => {
   cleanup();
 });
 
 describe("LeagueLayout", () => {
   it("renders a sidebar with a Home nav link", () => {
-    render(<LeagueLayout />);
+    renderWithProviders();
     const homeLink = screen.getByRole("link", { name: /home/i });
     expect(homeLink).toBeDefined();
   });
 
   it("renders the Outlet for child routes", () => {
-    render(<LeagueLayout />);
+    renderWithProviders();
     expect(screen.getByTestId("outlet")).toBeDefined();
   });
 
   it("renders the sidebar as a nav element", () => {
-    render(<LeagueLayout />);
+    renderWithProviders();
     expect(screen.getByRole("navigation")).toBeDefined();
   });
 
   it("renders a link back to the league select page", () => {
-    render(<LeagueLayout />);
+    renderWithProviders();
     const backLink = screen.getByRole("link", { name: /leagues/i });
     expect(backLink).toBeDefined();
     expect(backLink.getAttribute("href")).toBe("/");
   });
 
   it("renders icons in the nav links", () => {
-    render(<LeagueLayout />);
+    renderWithProviders();
     const nav = screen.getByRole("navigation");
     const svgs = nav.querySelectorAll("svg");
     expect(svgs.length).toBeGreaterThanOrEqual(2);
   });
 
   it("renders a Settings nav link", () => {
-    render(<LeagueLayout />);
+    renderWithProviders();
     const settingsLink = screen.getByRole("link", { name: /settings/i });
     expect(settingsLink).toBeDefined();
     expect(settingsLink.getAttribute("href")).toBe("/leagues/1/settings");
+  });
+
+  it("renders a Profile button at the bottom of the sidebar", () => {
+    renderWithProviders();
+    expect(screen.getByRole("button", { name: /profile/i })).toBeDefined();
   });
 });

--- a/client/src/features/league/layout.tsx
+++ b/client/src/features/league/layout.tsx
@@ -1,12 +1,13 @@
 import { Link, Outlet, useParams } from "@tanstack/react-router";
 import { ArrowLeft, Home, Settings } from "lucide-react";
+import { UserMenu } from "../../components/user-menu.tsx";
 
 export function LeagueLayout() {
   const { leagueId } = useParams({ strict: false });
 
   return (
     <div className="flex min-h-screen bg-gray-950 text-gray-100">
-      <nav className="w-60 border-r border-gray-800 p-4">
+      <nav className="flex w-60 flex-col border-r border-gray-800 p-4">
         <Link
           to="/"
           className="mb-4 flex items-center gap-2 text-sm text-gray-400 hover:text-gray-200"
@@ -14,7 +15,7 @@ export function LeagueLayout() {
           <ArrowLeft size={16} />
           All Leagues
         </Link>
-        <ul>
+        <ul className="flex-1">
           <li>
             <Link
               to={`/leagues/${leagueId}`}
@@ -34,6 +35,9 @@ export function LeagueLayout() {
             </Link>
           </li>
         </ul>
+        <div className="border-t border-gray-800 pt-2">
+          <UserMenu />
+        </div>
       </nav>
       <main className="flex-1 p-6">
         <Outlet />

--- a/client/src/hooks/use-delete-account.test.ts
+++ b/client/src/hooks/use-delete-account.test.ts
@@ -1,0 +1,54 @@
+import { renderHook, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { describe, expect, it, vi } from "vitest";
+import { useDeleteAccount } from "./use-delete-account.ts";
+import { createElement } from "react";
+
+const mockDelete = vi.fn();
+const mockSignOut = vi.fn();
+
+vi.mock("../api.ts", () => ({
+  api: {
+    api: {
+      users: {
+        me: {
+          $delete: (...args: unknown[]) => mockDelete(...args),
+        },
+      },
+    },
+  },
+}));
+
+vi.mock("../lib/auth-client.ts", () => ({
+  authClient: {
+    signOut: (...args: unknown[]) => mockSignOut(...args),
+  },
+}));
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return ({ children }: { children: React.ReactNode }) =>
+    createElement(QueryClientProvider, { client: queryClient }, children);
+}
+
+describe("useDeleteAccount", () => {
+  it("calls the delete endpoint and signs out on success", async () => {
+    mockDelete.mockResolvedValue({ ok: true });
+    mockSignOut.mockResolvedValue({});
+
+    const { result } = renderHook(() => useDeleteAccount(), {
+      wrapper: createWrapper(),
+    });
+
+    result.current.mutate();
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+
+    expect(mockDelete).toHaveBeenCalled();
+    expect(mockSignOut).toHaveBeenCalled();
+  });
+});

--- a/client/src/hooks/use-delete-account.ts
+++ b/client/src/hooks/use-delete-account.ts
@@ -1,0 +1,14 @@
+import { useMutation } from "@tanstack/react-query";
+import { api } from "../api.ts";
+import { authClient } from "../lib/auth-client.ts";
+
+export function useDeleteAccount() {
+  return useMutation({
+    mutationFn: async () => {
+      await api.api.users.me.$delete();
+    },
+    onSuccess: () => {
+      authClient.signOut();
+    },
+  });
+}

--- a/packages/shared/interfaces/repositories/user-repository.ts
+++ b/packages/shared/interfaces/repositories/user-repository.ts
@@ -1,0 +1,3 @@
+export interface UserRepository {
+  deleteById(id: string): Promise<void>;
+}

--- a/packages/shared/interfaces/services/user-service.ts
+++ b/packages/shared/interfaces/services/user-service.ts
@@ -1,0 +1,3 @@
+export interface UserService {
+  deleteById(id: string): Promise<void>;
+}

--- a/packages/shared/mod.ts
+++ b/packages/shared/mod.ts
@@ -6,10 +6,12 @@ export type { Team } from "./types/team.ts";
 // Interfaces — repositories
 export type { LeagueRepository } from "./interfaces/repositories/league-repository.ts";
 export type { TeamRepository } from "./interfaces/repositories/team-repository.ts";
+export type { UserRepository } from "./interfaces/repositories/user-repository.ts";
 
 // Interfaces — services
 export type { HealthService } from "./interfaces/services/health-service.ts";
 export type { LeagueService } from "./interfaces/services/league-service.ts";
+export type { UserService } from "./interfaces/services/user-service.ts";
 
 // Interfaces — simulation
 export type {

--- a/server/features/mod.ts
+++ b/server/features/mod.ts
@@ -8,6 +8,11 @@ import {
   createLeagueRouter,
   createLeagueService,
 } from "./league/mod.ts";
+import {
+  createUserRepository,
+  createUserRouter,
+  createUserService,
+} from "./user/mod.ts";
 
 export function createFeatureRouters(
   deps: {
@@ -40,12 +45,15 @@ export function createFeatureRouters(
 
   // Repositories
   const leagueRepo = createLeagueRepository({ db, log });
+  const userRepo = createUserRepository({ db, log });
 
   // Services
   const leagueService = createLeagueService({ leagueRepo, log });
+  const userService = createUserService({ userRepo, log });
 
   // Routers
   const leagueRouter = createLeagueRouter(leagueService);
+  const userRouter = createUserRouter(userService);
 
-  return { auth, authRouter, healthRouter, leagueRouter };
+  return { auth, authRouter, healthRouter, leagueRouter, userRouter };
 }

--- a/server/features/user/mod.ts
+++ b/server/features/user/mod.ts
@@ -1,0 +1,3 @@
+export { createUserRepository } from "./user.repository.ts";
+export { createUserService } from "./user.service.ts";
+export { createUserRouter } from "./user.router.ts";

--- a/server/features/user/user.repository.test.ts
+++ b/server/features/user/user.repository.test.ts
@@ -1,0 +1,42 @@
+import { assertEquals } from "@std/assert";
+import { createUserRepository } from "./user.repository.ts";
+import { users } from "../auth/auth.schema.ts";
+
+function createTestLogger() {
+  return {
+    child: () => createTestLogger(),
+    debug: () => {},
+    info: () => {},
+    warn: () => {},
+    error: () => {},
+  } as unknown as import("pino").Logger;
+}
+
+Deno.test("user.repository", async (t) => {
+  await t.step("deleteById calls db.delete with correct user id", async () => {
+    let deletedTable: unknown;
+    let deletedWhere: unknown;
+
+    const mockWhere = (condition: unknown) => {
+      deletedWhere = condition;
+      return Promise.resolve();
+    };
+
+    const mockDb = {
+      delete: (table: unknown) => {
+        deletedTable = table;
+        return { where: mockWhere };
+      },
+    };
+
+    const repo = createUserRepository({
+      db: mockDb as never,
+      log: createTestLogger(),
+    });
+
+    await repo.deleteById("user-to-delete");
+    assertEquals(deletedTable, users);
+    // The where clause is an Expression object; just verify it was called
+    assertEquals(deletedWhere !== undefined, true);
+  });
+});

--- a/server/features/user/user.repository.ts
+++ b/server/features/user/user.repository.ts
@@ -1,0 +1,19 @@
+import type { UserRepository } from "@zone-blitz/shared";
+import type pino from "pino";
+import { eq } from "drizzle-orm";
+import type { Database } from "../../db/connection.ts";
+import { users } from "../auth/auth.schema.ts";
+
+export function createUserRepository(deps: {
+  db: Database;
+  log: pino.Logger;
+}): UserRepository {
+  const log = deps.log.child({ module: "user.repository" });
+
+  return {
+    async deleteById(id) {
+      log.debug({ id }, "deleting user by id");
+      await deps.db.delete(users).where(eq(users.id, id));
+    },
+  };
+}

--- a/server/features/user/user.router.test.ts
+++ b/server/features/user/user.router.test.ts
@@ -1,0 +1,56 @@
+import { assertEquals } from "@std/assert";
+import { Hono } from "hono";
+import { createUserRouter } from "./user.router.ts";
+import type { UserService } from "@zone-blitz/shared";
+import type { AppEnv } from "../../env.ts";
+
+function createMockUserService(
+  overrides: Partial<UserService> = {},
+): UserService {
+  return {
+    deleteById: () => Promise.resolve(),
+    ...overrides,
+  };
+}
+
+function createAppWithUser(
+  userService: UserService,
+  user: { id: string; name: string } | null = { id: "user-1", name: "Test" },
+) {
+  const app = new Hono<AppEnv>();
+  app.use("*", async (c, next) => {
+    c.set("user", user as AppEnv["Variables"]["user"]);
+    c.set("session", null);
+    await next();
+  });
+  app.route("/", createUserRouter(userService));
+  return app;
+}
+
+Deno.test("user.router", async (t) => {
+  await t.step(
+    "DELETE /me deletes the current user and returns 204",
+    async () => {
+      let deletedId: string | undefined;
+      const service = createMockUserService({
+        deleteById: (id) => {
+          deletedId = id;
+          return Promise.resolve();
+        },
+      });
+      const app = createAppWithUser(service);
+
+      const res = await app.request("/me", { method: "DELETE" });
+      assertEquals(res.status, 204);
+      assertEquals(deletedId, "user-1");
+    },
+  );
+
+  await t.step("DELETE /me returns 401 when no user in context", async () => {
+    const service = createMockUserService();
+    const app = createAppWithUser(service, null);
+
+    const res = await app.request("/me", { method: "DELETE" });
+    assertEquals(res.status, 401);
+  });
+});

--- a/server/features/user/user.router.ts
+++ b/server/features/user/user.router.ts
@@ -1,0 +1,17 @@
+import { Hono } from "hono";
+import type { UserService } from "@zone-blitz/shared";
+import type { AppEnv } from "../../env.ts";
+
+export function createUserRouter(userService: UserService) {
+  return new Hono<AppEnv>()
+    .delete("/me", async (c) => {
+      const user = c.get("user");
+
+      if (!user) {
+        return c.json({ error: "UNAUTHORIZED" }, 401);
+      }
+
+      await userService.deleteById(user.id);
+      return c.body(null, 204);
+    });
+}

--- a/server/features/user/user.service.test.ts
+++ b/server/features/user/user.service.test.ts
@@ -1,0 +1,57 @@
+import { assertEquals, assertRejects } from "@std/assert";
+import { createUserService } from "./user.service.ts";
+import type { UserRepository } from "@zone-blitz/shared";
+
+function createMockUserRepo(
+  overrides: Partial<UserRepository> = {},
+): UserRepository {
+  return {
+    deleteById: () => Promise.resolve(),
+    ...overrides,
+  };
+}
+
+function createTestLogger() {
+  return {
+    child: () => createTestLogger(),
+    debug: () => {},
+    info: () => {},
+    warn: () => {},
+    error: () => {},
+  } as unknown as import("pino").Logger;
+}
+
+Deno.test("user.service", async (t) => {
+  await t.step("deleteById delegates to repository", async () => {
+    let deletedId: string | undefined;
+    const repo = createMockUserRepo({
+      deleteById: (id) => {
+        deletedId = id;
+        return Promise.resolve();
+      },
+    });
+    const service = createUserService({
+      userRepo: repo,
+      log: createTestLogger(),
+    });
+
+    await service.deleteById("user-123");
+    assertEquals(deletedId, "user-123");
+  });
+
+  await t.step("deleteById propagates repository errors", async () => {
+    const repo = createMockUserRepo({
+      deleteById: () => Promise.reject(new Error("db error")),
+    });
+    const service = createUserService({
+      userRepo: repo,
+      log: createTestLogger(),
+    });
+
+    await assertRejects(
+      () => service.deleteById("user-123"),
+      Error,
+      "db error",
+    );
+  });
+});

--- a/server/features/user/user.service.ts
+++ b/server/features/user/user.service.ts
@@ -1,0 +1,16 @@
+import type { UserRepository, UserService } from "@zone-blitz/shared";
+import type pino from "pino";
+
+export function createUserService(deps: {
+  userRepo: UserRepository;
+  log: pino.Logger;
+}): UserService {
+  const log = deps.log.child({ module: "user.service" });
+
+  return {
+    async deleteById(id) {
+      log.info({ id }, "deleting user account");
+      await deps.userRepo.deleteById(id);
+    },
+  };
+}

--- a/server/main.ts
+++ b/server/main.ts
@@ -32,7 +32,10 @@ const app = new Hono<AppEnv>()
   .route("/api/health", features.healthRouter)
   .use("/api/leagues/*", authGuard())
   .use("/api/leagues", authGuard())
-  .route("/api/leagues", features.leagueRouter);
+  .route("/api/leagues", features.leagueRouter)
+  .use("/api/users/*", authGuard())
+  .use("/api/users", authGuard())
+  .route("/api/users", features.userRouter);
 
 // Domain error handler
 app.onError((err, c) => {


### PR DESCRIPTION
## Summary

- Adds a `UserMenu` component with user info display, sign out, and account deletion (with confirmation)
- Placed in the top-right corner of the home/leagues page (dropdown) and at the bottom of the league dashboard sidebar (pop-up)
- Server-side `DELETE /api/users/me` endpoint behind auth guard, following the existing repository → service → router pattern
- Full test coverage across all new server and client code

🤖 Generated with [Claude Code](https://claude.com/claude-code)