### PR TITLE
feat(league-select): redesign home page as league grid with status

### DIFF
--- a/client/src/features/league-select/index.test.tsx
+++ b/client/src/features/league-select/index.test.tsx
@@ -115,27 +115,109 @@ describe("LeagueSelect", () => {
     });
   });
 
-  it("renders a table of leagues", async () => {
+  it("renders a grid of leagues with config and status columns", async () => {
     mockGet.mockReturnValue(
       Promise.resolve({
         json: () =>
           Promise.resolve([
-            { id: 1, name: "NFL League" },
-            { id: 2, name: "XFL League" },
+            {
+              id: 1,
+              name: "NFL League",
+              numberOfTeams: 32,
+              seasonLength: 17,
+              createdAt: "2026-01-15T00:00:00Z",
+              currentSeason: { year: 1, phase: "preseason", week: 1 },
+            },
+            {
+              id: 2,
+              name: "XFL League",
+              numberOfTeams: 8,
+              seasonLength: 10,
+              createdAt: "2026-02-20T00:00:00Z",
+              currentSeason: { year: 3, phase: "regular_season", week: 5 },
+            },
           ]),
       }),
     );
     renderWithProviders();
     await waitFor(() => {
       expect(screen.getByText("NFL League")).toBeDefined();
-      expect(screen.getByText("XFL League")).toBeDefined();
+    });
+    expect(screen.getByText("XFL League")).toBeDefined();
+    expect(screen.getByRole("columnheader", { name: "Name" })).toBeDefined();
+    expect(screen.getByRole("columnheader", { name: "Teams" })).toBeDefined();
+    expect(screen.getByRole("columnheader", { name: "Season Length" }))
+      .toBeDefined();
+    expect(screen.getByRole("columnheader", { name: "Status" })).toBeDefined();
+    expect(screen.getByRole("columnheader", { name: "Created" })).toBeDefined();
+    expect(screen.getByText("32")).toBeDefined();
+    expect(screen.getByText("17")).toBeDefined();
+    expect(screen.getByText(/Season 1 · Preseason/)).toBeDefined();
+    expect(screen.getByText(/Season 3 · Regular Season/)).toBeDefined();
+  });
+
+  it("renders a dash when a league has no current season", async () => {
+    mockGet.mockReturnValue(
+      Promise.resolve({
+        json: () =>
+          Promise.resolve([
+            {
+              id: 1,
+              name: "Stale League",
+              numberOfTeams: 32,
+              seasonLength: 17,
+              createdAt: "2026-01-15T00:00:00Z",
+              currentSeason: null,
+            },
+          ]),
+      }),
+    );
+    renderWithProviders();
+    await waitFor(() => {
+      expect(screen.getByText("Stale League")).toBeDefined();
+    });
+    expect(screen.getByText("—")).toBeDefined();
+  });
+
+  it.each([
+    ["playoffs", "Playoffs"],
+    ["offseason", "Offseason"],
+  ])("renders %s phase label", async (phase, label) => {
+    mockGet.mockReturnValue(
+      Promise.resolve({
+        json: () =>
+          Promise.resolve([
+            {
+              id: 1,
+              name: "League",
+              numberOfTeams: 32,
+              seasonLength: 17,
+              createdAt: "2026-01-15T00:00:00Z",
+              currentSeason: { year: 2, phase, week: 1 },
+            },
+          ]),
+      }),
+    );
+    renderWithProviders();
+    await waitFor(() => {
+      expect(screen.getByText(new RegExp(label))).toBeDefined();
     });
   });
 
   it("navigates to a league when clicking a league row", async () => {
     mockGet.mockReturnValue(
       Promise.resolve({
-        json: () => Promise.resolve([{ id: 42, name: "My League" }]),
+        json: () =>
+          Promise.resolve([
+            {
+              id: 42,
+              name: "My League",
+              numberOfTeams: 32,
+              seasonLength: 17,
+              createdAt: "2026-01-15T00:00:00Z",
+              currentSeason: { year: 1, phase: "preseason", week: 1 },
+            },
+          ]),
       }),
     );
     renderWithProviders();

--- a/client/src/features/league-select/index.tsx
+++ b/client/src/features/league-select/index.tsx
@@ -1,5 +1,6 @@
 import { useState } from "react";
 import { useNavigate } from "@tanstack/react-router";
+import type { SeasonPhase } from "@zone-blitz/shared";
 import { useCreateLeague, useLeagues } from "../../hooks/use-leagues.ts";
 import { UserMenu } from "../../components/user-menu.tsx";
 import { Button } from "@/components/ui/button";
@@ -15,6 +16,31 @@ import {
 import { Skeleton } from "@/components/ui/skeleton";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 
+const PHASE_LABELS: Record<SeasonPhase, string> = {
+  preseason: "Preseason",
+  regular_season: "Regular Season",
+  playoffs: "Playoffs",
+  offseason: "Offseason",
+};
+
+const PHASE_DOT_CLASSES: Record<SeasonPhase, string> = {
+  preseason: "bg-sky-500",
+  regular_season: "bg-emerald-500",
+  playoffs: "bg-amber-500",
+  offseason: "bg-muted-foreground",
+};
+
+const dateFormatter = new Intl.DateTimeFormat(undefined, {
+  month: "short",
+  day: "numeric",
+  year: "numeric",
+});
+
+function formatDate(value: string | Date): string {
+  const date = typeof value === "string" ? new Date(value) : value;
+  return dateFormatter.format(date);
+}
+
 export function LeagueSelect() {
   const { data: leagues, isLoading, error } = useLeagues();
   const createLeague = useCreateLeague();
@@ -22,22 +48,30 @@ export function LeagueSelect() {
   const [newName, setNewName] = useState("");
 
   return (
-    <div className="relative flex min-h-screen items-center justify-center bg-background text-foreground">
+    <div className="relative flex min-h-screen flex-col items-center bg-background px-4 pt-16 pb-24 text-foreground">
       <div className="absolute top-4 right-4">
         <UserMenu />
       </div>
-      <div className="w-full max-w-lg space-y-6 px-4 text-center">
+
+      <header className="w-full max-w-3xl space-y-4 text-center">
         <h1 className="text-5xl font-bold tracking-tight">Zone Blitz</h1>
         <p className="mx-auto max-w-md text-lg text-muted-foreground">
           Football franchise simulation. Scout, draft, trade, and build your
           dynasty.
         </p>
+      </header>
 
-        <div className="space-y-4 text-left">
-          <h2 className="text-xl font-semibold">Leagues</h2>
+      <section className="mt-12 w-full max-w-4xl space-y-4">
+        <div className="flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between">
+          <div>
+            <h2 className="text-xl font-semibold">Leagues</h2>
+            <p className="text-sm text-muted-foreground">
+              Pick up where you left off, or start a new franchise.
+            </p>
+          </div>
 
           <form
-            className="flex gap-2"
+            className="flex gap-2 sm:w-auto"
             onSubmit={(e) => {
               e.preventDefault();
               if (!newName.trim()) return;
@@ -60,7 +94,7 @@ export function LeagueSelect() {
               value={newName}
               onChange={(e) => setNewName(e.target.value)}
               placeholder="League name..."
-              className="flex-1"
+              className="sm:w-64"
             />
             <Button
               type="submit"
@@ -69,53 +103,94 @@ export function LeagueSelect() {
               {createLeague.isPending ? "Creating..." : "Create"}
             </Button>
           </form>
+        </div>
 
-          {isLoading && (
-            <div className="space-y-2">
-              <Skeleton className="h-8 w-full" />
-              <Skeleton className="h-8 w-full" />
-              <Skeleton className="h-8 w-3/4" />
-            </div>
-          )}
-          {error && (
-            <Alert variant="destructive">
-              <AlertTitle>Error</AlertTitle>
-              <AlertDescription>Failed to load leagues</AlertDescription>
-            </Alert>
-          )}
-          {leagues && leagues.length === 0 && (
+        {isLoading && (
+          <div className="space-y-2" data-testid="leagues-loading">
+            <Skeleton className="h-10 w-full" />
+            <Skeleton className="h-10 w-full" />
+            <Skeleton className="h-10 w-3/4" />
+          </div>
+        )}
+
+        {error && (
+          <Alert variant="destructive">
+            <AlertTitle>Error</AlertTitle>
+            <AlertDescription>Failed to load leagues</AlertDescription>
+          </Alert>
+        )}
+
+        {leagues && leagues.length === 0 && (
+          <div className="rounded-lg border border-dashed border-border p-10 text-center">
             <p className="text-sm text-muted-foreground">
               No leagues yet. Create one to get started.
             </p>
-          )}
-          {leagues && leagues.length > 0 && (
+          </div>
+        )}
+
+        {leagues && leagues.length > 0 && (
+          <div className="overflow-hidden rounded-lg border border-border">
             <Table>
               <TableHeader>
                 <TableRow>
                   <TableHead>Name</TableHead>
+                  <TableHead className="text-right">Teams</TableHead>
+                  <TableHead className="text-right">Season Length</TableHead>
+                  <TableHead>Status</TableHead>
+                  <TableHead className="text-right">Created</TableHead>
                 </TableRow>
               </TableHeader>
               <TableBody>
-                {leagues.map((league) => (
-                  <TableRow
-                    key={league.id}
-                    onClick={() =>
-                      navigate({
-                        to: "/leagues/$leagueId",
-                        params: { leagueId: String(league.id) },
-                      })}
-                    className="cursor-pointer"
-                  >
-                    <TableCell className="font-medium">
-                      {league.name}
-                    </TableCell>
-                  </TableRow>
-                ))}
+                {leagues.map((league) => {
+                  const phase = league.currentSeason?.phase;
+                  const year = league.currentSeason?.year;
+                  return (
+                    <TableRow
+                      key={league.id}
+                      onClick={() =>
+                        navigate({
+                          to: "/leagues/$leagueId",
+                          params: { leagueId: String(league.id) },
+                        })}
+                      className="cursor-pointer"
+                    >
+                      <TableCell className="font-medium">
+                        {league.name}
+                      </TableCell>
+                      <TableCell className="text-right tabular-nums">
+                        {league.numberOfTeams}
+                      </TableCell>
+                      <TableCell className="text-right tabular-nums">
+                        {league.seasonLength}
+                      </TableCell>
+                      <TableCell>
+                        {phase
+                          ? (
+                            <span className="inline-flex items-center gap-2">
+                              <span
+                                aria-hidden
+                                className={`size-2 rounded-full ${
+                                  PHASE_DOT_CLASSES[phase]
+                                }`}
+                              />
+                              <span>
+                                Season {year} · {PHASE_LABELS[phase]}
+                              </span>
+                            </span>
+                          )
+                          : <span className="text-muted-foreground">—</span>}
+                      </TableCell>
+                      <TableCell className="text-right text-muted-foreground">
+                        {formatDate(league.createdAt)}
+                      </TableCell>
+                    </TableRow>
+                  );
+                })}
               </TableBody>
             </Table>
-          )}
-        </div>
-      </div>
+          </div>
+        )}
+      </section>
     </div>
   );
 }

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -1,0 +1,19 @@
+# Backlog
+
+Lightweight list of follow-ups and small ideas we don't want to forget. Promote
+an entry to a GitHub issue or a full document under `docs/incidents/` (or a
+future `docs/action-items/`) once it grows past a one-liner.
+
+Format: one bullet per item. Add a date and a short context line. Remove the
+entry when it's resolved or superseded.
+
+## Open
+
+- **2026-04-13 — Finer-grained league phase sub-states.** The `season.phase`
+  enum only tracks `preseason | regular_season | playoffs | offseason`. Product
+  docs (`docs/product/league-management.md`) describe sub-steps during the
+  offseason (cut-down, draft, free agency, waiver periods). Decide whether to
+  expand the enum, add a separate `offseasonStage` field, or model these as
+  scheduled events. Surfaced while adding a league status column to the home
+  page — today we can only show "Offseason" rather than "Drafting" or "Free
+  Agency".

--- a/packages/shared/mod.ts
+++ b/packages/shared/mod.ts
@@ -1,6 +1,11 @@
 // Types
 export type { HealthStatus } from "./types/health.ts";
-export type { League, NewLeague } from "./types/league.ts";
+export type {
+  League,
+  LeagueListItem,
+  LeagueSeasonSummary,
+  NewLeague,
+} from "./types/league.ts";
 export type { Team } from "./types/team.ts";
 export type { NewSeason, Season, SeasonPhase } from "./types/season.ts";
 export type { FrontOfficeStaff, Scout } from "./types/personnel.ts";

--- a/packages/shared/types/league.ts
+++ b/packages/shared/types/league.ts
@@ -1,3 +1,5 @@
+import type { SeasonPhase } from "./season.ts";
+
 export interface League {
   id: string;
   name: string;
@@ -9,6 +11,16 @@ export interface League {
   rosterSize: number;
   createdAt: Date;
   updatedAt: Date;
+}
+
+export interface LeagueSeasonSummary {
+  year: number;
+  phase: SeasonPhase;
+  week: number;
+}
+
+export interface LeagueListItem extends League {
+  currentSeason: LeagueSeasonSummary | null;
 }
 
 export interface NewLeague {

--- a/server/features/league/league.router.test.ts
+++ b/server/features/league/league.router.test.ts
@@ -1,6 +1,6 @@
 import { assertEquals } from "@std/assert";
 import { createLeagueRouter } from "./league.router.ts";
-import type { League } from "@zone-blitz/shared";
+import type { League, LeagueListItem } from "@zone-blitz/shared";
 import type { LeagueService } from "./league.service.interface.ts";
 
 function createMockLeague(overrides: Partial<League> = {}): League {
@@ -32,10 +32,16 @@ function createMockLeagueService(
 }
 
 Deno.test("league.router", async (t) => {
-  await t.step("GET / returns all leagues", async () => {
-    const leagues: League[] = [
-      createMockLeague({ id: "1", name: "League One" }),
-      createMockLeague({ id: "2", name: "League Two" }),
+  await t.step("GET / returns all leagues with current season", async () => {
+    const leagues: LeagueListItem[] = [
+      {
+        ...createMockLeague({ id: "1", name: "League One" }),
+        currentSeason: { year: 1, phase: "preseason", week: 1 },
+      },
+      {
+        ...createMockLeague({ id: "2", name: "League Two" }),
+        currentSeason: null,
+      },
     ];
     const router = createLeagueRouter(
       createMockLeagueService({ getAll: () => Promise.resolve(leagues) }),
@@ -47,7 +53,12 @@ Deno.test("league.router", async (t) => {
     const body = await res.json();
     assertEquals(body.length, 2);
     assertEquals(body[0].name, "League One");
-    assertEquals(body[1].name, "League Two");
+    assertEquals(body[0].currentSeason, {
+      year: 1,
+      phase: "preseason",
+      week: 1,
+    });
+    assertEquals(body[1].currentSeason, null);
   });
 
   await t.step("GET / returns empty array when no leagues", async () => {

--- a/server/features/league/league.service.interface.ts
+++ b/server/features/league/league.service.interface.ts
@@ -1,7 +1,7 @@
-import type { League, NewLeague } from "@zone-blitz/shared";
+import type { League, LeagueListItem, NewLeague } from "@zone-blitz/shared";
 
 export interface LeagueService {
-  getAll(): Promise<League[]>;
+  getAll(): Promise<LeagueListItem[]>;
   getById(id: string): Promise<League>;
   create(input: NewLeague): Promise<League>;
   deleteById(id: string): Promise<void>;

--- a/server/features/league/league.service.test.ts
+++ b/server/features/league/league.service.test.ts
@@ -130,19 +130,65 @@ function createService(overrides: {
 }
 
 Deno.test("league.service", async (t) => {
-  await t.step("getAll returns all leagues from repository", async () => {
-    const leagues: League[] = [
-      createMockLeague({ id: "1", name: "League One" }),
-      createMockLeague({ id: "2", name: "League Two" }),
-    ];
-    const service = createService({
-      leagueRepo: { getAll: () => Promise.resolve(leagues) },
-    });
+  await t.step(
+    "getAll returns leagues with their current season embedded",
+    async () => {
+      const leagues: League[] = [
+        createMockLeague({ id: "1", name: "League One" }),
+        createMockLeague({ id: "2", name: "League Two" }),
+      ];
+      const service = createService({
+        leagueRepo: { getAll: () => Promise.resolve(leagues) },
+        seasonService: {
+          getByLeagueId: (leagueId) =>
+            Promise.resolve([
+              {
+                id: `${leagueId}-s1`,
+                leagueId,
+                year: 1,
+                phase: "preseason" as const,
+                week: 1,
+                createdAt: new Date(),
+                updatedAt: new Date(),
+              },
+              {
+                id: `${leagueId}-s2`,
+                leagueId,
+                year: 2,
+                phase: "regular_season" as const,
+                week: 5,
+                createdAt: new Date(),
+                updatedAt: new Date(),
+              },
+            ]),
+        },
+      });
 
-    const result = await service.getAll();
-    assertEquals(result.length, 2);
-    assertEquals(result[0].name, "League One");
-  });
+      const result = await service.getAll();
+      assertEquals(result.length, 2);
+      assertEquals(result[0].name, "League One");
+      assertEquals(result[0].currentSeason, {
+        year: 2,
+        phase: "regular_season",
+        week: 5,
+      });
+    },
+  );
+
+  await t.step(
+    "getAll returns currentSeason null when a league has no seasons",
+    async () => {
+      const service = createService({
+        leagueRepo: {
+          getAll: () => Promise.resolve([createMockLeague({ id: "1" })]),
+        },
+        seasonService: { getByLeagueId: () => Promise.resolve([]) },
+      });
+
+      const result = await service.getAll();
+      assertEquals(result[0].currentSeason, null);
+    },
+  );
 
   await t.step("getById returns league when found", async () => {
     const league = createMockLeague({ id: "1", name: "Found League" });

--- a/server/features/league/league.service.ts
+++ b/server/features/league/league.service.ts
@@ -20,7 +20,23 @@ export function createLeagueService(deps: {
   return {
     async getAll() {
       log.debug("fetching all leagues");
-      return await deps.leagueRepo.getAll();
+      const leagues = await deps.leagueRepo.getAll();
+      return await Promise.all(
+        leagues.map(async (league) => {
+          const seasons = await deps.seasonService.getByLeagueId(league.id);
+          const current = seasons.reduce<typeof seasons[number] | undefined>(
+            (latest, season) =>
+              !latest || season.year > latest.year ? season : latest,
+            undefined,
+          );
+          return {
+            ...league,
+            currentSeason: current
+              ? { year: current.year, phase: current.phase, week: current.week }
+              : null,
+          };
+        }),
+      );
     },
 
     async getById(id) {


### PR DESCRIPTION
## Summary

- Turn the home page league list into a real table with **Name · Teams · Season Length · Status · Created** columns so players can scan leagues at a glance.
- Status renders as `Season {year} · {Phase}` (Preseason / Regular Season / Playoffs / Offseason) fed by a new `currentSeason` summary embedded in `GET /api/leagues` — the league service now joins each league with its latest season.
- Seed `docs/backlog.md` as a lightweight one-liner-per-item follow-up log. First entry: modeling finer-grained offseason sub-phases (draft, free agency, cut-down) that product docs describe but the schema does not yet capture.

Note: I wasn't able to visually confirm in a browser from this session — tests and lint pass, but give the new grid a quick eyeball after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)