### PR TITLE
feat(client): brand league home and polish settings page

### DIFF
--- a/client/src/features/league/index.test.tsx
+++ b/client/src/features/league/index.test.tsx
@@ -13,4 +13,9 @@ describe("LeagueHome", () => {
       screen.getByRole("heading", { name: "League Home" }),
     ).toBeDefined();
   });
+
+  it("renders a coming soon badge", () => {
+    render(<LeagueHome />);
+    expect(screen.getByText(/coming soon/i)).toBeDefined();
+  });
 });

--- a/client/src/features/league/index.tsx
+++ b/client/src/features/league/index.tsx
@@ -1,7 +1,10 @@
+import { StubPage } from "./stub-page.tsx";
+
 export function LeagueHome() {
   return (
-    <div>
-      <h1>League Home</h1>
-    </div>
+    <StubPage
+      title="League Home"
+      description="Your league at a glance — standings, news, and what needs your attention."
+    />
   );
 }

--- a/client/src/features/league/settings.tsx
+++ b/client/src/features/league/settings.tsx
@@ -35,10 +35,13 @@ export function LeagueSettings() {
   };
 
   return (
-    <div>
-      <h1 className="mb-6 text-2xl font-bold">Settings</h1>
+    <div className="p-6">
+      <h1 className="text-2xl font-bold">Settings</h1>
+      <p className="mt-2 mb-6 max-w-2xl text-muted-foreground">
+        Manage your league's configuration and lifecycle.
+      </p>
 
-      <Card className="border-destructive/50">
+      <Card className="max-w-2xl border-destructive/50">
         <CardHeader>
           <CardTitle className="text-destructive">Danger Zone</CardTitle>
           <CardDescription>


### PR DESCRIPTION
## Summary
- Swap the bare League Home `<h1>` for `StubPage` so it matches the Coming Soon branding used on the other stub pages.
- Add `p-6` padding, a description, and a max-width on the Danger Zone card to bring Settings in line with the rest of the league pages.

Note: changes are visual — I did not spin up the dev server to eyeball them. Worth a quick browser check before merging.