### PR TITLE
refactor(players): extract players feature from personnel

### DIFF
--- a/packages/shared/mod.ts
+++ b/packages/shared/mod.ts
@@ -3,14 +3,8 @@ export type { HealthStatus } from "./types/health.ts";
 export type { League, NewLeague } from "./types/league.ts";
 export type { Team } from "./types/team.ts";
 export type { NewSeason, Season, SeasonPhase } from "./types/season.ts";
-export type {
-  Coach,
-  Contract,
-  DraftProspect,
-  FrontOfficeStaff,
-  Player,
-  Scout,
-} from "./types/personnel.ts";
+export type { Coach, FrontOfficeStaff, Scout } from "./types/personnel.ts";
+export type { Contract, DraftProspect, Player } from "./types/player.ts";
 export type { Game } from "./types/game.ts";
 
 // Interfaces — simulation

--- a/packages/shared/types/personnel.ts
+++ b/packages/shared/types/personnel.ts
@@ -1,13 +1,3 @@
-export interface Player {
-  id: string;
-  leagueId: string;
-  teamId: string | null;
-  firstName: string;
-  lastName: string;
-  createdAt: Date;
-  updatedAt: Date;
-}
-
 export interface Coach {
   id: string;
   leagueId: string;
@@ -32,29 +22,6 @@ export interface FrontOfficeStaff {
   id: string;
   leagueId: string;
   teamId: string;
-  firstName: string;
-  lastName: string;
-  createdAt: Date;
-  updatedAt: Date;
-}
-
-export interface Contract {
-  id: string;
-  playerId: string;
-  teamId: string;
-  totalYears: number;
-  currentYear: number;
-  totalSalary: number;
-  annualSalary: number;
-  guaranteedMoney: number;
-  signingBonus: number;
-  createdAt: Date;
-  updatedAt: Date;
-}
-
-export interface DraftProspect {
-  id: string;
-  seasonId: string;
   firstName: string;
   lastName: string;
   createdAt: Date;

--- a/packages/shared/types/player.ts
+++ b/packages/shared/types/player.ts
@@ -1,0 +1,32 @@
+export interface Player {
+  id: string;
+  leagueId: string;
+  teamId: string | null;
+  firstName: string;
+  lastName: string;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+export interface Contract {
+  id: string;
+  playerId: string;
+  teamId: string;
+  totalYears: number;
+  currentYear: number;
+  totalSalary: number;
+  annualSalary: number;
+  guaranteedMoney: number;
+  signingBonus: number;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+export interface DraftProspect {
+  id: string;
+  seasonId: string;
+  firstName: string;
+  lastName: string;
+  createdAt: Date;
+  updatedAt: Date;
+}

--- a/server/db/schema.ts
+++ b/server/db/schema.ts
@@ -12,12 +12,11 @@ export { teams } from "../features/team/team.schema.ts";
 export { seasonPhaseEnum, seasons } from "../features/season/season.schema.ts";
 export {
   coaches,
-  draftProspects,
   frontOfficeStaff,
-  players,
   scouts,
 } from "../features/personnel/personnel.schema.ts";
-export { contracts } from "../features/personnel/contract.schema.ts";
+export { draftProspects, players } from "../features/players/player.schema.ts";
+export { contracts } from "../features/players/contract.schema.ts";
 export { games } from "../features/schedule/game.schema.ts";
 export {
   accounts,

--- a/server/features/mod.ts
+++ b/server/features/mod.ts
@@ -24,6 +24,10 @@ import {
   createStubPersonnelGenerator,
 } from "./personnel/mod.ts";
 import {
+  createPlayersService,
+  createStubPlayersGenerator,
+} from "./players/mod.ts";
+import {
   createScheduleService,
   createStubScheduleGenerator,
 } from "./schedule/mod.ts";
@@ -67,8 +71,14 @@ export function createFeatureRouters(
   const userService = createUserService({ userRepo, log });
   const teamService = createTeamService({ teamRepo, log });
   const seasonService = createSeasonService({ seasonRepo, log });
+  const playersService = createPlayersService({
+    generator: createStubPlayersGenerator(),
+    db,
+    log,
+  });
   const personnelService = createPersonnelService({
     generator: createStubPersonnelGenerator(),
+    playersService,
     db,
     log,
   });

--- a/server/features/personnel/personnel.generator.interface.ts
+++ b/server/features/personnel/personnel.generator.interface.ts
@@ -1,38 +1,16 @@
-import type {
-  Coach,
-  Contract,
-  DraftProspect,
-  FrontOfficeStaff,
-  Player,
-  Scout,
-} from "@zone-blitz/shared";
+import type { Coach, FrontOfficeStaff, Scout } from "@zone-blitz/shared";
 
 export interface PersonnelGeneratorInput {
   leagueId: string;
-  seasonId: string;
   teamIds: string[];
-  rosterSize: number;
 }
 
 export interface GeneratedPersonnel {
-  players: Omit<Player, "id" | "createdAt" | "updatedAt">[];
   coaches: Omit<Coach, "id" | "createdAt" | "updatedAt">[];
   scouts: Omit<Scout, "id" | "createdAt" | "updatedAt">[];
   frontOfficeStaff: Omit<FrontOfficeStaff, "id" | "createdAt" | "updatedAt">[];
-  draftProspects: Omit<DraftProspect, "id" | "createdAt" | "updatedAt">[];
 }
-
-export interface ContractGeneratorInput {
-  salaryCap: number;
-  players: Pick<Player, "id" | "teamId">[];
-}
-
-export type GeneratedContract = Omit<
-  Contract,
-  "id" | "createdAt" | "updatedAt"
->;
 
 export interface PersonnelGenerator {
   generate(input: PersonnelGeneratorInput): GeneratedPersonnel;
-  generateContracts(input: ContractGeneratorInput): GeneratedContract[];
 }

--- a/server/features/personnel/personnel.schema.ts
+++ b/server/features/personnel/personnel.schema.ts
@@ -1,19 +1,6 @@
 import { pgTable, text, timestamp, uuid } from "drizzle-orm/pg-core";
 import { leagues } from "../league/league.schema.ts";
 import { teams } from "../team/team.schema.ts";
-import { seasons } from "../season/season.schema.ts";
-
-export const players = pgTable("players", {
-  id: uuid("id").defaultRandom().primaryKey(),
-  leagueId: uuid("league_id")
-    .notNull()
-    .references(() => leagues.id, { onDelete: "cascade" }),
-  teamId: uuid("team_id").references(() => teams.id, { onDelete: "set null" }),
-  firstName: text("first_name").notNull(),
-  lastName: text("last_name").notNull(),
-  createdAt: timestamp("created_at").defaultNow().notNull(),
-  updatedAt: timestamp("updated_at").defaultNow().notNull(),
-});
 
 export const coaches = pgTable("coaches", {
   id: uuid("id").defaultRandom().primaryKey(),
@@ -51,17 +38,6 @@ export const frontOfficeStaff = pgTable("front_office_staff", {
   teamId: uuid("team_id")
     .notNull()
     .references(() => teams.id, { onDelete: "cascade" }),
-  firstName: text("first_name").notNull(),
-  lastName: text("last_name").notNull(),
-  createdAt: timestamp("created_at").defaultNow().notNull(),
-  updatedAt: timestamp("updated_at").defaultNow().notNull(),
-});
-
-export const draftProspects = pgTable("draft_prospects", {
-  id: uuid("id").defaultRandom().primaryKey(),
-  seasonId: uuid("season_id")
-    .notNull()
-    .references(() => seasons.id, { onDelete: "cascade" }),
   firstName: text("first_name").notNull(),
   lastName: text("last_name").notNull(),
   createdAt: timestamp("created_at").defaultNow().notNull(),

--- a/server/features/personnel/personnel.service.test.ts
+++ b/server/features/personnel/personnel.service.test.ts
@@ -4,6 +4,7 @@ import type {
   GeneratedPersonnel,
   PersonnelGenerator,
 } from "./personnel.generator.interface.ts";
+import type { PlayersService } from "../players/players.service.interface.ts";
 
 function createTestLogger() {
   return {
@@ -17,11 +18,9 @@ function createTestLogger() {
 
 function createEmptyPersonnel(): GeneratedPersonnel {
   return {
-    players: [],
     coaches: [],
     scouts: [],
     frontOfficeStaff: [],
-    draftProspects: [],
   };
 }
 
@@ -30,7 +29,20 @@ function createMockGenerator(
 ): PersonnelGenerator {
   return {
     generate: () => createEmptyPersonnel(),
-    generateContracts: () => [],
+    ...overrides,
+  };
+}
+
+function createMockPlayersService(
+  overrides: Partial<PlayersService> = {},
+): PlayersService {
+  return {
+    generateAndPersist: () =>
+      Promise.resolve({
+        playerCount: 0,
+        draftProspectCount: 0,
+        contractCount: 0,
+      }),
     ...overrides,
   };
 }
@@ -40,7 +52,7 @@ interface InsertCall {
   values: unknown[];
 }
 
-function createMockDb(rosteredPlayerIds: string[] = []): {
+function createMockDb(): {
   db: import("../../db/connection.ts").Database;
   calls: InsertCall[];
 } {
@@ -50,19 +62,7 @@ function createMockDb(rosteredPlayerIds: string[] = []): {
       return {
         values(values: unknown[]) {
           calls.push({ table, values });
-          return {
-            returning(_columns?: unknown) {
-              if (Array.isArray(values)) {
-                return Promise.resolve(
-                  values.map((v, i) => ({
-                    id: rosteredPlayerIds[i] ?? `generated-${i}`,
-                    teamId: (v as { teamId?: string | null }).teamId ?? null,
-                  })),
-                );
-              }
-              return Promise.resolve([]);
-            },
-          };
+          return Promise.resolve([]);
         },
       };
     },
@@ -72,69 +72,46 @@ function createMockDb(rosteredPlayerIds: string[] = []): {
 
 Deno.test("personnel.service", async (t) => {
   await t.step(
-    "generateAndPersist inserts generated personnel and returns counts",
+    "generateAndPersist delegates to players service and inserts coaches/scouts/front office",
     async () => {
-      const { db, calls } = createMockDb(["p1", "p2"]);
+      const { db, calls } = createMockDb();
       const generator = createMockGenerator({
         generate: () => ({
-          players: [
-            {
-              leagueId: "l1",
-              teamId: "t1",
-              firstName: "A",
-              lastName: "B",
-            },
-            {
-              leagueId: "l1",
-              teamId: "t1",
-              firstName: "C",
-              lastName: "D",
-            },
-          ],
           coaches: [
-            {
-              leagueId: "l1",
-              teamId: "t1",
-              firstName: "E",
-              lastName: "F",
-            },
+            { leagueId: "l1", teamId: "t1", firstName: "E", lastName: "F" },
           ],
           scouts: [
-            {
-              leagueId: "l1",
-              teamId: "t1",
-              firstName: "G",
-              lastName: "H",
-            },
+            { leagueId: "l1", teamId: "t1", firstName: "G", lastName: "H" },
           ],
           frontOfficeStaff: [
-            {
-              leagueId: "l1",
-              teamId: "t1",
-              firstName: "I",
-              lastName: "J",
-            },
-          ],
-          draftProspects: [
-            { seasonId: "s1", firstName: "K", lastName: "L" },
+            { leagueId: "l1", teamId: "t1", firstName: "I", lastName: "J" },
           ],
         }),
-        generateContracts: (input) => {
-          return input.players.map((p) => ({
-            playerId: p.id,
-            teamId: p.teamId!,
-            totalYears: 3,
-            currentYear: 1,
-            totalSalary: 300_000,
-            annualSalary: 100_000,
-            guaranteedMoney: 100_000,
-            signingBonus: 0,
-          }));
+      });
+
+      let playersServiceInput:
+        | {
+          leagueId: string;
+          seasonId: string;
+          teamIds: string[];
+          rosterSize: number;
+          salaryCap: number;
+        }
+        | undefined;
+      const playersService = createMockPlayersService({
+        generateAndPersist: (input) => {
+          playersServiceInput = input;
+          return Promise.resolve({
+            playerCount: 2,
+            draftProspectCount: 1,
+            contractCount: 2,
+          });
         },
       });
 
       const service = createPersonnelService({
         generator,
+        playersService,
         db,
         log: createTestLogger(),
       });
@@ -154,8 +131,14 @@ Deno.test("personnel.service", async (t) => {
       assertEquals(result.draftProspectCount, 1);
       assertEquals(result.contractCount, 2);
 
-      // 6 insert calls: players, coaches, scouts, frontOffice, draftProspects, contracts
-      assertEquals(calls.length, 6);
+      assertEquals(playersServiceInput?.leagueId, "l1");
+      assertEquals(playersServiceInput?.seasonId, "s1");
+      assertEquals(playersServiceInput?.teamIds, ["t1"]);
+      assertEquals(playersServiceInput?.rosterSize, 2);
+      assertEquals(playersServiceInput?.salaryCap, 255_000_000);
+
+      // 3 insert calls: coaches, scouts, frontOffice
+      assertEquals(calls.length, 3);
     },
   );
 
@@ -164,9 +147,11 @@ Deno.test("personnel.service", async (t) => {
     async () => {
       const { db, calls } = createMockDb();
       const generator = createMockGenerator();
+      const playersService = createMockPlayersService();
 
       const service = createPersonnelService({
         generator,
+        playersService,
         db,
         log: createTestLogger(),
       });
@@ -186,55 +171,6 @@ Deno.test("personnel.service", async (t) => {
       assertEquals(result.draftProspectCount, 0);
       assertEquals(result.contractCount, 0);
       assertEquals(calls.length, 0);
-    },
-  );
-
-  await t.step(
-    "generateAndPersist passes inserted players to contract generator",
-    async () => {
-      const { db } = createMockDb(["player-1"]);
-      let contractsGeneratorReceivedPlayers:
-        | { id: string; teamId: string | null }[]
-        | undefined;
-
-      const generator = createMockGenerator({
-        generate: () => ({
-          players: [
-            {
-              leagueId: "l1",
-              teamId: "t1",
-              firstName: "A",
-              lastName: "B",
-            },
-          ],
-          coaches: [],
-          scouts: [],
-          frontOfficeStaff: [],
-          draftProspects: [],
-        }),
-        generateContracts: (input) => {
-          contractsGeneratorReceivedPlayers = input.players;
-          return [];
-        },
-      });
-
-      const service = createPersonnelService({
-        generator,
-        db,
-        log: createTestLogger(),
-      });
-
-      await service.generateAndPersist({
-        leagueId: "l1",
-        seasonId: "s1",
-        teamIds: ["t1"],
-        rosterSize: 1,
-        salaryCap: 100_000,
-      });
-
-      assertEquals(contractsGeneratorReceivedPlayers?.length, 1);
-      assertEquals(contractsGeneratorReceivedPlayers?.[0].id, "player-1");
-      assertEquals(contractsGeneratorReceivedPlayers?.[0].teamId, "t1");
     },
   );
 });

--- a/server/features/personnel/personnel.service.ts
+++ b/server/features/personnel/personnel.service.ts
@@ -1,18 +1,13 @@
 import type pino from "pino";
 import type { Database } from "../../db/connection.ts";
-import {
-  coaches,
-  draftProspects,
-  frontOfficeStaff,
-  players,
-  scouts,
-} from "./personnel.schema.ts";
-import { contracts } from "./contract.schema.ts";
+import { coaches, frontOfficeStaff, scouts } from "./personnel.schema.ts";
 import type { PersonnelGenerator } from "./personnel.generator.interface.ts";
 import type { PersonnelService } from "./personnel.service.interface.ts";
+import type { PlayersService } from "../players/players.service.interface.ts";
 
 export function createPersonnelService(deps: {
   generator: PersonnelGenerator;
+  playersService: PlayersService;
   db: Database;
   log: pino.Logger;
 }): PersonnelService {
@@ -25,21 +20,18 @@ export function createPersonnelService(deps: {
         "generating personnel",
       );
 
-      const personnel = deps.generator.generate({
+      const playersResult = await deps.playersService.generateAndPersist({
         leagueId: input.leagueId,
         seasonId: input.seasonId,
         teamIds: input.teamIds,
         rosterSize: input.rosterSize,
+        salaryCap: input.salaryCap,
       });
 
-      let insertedPlayers: { id: string; teamId: string | null }[] = [];
-
-      if (personnel.players.length > 0) {
-        insertedPlayers = await deps.db
-          .insert(players)
-          .values(personnel.players)
-          .returning({ id: players.id, teamId: players.teamId });
-      }
+      const personnel = deps.generator.generate({
+        leagueId: input.leagueId,
+        teamIds: input.teamIds,
+      });
 
       if (personnel.coaches.length > 0) {
         await deps.db.insert(coaches).values(personnel.coaches);
@@ -52,46 +44,24 @@ export function createPersonnelService(deps: {
           .insert(frontOfficeStaff)
           .values(personnel.frontOfficeStaff);
       }
-      if (personnel.draftProspects.length > 0) {
-        await deps.db.insert(draftProspects).values(personnel.draftProspects);
-      }
 
       log.info(
         {
           leagueId: input.leagueId,
-          players: insertedPlayers.length,
           coaches: personnel.coaches.length,
           scouts: personnel.scouts.length,
           frontOffice: personnel.frontOfficeStaff.length,
-          draftProspects: personnel.draftProspects.length,
         },
         "persisted personnel",
       );
 
-      const generatedContracts = deps.generator.generateContracts({
-        salaryCap: input.salaryCap,
-        players: insertedPlayers,
-      });
-
-      if (generatedContracts.length > 0) {
-        await deps.db.insert(contracts).values(generatedContracts);
-      }
-
-      log.info(
-        {
-          leagueId: input.leagueId,
-          contracts: generatedContracts.length,
-        },
-        "persisted contracts",
-      );
-
       return {
-        playerCount: insertedPlayers.length,
+        playerCount: playersResult.playerCount,
         coachCount: personnel.coaches.length,
         scoutCount: personnel.scouts.length,
         frontOfficeCount: personnel.frontOfficeStaff.length,
-        draftProspectCount: personnel.draftProspects.length,
-        contractCount: generatedContracts.length,
+        draftProspectCount: playersResult.draftProspectCount,
+        contractCount: playersResult.contractCount,
       };
     },
   };

--- a/server/features/personnel/stub-personnel-generator.test.ts
+++ b/server/features/personnel/stub-personnel-generator.test.ts
@@ -4,40 +4,8 @@ import { createStubPersonnelGenerator } from "./stub-personnel-generator.ts";
 const TEAM_IDS = ["team-1", "team-2", "team-3"];
 const INPUT = {
   leagueId: "league-1",
-  seasonId: "season-1",
   teamIds: TEAM_IDS,
-  rosterSize: 53,
 };
-
-Deno.test("generates correct number of rostered players per team", () => {
-  const generator = createStubPersonnelGenerator();
-  const result = generator.generate(INPUT);
-
-  const rosteredPlayers = result.players.filter((p) => p.teamId !== null);
-  assertEquals(rosteredPlayers.length, TEAM_IDS.length * INPUT.rosterSize);
-
-  for (const teamId of TEAM_IDS) {
-    const teamPlayers = rosteredPlayers.filter((p) => p.teamId === teamId);
-    assertEquals(teamPlayers.length, INPUT.rosterSize);
-  }
-});
-
-Deno.test("generates free agents with null teamId", () => {
-  const generator = createStubPersonnelGenerator();
-  const result = generator.generate(INPUT);
-
-  const freeAgents = result.players.filter((p) => p.teamId === null);
-  assertEquals(freeAgents.length, 50);
-});
-
-Deno.test("all players have the correct leagueId", () => {
-  const generator = createStubPersonnelGenerator();
-  const result = generator.generate(INPUT);
-
-  for (const player of result.players) {
-    assertEquals(player.leagueId, INPUT.leagueId);
-  }
-});
 
 Deno.test("generates coaches for each team", () => {
   const generator = createStubPersonnelGenerator();
@@ -74,63 +42,19 @@ Deno.test("generates front office staff for each team", () => {
   }
 });
 
-Deno.test("generates draft prospects linked to seasonId", () => {
-  const generator = createStubPersonnelGenerator();
-  const result = generator.generate(INPUT);
-
-  assertEquals(result.draftProspects.length, 250);
-  for (const prospect of result.draftProspects) {
-    assertEquals(prospect.seasonId, INPUT.seasonId);
-  }
-});
-
-Deno.test("generates contracts for rostered players only", () => {
-  const generator = createStubPersonnelGenerator();
-  const players = [
-    { id: "p1", teamId: "team-1" },
-    { id: "p2", teamId: "team-1" },
-    { id: "p3", teamId: null },
-  ];
-
-  const contracts = generator.generateContracts({
-    salaryCap: 255_000_000,
-    players,
-  });
-
-  assertEquals(contracts.length, 2);
-  assertEquals(contracts.every((c) => c.teamId === "team-1"), true);
-});
-
-Deno.test("stub contracts distribute salary evenly under cap", () => {
-  const generator = createStubPersonnelGenerator();
-  const salaryCap = 255_000_000;
-  const players = Array.from({ length: 53 }, (_, i) => ({
-    id: `p${i}`,
-    teamId: "team-1",
-  }));
-
-  const contracts = generator.generateContracts({ salaryCap, players });
-
-  const totalAnnual = contracts.reduce((sum, c) => sum + c.annualSalary, 0);
-  assertEquals(totalAnnual <= salaryCap, true);
-  assertEquals(contracts.every((c) => c.totalYears === 3), true);
-  assertEquals(contracts.every((c) => c.currentYear === 1), true);
-});
-
-Deno.test("all generated personnel have non-empty names", () => {
+Deno.test("all generated personnel have non-empty names and correct leagueId", () => {
   const generator = createStubPersonnelGenerator();
   const result = generator.generate(INPUT);
 
   const allPeople = [
-    ...result.players,
     ...result.coaches,
     ...result.scouts,
     ...result.frontOfficeStaff,
-    ...result.draftProspects,
   ];
 
   for (const person of allPeople) {
     assertEquals(person.firstName.length > 0, true);
     assertEquals(person.lastName.length > 0, true);
+    assertEquals(person.leagueId, INPUT.leagueId);
   }
 });

--- a/server/features/players/contract.schema.ts
+++ b/server/features/players/contract.schema.ts
@@ -1,5 +1,5 @@
 import { integer, pgTable, timestamp, uuid } from "drizzle-orm/pg-core";
-import { players } from "./personnel.schema.ts";
+import { players } from "./player.schema.ts";
 import { teams } from "../team/team.schema.ts";
 
 export const contracts = pgTable("contracts", {

--- a/server/features/players/mod.ts
+++ b/server/features/players/mod.ts
@@ -1,0 +1,3 @@
+export { createStubPlayersGenerator } from "./stub-players-generator.ts";
+export { createPlayersService } from "./players.service.ts";
+export type { PlayersService } from "./players.service.interface.ts";

--- a/server/features/players/player.schema.ts
+++ b/server/features/players/player.schema.ts
@@ -1,0 +1,27 @@
+import { pgTable, text, timestamp, uuid } from "drizzle-orm/pg-core";
+import { leagues } from "../league/league.schema.ts";
+import { teams } from "../team/team.schema.ts";
+import { seasons } from "../season/season.schema.ts";
+
+export const players = pgTable("players", {
+  id: uuid("id").defaultRandom().primaryKey(),
+  leagueId: uuid("league_id")
+    .notNull()
+    .references(() => leagues.id, { onDelete: "cascade" }),
+  teamId: uuid("team_id").references(() => teams.id, { onDelete: "set null" }),
+  firstName: text("first_name").notNull(),
+  lastName: text("last_name").notNull(),
+  createdAt: timestamp("created_at").defaultNow().notNull(),
+  updatedAt: timestamp("updated_at").defaultNow().notNull(),
+});
+
+export const draftProspects = pgTable("draft_prospects", {
+  id: uuid("id").defaultRandom().primaryKey(),
+  seasonId: uuid("season_id")
+    .notNull()
+    .references(() => seasons.id, { onDelete: "cascade" }),
+  firstName: text("first_name").notNull(),
+  lastName: text("last_name").notNull(),
+  createdAt: timestamp("created_at").defaultNow().notNull(),
+  updatedAt: timestamp("updated_at").defaultNow().notNull(),
+});

--- a/server/features/players/players.generator.interface.ts
+++ b/server/features/players/players.generator.interface.ts
@@ -1,0 +1,28 @@
+import type { Contract, DraftProspect, Player } from "@zone-blitz/shared";
+
+export interface PlayersGeneratorInput {
+  leagueId: string;
+  seasonId: string;
+  teamIds: string[];
+  rosterSize: number;
+}
+
+export interface GeneratedPlayers {
+  players: Omit<Player, "id" | "createdAt" | "updatedAt">[];
+  draftProspects: Omit<DraftProspect, "id" | "createdAt" | "updatedAt">[];
+}
+
+export interface ContractGeneratorInput {
+  salaryCap: number;
+  players: Pick<Player, "id" | "teamId">[];
+}
+
+export type GeneratedContract = Omit<
+  Contract,
+  "id" | "createdAt" | "updatedAt"
+>;
+
+export interface PlayersGenerator {
+  generate(input: PlayersGeneratorInput): GeneratedPlayers;
+  generateContracts(input: ContractGeneratorInput): GeneratedContract[];
+}

--- a/server/features/players/players.service.interface.ts
+++ b/server/features/players/players.service.interface.ts
@@ -1,0 +1,19 @@
+export interface PlayersGenerateInput {
+  leagueId: string;
+  seasonId: string;
+  teamIds: string[];
+  rosterSize: number;
+  salaryCap: number;
+}
+
+export interface PlayersGenerateResult {
+  playerCount: number;
+  draftProspectCount: number;
+  contractCount: number;
+}
+
+export interface PlayersService {
+  generateAndPersist(
+    input: PlayersGenerateInput,
+  ): Promise<PlayersGenerateResult>;
+}

--- a/server/features/players/players.service.test.ts
+++ b/server/features/players/players.service.test.ts
@@ -1,0 +1,189 @@
+import { assertEquals } from "@std/assert";
+import { createPlayersService } from "./players.service.ts";
+import type {
+  GeneratedPlayers,
+  PlayersGenerator,
+} from "./players.generator.interface.ts";
+
+function createTestLogger() {
+  return {
+    child: () => createTestLogger(),
+    debug: () => {},
+    info: () => {},
+    warn: () => {},
+    error: () => {},
+  } as unknown as import("pino").Logger;
+}
+
+function createEmptyPlayers(): GeneratedPlayers {
+  return {
+    players: [],
+    draftProspects: [],
+  };
+}
+
+function createMockGenerator(
+  overrides: Partial<PlayersGenerator> = {},
+): PlayersGenerator {
+  return {
+    generate: () => createEmptyPlayers(),
+    generateContracts: () => [],
+    ...overrides,
+  };
+}
+
+interface InsertCall {
+  table: unknown;
+  values: unknown[];
+}
+
+function createMockDb(rosteredPlayerIds: string[] = []): {
+  db: import("../../db/connection.ts").Database;
+  calls: InsertCall[];
+} {
+  const calls: InsertCall[] = [];
+  const db = {
+    insert(table: unknown) {
+      return {
+        values(values: unknown[]) {
+          calls.push({ table, values });
+          return {
+            returning(_columns?: unknown) {
+              if (Array.isArray(values)) {
+                return Promise.resolve(
+                  values.map((v, i) => ({
+                    id: rosteredPlayerIds[i] ?? `generated-${i}`,
+                    teamId: (v as { teamId?: string | null }).teamId ?? null,
+                  })),
+                );
+              }
+              return Promise.resolve([]);
+            },
+          };
+        },
+      };
+    },
+  } as unknown as import("../../db/connection.ts").Database;
+  return { db, calls };
+}
+
+Deno.test("players.service", async (t) => {
+  await t.step(
+    "generateAndPersist inserts players, draft prospects, contracts and returns counts",
+    async () => {
+      const { db, calls } = createMockDb(["p1", "p2"]);
+      const generator = createMockGenerator({
+        generate: () => ({
+          players: [
+            { leagueId: "l1", teamId: "t1", firstName: "A", lastName: "B" },
+            { leagueId: "l1", teamId: "t1", firstName: "C", lastName: "D" },
+          ],
+          draftProspects: [
+            { seasonId: "s1", firstName: "K", lastName: "L" },
+          ],
+        }),
+        generateContracts: (input) => {
+          return input.players.map((p) => ({
+            playerId: p.id,
+            teamId: p.teamId!,
+            totalYears: 3,
+            currentYear: 1,
+            totalSalary: 300_000,
+            annualSalary: 100_000,
+            guaranteedMoney: 100_000,
+            signingBonus: 0,
+          }));
+        },
+      });
+
+      const service = createPlayersService({
+        generator,
+        db,
+        log: createTestLogger(),
+      });
+
+      const result = await service.generateAndPersist({
+        leagueId: "l1",
+        seasonId: "s1",
+        teamIds: ["t1"],
+        rosterSize: 2,
+        salaryCap: 255_000_000,
+      });
+
+      assertEquals(result.playerCount, 2);
+      assertEquals(result.draftProspectCount, 1);
+      assertEquals(result.contractCount, 2);
+
+      // 3 insert calls: players, draftProspects, contracts
+      assertEquals(calls.length, 3);
+    },
+  );
+
+  await t.step(
+    "generateAndPersist skips inserts for empty generator output",
+    async () => {
+      const { db, calls } = createMockDb();
+      const generator = createMockGenerator();
+
+      const service = createPlayersService({
+        generator,
+        db,
+        log: createTestLogger(),
+      });
+
+      const result = await service.generateAndPersist({
+        leagueId: "l1",
+        seasonId: "s1",
+        teamIds: [],
+        rosterSize: 0,
+        salaryCap: 0,
+      });
+
+      assertEquals(result.playerCount, 0);
+      assertEquals(result.draftProspectCount, 0);
+      assertEquals(result.contractCount, 0);
+      assertEquals(calls.length, 0);
+    },
+  );
+
+  await t.step(
+    "generateAndPersist passes inserted players to contract generator",
+    async () => {
+      const { db } = createMockDb(["player-1"]);
+      let contractsGeneratorReceivedPlayers:
+        | { id: string; teamId: string | null }[]
+        | undefined;
+
+      const generator = createMockGenerator({
+        generate: () => ({
+          players: [
+            { leagueId: "l1", teamId: "t1", firstName: "A", lastName: "B" },
+          ],
+          draftProspects: [],
+        }),
+        generateContracts: (input) => {
+          contractsGeneratorReceivedPlayers = input.players;
+          return [];
+        },
+      });
+
+      const service = createPlayersService({
+        generator,
+        db,
+        log: createTestLogger(),
+      });
+
+      await service.generateAndPersist({
+        leagueId: "l1",
+        seasonId: "s1",
+        teamIds: ["t1"],
+        rosterSize: 1,
+        salaryCap: 100_000,
+      });
+
+      assertEquals(contractsGeneratorReceivedPlayers?.length, 1);
+      assertEquals(contractsGeneratorReceivedPlayers?.[0].id, "player-1");
+      assertEquals(contractsGeneratorReceivedPlayers?.[0].teamId, "t1");
+    },
+  );
+});

--- a/server/features/players/players.service.ts
+++ b/server/features/players/players.service.ts
@@ -1,0 +1,75 @@
+import type pino from "pino";
+import type { Database } from "../../db/connection.ts";
+import { draftProspects, players } from "./player.schema.ts";
+import { contracts } from "./contract.schema.ts";
+import type { PlayersGenerator } from "./players.generator.interface.ts";
+import type { PlayersService } from "./players.service.interface.ts";
+
+export function createPlayersService(deps: {
+  generator: PlayersGenerator;
+  db: Database;
+  log: pino.Logger;
+}): PlayersService {
+  const log = deps.log.child({ module: "players.service" });
+
+  return {
+    async generateAndPersist(input) {
+      log.info(
+        { leagueId: input.leagueId, seasonId: input.seasonId },
+        "generating players",
+      );
+
+      const generated = deps.generator.generate({
+        leagueId: input.leagueId,
+        seasonId: input.seasonId,
+        teamIds: input.teamIds,
+        rosterSize: input.rosterSize,
+      });
+
+      let insertedPlayers: { id: string; teamId: string | null }[] = [];
+
+      if (generated.players.length > 0) {
+        insertedPlayers = await deps.db
+          .insert(players)
+          .values(generated.players)
+          .returning({ id: players.id, teamId: players.teamId });
+      }
+
+      if (generated.draftProspects.length > 0) {
+        await deps.db.insert(draftProspects).values(generated.draftProspects);
+      }
+
+      log.info(
+        {
+          leagueId: input.leagueId,
+          players: insertedPlayers.length,
+          draftProspects: generated.draftProspects.length,
+        },
+        "persisted players",
+      );
+
+      const generatedContracts = deps.generator.generateContracts({
+        salaryCap: input.salaryCap,
+        players: insertedPlayers,
+      });
+
+      if (generatedContracts.length > 0) {
+        await deps.db.insert(contracts).values(generatedContracts);
+      }
+
+      log.info(
+        {
+          leagueId: input.leagueId,
+          contracts: generatedContracts.length,
+        },
+        "persisted contracts",
+      );
+
+      return {
+        playerCount: insertedPlayers.length,
+        draftProspectCount: generated.draftProspects.length,
+        contractCount: generatedContracts.length,
+      };
+    },
+  };
+}

--- a/server/features/players/stub-players-generator.test.ts
+++ b/server/features/players/stub-players-generator.test.ts
@@ -1,0 +1,95 @@
+import { assertEquals } from "@std/assert";
+import { createStubPlayersGenerator } from "./stub-players-generator.ts";
+
+const TEAM_IDS = ["team-1", "team-2", "team-3"];
+const INPUT = {
+  leagueId: "league-1",
+  seasonId: "season-1",
+  teamIds: TEAM_IDS,
+  rosterSize: 53,
+};
+
+Deno.test("generates correct number of rostered players per team", () => {
+  const generator = createStubPlayersGenerator();
+  const result = generator.generate(INPUT);
+
+  const rosteredPlayers = result.players.filter((p) => p.teamId !== null);
+  assertEquals(rosteredPlayers.length, TEAM_IDS.length * INPUT.rosterSize);
+
+  for (const teamId of TEAM_IDS) {
+    const teamPlayers = rosteredPlayers.filter((p) => p.teamId === teamId);
+    assertEquals(teamPlayers.length, INPUT.rosterSize);
+  }
+});
+
+Deno.test("generates free agents with null teamId", () => {
+  const generator = createStubPlayersGenerator();
+  const result = generator.generate(INPUT);
+
+  const freeAgents = result.players.filter((p) => p.teamId === null);
+  assertEquals(freeAgents.length, 50);
+});
+
+Deno.test("all players have the correct leagueId", () => {
+  const generator = createStubPlayersGenerator();
+  const result = generator.generate(INPUT);
+
+  for (const player of result.players) {
+    assertEquals(player.leagueId, INPUT.leagueId);
+  }
+});
+
+Deno.test("generates draft prospects linked to seasonId", () => {
+  const generator = createStubPlayersGenerator();
+  const result = generator.generate(INPUT);
+
+  assertEquals(result.draftProspects.length, 250);
+  for (const prospect of result.draftProspects) {
+    assertEquals(prospect.seasonId, INPUT.seasonId);
+  }
+});
+
+Deno.test("generates contracts for rostered players only", () => {
+  const generator = createStubPlayersGenerator();
+  const players = [
+    { id: "p1", teamId: "team-1" },
+    { id: "p2", teamId: "team-1" },
+    { id: "p3", teamId: null },
+  ];
+
+  const contracts = generator.generateContracts({
+    salaryCap: 255_000_000,
+    players,
+  });
+
+  assertEquals(contracts.length, 2);
+  assertEquals(contracts.every((c) => c.teamId === "team-1"), true);
+});
+
+Deno.test("stub contracts distribute salary evenly under cap", () => {
+  const generator = createStubPlayersGenerator();
+  const salaryCap = 255_000_000;
+  const players = Array.from({ length: 53 }, (_, i) => ({
+    id: `p${i}`,
+    teamId: "team-1",
+  }));
+
+  const contracts = generator.generateContracts({ salaryCap, players });
+
+  const totalAnnual = contracts.reduce((sum, c) => sum + c.annualSalary, 0);
+  assertEquals(totalAnnual <= salaryCap, true);
+  assertEquals(contracts.every((c) => c.totalYears === 3), true);
+  assertEquals(contracts.every((c) => c.currentYear === 1), true);
+});
+
+Deno.test("all generated players and prospects have non-empty names", () => {
+  const generator = createStubPlayersGenerator();
+  const result = generator.generate(INPUT);
+
+  const allPeople = [...result.players, ...result.draftProspects];
+
+  for (const person of allPeople) {
+    assertEquals(person.firstName.length > 0, true);
+    assertEquals(person.lastName.length > 0, true);
+  }
+});

--- a/server/features/players/stub-players-generator.ts
+++ b/server/features/players/stub-players-generator.ts
@@ -1,8 +1,10 @@
 import type {
-  GeneratedPersonnel,
-  PersonnelGenerator,
-  PersonnelGeneratorInput,
-} from "./personnel.generator.interface.ts";
+  ContractGeneratorInput,
+  GeneratedContract,
+  GeneratedPlayers,
+  PlayersGenerator,
+  PlayersGeneratorInput,
+} from "./players.generator.interface.ts";
 
 const FIRST_NAMES = [
   "James",
@@ -128,9 +130,8 @@ const LAST_NAMES = [
   "Murphy",
 ];
 
-const COACHES_PER_TEAM = 5;
-const SCOUTS_PER_TEAM = 3;
-const FRONT_OFFICE_PER_TEAM = 2;
+const FREE_AGENT_COUNT = 50;
+const DRAFT_PROSPECT_COUNT = 250;
 
 function randomName(index: number) {
   const firstName = FIRST_NAMES[index % FIRST_NAMES.length];
@@ -139,16 +140,16 @@ function randomName(index: number) {
   return { firstName, lastName };
 }
 
-export function createStubPersonnelGenerator(): PersonnelGenerator {
+export function createStubPlayersGenerator(): PlayersGenerator {
   return {
-    generate(input: PersonnelGeneratorInput): GeneratedPersonnel {
+    generate(input: PlayersGeneratorInput): GeneratedPlayers {
       let nameIndex = 0;
 
-      const coaches = [];
+      const players = [];
       for (const teamId of input.teamIds) {
-        for (let i = 0; i < COACHES_PER_TEAM; i++) {
+        for (let i = 0; i < input.rosterSize; i++) {
           const { firstName, lastName } = randomName(nameIndex++);
-          coaches.push({
+          players.push({
             leagueId: input.leagueId,
             teamId,
             firstName,
@@ -157,33 +158,45 @@ export function createStubPersonnelGenerator(): PersonnelGenerator {
         }
       }
 
-      const scouts = [];
-      for (const teamId of input.teamIds) {
-        for (let i = 0; i < SCOUTS_PER_TEAM; i++) {
-          const { firstName, lastName } = randomName(nameIndex++);
-          scouts.push({
-            leagueId: input.leagueId,
-            teamId,
-            firstName,
-            lastName,
-          });
-        }
+      for (let i = 0; i < FREE_AGENT_COUNT; i++) {
+        const { firstName, lastName } = randomName(nameIndex++);
+        players.push({
+          leagueId: input.leagueId,
+          teamId: null,
+          firstName,
+          lastName,
+        });
       }
 
-      const frontOfficeStaff = [];
-      for (const teamId of input.teamIds) {
-        for (let i = 0; i < FRONT_OFFICE_PER_TEAM; i++) {
-          const { firstName, lastName } = randomName(nameIndex++);
-          frontOfficeStaff.push({
-            leagueId: input.leagueId,
-            teamId,
-            firstName,
-            lastName,
-          });
-        }
+      const draftProspects = [];
+      for (let i = 0; i < DRAFT_PROSPECT_COUNT; i++) {
+        const { firstName, lastName } = randomName(nameIndex++);
+        draftProspects.push({
+          seasonId: input.seasonId,
+          firstName,
+          lastName,
+        });
       }
 
-      return { coaches, scouts, frontOfficeStaff };
+      return { players, draftProspects };
+    },
+
+    generateContracts(input: ContractGeneratorInput): GeneratedContract[] {
+      const rosteredPlayers = input.players.filter((p) => p.teamId !== null);
+      const perPlayerSalary = Math.floor(
+        input.salaryCap / Math.max(rosteredPlayers.length, 1),
+      );
+
+      return rosteredPlayers.map((player) => ({
+        playerId: player.id,
+        teamId: player.teamId!,
+        totalYears: 3,
+        currentYear: 1,
+        totalSalary: perPlayerSalary * 3,
+        annualSalary: perPlayerSalary,
+        guaranteedMoney: perPlayerSalary,
+        signingBonus: 0,
+      }));
     },
   };
 }


### PR DESCRIPTION
## Summary

- Extracts `players`, `draft_prospects`, and `contracts` out of the unified `personnel` feature into a new `server/features/players/` feature with its own schema, generator, service, and shared types.
- Personnel becomes a thin orchestrator: it delegates player-related work to `PlayersService` via DI and continues to own coaches, scouts, and front-office staff (to be split out in follow-up PRs for `coaches`, `scouts`, and `front-office`).
- Splits `packages/shared/types/personnel.ts` — `Player`, `Contract`, `DraftProspect` move to `types/player.ts`; `Coach`, `Scout`, `FrontOfficeStaff` stay in `personnel.ts` for now.
- No database schema changes; tables already lived in separate `pgTable` declarations and are only being re-homed in code (`drizzle-kit generate` reports no diff).
- Part of a larger split — grouping coaches/scouts/players/front-office under one "personnel" feature was too broad; each has distinct domain rules that will diverge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)