### PR TITLE
feat(schedule): add games table and stub schedule generator

### DIFF
--- a/packages/shared/interfaces/generators/schedule-generator.ts
+++ b/packages/shared/interfaces/generators/schedule-generator.ts
@@ -1,0 +1,19 @@
+import type { Game } from "../../types/game.ts";
+
+export interface TeamDivisionInfo {
+  teamId: string;
+  conference: string;
+  division: string;
+}
+
+export interface ScheduleGeneratorInput {
+  seasonId: string;
+  teams: TeamDivisionInfo[];
+  seasonLength: number;
+}
+
+export type GeneratedGame = Omit<Game, "id" | "createdAt" | "updatedAt">;
+
+export interface ScheduleGenerator {
+  generate(input: ScheduleGeneratorInput): GeneratedGame[];
+}

--- a/packages/shared/mod.ts
+++ b/packages/shared/mod.ts
@@ -11,6 +11,7 @@ export type {
   Player,
   Scout,
 } from "./types/personnel.ts";
+export type { Game } from "./types/game.ts";
 
 // Interfaces — repositories
 export type { LeagueRepository } from "./interfaces/repositories/league-repository.ts";
@@ -26,6 +27,12 @@ export type {
   PersonnelGenerator,
   PersonnelGeneratorInput,
 } from "./interfaces/generators/personnel-generator.ts";
+export type {
+  GeneratedGame,
+  ScheduleGenerator,
+  ScheduleGeneratorInput,
+  TeamDivisionInfo,
+} from "./interfaces/generators/schedule-generator.ts";
 
 // Interfaces — services
 export type { HealthService } from "./interfaces/services/health-service.ts";

--- a/packages/shared/types/game.ts
+++ b/packages/shared/types/game.ts
@@ -1,0 +1,9 @@
+export interface Game {
+  id: string;
+  seasonId: string;
+  week: number;
+  homeTeamId: string;
+  awayTeamId: string;
+  createdAt: Date;
+  updatedAt: Date;
+}

--- a/server/db/migrations/0008_little_taskmaster.sql
+++ b/server/db/migrations/0008_little_taskmaster.sql
@@ -1,0 +1,13 @@
+CREATE TABLE "games" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"season_id" uuid NOT NULL,
+	"week" integer NOT NULL,
+	"home_team_id" uuid NOT NULL,
+	"away_team_id" uuid NOT NULL,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"updated_at" timestamp DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "games" ADD CONSTRAINT "games_season_id_seasons_id_fk" FOREIGN KEY ("season_id") REFERENCES "public"."seasons"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "games" ADD CONSTRAINT "games_home_team_id_teams_id_fk" FOREIGN KEY ("home_team_id") REFERENCES "public"."teams"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "games" ADD CONSTRAINT "games_away_team_id_teams_id_fk" FOREIGN KEY ("away_team_id") REFERENCES "public"."teams"("id") ON DELETE cascade ON UPDATE no action;

