### PR TITLE
refactor(coaches): extract coaches feature from personnel

### DIFF
--- a/packages/shared/mod.ts
+++ b/packages/shared/mod.ts
@@ -3,7 +3,8 @@ export type { HealthStatus } from "./types/health.ts";
 export type { League, NewLeague } from "./types/league.ts";
 export type { Team } from "./types/team.ts";
 export type { NewSeason, Season, SeasonPhase } from "./types/season.ts";
-export type { Coach, FrontOfficeStaff, Scout } from "./types/personnel.ts";
+export type { FrontOfficeStaff, Scout } from "./types/personnel.ts";
+export type { Coach } from "./types/coach.ts";
 export type { Contract, DraftProspect, Player } from "./types/player.ts";
 export type { Game } from "./types/game.ts";
 

--- a/packages/shared/types/coach.ts
+++ b/packages/shared/types/coach.ts
@@ -1,0 +1,9 @@
+export interface Coach {
+  id: string;
+  leagueId: string;
+  teamId: string;
+  firstName: string;
+  lastName: string;
+  createdAt: Date;
+  updatedAt: Date;
+}

--- a/packages/shared/types/personnel.ts
+++ b/packages/shared/types/personnel.ts
@@ -1,13 +1,3 @@
-export interface Coach {
-  id: string;
-  leagueId: string;
-  teamId: string;
-  firstName: string;
-  lastName: string;
-  createdAt: Date;
-  updatedAt: Date;
-}
-
 export interface Scout {
   id: string;
   leagueId: string;

--- a/server/db/schema.ts
+++ b/server/db/schema.ts
@@ -11,10 +11,10 @@ export { leagues } from "../features/league/league.schema.ts";
 export { teams } from "../features/team/team.schema.ts";
 export { seasonPhaseEnum, seasons } from "../features/season/season.schema.ts";
 export {
-  coaches,
   frontOfficeStaff,
   scouts,
 } from "../features/personnel/personnel.schema.ts";
+export { coaches } from "../features/coaches/coach.schema.ts";
 export { draftProspects, players } from "../features/players/player.schema.ts";
 export { contracts } from "../features/players/contract.schema.ts";
 export { games } from "../features/schedule/game.schema.ts";

--- a/server/features/coaches/coach.schema.ts
+++ b/server/features/coaches/coach.schema.ts
@@ -2,21 +2,7 @@ import { pgTable, text, timestamp, uuid } from "drizzle-orm/pg-core";
 import { leagues } from "../league/league.schema.ts";
 import { teams } from "../team/team.schema.ts";
 
-export const scouts = pgTable("scouts", {
-  id: uuid("id").defaultRandom().primaryKey(),
-  leagueId: uuid("league_id")
-    .notNull()
-    .references(() => leagues.id, { onDelete: "cascade" }),
-  teamId: uuid("team_id")
-    .notNull()
-    .references(() => teams.id, { onDelete: "cascade" }),
-  firstName: text("first_name").notNull(),
-  lastName: text("last_name").notNull(),
-  createdAt: timestamp("created_at").defaultNow().notNull(),
-  updatedAt: timestamp("updated_at").defaultNow().notNull(),
-});
-
-export const frontOfficeStaff = pgTable("front_office_staff", {
+export const coaches = pgTable("coaches", {
   id: uuid("id").defaultRandom().primaryKey(),
   leagueId: uuid("league_id")
     .notNull()

--- a/server/features/coaches/coaches.generator.interface.ts
+++ b/server/features/coaches/coaches.generator.interface.ts
@@ -1,0 +1,12 @@
+import type { Coach } from "@zone-blitz/shared";
+
+export interface CoachesGeneratorInput {
+  leagueId: string;
+  teamIds: string[];
+}
+
+export type GeneratedCoach = Omit<Coach, "id" | "createdAt" | "updatedAt">;
+
+export interface CoachesGenerator {
+  generate(input: CoachesGeneratorInput): GeneratedCoach[];
+}

--- a/server/features/coaches/coaches.service.interface.ts
+++ b/server/features/coaches/coaches.service.interface.ts
@@ -1,0 +1,14 @@
+export interface CoachesGenerateInput {
+  leagueId: string;
+  teamIds: string[];
+}
+
+export interface CoachesGenerateResult {
+  coachCount: number;
+}
+
+export interface CoachesService {
+  generateAndPersist(
+    input: CoachesGenerateInput,
+  ): Promise<CoachesGenerateResult>;
+}

--- a/server/features/coaches/coaches.service.test.ts
+++ b/server/features/coaches/coaches.service.test.ts
@@ -1,0 +1,96 @@
+import { assertEquals } from "@std/assert";
+import { createCoachesService } from "./coaches.service.ts";
+import type { CoachesGenerator } from "./coaches.generator.interface.ts";
+
+function createTestLogger() {
+  return {
+    child: () => createTestLogger(),
+    debug: () => {},
+    info: () => {},
+    warn: () => {},
+    error: () => {},
+  } as unknown as import("pino").Logger;
+}
+
+function createMockGenerator(
+  overrides: Partial<CoachesGenerator> = {},
+): CoachesGenerator {
+  return {
+    generate: () => [],
+    ...overrides,
+  };
+}
+
+interface InsertCall {
+  table: unknown;
+  values: unknown[];
+}
+
+function createMockDb(): {
+  db: import("../../db/connection.ts").Database;
+  calls: InsertCall[];
+} {
+  const calls: InsertCall[] = [];
+  const db = {
+    insert(table: unknown) {
+      return {
+        values(values: unknown[]) {
+          calls.push({ table, values });
+          return Promise.resolve([]);
+        },
+      };
+    },
+  } as unknown as import("../../db/connection.ts").Database;
+  return { db, calls };
+}
+
+Deno.test("coaches.service", async (t) => {
+  await t.step(
+    "generateAndPersist inserts generated coaches and returns count",
+    async () => {
+      const { db, calls } = createMockDb();
+      const generator = createMockGenerator({
+        generate: () => [
+          { leagueId: "l1", teamId: "t1", firstName: "A", lastName: "B" },
+          { leagueId: "l1", teamId: "t1", firstName: "C", lastName: "D" },
+        ],
+      });
+
+      const service = createCoachesService({
+        generator,
+        db,
+        log: createTestLogger(),
+      });
+
+      const result = await service.generateAndPersist({
+        leagueId: "l1",
+        teamIds: ["t1"],
+      });
+
+      assertEquals(result.coachCount, 2);
+      assertEquals(calls.length, 1);
+    },
+  );
+
+  await t.step(
+    "generateAndPersist skips insert when generator returns empty",
+    async () => {
+      const { db, calls } = createMockDb();
+      const generator = createMockGenerator();
+
+      const service = createCoachesService({
+        generator,
+        db,
+        log: createTestLogger(),
+      });
+
+      const result = await service.generateAndPersist({
+        leagueId: "l1",
+        teamIds: [],
+      });
+
+      assertEquals(result.coachCount, 0);
+      assertEquals(calls.length, 0);
+    },
+  );
+});

--- a/server/features/coaches/coaches.service.ts
+++ b/server/features/coaches/coaches.service.ts
@@ -1,0 +1,35 @@
+import type pino from "pino";
+import type { Database } from "../../db/connection.ts";
+import { coaches } from "./coach.schema.ts";
+import type { CoachesGenerator } from "./coaches.generator.interface.ts";
+import type { CoachesService } from "./coaches.service.interface.ts";
+
+export function createCoachesService(deps: {
+  generator: CoachesGenerator;
+  db: Database;
+  log: pino.Logger;
+}): CoachesService {
+  const log = deps.log.child({ module: "coaches.service" });
+
+  return {
+    async generateAndPersist(input) {
+      log.info({ leagueId: input.leagueId }, "generating coaches");
+
+      const generated = deps.generator.generate({
+        leagueId: input.leagueId,
+        teamIds: input.teamIds,
+      });
+
+      if (generated.length > 0) {
+        await deps.db.insert(coaches).values(generated);
+      }
+
+      log.info(
+        { leagueId: input.leagueId, coaches: generated.length },
+        "persisted coaches",
+      );
+
+      return { coachCount: generated.length };
+    },
+  };
+}

--- a/server/features/coaches/mod.ts
+++ b/server/features/coaches/mod.ts
@@ -1,0 +1,3 @@
+export { createStubCoachesGenerator } from "./stub-coaches-generator.ts";
+export { createCoachesService } from "./coaches.service.ts";
+export type { CoachesService } from "./coaches.service.interface.ts";

--- a/server/features/coaches/stub-coaches-generator.test.ts
+++ b/server/features/coaches/stub-coaches-generator.test.ts
@@ -1,0 +1,36 @@
+import { assertEquals } from "@std/assert";
+import { createStubCoachesGenerator } from "./stub-coaches-generator.ts";
+
+const TEAM_IDS = ["team-1", "team-2", "team-3"];
+const INPUT = {
+  leagueId: "league-1",
+  teamIds: TEAM_IDS,
+};
+
+Deno.test("generates coaches for each team", () => {
+  const generator = createStubCoachesGenerator();
+  const result = generator.generate(INPUT);
+
+  assertEquals(result.length, TEAM_IDS.length * 5);
+  for (const teamId of TEAM_IDS) {
+    const teamCoaches = result.filter((c) => c.teamId === teamId);
+    assertEquals(teamCoaches.length, 5);
+  }
+});
+
+Deno.test("all coaches have the correct leagueId and non-empty names", () => {
+  const generator = createStubCoachesGenerator();
+  const result = generator.generate(INPUT);
+
+  for (const coach of result) {
+    assertEquals(coach.leagueId, INPUT.leagueId);
+    assertEquals(coach.firstName.length > 0, true);
+    assertEquals(coach.lastName.length > 0, true);
+  }
+});
+
+Deno.test("generates no coaches when no teams provided", () => {
+  const generator = createStubCoachesGenerator();
+  const result = generator.generate({ leagueId: "l1", teamIds: [] });
+  assertEquals(result.length, 0);
+});

--- a/server/features/coaches/stub-coaches-generator.ts
+++ b/server/features/coaches/stub-coaches-generator.ts
@@ -1,0 +1,61 @@
+import type {
+  CoachesGenerator,
+  CoachesGeneratorInput,
+  GeneratedCoach,
+} from "./coaches.generator.interface.ts";
+
+const FIRST_NAMES = [
+  "James",
+  "John",
+  "Robert",
+  "Michael",
+  "William",
+  "David",
+  "Richard",
+  "Joseph",
+  "Thomas",
+  "Charles",
+];
+
+const LAST_NAMES = [
+  "Smith",
+  "Johnson",
+  "Williams",
+  "Brown",
+  "Jones",
+  "Garcia",
+  "Miller",
+  "Davis",
+  "Rodriguez",
+  "Martinez",
+];
+
+const COACHES_PER_TEAM = 5;
+
+function randomName(index: number) {
+  const firstName = FIRST_NAMES[index % FIRST_NAMES.length];
+  const lastName =
+    LAST_NAMES[Math.floor(index / FIRST_NAMES.length) % LAST_NAMES.length];
+  return { firstName, lastName };
+}
+
+export function createStubCoachesGenerator(): CoachesGenerator {
+  return {
+    generate(input: CoachesGeneratorInput): GeneratedCoach[] {
+      let nameIndex = 0;
+      const coaches: GeneratedCoach[] = [];
+      for (const teamId of input.teamIds) {
+        for (let i = 0; i < COACHES_PER_TEAM; i++) {
+          const { firstName, lastName } = randomName(nameIndex++);
+          coaches.push({
+            leagueId: input.leagueId,
+            teamId,
+            firstName,
+            lastName,
+          });
+        }
+      }
+      return coaches;
+    },
+  };
+}

--- a/server/features/mod.ts
+++ b/server/features/mod.ts
@@ -28,6 +28,10 @@ import {
   createStubPlayersGenerator,
 } from "./players/mod.ts";
 import {
+  createCoachesService,
+  createStubCoachesGenerator,
+} from "./coaches/mod.ts";
+import {
   createScheduleService,
   createStubScheduleGenerator,
 } from "./schedule/mod.ts";
@@ -76,9 +80,15 @@ export function createFeatureRouters(
     db,
     log,
   });
+  const coachesService = createCoachesService({
+    generator: createStubCoachesGenerator(),
+    db,
+    log,
+  });
   const personnelService = createPersonnelService({
     generator: createStubPersonnelGenerator(),
     playersService,
+    coachesService,
     db,
     log,
   });

--- a/server/features/personnel/personnel.generator.interface.ts
+++ b/server/features/personnel/personnel.generator.interface.ts
@@ -1,4 +1,4 @@
-import type { Coach, FrontOfficeStaff, Scout } from "@zone-blitz/shared";
+import type { FrontOfficeStaff, Scout } from "@zone-blitz/shared";
 
 export interface PersonnelGeneratorInput {
   leagueId: string;
@@ -6,7 +6,6 @@ export interface PersonnelGeneratorInput {
 }
 
 export interface GeneratedPersonnel {
-  coaches: Omit<Coach, "id" | "createdAt" | "updatedAt">[];
   scouts: Omit<Scout, "id" | "createdAt" | "updatedAt">[];
   frontOfficeStaff: Omit<FrontOfficeStaff, "id" | "createdAt" | "updatedAt">[];
 }

--- a/server/features/personnel/personnel.service.test.ts
+++ b/server/features/personnel/personnel.service.test.ts
@@ -5,6 +5,7 @@ import type {
   PersonnelGenerator,
 } from "./personnel.generator.interface.ts";
 import type { PlayersService } from "../players/players.service.interface.ts";
+import type { CoachesService } from "../coaches/coaches.service.interface.ts";
 
 function createTestLogger() {
   return {
@@ -18,7 +19,6 @@ function createTestLogger() {
 
 function createEmptyPersonnel(): GeneratedPersonnel {
   return {
-    coaches: [],
     scouts: [],
     frontOfficeStaff: [],
   };
@@ -43,6 +43,15 @@ function createMockPlayersService(
         draftProspectCount: 0,
         contractCount: 0,
       }),
+    ...overrides,
+  };
+}
+
+function createMockCoachesService(
+  overrides: Partial<CoachesService> = {},
+): CoachesService {
+  return {
+    generateAndPersist: () => Promise.resolve({ coachCount: 0 }),
     ...overrides,
   };
 }
@@ -72,14 +81,11 @@ function createMockDb(): {
 
 Deno.test("personnel.service", async (t) => {
   await t.step(
-    "generateAndPersist delegates to players service and inserts coaches/scouts/front office",
+    "generateAndPersist delegates to players and coaches services and inserts scouts/front office",
     async () => {
       const { db, calls } = createMockDb();
       const generator = createMockGenerator({
         generate: () => ({
-          coaches: [
-            { leagueId: "l1", teamId: "t1", firstName: "E", lastName: "F" },
-          ],
           scouts: [
             { leagueId: "l1", teamId: "t1", firstName: "G", lastName: "H" },
           ],
@@ -109,9 +115,20 @@ Deno.test("personnel.service", async (t) => {
         },
       });
 
+      let coachesServiceInput:
+        | { leagueId: string; teamIds: string[] }
+        | undefined;
+      const coachesService = createMockCoachesService({
+        generateAndPersist: (input) => {
+          coachesServiceInput = input;
+          return Promise.resolve({ coachCount: 5 });
+        },
+      });
+
       const service = createPersonnelService({
         generator,
         playersService,
+        coachesService,
         db,
         log: createTestLogger(),
       });
@@ -125,7 +142,7 @@ Deno.test("personnel.service", async (t) => {
       });
 
       assertEquals(result.playerCount, 2);
-      assertEquals(result.coachCount, 1);
+      assertEquals(result.coachCount, 5);
       assertEquals(result.scoutCount, 1);
       assertEquals(result.frontOfficeCount, 1);
       assertEquals(result.draftProspectCount, 1);
@@ -137,8 +154,11 @@ Deno.test("personnel.service", async (t) => {
       assertEquals(playersServiceInput?.rosterSize, 2);
       assertEquals(playersServiceInput?.salaryCap, 255_000_000);
 
-      // 3 insert calls: coaches, scouts, frontOffice
-      assertEquals(calls.length, 3);
+      assertEquals(coachesServiceInput?.leagueId, "l1");
+      assertEquals(coachesServiceInput?.teamIds, ["t1"]);
+
+      // 2 insert calls: scouts, frontOffice
+      assertEquals(calls.length, 2);
     },
   );
 
@@ -148,10 +168,12 @@ Deno.test("personnel.service", async (t) => {
       const { db, calls } = createMockDb();
       const generator = createMockGenerator();
       const playersService = createMockPlayersService();
+      const coachesService = createMockCoachesService();
 
       const service = createPersonnelService({
         generator,
         playersService,
+        coachesService,
         db,
         log: createTestLogger(),
       });

--- a/server/features/personnel/personnel.service.ts
+++ b/server/features/personnel/personnel.service.ts
@@ -1,13 +1,15 @@
 import type pino from "pino";
 import type { Database } from "../../db/connection.ts";
-import { coaches, frontOfficeStaff, scouts } from "./personnel.schema.ts";
+import { frontOfficeStaff, scouts } from "./personnel.schema.ts";
 import type { PersonnelGenerator } from "./personnel.generator.interface.ts";
 import type { PersonnelService } from "./personnel.service.interface.ts";
 import type { PlayersService } from "../players/players.service.interface.ts";
+import type { CoachesService } from "../coaches/coaches.service.interface.ts";
 
 export function createPersonnelService(deps: {
   generator: PersonnelGenerator;
   playersService: PlayersService;
+  coachesService: CoachesService;
   db: Database;
   log: pino.Logger;
 }): PersonnelService {
@@ -28,14 +30,16 @@ export function createPersonnelService(deps: {
         salaryCap: input.salaryCap,
       });
 
+      const coachesResult = await deps.coachesService.generateAndPersist({
+        leagueId: input.leagueId,
+        teamIds: input.teamIds,
+      });
+
       const personnel = deps.generator.generate({
         leagueId: input.leagueId,
         teamIds: input.teamIds,
       });
 
-      if (personnel.coaches.length > 0) {
-        await deps.db.insert(coaches).values(personnel.coaches);
-      }
       if (personnel.scouts.length > 0) {
         await deps.db.insert(scouts).values(personnel.scouts);
       }
@@ -48,7 +52,6 @@ export function createPersonnelService(deps: {
       log.info(
         {
           leagueId: input.leagueId,
-          coaches: personnel.coaches.length,
           scouts: personnel.scouts.length,
           frontOffice: personnel.frontOfficeStaff.length,
         },
@@ -57,7 +60,7 @@ export function createPersonnelService(deps: {
 
       return {
         playerCount: playersResult.playerCount,
-        coachCount: personnel.coaches.length,
+        coachCount: coachesResult.coachCount,
         scoutCount: personnel.scouts.length,
         frontOfficeCount: personnel.frontOfficeStaff.length,
         draftProspectCount: playersResult.draftProspectCount,

--- a/server/features/personnel/stub-personnel-generator.test.ts
+++ b/server/features/personnel/stub-personnel-generator.test.ts
@@ -7,17 +7,6 @@ const INPUT = {
   teamIds: TEAM_IDS,
 };
 
-Deno.test("generates coaches for each team", () => {
-  const generator = createStubPersonnelGenerator();
-  const result = generator.generate(INPUT);
-
-  assertEquals(result.coaches.length, TEAM_IDS.length * 5);
-  for (const teamId of TEAM_IDS) {
-    const teamCoaches = result.coaches.filter((c) => c.teamId === teamId);
-    assertEquals(teamCoaches.length, 5);
-  }
-});
-
 Deno.test("generates scouts for each team", () => {
   const generator = createStubPersonnelGenerator();
   const result = generator.generate(INPUT);
@@ -46,11 +35,7 @@ Deno.test("all generated personnel have non-empty names and correct leagueId", (
   const generator = createStubPersonnelGenerator();
   const result = generator.generate(INPUT);
 
-  const allPeople = [
-    ...result.coaches,
-    ...result.scouts,
-    ...result.frontOfficeStaff,
-  ];
+  const allPeople = [...result.scouts, ...result.frontOfficeStaff];
 
   for (const person of allPeople) {
     assertEquals(person.firstName.length > 0, true);

--- a/server/features/personnel/stub-personnel-generator.ts
+++ b/server/features/personnel/stub-personnel-generator.ts
@@ -128,7 +128,6 @@ const LAST_NAMES = [
   "Murphy",
 ];
 
-const COACHES_PER_TEAM = 5;
 const SCOUTS_PER_TEAM = 3;
 const FRONT_OFFICE_PER_TEAM = 2;
 
@@ -143,19 +142,6 @@ export function createStubPersonnelGenerator(): PersonnelGenerator {
   return {
     generate(input: PersonnelGeneratorInput): GeneratedPersonnel {
       let nameIndex = 0;
-
-      const coaches = [];
-      for (const teamId of input.teamIds) {
-        for (let i = 0; i < COACHES_PER_TEAM; i++) {
-          const { firstName, lastName } = randomName(nameIndex++);
-          coaches.push({
-            leagueId: input.leagueId,
-            teamId,
-            firstName,
-            lastName,
-          });
-        }
-      }
 
       const scouts = [];
       for (const teamId of input.teamIds) {
@@ -183,7 +169,7 @@ export function createStubPersonnelGenerator(): PersonnelGenerator {
         }
       }
 
-      return { coaches, scouts, frontOfficeStaff };
+      return { scouts, frontOfficeStaff };
     },
   };
 }


### PR DESCRIPTION
## Summary

- Extracts `coaches` out of the unified `personnel` feature into a new `server/features/coaches/` feature with its own schema, generator, service, and shared type.
- Personnel orchestrator now delegates to `CoachesService` (alongside `PlayersService`); it still owns scouts and front-office staff pending follow-up PRs.
- Moves `Coach` from `packages/shared/types/personnel.ts` to `packages/shared/types/coach.ts`.
- No database schema changes; `drizzle-kit generate` reports no diff.
- Part 2 of the personnel split — see #60 for the first part (`players`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)