### PR TITLE
feat(client): stub nav items for product-vision features

### DIFF
--- a/client/src/features/league/coaches.test.tsx
+++ b/client/src/features/league/coaches.test.tsx
@@ -1,0 +1,14 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import { Coaches } from "./coaches.tsx";
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("Coaches", () => {
+  it("renders the Coaches heading", () => {
+    render(<Coaches />);
+    expect(screen.getByRole("heading", { name: "Coaches" })).toBeDefined();
+  });
+});

--- a/client/src/features/league/coaches.tsx
+++ b/client/src/features/league/coaches.tsx
@@ -1,0 +1,12 @@
+import { StubPage } from "./stub-page.tsx";
+
+// TODO: Replace with an org-chart tree showing the coaching staff:
+// Head Coach → (OC, DC, ST Coordinator) → position coaches.
+export function Coaches() {
+  return (
+    <StubPage
+      title="Coaches"
+      description="Your coaching staff, coordinators, and position coaches."
+    />
+  );
+}

--- a/client/src/features/league/draft.test.tsx
+++ b/client/src/features/league/draft.test.tsx
@@ -1,0 +1,14 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import { Draft } from "./draft.tsx";
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("Draft", () => {
+  it("renders the Draft heading", () => {
+    render(<Draft />);
+    expect(screen.getByRole("heading", { name: "Draft" })).toBeDefined();
+  });
+});

--- a/client/src/features/league/draft.tsx
+++ b/client/src/features/league/draft.tsx
@@ -1,0 +1,10 @@
+import { StubPage } from "./stub-page.tsx";
+
+export function Draft() {
+  return (
+    <StubPage
+      title="Draft"
+      description="Prospect generation, the draft board, draft day, and post-draft."
+    />
+  );
+}

--- a/client/src/features/league/free-agency.test.tsx
+++ b/client/src/features/league/free-agency.test.tsx
@@ -1,0 +1,16 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import { FreeAgency } from "./free-agency.tsx";
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("FreeAgency", () => {
+  it("renders the Free Agency heading", () => {
+    render(<FreeAgency />);
+    expect(
+      screen.getByRole("heading", { name: "Free Agency" }),
+    ).toBeDefined();
+  });
+});

--- a/client/src/features/league/free-agency.tsx
+++ b/client/src/features/league/free-agency.tsx
@@ -1,0 +1,10 @@
+import { StubPage } from "./stub-page.tsx";
+
+export function FreeAgency() {
+  return (
+    <StubPage
+      title="Free Agency"
+      description="Bid on free agents, negotiate contracts, and win the signing game."
+    />
+  );
+}

--- a/client/src/features/league/layout.test.tsx
+++ b/client/src/features/league/layout.test.tsx
@@ -172,4 +172,35 @@ describe("LeagueLayout", () => {
     const footer = document.querySelector('[data-slot="sidebar-footer"]');
     expect(footer?.textContent).toContain("All Leagues");
   });
+
+  it.each([
+    ["Team"],
+    ["Team Building"],
+    ["League"],
+  ])("renders the %s sidebar group label", (label) => {
+    renderWithProviders();
+    const labels = Array.from(
+      document.querySelectorAll('[data-sidebar="group-label"]'),
+    ).map((el) => el.textContent);
+    expect(labels).toContain(label);
+  });
+
+  it.each([
+    ["Roster", "/leagues/1/roster"],
+    ["Coaches", "/leagues/1/coaches"],
+    ["Schemes", "/leagues/1/schemes"],
+    ["Scouting", "/leagues/1/scouting"],
+    ["Draft", "/leagues/1/draft"],
+    ["Trades", "/leagues/1/trades"],
+    ["Free Agency", "/leagues/1/free-agency"],
+    ["Salary Cap", "/leagues/1/salary-cap"],
+    ["Standings", "/leagues/1/standings"],
+    ["Schedule", "/leagues/1/schedule"],
+    ["Media", "/leagues/1/media"],
+    ["Owner", "/leagues/1/owner"],
+  ])("renders a %s nav link pointing to %s", (name, href) => {
+    renderWithProviders();
+    const link = screen.getByRole("link", { name });
+    expect(link.getAttribute("href")).toBe(href);
+  });
 });

