### PR TITLE
feat(league): wire generators into league creation

### DIFF
--- a/server/features/league/league.service.test.ts
+++ b/server/features/league/league.service.test.ts
@@ -2,7 +2,14 @@ import { assertEquals, assertRejects } from "@std/assert";
 import { createLeagueService } from "./league.service.ts";
 import { DomainError } from "@zone-blitz/shared";
 import pino from "pino";
-import type { League, LeagueRepository } from "@zone-blitz/shared";
+import type {
+  League,
+  LeagueRepository,
+  PersonnelGenerator,
+  ScheduleGenerator,
+  SeasonRepository,
+  TeamRepository,
+} from "@zone-blitz/shared";
 
 function createTestLogger() {
   return pino({ level: "silent" });
@@ -36,15 +43,156 @@ function createMockRepo(
   };
 }
 
+function createMockSeasonRepo(
+  overrides: Partial<SeasonRepository> = {},
+): SeasonRepository {
+  return {
+    getByLeagueId: () => Promise.resolve([]),
+    getById: () => Promise.resolve(undefined),
+    create: () =>
+      Promise.resolve({
+        id: "season-1",
+        leagueId: "new-id",
+        year: 1,
+        phase: "preseason" as const,
+        week: 1,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      }),
+    ...overrides,
+  };
+}
+
+function createMockTeamRepo(
+  overrides: Partial<TeamRepository> = {},
+): TeamRepository {
+  return {
+    getAll: () =>
+      Promise.resolve([
+        {
+          id: "team-1",
+          name: "Team A",
+          city: "City A",
+          abbreviation: "TA",
+          primaryColor: "#000",
+          secondaryColor: "#FFF",
+          accentColor: "#F00",
+          conference: "AFC",
+          division: "AFC East",
+          createdAt: new Date(),
+          updatedAt: new Date(),
+        },
+      ]),
+    getById: () => Promise.resolve(undefined),
+    ...overrides,
+  };
+}
+
+function createMockPersonnelGenerator(): PersonnelGenerator {
+  return {
+    generate: () => ({
+      players: [
+        {
+          leagueId: "new-id",
+          teamId: "team-1",
+          firstName: "John",
+          lastName: "Doe",
+        },
+      ],
+      coaches: [
+        {
+          leagueId: "new-id",
+          teamId: "team-1",
+          firstName: "Coach",
+          lastName: "Smith",
+        },
+      ],
+      scouts: [
+        {
+          leagueId: "new-id",
+          teamId: "team-1",
+          firstName: "Scout",
+          lastName: "Jones",
+        },
+      ],
+      frontOfficeStaff: [
+        {
+          leagueId: "new-id",
+          teamId: "team-1",
+          firstName: "Staff",
+          lastName: "Brown",
+        },
+      ],
+      draftProspects: [
+        { seasonId: "season-1", firstName: "Prospect", lastName: "Wilson" },
+      ],
+    }),
+    generateContracts: () => [
+      {
+        playerId: "player-1",
+        teamId: "team-1",
+        totalYears: 3,
+        currentYear: 1,
+        totalSalary: 15_000_000,
+        annualSalary: 5_000_000,
+        guaranteedMoney: 5_000_000,
+        signingBonus: 0,
+      },
+    ],
+  };
+}
+
+function createMockScheduleGenerator(): ScheduleGenerator {
+  return {
+    generate: () => [
+      {
+        seasonId: "season-1",
+        week: 1,
+        homeTeamId: "team-1",
+        awayTeamId: "team-2",
+      },
+    ],
+  };
+}
+
+// deno-lint-ignore no-explicit-any
+function createMockDb(): any {
+  const mockInsert = () => ({
+    values: () => ({
+      returning: () => Promise.resolve([{ id: "player-1", teamId: "team-1" }]),
+    }),
+  });
+  return { insert: mockInsert };
+}
+
+function createService(overrides: {
+  leagueRepo?: Partial<LeagueRepository>;
+  seasonRepo?: Partial<SeasonRepository>;
+  teamRepo?: Partial<TeamRepository>;
+  personnelGenerator?: PersonnelGenerator;
+  scheduleGenerator?: ScheduleGenerator;
+} = {}) {
+  return createLeagueService({
+    leagueRepo: createMockRepo(overrides.leagueRepo),
+    seasonRepo: createMockSeasonRepo(overrides.seasonRepo),
+    teamRepo: createMockTeamRepo(overrides.teamRepo),
+    personnelGenerator: overrides.personnelGenerator ??
+      createMockPersonnelGenerator(),
+    scheduleGenerator: overrides.scheduleGenerator ??
+      createMockScheduleGenerator(),
+    db: createMockDb(),
+    log: createTestLogger(),
+  });
+}
+
 Deno.test("league.service", async (t) => {
   await t.step("getAll returns all leagues from repository", async () => {
     const leagues: League[] = [
       createMockLeague({ id: "1", name: "League One" }),
       createMockLeague({ id: "2", name: "League Two" }),
     ];
-    const service = createLeagueService({
-      leagueRepo: createMockRepo({ getAll: () => Promise.resolve(leagues) }),
-      log: createTestLogger(),
+    const service = createService({
+      leagueRepo: { getAll: () => Promise.resolve(leagues) },
     });
 
     const result = await service.getAll();
@@ -54,9 +202,8 @@ Deno.test("league.service", async (t) => {
 
   await t.step("getById returns league when found", async () => {
     const league = createMockLeague({ id: "1", name: "Found League" });
-    const service = createLeagueService({
-      leagueRepo: createMockRepo({ getById: () => Promise.resolve(league) }),
-      log: createTestLogger(),
+    const service = createService({
+      leagueRepo: { getById: () => Promise.resolve(league) },
     });
 
     const result = await service.getById("1");
@@ -64,9 +211,8 @@ Deno.test("league.service", async (t) => {
   });
 
   await t.step("getById throws NOT_FOUND when league missing", async () => {
-    const service = createLeagueService({
-      leagueRepo: createMockRepo({ getById: () => Promise.resolve(undefined) }),
-      log: createTestLogger(),
+    const service = createService({
+      leagueRepo: { getById: () => Promise.resolve(undefined) },
     });
 
     await assertRejects(
@@ -76,35 +222,92 @@ Deno.test("league.service", async (t) => {
     );
   });
 
-  await t.step(
-    "create delegates to repository and returns league",
-    async () => {
-      const created = createMockLeague({ id: "new-id", name: "New League" });
-      const service = createLeagueService({
-        leagueRepo: createMockRepo({ create: () => Promise.resolve(created) }),
-        log: createTestLogger(),
-      });
+  await t.step("create orchestrates league world generation", async () => {
+    let seasonCreated = false;
+    let personnelGenerated = false;
+    let contractsGenerated = false;
+    let scheduleGenerated = false;
 
-      const result = await service.create({ name: "New League" });
-      assertEquals(result.id, "new-id");
-      assertEquals(result.name, "New League");
-    },
-  );
+    const service = createService({
+      seasonRepo: {
+        create: (input) => {
+          seasonCreated = true;
+          assertEquals(input.leagueId, "new-id");
+          return Promise.resolve({
+            id: "season-1",
+            leagueId: "new-id",
+            year: 1,
+            phase: "preseason" as const,
+            week: 1,
+            createdAt: new Date(),
+            updatedAt: new Date(),
+          });
+        },
+      },
+      personnelGenerator: {
+        generate: (input) => {
+          personnelGenerated = true;
+          assertEquals(input.leagueId, "new-id");
+          assertEquals(input.seasonId, "season-1");
+          assertEquals(input.rosterSize, 53);
+          return {
+            players: [
+              {
+                leagueId: "new-id",
+                teamId: "team-1",
+                firstName: "J",
+                lastName: "D",
+              },
+            ],
+            coaches: [],
+            scouts: [],
+            frontOfficeStaff: [],
+            draftProspects: [],
+          };
+        },
+        generateContracts: (input) => {
+          contractsGenerated = true;
+          assertEquals(input.salaryCap, 255_000_000);
+          return [];
+        },
+      },
+      scheduleGenerator: {
+        generate: (input) => {
+          scheduleGenerated = true;
+          assertEquals(input.seasonId, "season-1");
+          return [];
+        },
+      },
+    });
+
+    const result = await service.create({ name: "New League" });
+    assertEquals(result.id, "new-id");
+    assertEquals(seasonCreated, true);
+    assertEquals(personnelGenerated, true);
+    assertEquals(contractsGenerated, true);
+    assertEquals(scheduleGenerated, true);
+  });
+
+  await t.step("create returns the league", async () => {
+    const service = createService();
+    const result = await service.create({ name: "New League" });
+    assertEquals(result.id, "new-id");
+    assertEquals(result.name, "Test");
+  });
 
   await t.step(
     "deleteById delegates to repository when league exists",
     async () => {
       let deletedId: string | undefined;
       const league = createMockLeague({ id: "delete-me", name: "Delete Me" });
-      const service = createLeagueService({
-        leagueRepo: createMockRepo({
+      const service = createService({
+        leagueRepo: {
           getById: () => Promise.resolve(league),
           deleteById: (id) => {
             deletedId = id;
             return Promise.resolve();
           },
-        }),
-        log: createTestLogger(),
+        },
       });
 
       await service.deleteById("delete-me");
@@ -115,11 +318,8 @@ Deno.test("league.service", async (t) => {
   await t.step(
     "deleteById throws NOT_FOUND when league does not exist",
     async () => {
-      const service = createLeagueService({
-        leagueRepo: createMockRepo({
-          getById: () => Promise.resolve(undefined),
-        }),
-        log: createTestLogger(),
+      const service = createService({
+        leagueRepo: { getById: () => Promise.resolve(undefined) },
       });
 
       await assertRejects(

--- a/server/features/league/league.service.ts
+++ b/server/features/league/league.service.ts
@@ -1,9 +1,31 @@
-import type { LeagueRepository, LeagueService } from "@zone-blitz/shared";
+import type {
+  LeagueRepository,
+  LeagueService,
+  PersonnelGenerator,
+  ScheduleGenerator,
+  SeasonRepository,
+  TeamRepository,
+} from "@zone-blitz/shared";
 import { DomainError } from "@zone-blitz/shared";
 import type pino from "pino";
+import type { Database } from "../../db/connection.ts";
+import {
+  coaches,
+  draftProspects,
+  frontOfficeStaff,
+  players,
+  scouts,
+} from "../personnel/personnel.schema.ts";
+import { contracts } from "../personnel/contract.schema.ts";
+import { games } from "../schedule/game.schema.ts";
 
 export function createLeagueService(deps: {
   leagueRepo: LeagueRepository;
+  seasonRepo: SeasonRepository;
+  teamRepo: TeamRepository;
+  personnelGenerator: PersonnelGenerator;
+  scheduleGenerator: ScheduleGenerator;
+  db: Database;
   log: pino.Logger;
 }): LeagueService {
   const log = deps.log.child({ module: "league.service" });
@@ -25,7 +47,87 @@ export function createLeagueService(deps: {
 
     async create(input) {
       log.info({ name: input.name }, "creating league");
-      return await deps.leagueRepo.create(input);
+
+      // 1. Create the league
+      const league = await deps.leagueRepo.create(input);
+
+      // 2. Create Season 1 (Preseason, Week 1)
+      const season = await deps.seasonRepo.create({ leagueId: league.id });
+      log.info(
+        { leagueId: league.id, seasonId: season.id },
+        "created season 1",
+      );
+
+      // 3. Get all teams for generation
+      const teams = await deps.teamRepo.getAll();
+      const teamIds = teams.map((t) => t.id);
+
+      // 4. Generate and persist personnel
+      const personnel = deps.personnelGenerator.generate({
+        leagueId: league.id,
+        seasonId: season.id,
+        teamIds,
+        rosterSize: league.rosterSize,
+      });
+
+      const insertedPlayers = await deps.db
+        .insert(players)
+        .values(personnel.players)
+        .returning({ id: players.id, teamId: players.teamId });
+
+      await deps.db.insert(coaches).values(personnel.coaches);
+      await deps.db.insert(scouts).values(personnel.scouts);
+      await deps.db.insert(frontOfficeStaff).values(personnel.frontOfficeStaff);
+      await deps.db.insert(draftProspects).values(personnel.draftProspects);
+
+      log.info(
+        {
+          leagueId: league.id,
+          players: insertedPlayers.length,
+          coaches: personnel.coaches.length,
+          scouts: personnel.scouts.length,
+          frontOffice: personnel.frontOfficeStaff.length,
+          draftProspects: personnel.draftProspects.length,
+        },
+        "generated personnel",
+      );
+
+      // 5. Generate and persist contracts for rostered players
+      const generatedContracts = deps.personnelGenerator.generateContracts({
+        salaryCap: league.salaryCap,
+        players: insertedPlayers,
+      });
+
+      if (generatedContracts.length > 0) {
+        await deps.db.insert(contracts).values(generatedContracts);
+      }
+
+      log.info(
+        { leagueId: league.id, contracts: generatedContracts.length },
+        "generated contracts",
+      );
+
+      // 6. Generate and persist schedule
+      const generatedGames = deps.scheduleGenerator.generate({
+        seasonId: season.id,
+        teams: teams.map((t) => ({
+          teamId: t.id,
+          conference: t.conference,
+          division: t.division,
+        })),
+        seasonLength: league.seasonLength,
+      });
+
+      if (generatedGames.length > 0) {
+        await deps.db.insert(games).values(generatedGames);
+      }
+
+      log.info(
+        { leagueId: league.id, games: generatedGames.length },
+        "generated schedule",
+      );
+
+      return league;
     },
 
     async deleteById(id) {

--- a/server/features/mod.ts
+++ b/server/features/mod.ts
@@ -14,6 +14,9 @@ import {
   createUserService,
 } from "./user/mod.ts";
 import { createTeamRepository, createTeamRouter } from "./team/mod.ts";
+import { createSeasonRepository } from "./season/mod.ts";
+import { createStubPersonnelGenerator } from "./personnel/mod.ts";
+import { createStubScheduleGenerator } from "./schedule/mod.ts";
 
 export function createFeatureRouters(
   deps: {
@@ -48,9 +51,22 @@ export function createFeatureRouters(
   const leagueRepo = createLeagueRepository({ db, log });
   const userRepo = createUserRepository({ db, log });
   const teamRepo = createTeamRepository({ db, log });
+  const seasonRepo = createSeasonRepository({ db, log });
+
+  // Generators
+  const personnelGenerator = createStubPersonnelGenerator();
+  const scheduleGenerator = createStubScheduleGenerator();
 
   // Services
-  const leagueService = createLeagueService({ leagueRepo, log });
+  const leagueService = createLeagueService({
+    leagueRepo,
+    seasonRepo,
+    teamRepo,
+    personnelGenerator,
+    scheduleGenerator,
+    db,
+    log,
+  });
   const userService = createUserService({ userRepo, log });
 
   // Routers


### PR DESCRIPTION
## Summary

- League creation now orchestrates full world generation: season, personnel, contracts, and schedule
- Creates Season 1 (Preseason, Week 1) on league creation
- Generates all personnel (players, coaches, scouts, front office, draft prospects) via `PersonnelGenerator` interface
- Generates contracts for rostered players via `generateContracts()`
- Generates 272-game season schedule via `ScheduleGenerator` interface
- All generators are injected as dependencies — currently using stub implementations

🤖 Generated with [Claude Code](https://claude.com/claude-code)