### PR TITLE
fix(league): guard empty arrays in personnel inserts and seed teams on prod

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,4 +31,4 @@ ENV DENO_ENV=production
 EXPOSE 3000
 
 # Run migrations then start the server
-CMD ["sh", "-c", "cd server && deno run --allow-net --allow-env --allow-read --allow-sys db/migrate.ts && deno run --allow-net --allow-env --allow-read --allow-sys main.ts"]
+CMD ["sh", "-c", "cd server && deno run --allow-net --allow-env --allow-read --allow-sys db/migrate.ts && deno run --allow-net --allow-env --allow-read --allow-sys db/seed.ts && deno run --allow-net --allow-env --allow-read --allow-sys main.ts"]

--- a/server/features/league/league.service.test.ts
+++ b/server/features/league/league.service.test.ts
@@ -158,9 +158,15 @@ function createMockScheduleGenerator(): ScheduleGenerator {
 // deno-lint-ignore no-explicit-any
 function createMockDb(): any {
   const mockInsert = () => ({
-    values: () => ({
-      returning: () => Promise.resolve([{ id: "player-1", teamId: "team-1" }]),
-    }),
+    values: (v: unknown[]) => {
+      if (!Array.isArray(v) || v.length === 0) {
+        throw new Error("values() must be called with at least one value");
+      }
+      return {
+        returning: () =>
+          Promise.resolve([{ id: "player-1", teamId: "team-1" }]),
+      };
+    },
   });
   return { insert: mockInsert };
 }

--- a/server/features/league/league.service.ts
+++ b/server/features/league/league.service.ts
@@ -70,15 +70,29 @@ export function createLeagueService(deps: {
         rosterSize: league.rosterSize,
       });
 
-      const insertedPlayers = await deps.db
-        .insert(players)
-        .values(personnel.players)
-        .returning({ id: players.id, teamId: players.teamId });
+      let insertedPlayers: { id: string; teamId: string | null }[] = [];
 
-      await deps.db.insert(coaches).values(personnel.coaches);
-      await deps.db.insert(scouts).values(personnel.scouts);
-      await deps.db.insert(frontOfficeStaff).values(personnel.frontOfficeStaff);
-      await deps.db.insert(draftProspects).values(personnel.draftProspects);
+      if (personnel.players.length > 0) {
+        insertedPlayers = await deps.db
+          .insert(players)
+          .values(personnel.players)
+          .returning({ id: players.id, teamId: players.teamId });
+      }
+
+      if (personnel.coaches.length > 0) {
+        await deps.db.insert(coaches).values(personnel.coaches);
+      }
+      if (personnel.scouts.length > 0) {
+        await deps.db.insert(scouts).values(personnel.scouts);
+      }
+      if (personnel.frontOfficeStaff.length > 0) {
+        await deps.db
+          .insert(frontOfficeStaff)
+          .values(personnel.frontOfficeStaff);
+      }
+      if (personnel.draftProspects.length > 0) {
+        await deps.db.insert(draftProspects).values(personnel.draftProspects);
+      }
 
       log.info(
         {


### PR DESCRIPTION
## Summary

- Adds `length > 0` guards around all personnel bulk-insert calls (players, coaches, scouts, front office, draft prospects) in the league service, consistent with the existing guards on contracts and games inserts. This prevents the Drizzle `values() must be called with at least one value` error when no teams exist.
- Runs `db/seed.ts` in the production Dockerfile CMD after migrations so default teams are seeded on startup (idempotent via `onConflictDoNothing`).
- Updates the mock DB in league service tests to enforce the same empty-values constraint as real Drizzle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)