### PR TITLE
refactor(client): use shadcn Skeleton and Alert for loading/error states

### DIFF
--- a/client/src/components/ui/alert.tsx
+++ b/client/src/components/ui/alert.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import type * as React from "react";
 import { cva, type VariantProps } from "class-variance-authority";
 
 import { cn } from "@/lib/utils";

--- a/client/src/components/ui/alert.tsx
+++ b/client/src/components/ui/alert.tsx
@@ -1,0 +1,76 @@
+import * as React from "react";
+import { cva, type VariantProps } from "class-variance-authority";
+
+import { cn } from "@/lib/utils";
+
+const alertVariants = cva(
+  "group/alert relative grid w-full gap-0.5 rounded-lg border px-2.5 py-2 text-left text-sm has-data-[slot=alert-action]:relative has-data-[slot=alert-action]:pr-18 has-[>svg]:grid-cols-[auto_1fr] has-[>svg]:gap-x-2 *:[svg]:row-span-2 *:[svg]:translate-y-0.5 *:[svg]:text-current *:[svg:not([class*='size-'])]:size-4",
+  {
+    variants: {
+      variant: {
+        default: "bg-card text-card-foreground",
+        destructive:
+          "bg-card text-destructive *:data-[slot=alert-description]:text-destructive/90 *:[svg]:text-current",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+    },
+  },
+);
+
+function Alert({
+  className,
+  variant,
+  ...props
+}: React.ComponentProps<"div"> & VariantProps<typeof alertVariants>) {
+  return (
+    <div
+      data-slot="alert"
+      role="alert"
+      className={cn(alertVariants({ variant }), className)}
+      {...props}
+    />
+  );
+}
+
+function AlertTitle({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="alert-title"
+      className={cn(
+        "font-heading font-medium group-has-[>svg]/alert:col-start-2 [&_a]:underline [&_a]:underline-offset-3 [&_a]:hover:text-foreground",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function AlertDescription({
+  className,
+  ...props
+}: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="alert-description"
+      className={cn(
+        "text-sm text-balance text-muted-foreground md:text-pretty [&_a]:underline [&_a]:underline-offset-3 [&_a]:hover:text-foreground [&_p:not(:last-child)]:mb-4",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function AlertAction({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="alert-action"
+      className={cn("absolute top-2 right-2", className)}
+      {...props}
+    />
+  );
+}
+
+export { Alert, AlertAction, AlertDescription, AlertTitle };

--- a/client/src/components/ui/skeleton.tsx
+++ b/client/src/components/ui/skeleton.tsx
@@ -1,0 +1,13 @@
+import { cn } from "@/lib/utils";
+
+function Skeleton({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="skeleton"
+      className={cn("animate-pulse rounded-md bg-muted", className)}
+      {...props}
+    />
+  );
+}
+
+export { Skeleton };

--- a/client/src/features/league-select/index.test.tsx
+++ b/client/src/features/league-select/index.test.tsx
@@ -86,16 +86,19 @@ describe("LeagueSelect", () => {
     expect(screen.getByText(/football franchise simulation/i)).toBeDefined();
   });
 
-  it("shows loading state while fetching leagues", () => {
+  it("shows skeleton loading state while fetching leagues", () => {
     mockGet.mockReturnValue(new Promise(() => {}));
     renderWithProviders();
-    expect(screen.getByText("Loading leagues...")).toBeDefined();
+    const skeletons = document.querySelectorAll('[data-slot="skeleton"]');
+    expect(skeletons.length).toBeGreaterThan(0);
   });
 
-  it("shows error state when fetch fails", async () => {
+  it("shows alert error state when fetch fails", async () => {
     mockGet.mockReturnValue(Promise.reject(new Error("network error")));
     renderWithProviders();
     await waitFor(() => {
+      const alert = screen.getByRole("alert");
+      expect(alert).toBeDefined();
       expect(screen.getByText("Failed to load leagues")).toBeDefined();
     });
   });

--- a/client/src/features/league-select/index.tsx
+++ b/client/src/features/league-select/index.tsx
@@ -12,6 +12,8 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/table";
+import { Skeleton } from "@/components/ui/skeleton";
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 
 export function LeagueSelect() {
   const { data: leagues, isLoading, error } = useLeagues();
@@ -69,10 +71,17 @@ export function LeagueSelect() {
           </form>
 
           {isLoading && (
-            <p className="text-sm text-muted-foreground">Loading leagues...</p>
+            <div className="space-y-2">
+              <Skeleton className="h-8 w-full" />
+              <Skeleton className="h-8 w-full" />
+              <Skeleton className="h-8 w-3/4" />
+            </div>
           )}
           {error && (
-            <p className="text-sm text-destructive">Failed to load leagues</p>
+            <Alert variant="destructive">
+              <AlertTitle>Error</AlertTitle>
+              <AlertDescription>Failed to load leagues</AlertDescription>
+            </Alert>
           )}
           {leagues && leagues.length === 0 && (
             <p className="text-sm text-muted-foreground">

--- a/client/src/features/team-select/index.test.tsx
+++ b/client/src/features/team-select/index.test.tsx
@@ -89,16 +89,19 @@ describe("TeamSelect", () => {
     });
   });
 
-  it("shows loading state while fetching teams", () => {
+  it("shows skeleton loading state while fetching teams", () => {
     mockTeamsGet.mockReturnValue(new Promise(() => {}));
     renderWithProviders();
-    expect(screen.getByText("Loading teams...")).toBeDefined();
+    const skeletons = document.querySelectorAll('[data-slot="skeleton"]');
+    expect(skeletons.length).toBeGreaterThan(0);
   });
 
-  it("shows error state when fetch fails", async () => {
+  it("shows alert error state when fetch fails", async () => {
     mockTeamsGet.mockReturnValue(Promise.reject(new Error("network error")));
     renderWithProviders();
     await waitFor(() => {
+      const alert = screen.getByRole("alert");
+      expect(alert).toBeDefined();
       expect(screen.getByText("Failed to load teams")).toBeDefined();
     });
   });

--- a/client/src/features/team-select/index.tsx
+++ b/client/src/features/team-select/index.tsx
@@ -2,6 +2,8 @@ import { useNavigate, useParams } from "@tanstack/react-router";
 import { useTeams } from "../../hooks/use-teams.ts";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Separator } from "@/components/ui/separator";
+import { Skeleton } from "@/components/ui/skeleton";
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 
 interface Team {
   id: string;
@@ -66,8 +68,15 @@ export function TeamSelect() {
 
   if (isLoading) {
     return (
-      <div className="min-h-screen bg-background text-foreground flex items-center justify-center">
-        <p className="text-muted-foreground">Loading teams...</p>
+      <div className="min-h-screen bg-background text-foreground p-8">
+        <div className="max-w-5xl mx-auto space-y-8">
+          <div className="text-center space-y-2">
+            <Skeleton className="h-9 w-64 mx-auto" />
+            <Skeleton className="h-5 w-80 mx-auto" />
+          </div>
+          <Skeleton className="h-48 w-full" />
+          <Skeleton className="h-48 w-full" />
+        </div>
       </div>
     );
   }
@@ -75,7 +84,10 @@ export function TeamSelect() {
   if (error || !teams) {
     return (
       <div className="min-h-screen bg-background text-foreground flex items-center justify-center">
-        <p className="text-destructive">Failed to load teams</p>
+        <Alert variant="destructive" className="max-w-md">
+          <AlertTitle>Error</AlertTitle>
+          <AlertDescription>Failed to load teams</AlertDescription>
+        </Alert>
       </div>
     );
   }


### PR DESCRIPTION
## Summary

- Adds shadcn `Skeleton` and `Alert` components to `client/src/components/ui/`
- Replaces inline `<p>` loading states with `Skeleton` placeholders in `team-select` and `league-select`
- Replaces inline `<p>` error states with `Alert` (destructive variant) in `team-select` and `league-select`
- Updates tests to assert on proper semantic elements (`data-slot="skeleton"`, `role="alert"`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)