### PR TITLE
refactor(client): replace delete confirmation with shadcn AlertDialog

### DIFF
--- a/client/src/components/ui/alert-dialog.tsx
+++ b/client/src/components/ui/alert-dialog.tsx
@@ -1,0 +1,186 @@
+import type * as React from "react";
+import { AlertDialog as AlertDialogPrimitive } from "@base-ui/react/alert-dialog";
+
+import { cn } from "@/lib/utils";
+import { Button } from "@/components/ui/button";
+
+function AlertDialog({ ...props }: AlertDialogPrimitive.Root.Props) {
+  return <AlertDialogPrimitive.Root data-slot="alert-dialog" {...props} />;
+}
+
+function AlertDialogTrigger({ ...props }: AlertDialogPrimitive.Trigger.Props) {
+  return (
+    <AlertDialogPrimitive.Trigger data-slot="alert-dialog-trigger" {...props} />
+  );
+}
+
+function AlertDialogPortal({ ...props }: AlertDialogPrimitive.Portal.Props) {
+  return (
+    <AlertDialogPrimitive.Portal data-slot="alert-dialog-portal" {...props} />
+  );
+}
+
+function AlertDialogOverlay({
+  className,
+  ...props
+}: AlertDialogPrimitive.Backdrop.Props) {
+  return (
+    <AlertDialogPrimitive.Backdrop
+      data-slot="alert-dialog-overlay"
+      className={cn(
+        "fixed inset-0 isolate z-50 bg-black/10 duration-100 supports-backdrop-filter:backdrop-blur-xs data-open:animate-in data-open:fade-in-0 data-closed:animate-out data-closed:fade-out-0",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function AlertDialogContent({
+  className,
+  size = "default",
+  ...props
+}: AlertDialogPrimitive.Popup.Props & {
+  size?: "default" | "sm";
+}) {
+  return (
+    <AlertDialogPortal>
+      <AlertDialogOverlay />
+      <AlertDialogPrimitive.Popup
+        data-slot="alert-dialog-content"
+        data-size={size}
+        className={cn(
+          "group/alert-dialog-content fixed top-1/2 left-1/2 z-50 grid w-full -translate-x-1/2 -translate-y-1/2 gap-4 rounded-xl bg-popover p-4 text-popover-foreground ring-1 ring-foreground/10 duration-100 outline-none data-[size=default]:max-w-xs data-[size=sm]:max-w-xs data-[size=default]:sm:max-w-sm data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95",
+          className,
+        )}
+        {...props}
+      />
+    </AlertDialogPortal>
+  );
+}
+
+function AlertDialogHeader({
+  className,
+  ...props
+}: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="alert-dialog-header"
+      className={cn(
+        "grid grid-rows-[auto_1fr] place-items-center gap-1.5 text-center has-data-[slot=alert-dialog-media]:grid-rows-[auto_auto_1fr] has-data-[slot=alert-dialog-media]:gap-x-4 sm:group-data-[size=default]/alert-dialog-content:place-items-start sm:group-data-[size=default]/alert-dialog-content:text-left sm:group-data-[size=default]/alert-dialog-content:has-data-[slot=alert-dialog-media]:grid-rows-[auto_1fr]",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function AlertDialogFooter({
+  className,
+  ...props
+}: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="alert-dialog-footer"
+      className={cn(
+        "-mx-4 -mb-4 flex flex-col-reverse gap-2 rounded-b-xl border-t bg-muted/50 p-4 group-data-[size=sm]/alert-dialog-content:grid group-data-[size=sm]/alert-dialog-content:grid-cols-2 sm:flex-row sm:justify-end",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function AlertDialogMedia({
+  className,
+  ...props
+}: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="alert-dialog-media"
+      className={cn(
+        "mb-2 inline-flex size-10 items-center justify-center rounded-md bg-muted sm:group-data-[size=default]/alert-dialog-content:row-span-2 *:[svg:not([class*='size-'])]:size-6",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function AlertDialogTitle({
+  className,
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Title>) {
+  return (
+    <AlertDialogPrimitive.Title
+      data-slot="alert-dialog-title"
+      className={cn(
+        "font-heading text-base font-medium sm:group-data-[size=default]/alert-dialog-content:group-has-data-[slot=alert-dialog-media]/alert-dialog-content:col-start-2",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function AlertDialogDescription({
+  className,
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Description>) {
+  return (
+    <AlertDialogPrimitive.Description
+      data-slot="alert-dialog-description"
+      className={cn(
+        "text-sm text-balance text-muted-foreground md:text-pretty *:[a]:underline *:[a]:underline-offset-3 *:[a]:hover:text-foreground",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function AlertDialogAction({
+  className,
+  ...props
+}: React.ComponentProps<typeof Button>) {
+  return (
+    <Button
+      data-slot="alert-dialog-action"
+      className={cn(className)}
+      {...props}
+    />
+  );
+}
+
+function AlertDialogCancel({
+  className,
+  variant = "outline",
+  size = "default",
+  ...props
+}:
+  & AlertDialogPrimitive.Close.Props
+  & Pick<React.ComponentProps<typeof Button>, "variant" | "size">) {
+  return (
+    <AlertDialogPrimitive.Close
+      data-slot="alert-dialog-cancel"
+      className={cn(className)}
+      render={<Button variant={variant} size={size} />}
+      {...props}
+    />
+  );
+}
+
+export {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogMedia,
+  AlertDialogOverlay,
+  AlertDialogPortal,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+};

--- a/client/src/features/league/settings.test.tsx
+++ b/client/src/features/league/settings.test.tsx
@@ -65,24 +65,35 @@ describe("LeagueSettings", () => {
     ).toBeDefined();
   });
 
-  it("shows confirmation buttons after clicking Delete League", () => {
+  it("shows alert dialog with confirmation after clicking Delete League", async () => {
     renderWithProviders();
     fireEvent.click(screen.getByRole("button", { name: "Delete League" }));
-    expect(
-      screen.getByRole("button", { name: "Confirm Delete" }),
-    ).toBeDefined();
-    expect(
-      screen.getByRole("button", { name: "Cancel" }),
-    ).toBeDefined();
+    await waitFor(() => {
+      expect(screen.getByText("Delete this league?")).toBeDefined();
+      expect(
+        screen.getByText(
+          /this action cannot be undone/i,
+        ),
+      ).toBeDefined();
+      expect(
+        screen.getByRole("button", { name: "Confirm Delete" }),
+      ).toBeDefined();
+      expect(
+        screen.getByRole("button", { name: "Cancel" }),
+      ).toBeDefined();
+    });
   });
 
-  it("hides confirmation buttons when Cancel is clicked", () => {
+  it("closes dialog when Cancel is clicked", async () => {
     renderWithProviders();
     fireEvent.click(screen.getByRole("button", { name: "Delete League" }));
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: "Cancel" })).toBeDefined();
+    });
     fireEvent.click(screen.getByRole("button", { name: "Cancel" }));
-    expect(
-      screen.getByRole("button", { name: "Delete League" }),
-    ).toBeDefined();
+    await waitFor(() => {
+      expect(screen.queryByText("Delete this league?")).toBeNull();
+    });
   });
 
   it("calls delete API when Confirm Delete is clicked", async () => {
@@ -90,6 +101,11 @@ describe("LeagueSettings", () => {
     renderWithProviders();
 
     fireEvent.click(screen.getByRole("button", { name: "Delete League" }));
+    await waitFor(() => {
+      expect(
+        screen.getByRole("button", { name: "Confirm Delete" }),
+      ).toBeDefined();
+    });
     fireEvent.click(screen.getByRole("button", { name: "Confirm Delete" }));
 
     await waitFor(() => {
@@ -102,6 +118,11 @@ describe("LeagueSettings", () => {
     renderWithProviders();
 
     fireEvent.click(screen.getByRole("button", { name: "Delete League" }));
+    await waitFor(() => {
+      expect(
+        screen.getByRole("button", { name: "Confirm Delete" }),
+      ).toBeDefined();
+    });
     fireEvent.click(screen.getByRole("button", { name: "Confirm Delete" }));
 
     await waitFor(() => {
@@ -114,6 +135,11 @@ describe("LeagueSettings", () => {
     renderWithProviders();
 
     fireEvent.click(screen.getByRole("button", { name: "Delete League" }));
+    await waitFor(() => {
+      expect(
+        screen.getByRole("button", { name: "Confirm Delete" }),
+      ).toBeDefined();
+    });
     fireEvent.click(screen.getByRole("button", { name: "Confirm Delete" }));
 
     await waitFor(() => {

--- a/client/src/features/league/settings.tsx
+++ b/client/src/features/league/settings.tsx
@@ -1,5 +1,4 @@
 import { useNavigate, useParams } from "@tanstack/react-router";
-import { useState } from "react";
 import { useDeleteLeague } from "../../hooks/use-leagues.ts";
 import { Button } from "@/components/ui/button";
 import {
@@ -9,12 +8,22 @@ import {
   CardHeader,
   CardTitle,
 } from "@/components/ui/card";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from "@/components/ui/alert-dialog";
 
 export function LeagueSettings() {
   const { leagueId } = useParams({ strict: false });
   const navigate = useNavigate();
   const deleteLeague = useDeleteLeague();
-  const [showConfirm, setShowConfirm] = useState(false);
 
   const handleDelete = () => {
     if (!leagueId) return;
@@ -38,32 +47,32 @@ export function LeagueSettings() {
           </CardDescription>
         </CardHeader>
         <CardContent>
-          {!showConfirm
-            ? (
-              <Button
-                variant="destructive"
-                onClick={() => setShowConfirm(true)}
-              >
-                Delete League
-              </Button>
-            )
-            : (
-              <div className="flex items-center gap-3">
-                <Button
+          <AlertDialog>
+            <AlertDialogTrigger
+              render={<Button variant="destructive" />}
+            >
+              Delete League
+            </AlertDialogTrigger>
+            <AlertDialogContent>
+              <AlertDialogHeader>
+                <AlertDialogTitle>Delete this league?</AlertDialogTitle>
+                <AlertDialogDescription>
+                  This action cannot be undone. All league data including teams,
+                  players, and seasons will be permanently deleted.
+                </AlertDialogDescription>
+              </AlertDialogHeader>
+              <AlertDialogFooter>
+                <AlertDialogCancel>Cancel</AlertDialogCancel>
+                <AlertDialogAction
                   variant="destructive"
                   onClick={handleDelete}
                   disabled={deleteLeague.isPending}
                 >
                   {deleteLeague.isPending ? "Deleting..." : "Confirm Delete"}
-                </Button>
-                <Button
-                  variant="ghost"
-                  onClick={() => setShowConfirm(false)}
-                >
-                  Cancel
-                </Button>
-              </div>
-            )}
+                </AlertDialogAction>
+              </AlertDialogFooter>
+            </AlertDialogContent>
+          </AlertDialog>
         </CardContent>
       </Card>
     </div>


### PR DESCRIPTION
## Summary

- Installs the shadcn `AlertDialog` component
- Replaces the inline `useState` toggle delete confirmation in `league/settings.tsx` with a proper `AlertDialog` modal
- Provides focus trapping, accessible labeling, and consistent styling
- Addresses action item #1 from the custom-components-vs-shadcn retrospective (docs/incidents/002)

🤖 Generated with [Claude Code](https://claude.com/claude-code)