### PR TITLE
feat(client): add collapsible sidebar to league dashboard

### DIFF
--- a/client/src/features/league/layout.test.tsx
+++ b/client/src/features/league/layout.test.tsx
@@ -1,4 +1,4 @@
-import { cleanup, render, screen } from "@testing-library/react";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { LeagueLayout } from "./layout.tsx";
 
@@ -60,5 +60,57 @@ describe("LeagueLayout", () => {
     const settingsLink = screen.getByRole("link", { name: /settings/i });
     expect(settingsLink).toBeDefined();
     expect(settingsLink.getAttribute("href")).toBe("/leagues/1/settings");
+  });
+
+  it("renders a toggle button to collapse the sidebar", () => {
+    render(<LeagueLayout />);
+    const toggleButton = screen.getByRole("button", {
+      name: /collapse sidebar/i,
+    });
+    expect(toggleButton).toBeDefined();
+  });
+
+  it("hides nav link text labels when the sidebar is collapsed", () => {
+    render(<LeagueLayout />);
+
+    const toggleButton = screen.getByRole("button", {
+      name: /collapse sidebar/i,
+    });
+    fireEvent.click(toggleButton);
+
+    expect(screen.queryByText("Home")).toBeNull();
+    expect(screen.queryByText("Settings")).toBeNull();
+    expect(screen.queryByText("All Leagues")).toBeNull();
+  });
+
+  it("keeps nav link icons visible when the sidebar is collapsed", () => {
+    render(<LeagueLayout />);
+
+    const toggleButton = screen.getByRole("button", {
+      name: /collapse sidebar/i,
+    });
+    fireEvent.click(toggleButton);
+
+    const nav = screen.getByRole("navigation");
+    const svgs = nav.querySelectorAll("svg");
+    expect(svgs.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it("expands the sidebar when the toggle is clicked again", () => {
+    render(<LeagueLayout />);
+
+    const toggleButton = screen.getByRole("button", {
+      name: /collapse sidebar/i,
+    });
+    fireEvent.click(toggleButton);
+
+    const expandButton = screen.getByRole("button", {
+      name: /expand sidebar/i,
+    });
+    fireEvent.click(expandButton);
+
+    expect(screen.getByText("Home")).toBeDefined();
+    expect(screen.getByText("Settings")).toBeDefined();
+    expect(screen.getByText("All Leagues")).toBeDefined();
   });
 });

--- a/client/src/features/league/layout.tsx
+++ b/client/src/features/league/layout.tsx
@@ -1,39 +1,78 @@
+import { useState } from "react";
 import { Link, Outlet, useParams } from "@tanstack/react-router";
-import { ArrowLeft, Home, Settings } from "lucide-react";
+import {
+  ArrowLeft,
+  ChevronLeft,
+  ChevronRight,
+  Home,
+  Settings,
+} from "lucide-react";
 
 export function LeagueLayout() {
   const { leagueId } = useParams({ strict: false });
+  const [collapsed, setCollapsed] = useState(false);
 
   return (
     <div className="flex min-h-screen bg-gray-950 text-gray-100">
-      <nav className="w-60 border-r border-gray-800 p-4">
-        <Link
-          to="/"
-          className="mb-4 flex items-center gap-2 text-sm text-gray-400 hover:text-gray-200"
-        >
-          <ArrowLeft size={16} />
-          All Leagues
-        </Link>
+      <nav
+        className={`${
+          collapsed ? "w-14" : "w-60"
+        } border-r border-gray-800 p-4 transition-all duration-200`}
+      >
+        <div className="flex items-center justify-between mb-4">
+          {!collapsed && (
+            <Link
+              to="/"
+              className="flex items-center gap-2 text-sm text-gray-400 hover:text-gray-200"
+            >
+              <ArrowLeft size={16} />
+              All Leagues
+            </Link>
+          )}
+          {collapsed && (
+            <Link
+              to="/"
+              className="flex items-center justify-center text-sm text-gray-400 hover:text-gray-200"
+              title="All Leagues"
+            >
+              <ArrowLeft size={16} />
+            </Link>
+          )}
+        </div>
         <ul>
           <li>
             <Link
               to={`/leagues/${leagueId}`}
-              className="flex items-center gap-2 rounded px-3 py-2 text-sm font-medium text-gray-300 hover:bg-gray-800 hover:text-gray-100"
+              className={`flex items-center ${
+                collapsed ? "justify-center" : "gap-2 px-3"
+              } rounded py-2 text-sm font-medium text-gray-300 hover:bg-gray-800 hover:text-gray-100`}
+              title={collapsed ? "Home" : undefined}
             >
               <Home size={16} />
-              Home
+              {!collapsed && "Home"}
             </Link>
           </li>
           <li>
             <Link
               to={`/leagues/${leagueId}/settings`}
-              className="flex items-center gap-2 rounded px-3 py-2 text-sm font-medium text-gray-300 hover:bg-gray-800 hover:text-gray-100"
+              className={`flex items-center ${
+                collapsed ? "justify-center" : "gap-2 px-3"
+              } rounded py-2 text-sm font-medium text-gray-300 hover:bg-gray-800 hover:text-gray-100`}
+              title={collapsed ? "Settings" : undefined}
             >
               <Settings size={16} />
-              Settings
+              {!collapsed && "Settings"}
             </Link>
           </li>
         </ul>
+        <button
+          type="button"
+          onClick={() => setCollapsed(!collapsed)}
+          className="mt-4 flex w-full items-center justify-center rounded py-2 text-sm text-gray-400 hover:bg-gray-800 hover:text-gray-200"
+          aria-label={collapsed ? "Expand sidebar" : "Collapse sidebar"}
+        >
+          {collapsed ? <ChevronRight size={16} /> : <ChevronLeft size={16} />}
+        </button>
       </nav>
       <main className="flex-1 p-6">
         <Outlet />


### PR DESCRIPTION
## Summary

- Adds a chevron toggle button to the league dashboard sidebar that collapses it to icon-only mode (`w-14`), giving users more screen real estate for main content.
- Clicking the chevron again expands the sidebar back to full width (`w-60`) with text labels.
- Includes smooth CSS transition animation between states.

🤖 Generated with [Claude Code](https://claude.com/claude-code)