### PR TITLE
feat(team-select): add team selection flow after league creation

### DIFF
--- a/client/src/features/league-select/index.test.tsx
+++ b/client/src/features/league-select/index.test.tsx
@@ -147,7 +147,7 @@ describe("LeagueSelect", () => {
     });
   });
 
-  it("submits the create league form", async () => {
+  it("submits the create league form and navigates to team select", async () => {
     mockGet.mockReturnValue(
       Promise.resolve({ json: () => Promise.resolve([]) }),
     );
@@ -170,6 +170,13 @@ describe("LeagueSelect", () => {
 
     await waitFor(() => {
       expect(mockPost).toHaveBeenCalledWith({ json: { name: "New League" } });
+    });
+
+    await waitFor(() => {
+      expect(mockNavigate).toHaveBeenCalledWith({
+        to: "/leagues/$leagueId/team-select",
+        params: { leagueId: "3" },
+      });
     });
   });
 

--- a/client/src/features/league-select/index.tsx
+++ b/client/src/features/league-select/index.tsx
@@ -29,7 +29,17 @@ export function LeagueSelect() {
             onSubmit={(e) => {
               e.preventDefault();
               if (!newName.trim()) return;
-              createLeague.mutate({ name: newName.trim() });
+              createLeague.mutate(
+                { name: newName.trim() },
+                {
+                  onSuccess: (league) => {
+                    navigate({
+                      to: "/leagues/$leagueId/team-select",
+                      params: { leagueId: String(league.id) },
+                    });
+                  },
+                },
+              );
               setNewName("");
             }}
           >

--- a/client/src/features/team-select/index.test.tsx
+++ b/client/src/features/team-select/index.test.tsx
@@ -1,0 +1,155 @@
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { TeamSelect } from "./index.tsx";
+
+const mockTeamsGet = vi.fn();
+const mockNavigate = vi.fn();
+
+vi.mock("../../api.ts", () => ({
+  api: {
+    api: {
+      teams: {
+        $get: (...args: unknown[]) => mockTeamsGet(...args),
+      },
+    },
+  },
+}));
+
+vi.mock("@tanstack/react-router", () => ({
+  useNavigate: () => mockNavigate,
+  useParams: () => ({ leagueId: "league-1" }),
+}));
+
+const MOCK_TEAMS = [
+  {
+    id: "t1",
+    name: "Minutemen",
+    city: "Boston",
+    abbreviation: "BOS",
+    primaryColor: "#0B2240",
+    secondaryColor: "#C41230",
+    conference: "AFC",
+    division: "AFC East",
+  },
+  {
+    id: "t2",
+    name: "Sharks",
+    city: "Miami",
+    abbreviation: "MIA",
+    primaryColor: "#006B70",
+    secondaryColor: "#FF6B35",
+    conference: "AFC",
+    division: "AFC East",
+  },
+  {
+    id: "t3",
+    name: "Lumberjacks",
+    city: "Green Bay",
+    abbreviation: "GBL",
+    primaryColor: "#204E32",
+    secondaryColor: "#FFB612",
+    conference: "NFC",
+    division: "NFC North",
+  },
+];
+
+function renderWithProviders() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <TeamSelect />
+    </QueryClientProvider>,
+  );
+}
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+describe("TeamSelect", () => {
+  it("renders the Choose Your Team heading", async () => {
+    mockTeamsGet.mockReturnValue(
+      Promise.resolve({ json: () => Promise.resolve(MOCK_TEAMS) }),
+    );
+    renderWithProviders();
+    await waitFor(() => {
+      expect(
+        screen.getByRole("heading", { name: "Choose Your Team" }),
+      ).toBeDefined();
+    });
+  });
+
+  it("shows loading state while fetching teams", () => {
+    mockTeamsGet.mockReturnValue(new Promise(() => {}));
+    renderWithProviders();
+    expect(screen.getByText("Loading teams...")).toBeDefined();
+  });
+
+  it("shows error state when fetch fails", async () => {
+    mockTeamsGet.mockReturnValue(Promise.reject(new Error("network error")));
+    renderWithProviders();
+    await waitFor(() => {
+      expect(screen.getByText("Failed to load teams")).toBeDefined();
+    });
+  });
+
+  it("renders teams grouped by conference", async () => {
+    mockTeamsGet.mockReturnValue(
+      Promise.resolve({ json: () => Promise.resolve(MOCK_TEAMS) }),
+    );
+    renderWithProviders();
+    await waitFor(() => {
+      expect(screen.getByText("AFC")).toBeDefined();
+      expect(screen.getByText("NFC")).toBeDefined();
+    });
+  });
+
+  it("renders teams with city and name", async () => {
+    mockTeamsGet.mockReturnValue(
+      Promise.resolve({ json: () => Promise.resolve(MOCK_TEAMS) }),
+    );
+    renderWithProviders();
+    await waitFor(() => {
+      expect(screen.getByText("Boston Minutemen")).toBeDefined();
+      expect(screen.getByText("Miami Sharks")).toBeDefined();
+      expect(screen.getByText("Green Bay Lumberjacks")).toBeDefined();
+    });
+  });
+
+  it("renders division headings", async () => {
+    mockTeamsGet.mockReturnValue(
+      Promise.resolve({ json: () => Promise.resolve(MOCK_TEAMS) }),
+    );
+    renderWithProviders();
+    await waitFor(() => {
+      expect(screen.getByText("AFC East")).toBeDefined();
+      expect(screen.getByText("NFC North")).toBeDefined();
+    });
+  });
+
+  it("navigates to league dashboard when a team is selected", async () => {
+    mockTeamsGet.mockReturnValue(
+      Promise.resolve({ json: () => Promise.resolve(MOCK_TEAMS) }),
+    );
+    renderWithProviders();
+    await waitFor(() => {
+      expect(screen.getByText("Boston Minutemen")).toBeDefined();
+    });
+
+    fireEvent.click(screen.getByText("Boston Minutemen"));
+    expect(mockNavigate).toHaveBeenCalledWith({
+      to: "/leagues/$leagueId",
+      params: { leagueId: "league-1" },
+    });
+  });
+});

--- a/client/src/features/team-select/index.tsx
+++ b/client/src/features/team-select/index.tsx
@@ -1,0 +1,127 @@
+import { useNavigate, useParams } from "@tanstack/react-router";
+import { useTeams } from "../../hooks/use-teams.ts";
+
+interface Team {
+  id: string;
+  name: string;
+  city: string;
+  abbreviation: string;
+  primaryColor: string;
+  secondaryColor: string;
+  conference: string;
+  division: string;
+}
+
+function groupByDivision(teams: Team[]) {
+  const grouped = new Map<string, Team[]>();
+  for (const team of teams) {
+    if (!grouped.has(team.division)) {
+      grouped.set(team.division, []);
+    }
+    grouped.get(team.division)!.push(team);
+  }
+  return grouped;
+}
+
+function TeamCard({
+  team,
+  onSelect,
+}: {
+  team: Team;
+  onSelect: (team: Team) => void;
+}) {
+  return (
+    <button
+      onClick={() => onSelect(team)}
+      className="flex items-center gap-3 rounded-lg border border-gray-700 bg-gray-800 px-4 py-3 text-left transition hover:border-gray-500 hover:bg-gray-750 w-full"
+    >
+      <div
+        className="h-8 w-8 rounded-full shrink-0"
+        style={{ backgroundColor: team.primaryColor }}
+      />
+      <div className="min-w-0">
+        <p className="text-sm font-medium text-gray-100 truncate">
+          {team.city} {team.name}
+        </p>
+        <p className="text-xs text-gray-400">{team.abbreviation}</p>
+      </div>
+    </button>
+  );
+}
+
+export function TeamSelect() {
+  const { leagueId } = useParams({ strict: false });
+  const { data: teams, isLoading, error } = useTeams();
+  const navigate = useNavigate();
+
+  const handleSelect = (_team: Team) => {
+    navigate({
+      to: "/leagues/$leagueId",
+      params: { leagueId: leagueId! },
+    });
+  };
+
+  if (isLoading) {
+    return (
+      <div className="min-h-screen bg-gray-950 text-gray-100 flex items-center justify-center">
+        <p className="text-gray-400">Loading teams...</p>
+      </div>
+    );
+  }
+
+  if (error || !teams) {
+    return (
+      <div className="min-h-screen bg-gray-950 text-gray-100 flex items-center justify-center">
+        <p className="text-red-400">Failed to load teams</p>
+      </div>
+    );
+  }
+
+  const divisions = groupByDivision(teams as Team[]);
+  const conferences = [...new Set((teams as Team[]).map((t) => t.conference))];
+
+  return (
+    <div className="min-h-screen bg-gray-950 text-gray-100 p-8">
+      <div className="max-w-5xl mx-auto space-y-8">
+        <div className="text-center space-y-2">
+          <h1 className="text-3xl font-bold tracking-tight">
+            Choose Your Team
+          </h1>
+          <p className="text-gray-400">
+            Select the franchise you want to manage.
+          </p>
+        </div>
+
+        {conferences.map((conference) => (
+          <div key={conference} className="space-y-6">
+            <h2 className="text-xl font-semibold text-gray-200 border-b border-gray-700 pb-2">
+              {conference}
+            </h2>
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+              {[...divisions.entries()]
+                .filter(([div]) =>
+                  div.startsWith(conference)
+                )
+                .map(([division, divTeams]) => (
+                  <div key={division} className="space-y-2">
+                    <h3 className="text-sm font-medium text-gray-400 uppercase tracking-wider">
+                      {division}
+                    </h3>
+                    <div className="space-y-1">
+                      {divTeams.map((team) => (
+                        <TeamCard
+                          key={team.id}
+                          team={team}
+                          onSelect={handleSelect}
+                        />
+                      ))}
+                    </div>
+                  </div>
+                ))}
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/client/src/features/team-select/index.tsx
+++ b/client/src/features/team-select/index.tsx
@@ -32,6 +32,7 @@ function TeamCard({
 }) {
   return (
     <button
+      type="button"
       onClick={() => onSelect(team)}
       className="flex items-center gap-3 rounded-lg border border-gray-700 bg-gray-800 px-4 py-3 text-left transition hover:border-gray-500 hover:bg-gray-750 w-full"
     >

--- a/client/src/hooks/use-teams.ts
+++ b/client/src/hooks/use-teams.ts
@@ -1,0 +1,12 @@
+import { useQuery } from "@tanstack/react-query";
+import { api } from "../api.ts";
+
+export function useTeams() {
+  return useQuery({
+    queryKey: ["teams"],
+    queryFn: async () => {
+      const res = await api.api.teams.$get();
+      return res.json();
+    },
+  });
+}

--- a/client/src/router.test.tsx
+++ b/client/src/router.test.tsx
@@ -5,6 +5,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { createAppRouter, createTestRouter } from "./router.tsx";
 
 const mockGet = vi.fn();
+const mockTeamsGet = vi.fn();
 const mockUseSession = vi.fn();
 
 vi.mock("./api.ts", () => ({
@@ -13,6 +14,9 @@ vi.mock("./api.ts", () => ({
       leagues: {
         $get: (...args: unknown[]) => mockGet(...args),
         $post: vi.fn(),
+      },
+      teams: {
+        $get: (...args: unknown[]) => mockTeamsGet(...args),
       },
     },
   },
@@ -91,6 +95,36 @@ describe("Router", () => {
     await waitFor(() => {
       expect(
         screen.getByRole("heading", { name: "Zone Blitz" }),
+      ).toBeDefined();
+    });
+  });
+
+  it("renders the team select page at /leagues/:leagueId/team-select when authenticated", async () => {
+    mockUseSession.mockReturnValue({
+      data: { user: { id: "1", name: "Test" }, session: { id: "s1" } },
+      isPending: false,
+    });
+    mockTeamsGet.mockReturnValue(
+      Promise.resolve({
+        json: () =>
+          Promise.resolve([
+            {
+              id: "t1",
+              name: "Minutemen",
+              city: "Boston",
+              abbreviation: "BOS",
+              primaryColor: "#000",
+              secondaryColor: "#FFF",
+              conference: "AFC",
+              division: "AFC East",
+            },
+          ]),
+      }),
+    );
+    renderRouter("/leagues/1/team-select");
+    await waitFor(() => {
+      expect(
+        screen.getByRole("heading", { name: "Choose Your Team" }),
       ).toBeDefined();
     });
   });

--- a/client/src/router.tsx
+++ b/client/src/router.tsx
@@ -12,6 +12,7 @@ import { LeagueSelect } from "./features/league-select/index.tsx";
 import { LeagueLayout } from "./features/league/layout.tsx";
 import { LeagueHome } from "./features/league/index.tsx";
 import { LeagueSettings } from "./features/league/settings.tsx";
+import { TeamSelect } from "./features/team-select/index.tsx";
 
 const rootRoute = createRootRoute();
 
@@ -51,6 +52,12 @@ const leagueSelectRoute = createRoute({
   component: LeagueSelect,
 });
 
+const teamSelectRoute = createRoute({
+  getParentRoute: () => authenticatedRoute,
+  path: "leagues/$leagueId/team-select",
+  component: TeamSelect,
+});
+
 const leagueLayoutRoute = createRoute({
   getParentRoute: () => authenticatedRoute,
   path: "leagues/$leagueId",
@@ -73,6 +80,7 @@ const routeTree = rootRoute.addChildren([
   loginRoute,
   authenticatedRoute.addChildren([
     leagueSelectRoute,
+    teamSelectRoute,
     leagueLayoutRoute.addChildren([leagueHomeRoute, leagueSettingsRoute]),
   ]),
 ]);

--- a/server/features/mod.ts
+++ b/server/features/mod.ts
@@ -13,6 +13,7 @@ import {
   createUserRouter,
   createUserService,
 } from "./user/mod.ts";
+import { createTeamRepository, createTeamRouter } from "./team/mod.ts";
 
 export function createFeatureRouters(
   deps: {
@@ -46,6 +47,7 @@ export function createFeatureRouters(
   // Repositories
   const leagueRepo = createLeagueRepository({ db, log });
   const userRepo = createUserRepository({ db, log });
+  const teamRepo = createTeamRepository({ db, log });
 
   // Services
   const leagueService = createLeagueService({ leagueRepo, log });
@@ -54,6 +56,14 @@ export function createFeatureRouters(
   // Routers
   const leagueRouter = createLeagueRouter(leagueService);
   const userRouter = createUserRouter(userService);
+  const teamRouter = createTeamRouter(teamRepo);
 
-  return { auth, authRouter, healthRouter, leagueRouter, userRouter };
+  return {
+    auth,
+    authRouter,
+    healthRouter,
+    leagueRouter,
+    userRouter,
+    teamRouter,
+  };
 }

--- a/server/features/team/mod.ts
+++ b/server/features/team/mod.ts
@@ -1,3 +1,4 @@
 export { createTeamRepository } from "./team.repository.ts";
+export { createTeamRouter } from "./team.router.ts";
 export { DEFAULT_TEAMS } from "./default-teams.ts";
 export type { DefaultTeam } from "./default-teams.ts";

--- a/server/features/team/team.router.test.ts
+++ b/server/features/team/team.router.test.ts
@@ -1,0 +1,60 @@
+import { assertEquals } from "@std/assert";
+import { createTeamRouter } from "./team.router.ts";
+import type { Team, TeamRepository } from "@zone-blitz/shared";
+
+function createMockTeam(overrides: Partial<Team> = {}): Team {
+  return {
+    id: "1",
+    name: "Test Team",
+    city: "Test City",
+    abbreviation: "TST",
+    primaryColor: "#000000",
+    secondaryColor: "#FFFFFF",
+    accentColor: "#FF0000",
+    conference: "AFC",
+    division: "AFC East",
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    ...overrides,
+  };
+}
+
+function createMockTeamRepo(
+  overrides: Partial<TeamRepository> = {},
+): TeamRepository {
+  return {
+    getAll: () => Promise.resolve([]),
+    getById: () => Promise.resolve(undefined),
+    ...overrides,
+  };
+}
+
+Deno.test("team.router", async (t) => {
+  await t.step("GET / returns all teams", async () => {
+    const teams = [
+      createMockTeam({ id: "1", name: "Team A" }),
+      createMockTeam({ id: "2", name: "Team B" }),
+    ];
+    const router = createTeamRouter(
+      createMockTeamRepo({ getAll: () => Promise.resolve(teams) }),
+    );
+
+    const res = await router.request("/");
+    assertEquals(res.status, 200);
+
+    const body = await res.json();
+    assertEquals(body.length, 2);
+    assertEquals(body[0].name, "Team A");
+    assertEquals(body[1].name, "Team B");
+  });
+
+  await t.step("GET / returns empty array when no teams", async () => {
+    const router = createTeamRouter(createMockTeamRepo());
+
+    const res = await router.request("/");
+    assertEquals(res.status, 200);
+
+    const body = await res.json();
+    assertEquals(body.length, 0);
+  });
+});

--- a/server/features/team/team.router.ts
+++ b/server/features/team/team.router.ts
@@ -1,0 +1,11 @@
+import { Hono } from "hono";
+import type { TeamRepository } from "@zone-blitz/shared";
+import type { AppEnv } from "../../env.ts";
+
+export function createTeamRouter(teamRepo: TeamRepository) {
+  return new Hono<AppEnv>()
+    .get("/", async (c) => {
+      const teams = await teamRepo.getAll();
+      return c.json(teams);
+    });
+}

--- a/server/main.ts
+++ b/server/main.ts
@@ -35,7 +35,10 @@ const app = new Hono<AppEnv>()
   .route("/api/leagues", features.leagueRouter)
   .use("/api/users/*", authGuard())
   .use("/api/users", authGuard())
-  .route("/api/users", features.userRouter);
+  .route("/api/users", features.userRouter)
+  .use("/api/teams/*", authGuard())
+  .use("/api/teams", authGuard())
+  .route("/api/teams", features.teamRouter);
 
 // Domain error handler
 app.onError((err, c) => {


### PR DESCRIPTION
## Summary

- Adds `GET /api/teams` endpoint returning the 32 seeded teams (behind auth guard)
- After creating a league, user is now navigated to a team selection page (`/leagues/$leagueId/team-select`)
- Team selection page displays all 32 teams grouped by conference and division, each with city, name, abbreviation, and primary color swatch
- Selecting a team navigates to the league dashboard
- Adds `useTeams()` React Query hook for fetching teams
- Full test coverage: server router tests, client component tests, router integration tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)