### PR TITLE
feat(season): add seasons table with phase tracking

### DIFF
--- a/packages/shared/interfaces/repositories/season-repository.ts
+++ b/packages/shared/interfaces/repositories/season-repository.ts
@@ -1,0 +1,7 @@
+import type { NewSeason, Season } from "../../types/season.ts";
+
+export interface SeasonRepository {
+  getByLeagueId(leagueId: string): Promise<Season[]>;
+  getById(id: string): Promise<Season | undefined>;
+  create(season: NewSeason): Promise<Season>;
+}

--- a/packages/shared/mod.ts
+++ b/packages/shared/mod.ts
@@ -2,11 +2,13 @@
 export type { HealthStatus } from "./types/health.ts";
 export type { League, NewLeague } from "./types/league.ts";
 export type { Team } from "./types/team.ts";
+export type { NewSeason, Season, SeasonPhase } from "./types/season.ts";
 
 // Interfaces — repositories
 export type { LeagueRepository } from "./interfaces/repositories/league-repository.ts";
 export type { TeamRepository } from "./interfaces/repositories/team-repository.ts";
 export type { UserRepository } from "./interfaces/repositories/user-repository.ts";
+export type { SeasonRepository } from "./interfaces/repositories/season-repository.ts";
 
 // Interfaces — services
 export type { HealthService } from "./interfaces/services/health-service.ts";

