### PR TITLE
refactor(client): move sidebar toggle to content header

### DIFF
--- a/client/src/features/league/layout.tsx
+++ b/client/src/features/league/layout.tsx
@@ -12,7 +12,6 @@ import {
   SidebarMenuButton,
   SidebarMenuItem,
   SidebarProvider,
-  SidebarSeparator,
   SidebarTrigger,
 } from "@/components/ui/sidebar";
 import { UserMenu } from "../../components/user-menu.tsx";
@@ -73,11 +72,12 @@ export function LeagueLayout() {
               />
             </SidebarMenuItem>
           </SidebarMenu>
-          <SidebarSeparator />
-          <SidebarTrigger />
         </SidebarFooter>
       </Sidebar>
       <SidebarInset>
+        <header className="flex h-12 items-center px-4">
+          <SidebarTrigger />
+        </header>
         <Outlet />
       </SidebarInset>
     </SidebarProvider>


### PR DESCRIPTION
## Summary

- Moved the sidebar collapse trigger from its own row in the sidebar footer to a header bar in the main content area (`SidebarInset`), following the standard shadcn sidebar pattern
- Removed the `SidebarSeparator` that visually disconnected the toggle from the rest of the footer
- The footer now cleanly contains only the Profile menu

🤖 Generated with [Claude Code](https://claude.com/claude-code)