--- a/server/db/migrations/meta/0008_snapshot.json
+++ b/server/db/migrations/meta/0008_snapshot.json
@@ -1,0 +1,1235 @@
+{
+  "id": "fe2fb083-a90d-4c25-b269-f14c18ce76cf",
+  "prevId": "8e363a28-ecf5-4fc5-bc92-5f5b69c2202c",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.accounts": {
+      "name": "accounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "accounts_user_id_users_id_fk": {
+          "name": "accounts_user_id_users_id_fk",
+          "tableFrom": "accounts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.coaches": {
+      "name": "coaches",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "league_id": {
+          "name": "league_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "coaches_league_id_leagues_id_fk": {
+          "name": "coaches_league_id_leagues_id_fk",
+          "tableFrom": "coaches",
+          "tableTo": "leagues",
+          "columnsFrom": [
+            "league_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "coaches_team_id_teams_id_fk": {
+          "name": "coaches_team_id_teams_id_fk",
+          "tableFrom": "coaches",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.contracts": {
+      "name": "contracts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "player_id": {
+          "name": "player_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_years": {
+          "name": "total_years",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "current_year": {
+          "name": "current_year",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "total_salary": {
+          "name": "total_salary",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "annual_salary": {
+          "name": "annual_salary",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "guaranteed_money": {
+          "name": "guaranteed_money",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "signing_bonus": {
+          "name": "signing_bonus",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "contracts_player_id_players_id_fk": {
+          "name": "contracts_player_id_players_id_fk",
+          "tableFrom": "contracts",
+          "tableTo": "players",
+          "columnsFrom": [
+            "player_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "contracts_team_id_teams_id_fk": {
+          "name": "contracts_team_id_teams_id_fk",
+          "tableFrom": "contracts",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.draft_prospects": {
+      "name": "draft_prospects",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "season_id": {
+          "name": "season_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "draft_prospects_season_id_seasons_id_fk": {
+          "name": "draft_prospects_season_id_seasons_id_fk",
+          "tableFrom": "draft_prospects",
+          "tableTo": "seasons",
+          "columnsFrom": [
+            "season_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.front_office_staff": {
+      "name": "front_office_staff",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "league_id": {
+          "name": "league_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "front_office_staff_league_id_leagues_id_fk": {
+          "name": "front_office_staff_league_id_leagues_id_fk",
+          "tableFrom": "front_office_staff",
+          "tableTo": "leagues",
+          "columnsFrom": [
+            "league_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "front_office_staff_team_id_teams_id_fk": {
+          "name": "front_office_staff_team_id_teams_id_fk",
+          "tableFrom": "front_office_staff",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.games": {
+      "name": "games",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "season_id": {
+          "name": "season_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "week": {
+          "name": "week",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "home_team_id": {
+          "name": "home_team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "away_team_id": {
+          "name": "away_team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "games_season_id_seasons_id_fk": {
+          "name": "games_season_id_seasons_id_fk",
+          "tableFrom": "games",
+          "tableTo": "seasons",
+          "columnsFrom": [
+            "season_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "games_home_team_id_teams_id_fk": {
+          "name": "games_home_team_id_teams_id_fk",
+          "tableFrom": "games",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "home_team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "games_away_team_id_teams_id_fk": {
+          "name": "games_away_team_id_teams_id_fk",
+          "tableFrom": "games",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "away_team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.health_checks": {
+      "name": "health_checks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "checked_at": {
+          "name": "checked_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.leagues": {
+      "name": "leagues",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "number_of_teams": {
+          "name": "number_of_teams",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 32
+        },
+        "season_length": {
+          "name": "season_length",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 17
+        },
+        "salary_cap": {
+          "name": "salary_cap",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 255000000
+        },
+        "cap_floor_percent": {
+          "name": "cap_floor_percent",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 89
+        },
+        "cap_growth_rate": {
+          "name": "cap_growth_rate",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 5
+        },
+        "roster_size": {
+          "name": "roster_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 53
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.players": {
+      "name": "players",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "league_id": {
+          "name": "league_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "players_league_id_leagues_id_fk": {
+          "name": "players_league_id_leagues_id_fk",
+          "tableFrom": "players",
+          "tableTo": "leagues",
+          "columnsFrom": [
+            "league_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "players_team_id_teams_id_fk": {
+          "name": "players_team_id_teams_id_fk",
+          "tableFrom": "players",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.scouts": {
+      "name": "scouts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "league_id": {
+          "name": "league_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "scouts_league_id_leagues_id_fk": {
+          "name": "scouts_league_id_leagues_id_fk",
+          "tableFrom": "scouts",
+          "tableTo": "leagues",
+          "columnsFrom": [
+            "league_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "scouts_team_id_teams_id_fk": {
+          "name": "scouts_team_id_teams_id_fk",
+          "tableFrom": "scouts",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.seasons": {
+      "name": "seasons",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "league_id": {
+          "name": "league_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "year": {
+          "name": "year",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "phase": {
+          "name": "phase",
+          "type": "season_phase",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'preseason'"
+        },
+        "week": {
+          "name": "week",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "seasons_league_id_leagues_id_fk": {
+          "name": "seasons_league_id_leagues_id_fk",
+          "tableFrom": "seasons",
+          "tableTo": "leagues",
+          "columnsFrom": [
+            "league_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "sessions_token_unique": {
+          "name": "sessions_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.teams": {
+      "name": "teams",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "city": {
+          "name": "city",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "abbreviation": {
+          "name": "abbreviation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "primary_color": {
+          "name": "primary_color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "secondary_color": {
+          "name": "secondary_color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "accent_color": {
+          "name": "accent_color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conference": {
+          "name": "conference",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "division": {
+          "name": "division",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "teams_abbreviation_unique": {
+          "name": "teams_abbreviation_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "abbreviation"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verifications": {
+      "name": "verifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.season_phase": {
+      "name": "season_phase",
+      "schema": "public",
+      "values": [
+        "preseason",
+        "regular_season",
+        "playoffs",
+        "offseason"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/server/db/migrations/meta/_journal.json
+++ b/server/db/migrations/meta/_journal.json
@@ -57,6 +57,13 @@
       "when": 1776116142125,
       "tag": "0007_small_rogue",
       "breakpoints": true
+    },
+    {
+      "idx": 8,
+      "version": "7",
+      "when": 1776116477104,
+      "tag": "0008_little_taskmaster",
+      "breakpoints": true
     }
   ]
 }

--- a/server/db/schema.ts
+++ b/server/db/schema.ts
@@ -18,6 +18,7 @@ export {
   scouts,
 } from "../features/personnel/personnel.schema.ts";
 export { contracts } from "../features/personnel/contract.schema.ts";
+export { games } from "../features/schedule/game.schema.ts";
 export {
   accounts,
   sessions,

--- a/server/features/schedule/game.schema.ts
+++ b/server/features/schedule/game.schema.ts
@@ -1,0 +1,19 @@
+import { integer, pgTable, timestamp, uuid } from "drizzle-orm/pg-core";
+import { seasons } from "../season/season.schema.ts";
+import { teams } from "../team/team.schema.ts";
+
+export const games = pgTable("games", {
+  id: uuid("id").defaultRandom().primaryKey(),
+  seasonId: uuid("season_id")
+    .notNull()
+    .references(() => seasons.id, { onDelete: "cascade" }),
+  week: integer("week").notNull(),
+  homeTeamId: uuid("home_team_id")
+    .notNull()
+    .references(() => teams.id, { onDelete: "cascade" }),
+  awayTeamId: uuid("away_team_id")
+    .notNull()
+    .references(() => teams.id, { onDelete: "cascade" }),
+  createdAt: timestamp("created_at").defaultNow().notNull(),
+  updatedAt: timestamp("updated_at").defaultNow().notNull(),
+});

--- a/server/features/schedule/mod.ts
+++ b/server/features/schedule/mod.ts
@@ -1,0 +1,1 @@
+export { createStubScheduleGenerator } from "./stub-schedule-generator.ts";

--- a/server/features/schedule/stub-schedule-generator.test.ts
+++ b/server/features/schedule/stub-schedule-generator.test.ts
@@ -1,0 +1,154 @@
+import { assertEquals } from "@std/assert";
+import { createStubScheduleGenerator } from "./stub-schedule-generator.ts";
+import { DEFAULT_TEAMS } from "../team/default-teams.ts";
+import type { TeamDivisionInfo } from "@zone-blitz/shared";
+
+const TEAMS: TeamDivisionInfo[] = DEFAULT_TEAMS.map((t, i) => ({
+  teamId: `team-${i}`,
+  conference: t.conference,
+  division: t.division,
+}));
+
+const INPUT = {
+  seasonId: "season-1",
+  teams: TEAMS,
+  seasonLength: 17,
+};
+
+function generateSchedule() {
+  const generator = createStubScheduleGenerator();
+  return generator.generate(INPUT);
+}
+
+Deno.test("each team plays exactly 17 games", () => {
+  const games = generateSchedule();
+  const teamGameCounts = new Map<string, number>();
+
+  for (const game of games) {
+    teamGameCounts.set(
+      game.homeTeamId,
+      (teamGameCounts.get(game.homeTeamId) ?? 0) + 1,
+    );
+    teamGameCounts.set(
+      game.awayTeamId,
+      (teamGameCounts.get(game.awayTeamId) ?? 0) + 1,
+    );
+  }
+
+  for (const team of TEAMS) {
+    assertEquals(
+      teamGameCounts.get(team.teamId),
+      17,
+      `${team.teamId} should play 17 games`,
+    );
+  }
+});
+
+Deno.test("generates 272 total games (32 teams * 17 games / 2)", () => {
+  const games = generateSchedule();
+  assertEquals(games.length, 272);
+});
+
+Deno.test("no team plays more than once per week", () => {
+  const games = generateSchedule();
+  const teamWeeks = new Map<string, Set<number>>();
+
+  for (const game of games) {
+    for (const teamId of [game.homeTeamId, game.awayTeamId]) {
+      if (!teamWeeks.has(teamId)) {
+        teamWeeks.set(teamId, new Set());
+      }
+      const weeks = teamWeeks.get(teamId)!;
+      assertEquals(
+        weeks.has(game.week),
+        false,
+        `${teamId} has duplicate game in week ${game.week}`,
+      );
+      weeks.add(game.week);
+    }
+  }
+});
+
+Deno.test("each team has exactly 1 bye week", () => {
+  const games = generateSchedule();
+  const teamWeeks = new Map<string, Set<number>>();
+
+  for (const game of games) {
+    for (const teamId of [game.homeTeamId, game.awayTeamId]) {
+      if (!teamWeeks.has(teamId)) {
+        teamWeeks.set(teamId, new Set());
+      }
+      teamWeeks.get(teamId)!.add(game.week);
+    }
+  }
+
+  for (const team of TEAMS) {
+    const weeksPlayed = teamWeeks.get(team.teamId)!.size;
+    assertEquals(
+      weeksPlayed,
+      17,
+      `${team.teamId} plays ${weeksPlayed} weeks, should be 17 (1 bye)`,
+    );
+  }
+});
+
+Deno.test("home team and away team are always different", () => {
+  const games = generateSchedule();
+  for (const game of games) {
+    assertEquals(
+      game.homeTeamId !== game.awayTeamId,
+      true,
+      `Game has same home and away team: ${game.homeTeamId}`,
+    );
+  }
+});
+
+Deno.test("division rivals play each other home-and-away (6 division games per team)", () => {
+  const games = generateSchedule();
+
+  // Build division map
+  const teamDivision = new Map<string, string>();
+  for (const team of TEAMS) {
+    teamDivision.set(team.teamId, team.division);
+  }
+
+  // Count division games per team
+  const divGameCounts = new Map<string, number>();
+  for (const game of games) {
+    if (
+      teamDivision.get(game.homeTeamId) ===
+        teamDivision.get(game.awayTeamId)
+    ) {
+      divGameCounts.set(
+        game.homeTeamId,
+        (divGameCounts.get(game.homeTeamId) ?? 0) + 1,
+      );
+      divGameCounts.set(
+        game.awayTeamId,
+        (divGameCounts.get(game.awayTeamId) ?? 0) + 1,
+      );
+    }
+  }
+
+  for (const team of TEAMS) {
+    assertEquals(
+      divGameCounts.get(team.teamId),
+      6,
+      `${team.teamId} should have 6 division games`,
+    );
+  }
+});
+
+Deno.test("all games are within weeks 1-18", () => {
+  const games = generateSchedule();
+  for (const game of games) {
+    assertEquals(game.week >= 1 && game.week <= 18, true);
+  }
+});
+
+Deno.test("all games reference the correct seasonId", () => {
+  const games = generateSchedule();
+  for (const game of games) {
+    assertEquals(game.seasonId, "season-1");
+  }
+});

--- a/server/features/schedule/stub-schedule-generator.ts
+++ b/server/features/schedule/stub-schedule-generator.ts
@@ -1,0 +1,233 @@
+import type {
+  GeneratedGame,
+  ScheduleGenerator,
+  ScheduleGeneratorInput,
+  TeamDivisionInfo,
+} from "@zone-blitz/shared";
+
+const TOTAL_WEEKS = 18;
+
+/**
+ * A stub schedule generator that produces a legal schedule:
+ * - Each team plays exactly 17 games across 18 weeks
+ * - Each team has exactly 1 bye week
+ * - No team plays twice in the same week
+ * - Division rivals play home-and-away (6 division games)
+ * - Remaining 11 games are filled from non-division opponents
+ */
+export function createStubScheduleGenerator(): ScheduleGenerator {
+  return {
+    generate(input: ScheduleGeneratorInput): GeneratedGame[] {
+      const { seasonId, teams } = input;
+
+      // Group teams by division and conference
+      const divisionMap = new Map<string, TeamDivisionInfo[]>();
+      const conferenceMap = new Map<string, string[]>();
+      for (const team of teams) {
+        if (!divisionMap.has(team.division)) {
+          divisionMap.set(team.division, []);
+        }
+        divisionMap.get(team.division)!.push(team);
+
+        if (!conferenceMap.has(team.conference)) {
+          conferenceMap.set(team.conference, []);
+        }
+        const confDivs = conferenceMap.get(team.conference)!;
+        if (!confDivs.includes(team.division)) {
+          confDivs.push(team.division);
+        }
+      }
+
+      const conferences = [...conferenceMap.keys()];
+      const matchups: { home: string; away: string }[] = [];
+
+      // 1. Division games: home-and-away vs each rival (6 per team)
+      for (const divTeams of divisionMap.values()) {
+        for (let i = 0; i < divTeams.length; i++) {
+          for (let j = i + 1; j < divTeams.length; j++) {
+            matchups.push({
+              home: divTeams[i].teamId,
+              away: divTeams[j].teamId,
+            });
+            matchups.push({
+              home: divTeams[j].teamId,
+              away: divTeams[i].teamId,
+            });
+          }
+        }
+      }
+
+      // 2. Intra-conference partner division (4 games per team)
+      // Pair divisions within each conference: [0,1] and [2,3]
+      for (const conf of conferences) {
+        const divs = conferenceMap.get(conf)!;
+        const pairs = [
+          [divs[0], divs[1]],
+          [divs[2], divs[3]],
+        ];
+        for (const [divA, divB] of pairs) {
+          const teamsA = divisionMap.get(divA)!;
+          const teamsB = divisionMap.get(divB)!;
+          for (let i = 0; i < teamsA.length; i++) {
+            // Each team plays the opponent at the same index at home,
+            // and the next index away (wrapping)
+            const homeOpp = teamsB[i];
+            const awayOpp = teamsB[(i + 1) % teamsB.length];
+            matchups.push({
+              home: teamsA[i].teamId,
+              away: homeOpp.teamId,
+            });
+            matchups.push({
+              home: awayOpp.teamId,
+              away: teamsA[i].teamId,
+            });
+            // Two more: next two opponents
+            const opp3 = teamsB[(i + 2) % teamsB.length];
+            const opp4 = teamsB[(i + 3) % teamsB.length];
+            matchups.push({
+              home: teamsA[i].teamId,
+              away: opp3.teamId,
+            });
+            matchups.push({
+              home: opp4.teamId,
+              away: teamsA[i].teamId,
+            });
+          }
+        }
+      }
+
+      // 3. Inter-conference partner division (4 games per team)
+      // Pair first conference divs with second conference divs by index
+      const conf0Divs = conferenceMap.get(conferences[0])!;
+      const conf1Divs = conferenceMap.get(conferences[1])!;
+      for (let d = 0; d < conf0Divs.length; d++) {
+        const teamsA = divisionMap.get(conf0Divs[d])!;
+        const teamsB = divisionMap.get(conf1Divs[d])!;
+        for (let i = 0; i < teamsA.length; i++) {
+          const homeOpp = teamsB[i];
+          const awayOpp = teamsB[(i + 1) % teamsB.length];
+          matchups.push({
+            home: teamsA[i].teamId,
+            away: homeOpp.teamId,
+          });
+          matchups.push({
+            home: awayOpp.teamId,
+            away: teamsA[i].teamId,
+          });
+          const opp3 = teamsB[(i + 2) % teamsB.length];
+          const opp4 = teamsB[(i + 3) % teamsB.length];
+          matchups.push({
+            home: teamsA[i].teamId,
+            away: opp3.teamId,
+          });
+          matchups.push({
+            home: opp4.teamId,
+            away: teamsA[i].teamId,
+          });
+        }
+      }
+
+      // 4. Remaining 3 games per team: same-place finishers from other divs
+      // For year 1 (no standings), pair by index within remaining divisions
+      for (const conf of conferences) {
+        const divs = conferenceMap.get(conf)!;
+        // Each team plays the same-index team from the 2 non-partner divs
+        // Partner pairs are [0,1] and [2,3], so remaining for div 0 = [2,3]
+        const remaining: [number, number][] = [
+          [0, 2],
+          [0, 3],
+          [1, 2],
+          [1, 3],
+        ];
+        for (const [a, b] of remaining) {
+          const teamsA = divisionMap.get(divs[a])!;
+          const teamsB = divisionMap.get(divs[b])!;
+          for (let i = 0; i < teamsA.length; i++) {
+            // Only add one game per pair (avoid duplicates)
+            const key1 = `${teamsA[i].teamId}:${teamsB[i].teamId}`;
+            const key2 = `${teamsB[i].teamId}:${teamsA[i].teamId}`;
+            const alreadyPaired = matchups.some(
+              (m) =>
+                (`${m.home}:${m.away}` === key1) ||
+                (`${m.home}:${m.away}` === key2),
+            );
+            if (!alreadyPaired) {
+              matchups.push({
+                home: teamsA[i].teamId,
+                away: teamsB[i].teamId,
+              });
+            }
+          }
+        }
+      }
+
+      // Also add 1 inter-conference same-place game from non-partner division
+      for (let d = 0; d < conf0Divs.length; d++) {
+        const partnerD = d; // already paired by index
+        const otherD = (d + 1) % conf0Divs.length;
+        if (otherD === partnerD) continue;
+        const teamsA = divisionMap.get(conf0Divs[d])!;
+        const teamsB = divisionMap.get(conf1Divs[otherD])!;
+        for (let i = 0; i < teamsA.length; i++) {
+          const key1 = `${teamsA[i].teamId}:${teamsB[i].teamId}`;
+          const key2 = `${teamsB[i].teamId}:${teamsA[i].teamId}`;
+          const alreadyPaired = matchups.some(
+            (m) =>
+              (`${m.home}:${m.away}` === key1) ||
+              (`${m.home}:${m.away}` === key2),
+          );
+          if (!alreadyPaired) {
+            matchups.push({
+              home: teamsA[i].teamId,
+              away: teamsB[i].teamId,
+            });
+          }
+        }
+      }
+
+      // Trim to exactly 17 per team if over
+      const teamGameCounts = new Map<string, number>();
+      for (const team of teams) {
+        teamGameCounts.set(team.teamId, 0);
+      }
+      const finalMatchups: typeof matchups = [];
+      for (const m of matchups) {
+        const hc = teamGameCounts.get(m.home) ?? 0;
+        const ac = teamGameCounts.get(m.away) ?? 0;
+        if (hc < 17 && ac < 17) {
+          finalMatchups.push(m);
+          teamGameCounts.set(m.home, hc + 1);
+          teamGameCounts.set(m.away, ac + 1);
+        }
+      }
+
+      // 5. Assign matchups to weeks using greedy scheduling
+      const teamWeekUsed = new Map<string, Set<number>>();
+      for (const team of teams) {
+        teamWeekUsed.set(team.teamId, new Set());
+      }
+
+      const games: GeneratedGame[] = [];
+
+      for (const matchup of finalMatchups) {
+        for (let week = 1; week <= TOTAL_WEEKS; week++) {
+          const homeUsed = teamWeekUsed.get(matchup.home)!;
+          const awayUsed = teamWeekUsed.get(matchup.away)!;
+          if (!homeUsed.has(week) && !awayUsed.has(week)) {
+            games.push({
+              seasonId,
+              week,
+              homeTeamId: matchup.home,
+              awayTeamId: matchup.away,
+            });
+            homeUsed.add(week);
+            awayUsed.add(week);
+            break;
+          }
+        }
+      }
+
+      return games;
+    },
+  };
+}


### PR DESCRIPTION
## Summary

- Adds `games` table with `seasonId`, `week`, `homeTeamId`, `awayTeamId` and cascade deletes
- Defines `ScheduleGenerator` interface and `TeamDivisionInfo`, `GeneratedGame` shared types
- Implements stub schedule generator producing a legal 17-game, 18-week schedule for 32 teams
  - 6 division games (home-and-away), 4 intra-conference, 4 inter-conference, 3 remaining
  - Greedy week assignment with 1 bye per team, no double-bookings
- Tests verify all schedule invariants: 272 games, 17 per team, division home-and-away, weeks 1-18

🤖 Generated with [Claude Code](https://claude.com/claude-code)