--- a/packages/shared/types/season.ts
+++ b/packages/shared/types/season.ts
@@ -1,0 +1,22 @@
+export type SeasonPhase =
+  | "preseason"
+  | "regular_season"
+  | "playoffs"
+  | "offseason";
+
+export interface Season {
+  id: string;
+  leagueId: string;
+  year: number;
+  phase: SeasonPhase;
+  week: number;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+export interface NewSeason {
+  leagueId: string;
+  year?: number;
+  phase?: SeasonPhase;
+  week?: number;
+}

--- a/server/db/migrations/0005_exotic_jigsaw.sql
+++ b/server/db/migrations/0005_exotic_jigsaw.sql
@@ -1,0 +1,12 @@
+CREATE TYPE "public"."season_phase" AS ENUM('preseason', 'regular_season', 'playoffs', 'offseason');--> statement-breakpoint
+CREATE TABLE "seasons" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"league_id" uuid NOT NULL,
+	"year" integer DEFAULT 1 NOT NULL,
+	"phase" "season_phase" DEFAULT 'preseason' NOT NULL,
+	"week" integer DEFAULT 1 NOT NULL,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"updated_at" timestamp DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "seasons" ADD CONSTRAINT "seasons_league_id_leagues_id_fk" FOREIGN KEY ("league_id") REFERENCES "public"."leagues"("id") ON DELETE cascade ON UPDATE no action;

--- a/server/db/migrations/meta/0005_snapshot.json
+++ b/server/db/migrations/meta/0005_snapshot.json
@@ -1,0 +1,619 @@
+{
+  "id": "f7002a76-8e3b-470c-80fd-3b3dc280aeb4",
+  "prevId": "bbd997e6-471a-4adb-a5af-dd00bbe9eddb",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.accounts": {
+      "name": "accounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "accounts_user_id_users_id_fk": {
+          "name": "accounts_user_id_users_id_fk",
+          "tableFrom": "accounts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.health_checks": {
+      "name": "health_checks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "checked_at": {
+          "name": "checked_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.leagues": {
+      "name": "leagues",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "number_of_teams": {
+          "name": "number_of_teams",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 32
+        },
+        "season_length": {
+          "name": "season_length",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 17
+        },
+        "salary_cap": {
+          "name": "salary_cap",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 255000000
+        },
+        "cap_floor_percent": {
+          "name": "cap_floor_percent",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 89
+        },
+        "cap_growth_rate": {
+          "name": "cap_growth_rate",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 5
+        },
+        "roster_size": {
+          "name": "roster_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 53
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.seasons": {
+      "name": "seasons",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "league_id": {
+          "name": "league_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "year": {
+          "name": "year",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "phase": {
+          "name": "phase",
+          "type": "season_phase",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'preseason'"
+        },
+        "week": {
+          "name": "week",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "seasons_league_id_leagues_id_fk": {
+          "name": "seasons_league_id_leagues_id_fk",
+          "tableFrom": "seasons",
+          "tableTo": "leagues",
+          "columnsFrom": [
+            "league_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "sessions_token_unique": {
+          "name": "sessions_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.teams": {
+      "name": "teams",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "city": {
+          "name": "city",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "abbreviation": {
+          "name": "abbreviation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "primary_color": {
+          "name": "primary_color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "secondary_color": {
+          "name": "secondary_color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "accent_color": {
+          "name": "accent_color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conference": {
+          "name": "conference",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "division": {
+          "name": "division",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "teams_abbreviation_unique": {
+          "name": "teams_abbreviation_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "abbreviation"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verifications": {
+      "name": "verifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.season_phase": {
+      "name": "season_phase",
+      "schema": "public",
+      "values": [
+        "preseason",
+        "regular_season",
+        "playoffs",
+        "offseason"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/server/db/migrations/meta/_journal.json
+++ b/server/db/migrations/meta/_journal.json
@@ -36,6 +36,13 @@
       "when": 1776114459832,
       "tag": "0004_chunky_silver_fox",
       "breakpoints": true
+    },
+    {
+      "idx": 5,
+      "version": "7",
+      "when": 1776114882838,
+      "tag": "0005_exotic_jigsaw",
+      "breakpoints": true
     }
   ]
 }

--- a/server/db/schema.ts
+++ b/server/db/schema.ts
@@ -9,6 +9,7 @@ export const healthChecks = pgTable("health_checks", {
 // Feature schemas
 export { leagues } from "../features/league/league.schema.ts";
 export { teams } from "../features/team/team.schema.ts";
+export { seasonPhaseEnum, seasons } from "../features/season/season.schema.ts";
 export {
   accounts,
   sessions,

--- a/server/features/season/mod.ts
+++ b/server/features/season/mod.ts
@@ -1,0 +1,1 @@
+export { createSeasonRepository } from "./season.repository.ts";

--- a/server/features/season/season.repository.test.ts
+++ b/server/features/season/season.repository.test.ts
@@ -1,0 +1,198 @@
+import { assertEquals } from "@std/assert";
+import { drizzle } from "drizzle-orm/postgres-js";
+import postgres from "postgres";
+import * as schema from "../../db/schema.ts";
+import { seasons } from "./season.schema.ts";
+import { leagues } from "../league/league.schema.ts";
+import { createSeasonRepository } from "./season.repository.ts";
+import pino from "pino";
+import { eq } from "drizzle-orm";
+
+function createTestDb() {
+  const connectionString = Deno.env.get("DATABASE_URL");
+  if (!connectionString) {
+    throw new Error("DATABASE_URL is required for integration tests");
+  }
+  const client = postgres(connectionString);
+  const db = drizzle(client, { schema });
+  return { db, client };
+}
+
+function createTestLogger() {
+  return pino({ level: "silent" });
+}
+
+async function createTestLeague(db: ReturnType<typeof createTestDb>["db"]) {
+  const [league] = await db
+    .insert(leagues)
+    .values({ name: "Test League" })
+    .returning();
+  return league;
+}
+
+Deno.test({
+  name: "seasonRepository.getByLeagueId: returns seasons for a league",
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    const { db, client } = createTestDb();
+    const repo = createSeasonRepository({ db, log: createTestLogger() });
+    let leagueId: string | undefined;
+
+    try {
+      const league = await createTestLeague(db);
+      leagueId = league.id;
+
+      await db
+        .insert(seasons)
+        .values([
+          { leagueId: league.id, year: 1 },
+          { leagueId: league.id, year: 2 },
+        ]);
+
+      const result = await repo.getByLeagueId(league.id);
+      assertEquals(result.length, 2);
+
+      const years = result.map((s) => s.year);
+      assertEquals(years.includes(1), true);
+      assertEquals(years.includes(2), true);
+    } finally {
+      if (leagueId) {
+        await db.delete(seasons).where(eq(seasons.leagueId, leagueId));
+        await db.delete(leagues).where(eq(leagues.id, leagueId));
+      }
+      await client.end();
+    }
+  },
+});
+
+Deno.test({
+  name: "seasonRepository.getByLeagueId: returns empty array when no seasons",
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    const { db, client } = createTestDb();
+    const repo = createSeasonRepository({ db, log: createTestLogger() });
+
+    try {
+      const result = await repo.getByLeagueId(crypto.randomUUID());
+      assertEquals(result.length, 0);
+    } finally {
+      await client.end();
+    }
+  },
+});
+
+Deno.test({
+  name: "seasonRepository.getById: returns the season when it exists",
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    const { db, client } = createTestDb();
+    const repo = createSeasonRepository({ db, log: createTestLogger() });
+    let leagueId: string | undefined;
+
+    try {
+      const league = await createTestLeague(db);
+      leagueId = league.id;
+
+      const [created] = await db
+        .insert(seasons)
+        .values({ leagueId: league.id, year: 1 })
+        .returning();
+
+      const result = await repo.getById(created.id);
+      assertEquals(result?.id, created.id);
+      assertEquals(result?.year, 1);
+      assertEquals(result?.phase, "preseason");
+      assertEquals(result?.week, 1);
+    } finally {
+      if (leagueId) {
+        await db.delete(seasons).where(eq(seasons.leagueId, leagueId));
+        await db.delete(leagues).where(eq(leagues.id, leagueId));
+      }
+      await client.end();
+    }
+  },
+});
+
+Deno.test({
+  name: "seasonRepository.getById: returns undefined when not found",
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    const { db, client } = createTestDb();
+    const repo = createSeasonRepository({ db, log: createTestLogger() });
+
+    try {
+      const result = await repo.getById(crypto.randomUUID());
+      assertEquals(result, undefined);
+    } finally {
+      await client.end();
+    }
+  },
+});
+
+Deno.test({
+  name:
+    "seasonRepository.create: inserts and returns the new season with defaults",
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    const { db, client } = createTestDb();
+    const repo = createSeasonRepository({ db, log: createTestLogger() });
+    let leagueId: string | undefined;
+
+    try {
+      const league = await createTestLeague(db);
+      leagueId = league.id;
+
+      const result = await repo.create({ leagueId: league.id });
+
+      assertEquals(result.leagueId, league.id);
+      assertEquals(result.year, 1);
+      assertEquals(result.phase, "preseason");
+      assertEquals(result.week, 1);
+      assertEquals(typeof result.id, "string");
+    } finally {
+      if (leagueId) {
+        await db.delete(seasons).where(eq(seasons.leagueId, leagueId));
+        await db.delete(leagues).where(eq(leagues.id, leagueId));
+      }
+      await client.end();
+    }
+  },
+});
+
+Deno.test({
+  name: "seasonRepository.create: accepts custom year, phase, and week",
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    const { db, client } = createTestDb();
+    const repo = createSeasonRepository({ db, log: createTestLogger() });
+    let leagueId: string | undefined;
+
+    try {
+      const league = await createTestLeague(db);
+      leagueId = league.id;
+
+      const result = await repo.create({
+        leagueId: league.id,
+        year: 3,
+        phase: "regular_season",
+        week: 10,
+      });
+
+      assertEquals(result.year, 3);
+      assertEquals(result.phase, "regular_season");
+      assertEquals(result.week, 10);
+    } finally {
+      if (leagueId) {
+        await db.delete(seasons).where(eq(seasons.leagueId, leagueId));
+        await db.delete(leagues).where(eq(leagues.id, leagueId));
+      }
+      await client.end();
+    }
+  },
+});

--- a/server/features/season/season.repository.ts
+++ b/server/features/season/season.repository.ts
@@ -1,0 +1,46 @@
+import type { SeasonRepository } from "@zone-blitz/shared";
+import type pino from "pino";
+import { eq } from "drizzle-orm";
+import type { Database } from "../../db/connection.ts";
+import { seasons } from "./season.schema.ts";
+
+export function createSeasonRepository(deps: {
+  db: Database;
+  log: pino.Logger;
+}): SeasonRepository {
+  const log = deps.log.child({ module: "season.repository" });
+
+  return {
+    async getByLeagueId(leagueId) {
+      log.debug({ leagueId }, "fetching seasons by league id");
+      return await deps.db
+        .select()
+        .from(seasons)
+        .where(eq(seasons.leagueId, leagueId));
+    },
+
+    async getById(id) {
+      log.debug({ id }, "fetching season by id");
+      const [season] = await deps.db
+        .select()
+        .from(seasons)
+        .where(eq(seasons.id, id))
+        .limit(1);
+      return season;
+    },
+
+    async create(input) {
+      log.debug({ leagueId: input.leagueId }, "creating season");
+      const [season] = await deps.db
+        .insert(seasons)
+        .values({
+          leagueId: input.leagueId,
+          year: input.year,
+          phase: input.phase,
+          week: input.week,
+        })
+        .returning();
+      return season;
+    },
+  };
+}

--- a/server/features/season/season.schema.ts
+++ b/server/features/season/season.schema.ts
@@ -1,0 +1,21 @@
+import { integer, pgEnum, pgTable, timestamp, uuid } from "drizzle-orm/pg-core";
+import { leagues } from "../league/league.schema.ts";
+
+export const seasonPhaseEnum = pgEnum("season_phase", [
+  "preseason",
+  "regular_season",
+  "playoffs",
+  "offseason",
+]);
+
+export const seasons = pgTable("seasons", {
+  id: uuid("id").defaultRandom().primaryKey(),
+  leagueId: uuid("league_id")
+    .notNull()
+    .references(() => leagues.id, { onDelete: "cascade" }),
+  year: integer("year").notNull().default(1),
+  phase: seasonPhaseEnum("phase").notNull().default("preseason"),
+  week: integer("week").notNull().default(1),
+  createdAt: timestamp("created_at").defaultNow().notNull(),
+  updatedAt: timestamp("updated_at").defaultNow().notNull(),
+});


### PR DESCRIPTION
## Summary

- Adds `seasons` table with `leagueId` (FK with cascade delete), `year`, `phase` (Postgres enum: preseason, regular_season, playoffs, offseason), and `week`
- Defaults to Year 1, Preseason, Week 1 — matching the league creation starting state
- Adds `Season`, `NewSeason`, `SeasonPhase` shared types and `SeasonRepository` interface
- Server-side repository with `getByLeagueId`, `getById`, and `create` methods
- Integration tests covering all repository methods including default and custom values

🤖 Generated with [Claude Code](https://claude.com/claude-code)