--- a/client/src/features/league/layout.tsx
+++ b/client/src/features/league/layout.tsx
@@ -1,11 +1,29 @@
 import { Link, Outlet, useParams } from "@tanstack/react-router";
-import { ArrowLeftIcon, HomeIcon, SettingsIcon, UserIcon } from "lucide-react";
+import {
+  ArrowLeftIcon,
+  ArrowLeftRightIcon,
+  BookOpenIcon,
+  CalendarIcon,
+  ClipboardListIcon,
+  CrownIcon,
+  DollarSignIcon,
+  HomeIcon,
+  ListOrderedIcon,
+  NewspaperIcon,
+  SearchIcon,
+  SettingsIcon,
+  TrophyIcon,
+  UserIcon,
+  UserPlusIcon,
+  UsersIcon,
+} from "lucide-react";
 import {
   Sidebar,
   SidebarContent,
   SidebarFooter,
   SidebarGroup,
   SidebarGroupContent,
+  SidebarGroupLabel,
   SidebarHeader,
   SidebarInset,
   SidebarMenu,
@@ -18,31 +36,92 @@ import {
 import { UserMenu } from "../../components/user-menu.tsx";
 import { useLeague } from "../../hooks/use-league.ts";
 
+type NavItem = {
+  label: string;
+  path: string;
+  Icon: typeof HomeIcon;
+};
+
+type NavGroup = {
+  label: string;
+  items: NavItem[];
+};
+
+const navGroups: NavGroup[] = [
+  {
+    label: "Team",
+    items: [
+      { label: "Home", path: "", Icon: HomeIcon },
+      { label: "Roster", path: "roster", Icon: UsersIcon },
+      { label: "Coaches", path: "coaches", Icon: ClipboardListIcon },
+      { label: "Schemes", path: "schemes", Icon: BookOpenIcon },
+    ],
+  },
+  {
+    label: "Team Building",
+    items: [
+      { label: "Scouting", path: "scouting", Icon: SearchIcon },
+      { label: "Draft", path: "draft", Icon: ListOrderedIcon },
+      { label: "Trades", path: "trades", Icon: ArrowLeftRightIcon },
+      { label: "Free Agency", path: "free-agency", Icon: UserPlusIcon },
+      { label: "Salary Cap", path: "salary-cap", Icon: DollarSignIcon },
+    ],
+  },
+  {
+    label: "League",
+    items: [
+      { label: "Standings", path: "standings", Icon: TrophyIcon },
+      { label: "Schedule", path: "schedule", Icon: CalendarIcon },
+      { label: "Media", path: "media", Icon: NewspaperIcon },
+      { label: "Owner", path: "owner", Icon: CrownIcon },
+    ],
+  },
+];
+
 export function LeagueLayout() {
   const { leagueId } = useParams({ strict: false });
   const { data: league } = useLeague(leagueId ?? "");
+
+  const basePath = `/leagues/${leagueId}`;
 
   return (
     <SidebarProvider>
       <Sidebar collapsible="icon">
         <LeagueSidebarHeader name={league?.name} />
         <SidebarContent>
+          {navGroups.map((group) => (
+            <SidebarGroup key={group.label}>
+              <SidebarGroupLabel>{group.label}</SidebarGroupLabel>
+              <SidebarGroupContent>
+                <SidebarMenu>
+                  {group.items.map((item) => (
+                    <SidebarMenuItem key={item.label}>
+                      <SidebarMenuButton
+                        tooltip={item.label}
+                        render={
+                          <Link
+                            to={item.path
+                              ? `${basePath}/${item.path}`
+                              : basePath}
+                          />
+                        }
+                      >
+                        <item.Icon />
+                        <span>{item.label}</span>
+                      </SidebarMenuButton>
+                    </SidebarMenuItem>
+                  ))}
+                </SidebarMenu>
+              </SidebarGroupContent>
+            </SidebarGroup>
+          ))}
           <SidebarGroup>
             <SidebarGroupContent>
               <SidebarMenu>
                 <SidebarMenuItem>
                   <SidebarMenuButton
-                    tooltip="Home"
-                    render={<Link to={`/leagues/${leagueId}`} />}
-                  >
-                    <HomeIcon />
-                    <span>Home</span>
-                  </SidebarMenuButton>
-                </SidebarMenuItem>
-                <SidebarMenuItem>
-                  <SidebarMenuButton
                     tooltip="Settings"
-                    render={<Link to={`/leagues/${leagueId}/settings`} />}
+                    render={<Link to={`${basePath}/settings`} />}
                   >
                     <SettingsIcon />
                     <span>Settings</span>

--- a/client/src/features/league/media.test.tsx
+++ b/client/src/features/league/media.test.tsx
@@ -1,0 +1,14 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import { Media } from "./media.tsx";
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("Media", () => {
+  it("renders the Media heading", () => {
+    render(<Media />);
+    expect(screen.getByRole("heading", { name: "Media" })).toBeDefined();
+  });
+});

--- a/client/src/features/league/media.tsx
+++ b/client/src/features/league/media.tsx
@@ -1,0 +1,10 @@
+import { StubPage } from "./stub-page.tsx";
+
+export function Media() {
+  return (
+    <StubPage
+      title="Media"
+      description="Headlines, analyst grades, and narratives shaping your franchise."
+    />
+  );
+}

--- a/client/src/features/league/owner.test.tsx
+++ b/client/src/features/league/owner.test.tsx
@@ -1,0 +1,14 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import { Owner } from "./owner.tsx";
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("Owner", () => {
+  it("renders the Owner heading", () => {
+    render(<Owner />);
+    expect(screen.getByRole("heading", { name: "Owner" })).toBeDefined();
+  });
+});

--- a/client/src/features/league/owner.tsx
+++ b/client/src/features/league/owner.tsx
@@ -1,0 +1,10 @@
+import { StubPage } from "./stub-page.tsx";
+
+export function Owner() {
+  return (
+    <StubPage
+      title="Owner"
+      description="Owner directives, expectations, and your job security."
+    />
+  );
+}

--- a/client/src/features/league/roster.test.tsx
+++ b/client/src/features/league/roster.test.tsx
@@ -1,0 +1,14 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import { Roster } from "./roster.tsx";
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("Roster", () => {
+  it("renders the Roster heading", () => {
+    render(<Roster />);
+    expect(screen.getByRole("heading", { name: "Roster" })).toBeDefined();
+  });
+});

--- a/client/src/features/league/roster.tsx
+++ b/client/src/features/league/roster.tsx
@@ -1,0 +1,10 @@
+import { StubPage } from "./stub-page.tsx";
+
+export function Roster() {
+  return (
+    <StubPage
+      title="Roster"
+      description="Your active roster, depth chart, and player development."
+    />
+  );
+}

--- a/client/src/features/league/salary-cap.test.tsx
+++ b/client/src/features/league/salary-cap.test.tsx
@@ -1,0 +1,16 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import { SalaryCap } from "./salary-cap.tsx";
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("SalaryCap", () => {
+  it("renders the Salary Cap heading", () => {
+    render(<SalaryCap />);
+    expect(
+      screen.getByRole("heading", { name: "Salary Cap" }),
+    ).toBeDefined();
+  });
+});

--- a/client/src/features/league/salary-cap.tsx
+++ b/client/src/features/league/salary-cap.tsx
@@ -1,0 +1,10 @@
+import { StubPage } from "./stub-page.tsx";
+
+export function SalaryCap() {
+  return (
+    <StubPage
+      title="Salary Cap"
+      description="Contract structure, dead money, and multi-year financial planning."
+    />
+  );
+}

--- a/client/src/features/league/schedule.test.tsx
+++ b/client/src/features/league/schedule.test.tsx
@@ -1,0 +1,16 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import { Schedule } from "./schedule.tsx";
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("Schedule", () => {
+  it("renders the Schedule heading", () => {
+    render(<Schedule />);
+    expect(
+      screen.getByRole("heading", { name: "Schedule" }),
+    ).toBeDefined();
+  });
+});

--- a/client/src/features/league/schedule.tsx
+++ b/client/src/features/league/schedule.tsx
@@ -1,0 +1,10 @@
+import { StubPage } from "./stub-page.tsx";
+
+export function Schedule() {
+  return (
+    <StubPage
+      title="Schedule"
+      description="Weekly matchups, results, and upcoming games."
+    />
+  );
+}

--- a/client/src/features/league/schemes.test.tsx
+++ b/client/src/features/league/schemes.test.tsx
@@ -1,0 +1,14 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import { Schemes } from "./schemes.tsx";
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("Schemes", () => {
+  it("renders the Schemes heading", () => {
+    render(<Schemes />);
+    expect(screen.getByRole("heading", { name: "Schemes" })).toBeDefined();
+  });
+});

--- a/client/src/features/league/schemes.tsx
+++ b/client/src/features/league/schemes.tsx
@@ -1,0 +1,10 @@
+import { StubPage } from "./stub-page.tsx";
+
+export function Schemes() {
+  return (
+    <StubPage
+      title="Schemes"
+      description="Offensive and defensive scheme identity and personnel philosophy."
+    />
+  );
+}

--- a/client/src/features/league/scouting.test.tsx
+++ b/client/src/features/league/scouting.test.tsx
@@ -1,0 +1,14 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import { Scouting } from "./scouting.tsx";
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("Scouting", () => {
+  it("renders the Scouting heading", () => {
+    render(<Scouting />);
+    expect(screen.getByRole("heading", { name: "Scouting" })).toBeDefined();
+  });
+});

--- a/client/src/features/league/scouting.tsx
+++ b/client/src/features/league/scouting.tsx
@@ -1,0 +1,12 @@
+import { StubPage } from "./stub-page.tsx";
+
+// TODO: Replace with a scouting staff view (Director of College Scouting,
+// Director of Pro Scouting, regional scouts) plus scouting assignments.
+export function Scouting() {
+  return (
+    <StubPage
+      title="Scouting"
+      description="Manage your scouts, evaluate prospects, and build your draft board."
+    />
+  );
+}

--- a/client/src/features/league/standings.test.tsx
+++ b/client/src/features/league/standings.test.tsx
@@ -1,0 +1,16 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import { Standings } from "./standings.tsx";
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("Standings", () => {
+  it("renders the Standings heading", () => {
+    render(<Standings />);
+    expect(
+      screen.getByRole("heading", { name: "Standings" }),
+    ).toBeDefined();
+  });
+});

--- a/client/src/features/league/standings.tsx
+++ b/client/src/features/league/standings.tsx
@@ -1,0 +1,10 @@
+import { StubPage } from "./stub-page.tsx";
+
+export function Standings() {
+  return (
+    <StubPage
+      title="Standings"
+      description="League standings by conference and division."
+    />
+  );
+}

--- a/client/src/features/league/stub-page.test.tsx
+++ b/client/src/features/league/stub-page.test.tsx
@@ -1,0 +1,26 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import { StubPage } from "./stub-page.tsx";
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("StubPage", () => {
+  it("renders the title as a heading", () => {
+    render(<StubPage title="Scouting" description="desc" />);
+    expect(
+      screen.getByRole("heading", { name: "Scouting" }),
+    ).toBeDefined();
+  });
+
+  it("renders the description", () => {
+    render(<StubPage title="Scouting" description="the info engine" />);
+    expect(screen.getByText("the info engine")).toBeDefined();
+  });
+
+  it("renders a coming soon badge", () => {
+    render(<StubPage title="Scouting" description="desc" />);
+    expect(screen.getByText(/coming soon/i)).toBeDefined();
+  });
+});

--- a/client/src/features/league/stub-page.tsx
+++ b/client/src/features/league/stub-page.tsx
@@ -1,0 +1,22 @@
+import type { ReactNode } from "react";
+
+interface StubPageProps {
+  title: string;
+  description: string;
+  children?: ReactNode;
+}
+
+export function StubPage({ title, description, children }: StubPageProps) {
+  return (
+    <div className="p-6">
+      <div className="mb-6 flex items-center gap-3">
+        <h1 className="text-2xl font-bold">{title}</h1>
+        <span className="rounded-full border border-border bg-muted px-2 py-0.5 text-xs font-medium text-muted-foreground">
+          Coming Soon
+        </span>
+      </div>
+      <p className="max-w-2xl text-muted-foreground">{description}</p>
+      {children}
+    </div>
+  );
+}

--- a/client/src/features/league/trades.test.tsx
+++ b/client/src/features/league/trades.test.tsx
@@ -1,0 +1,14 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import { Trades } from "./trades.tsx";
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("Trades", () => {
+  it("renders the Trades heading", () => {
+    render(<Trades />);
+    expect(screen.getByRole("heading", { name: "Trades" })).toBeDefined();
+  });
+});

--- a/client/src/features/league/trades.tsx
+++ b/client/src/features/league/trades.tsx
@@ -1,0 +1,10 @@
+import { StubPage } from "./stub-page.tsx";
+
+export function Trades() {
+  return (
+    <StubPage
+      title="Trades"
+      description="Negotiate trades, shop players, and work the phones."
+    />
+  );
+}

--- a/client/src/router.test.tsx
+++ b/client/src/router.test.tsx
@@ -144,4 +144,32 @@ describe("Router", () => {
       ).toBeDefined();
     });
   });
+
+  const stubRoutes: Array<[string, string]> = [
+    ["roster", "Roster"],
+    ["coaches", "Coaches"],
+    ["schemes", "Schemes"],
+    ["scouting", "Scouting"],
+    ["draft", "Draft"],
+    ["trades", "Trades"],
+    ["free-agency", "Free Agency"],
+    ["salary-cap", "Salary Cap"],
+    ["standings", "Standings"],
+    ["schedule", "Schedule"],
+    ["media", "Media"],
+    ["owner", "Owner"],
+  ];
+
+  for (const [path, heading] of stubRoutes) {
+    it(`renders the ${heading} stub page at /leagues/:leagueId/${path}`, async () => {
+      mockUseSession.mockReturnValue({
+        data: { user: { id: "1", name: "Test" }, session: { id: "s1" } },
+        isPending: false,
+      });
+      renderRouter(`/leagues/1/${path}`);
+      await waitFor(() => {
+        expect(screen.getByRole("heading", { name: heading })).toBeDefined();
+      });
+    });
+  }
 });

