### PR TITLE
refactor(client): redesign league sidebar header and footer

### DIFF
--- a/client/src/features/league/layout.test.tsx
+++ b/client/src/features/league/layout.test.tsx
@@ -1,4 +1,10 @@
-import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { LeagueLayout } from "./layout.tsx";
@@ -45,6 +51,13 @@ vi.mock("../../api.ts", () => ({
       users: {
         me: {
           $delete: vi.fn(),
+        },
+      },
+      leagues: {
+        [":id"]: {
+          $get: vi.fn().mockResolvedValue({
+            json: () => Promise.resolve({ id: 1, name: "My League" }),
+          }),
         },
       },
     },
@@ -129,20 +142,34 @@ describe("LeagueLayout", () => {
 
   it("expands the sidebar when the toggle is clicked again", () => {
     renderWithProviders();
-    const toggleButton = screen.getByRole("button", {
-      name: /toggle sidebar/i,
-    });
 
-    fireEvent.click(toggleButton);
+    fireEvent.click(
+      screen.getByRole("button", { name: /toggle sidebar/i }),
+    );
     const sidebar = document.querySelector('[data-slot="sidebar"]');
     expect(sidebar?.getAttribute("data-state")).toBe("collapsed");
 
-    fireEvent.click(toggleButton);
+    fireEvent.click(
+      screen.getByRole("button", { name: /toggle sidebar/i }),
+    );
     expect(sidebar?.getAttribute("data-state")).toBe("expanded");
   });
 
   it("renders a Profile button at the bottom of the sidebar", () => {
     renderWithProviders();
     expect(screen.getByRole("button", { name: /profile/i })).toBeDefined();
+  });
+
+  it("renders the league name in the sidebar header", async () => {
+    renderWithProviders();
+    await waitFor(() => {
+      expect(screen.getByText("My League")).toBeDefined();
+    });
+  });
+
+  it("renders the All Leagues back link in the sidebar footer", () => {
+    renderWithProviders();
+    const footer = document.querySelector('[data-slot="sidebar-footer"]');
+    expect(footer?.textContent).toContain("All Leagues");
   });
 });

--- a/client/src/features/league/layout.tsx
+++ b/client/src/features/league/layout.tsx
@@ -13,25 +13,19 @@ import {
   SidebarMenuItem,
   SidebarProvider,
   SidebarTrigger,
+  useSidebar,
 } from "@/components/ui/sidebar";
 import { UserMenu } from "../../components/user-menu.tsx";
+import { useLeague } from "../../hooks/use-league.ts";
 
 export function LeagueLayout() {
   const { leagueId } = useParams({ strict: false });
+  const { data: league } = useLeague(leagueId ?? "");
 
   return (
     <SidebarProvider>
       <Sidebar collapsible="icon">
-        <SidebarHeader>
-          <SidebarMenu>
-            <SidebarMenuItem>
-              <SidebarMenuButton tooltip="All Leagues" render={<Link to="/" />}>
-                <ArrowLeftIcon />
-                <span>All Leagues</span>
-              </SidebarMenuButton>
-            </SidebarMenuItem>
-          </SidebarMenu>
-        </SidebarHeader>
+        <LeagueSidebarHeader name={league?.name} />
         <SidebarContent>
           <SidebarGroup>
             <SidebarGroupContent>
@@ -61,6 +55,12 @@ export function LeagueLayout() {
         <SidebarFooter>
           <SidebarMenu>
             <SidebarMenuItem>
+              <SidebarMenuButton tooltip="All Leagues" render={<Link to="/" />}>
+                <ArrowLeftIcon />
+                <span>All Leagues</span>
+              </SidebarMenuButton>
+            </SidebarMenuItem>
+            <SidebarMenuItem>
               <UserMenu
                 side="top"
                 trigger={
@@ -75,11 +75,36 @@ export function LeagueLayout() {
         </SidebarFooter>
       </Sidebar>
       <SidebarInset>
-        <header className="flex h-12 items-center px-4">
-          <SidebarTrigger />
-        </header>
         <Outlet />
       </SidebarInset>
     </SidebarProvider>
+  );
+}
+
+function LeagueSidebarHeader({ name }: { name?: string }) {
+  const { state } = useSidebar();
+  const isCollapsed = state === "collapsed";
+
+  if (isCollapsed) {
+    return (
+      <SidebarHeader>
+        <SidebarMenu>
+          <SidebarMenuItem>
+            <SidebarTrigger className="w-full" />
+          </SidebarMenuItem>
+        </SidebarMenu>
+      </SidebarHeader>
+    );
+  }
+
+  return (
+    <SidebarHeader>
+      <div className="flex items-center justify-between gap-2 px-2 py-1">
+        <span className="truncate text-sm font-semibold">
+          {name ?? "League"}
+        </span>
+        <SidebarTrigger />
+      </div>
+    </SidebarHeader>
   );
 }

--- a/client/src/hooks/use-league.test.ts
+++ b/client/src/hooks/use-league.test.ts
@@ -1,0 +1,45 @@
+import { renderHook, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { describe, expect, it, vi } from "vitest";
+import { useLeague } from "./use-league.ts";
+import { createElement } from "react";
+
+const mockGet = vi.fn();
+
+vi.mock("../api.ts", () => ({
+  api: {
+    api: {
+      leagues: {
+        [":id"]: {
+          $get: (...args: unknown[]) => mockGet(...args),
+        },
+      },
+    },
+  },
+}));
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return ({ children }: { children: React.ReactNode }) =>
+    createElement(QueryClientProvider, { client: queryClient }, children);
+}
+
+describe("useLeague", () => {
+  it("fetches a league by id", async () => {
+    const league = { id: 1, name: "Test League" };
+    mockGet.mockResolvedValue({ json: () => Promise.resolve(league) });
+
+    const { result } = renderHook(() => useLeague("1"), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+
+    expect(result.current.data).toEqual(league);
+    expect(mockGet).toHaveBeenCalledWith({ param: { id: "1" } });
+  });
+});

--- a/client/src/hooks/use-league.ts
+++ b/client/src/hooks/use-league.ts
@@ -1,0 +1,12 @@
+import { useQuery } from "@tanstack/react-query";
+import { api } from "../api.ts";
+
+export function useLeague(id: string) {
+  return useQuery({
+    queryKey: ["leagues", id],
+    queryFn: async () => {
+      const res = await api.api.leagues[":id"].$get({ param: { id } });
+      return res.json();
+    },
+  });
+}


### PR DESCRIPTION
## Summary

- Move the sidebar collapse trigger into the league sidebar header, inline with the league name (claude.ai pattern). Collapsed state shows the trigger as a full-width icon button.
- Relocate the "All Leagues" back link from the header into the footer, grouped above the Profile menu — both are navigation-away actions.
- Add a `useLeague` hook to fetch the current league's name for display in the header.