### PR TITLE
feat(server): enable pino-pretty logging in production

### DIFF
--- a/server/logger.ts
+++ b/server/logger.ts
@@ -4,9 +4,7 @@ const isProduction = Deno.env.get("DENO_ENV") === "production";
 
 export const logger = pino({
   level: isProduction ? "info" : "debug",
-  ...(!isProduction && {
-    transport: {
-      target: "pino-pretty",
-    },
-  }),
+  transport: {
+    target: "pino-pretty",
+  },
 });


### PR DESCRIPTION
## Summary

- Enables pino-pretty transport in production so logs are human-readable when tailing via SSH
- Removes the conditional that restricted pino-pretty to development only

🤖 Generated with [Claude Code](https://claude.com/claude-code)