--- a/client/src/router.tsx
+++ b/client/src/router.tsx
@@ -12,6 +12,18 @@ import { LeagueSelect } from "./features/league-select/index.tsx";
 import { LeagueLayout } from "./features/league/layout.tsx";
 import { LeagueHome } from "./features/league/index.tsx";
 import { LeagueSettings } from "./features/league/settings.tsx";
+import { Roster } from "./features/league/roster.tsx";
+import { Coaches } from "./features/league/coaches.tsx";
+import { Schemes } from "./features/league/schemes.tsx";
+import { Scouting } from "./features/league/scouting.tsx";
+import { Draft } from "./features/league/draft.tsx";
+import { Trades } from "./features/league/trades.tsx";
+import { FreeAgency } from "./features/league/free-agency.tsx";
+import { SalaryCap } from "./features/league/salary-cap.tsx";
+import { Standings } from "./features/league/standings.tsx";
+import { Schedule } from "./features/league/schedule.tsx";
+import { Media } from "./features/league/media.tsx";
+import { Owner } from "./features/league/owner.tsx";
 import { TeamSelect } from "./features/team-select/index.tsx";
 
 const rootRoute = createRootRoute();
@@ -76,12 +88,99 @@ const leagueSettingsRoute = createRoute({
   component: LeagueSettings,
 });
 
+const rosterRoute = createRoute({
+  getParentRoute: () => leagueLayoutRoute,
+  path: "roster",
+  component: Roster,
+});
+
+const coachesRoute = createRoute({
+  getParentRoute: () => leagueLayoutRoute,
+  path: "coaches",
+  component: Coaches,
+});
+
+const schemesRoute = createRoute({
+  getParentRoute: () => leagueLayoutRoute,
+  path: "schemes",
+  component: Schemes,
+});
+
+const scoutingRoute = createRoute({
+  getParentRoute: () => leagueLayoutRoute,
+  path: "scouting",
+  component: Scouting,
+});
+
+const draftRoute = createRoute({
+  getParentRoute: () => leagueLayoutRoute,
+  path: "draft",
+  component: Draft,
+});
+
+const tradesRoute = createRoute({
+  getParentRoute: () => leagueLayoutRoute,
+  path: "trades",
+  component: Trades,
+});
+
+const freeAgencyRoute = createRoute({
+  getParentRoute: () => leagueLayoutRoute,
+  path: "free-agency",
+  component: FreeAgency,
+});
+
+const salaryCapRoute = createRoute({
+  getParentRoute: () => leagueLayoutRoute,
+  path: "salary-cap",
+  component: SalaryCap,
+});
+
+const standingsRoute = createRoute({
+  getParentRoute: () => leagueLayoutRoute,
+  path: "standings",
+  component: Standings,
+});
+
+const scheduleRoute = createRoute({
+  getParentRoute: () => leagueLayoutRoute,
+  path: "schedule",
+  component: Schedule,
+});
+
+const mediaRoute = createRoute({
+  getParentRoute: () => leagueLayoutRoute,
+  path: "media",
+  component: Media,
+});
+
+const ownerRoute = createRoute({
+  getParentRoute: () => leagueLayoutRoute,
+  path: "owner",
+  component: Owner,
+});
+
 const routeTree = rootRoute.addChildren([
   loginRoute,
   authenticatedRoute.addChildren([
     leagueSelectRoute,
     teamSelectRoute,
-    leagueLayoutRoute.addChildren([leagueHomeRoute, leagueSettingsRoute]),
+    leagueLayoutRoute.addChildren([
+      leagueHomeRoute,
+      leagueSettingsRoute,
+      rosterRoute,
+      coachesRoute,
+      schemesRoute,
+      scoutingRoute,
+      draftRoute,
+      tradesRoute,
+      freeAgencyRoute,
+      salaryCapRoute,
+      standingsRoute,
+      scheduleRoute,
+      mediaRoute,
+      ownerRoute,
+    ]),
   ]),
 ]);
 


### PR DESCRIPTION
## Summary

- Adds Coming Soon stub pages for each feature area in the product vision docs: Roster, Coaches, Schemes, Scouting, Draft, Trades, Free Agency, Salary Cap, Standings, Schedule, Media, Owner.
- Surfaces them in the league sidebar under three groups — **Team**, **Team Building**, **League** — with lucide icons, keeping Settings and All Leagues in place.
- Coaches and Scouting carry TODOs for the future staff-tree UIs (coaching org chart and scouting department) described in the product docs; pages remain simple Coming Soon placeholders for now.
- A shared `StubPage` component renders title + description + "Coming Soon" badge so future features can light up incrementally.