### PR TITLE
docs(product): add roster page PRD and statistics north star

### DIFF
--- a/docs/product/README.md
+++ b/docs/product/README.md
@@ -88,6 +88,8 @@ Each of these has a dedicated vision document:
 - [Game Simulation](./north-star/game-simulation.md) — what happens on the field
 - [Player Attributes](./north-star/player-attributes.md) — the true 0-100 scale,
   hidden potential, and progression
+- [Statistics](./north-star/statistics.md) — sim-driven stats for players,
+  teams, and the league; the primary feedback loop for GM decisions
 - [Coaches](./north-star/coaches.md) — the coaching staff; hidden attributes,
   coaching trees, the GM-coach relationship, and the coaching market
 - [Media](./north-star/media.md) — analysts, headlines, grades, narratives, and

--- a/docs/product/decisions/0001-roster-page.md
+++ b/docs/product/decisions/0001-roster-page.md
@@ -1,0 +1,85 @@
+# 0001 — Roster page: active roster + depth chart view
+
+- **Date:** 2026-04-13
+- **Status:** Accepted
+- **Area:** roster — see
+  [`../north-star/player-attributes.md`](../north-star/player-attributes.md),
+  [`../north-star/coaches.md`](../north-star/coaches.md),
+  [`../north-star/statistics.md`](../north-star/statistics.md)
+
+## Context
+
+The roster page is where the GM sees the current 53-man team and the coach's
+depth chart. It needs to reinforce the core invariant that the GM controls the
+roster but the coach controls the depth chart.
+
+## Decision
+
+Ship a single roster page with three primary views — **Active Roster**, **Depth
+Chart**, and **Statistics** — and no UI affordances that let the user override
+the coach.
+
+## Requirements
+
+### Active Roster view
+
+- List all 53 players on the active roster, grouped by position.
+- Per player, show: name, position, age, cap hit, contract years remaining,
+  injury status.
+- No overall rating, grade, or any scout/attribute verdict on the player — the
+  GM trusts the coaching staff's evaluation, not a number on a page.
+- Sort/filter by position group, cap hit, age, contract years.
+- Actions available: release, trade, restructure (opens relevant flow). No
+  start/bench/promote actions.
+- Show position-group totals: headcount and total cap $ per group.
+- Show total roster cap $ and remaining cap space.
+
+### Depth Chart view
+
+- Read-only. Rendered from the coach's current depth chart.
+- Grouped by position with ordinal slots (1st, 2nd, 3rd…).
+- Per slot, show: player name, injury status. No overall rating.
+- Surface game-day inactives as a separate list.
+- Include a "last updated" timestamp and the coach who owns the chart.
+
+### Statistics view
+
+- Table of per-player season statistics, scoped to the current season by default
+  with a selector for prior seasons and career totals.
+- Columns adapt to position group (passing for QB; rushing for RB; receiving for
+  WR/TE; defensive stats for front seven / secondary; kicking/punting for
+  specialists).
+- Support sort by any column and filter by position group.
+- Per-player row links to a detail view with game-by-game splits.
+- Stats reflect in-game sim output only; no fictional or projected numbers.
+
+### Out of scope
+
+- Drag-to-reorder, "set as starter," or any depth-chart editing UI.
+- Practice squad, IR, waivers, weekly transactions log.
+- Scheme fit indicators, snap counts, player development trends.
+- Coach directives from this page (handled on the coaches page).
+
+## Alternatives considered
+
+- **Single combined view** — one table showing roster + depth-chart ordinal —
+  rejected. Collapses the "GM picks 53, coach picks 11" distinction into one
+  grid and invites editing affordances on the depth chart.
+- **Editable depth chart with coach-override warnings** — rejected. Breaks the
+  core fiction; coach autonomy is the game.
+- **Defer depth chart to a later page** — rejected. The disconnect between
+  roster and depth chart is the most important read on the page; shipping
+  without it leaves the roster page feeling like a spreadsheet.
+
+## Consequences
+
+- Users who expect EA-style manual depth chart control will push back. The UI
+  has to make the constraint feel intentional, not missing.
+- Requires the coach sim to publish a stable depth-chart artifact the page can
+  read.
+- The roster page intentionally exposes no attribute-based evaluation of
+  players. Judgment comes from stats, contract, age, and the coach's depth chart
+  — not a rating. Scout-view of rostered players lives elsewhere if surfaced at
+  all.
+- Future PRDs will extend this page for practice squad, IR, and weekly
+  transactions.

--- a/docs/product/decisions/README.md
+++ b/docs/product/decisions/README.md
@@ -17,5 +17,5 @@ as superseded.
 
 ## Log
 
-<!-- Add entries here in reverse-chronological order: -->
-<!-- - [0001 — Title](./0001-title.md) — one-line hook -->
+- [0001 — Roster page: active roster + depth chart view](./0001-roster-page.md)
+  — single page, two views, no depth-chart editing

--- a/docs/product/north-star/statistics.md
+++ b/docs/product/north-star/statistics.md
@@ -1,0 +1,94 @@
+# Statistics
+
+Statistics are how the GM reads the team. Every decision — who to re-sign, who
+to cut, which coach is working, which scheme is breaking down — gets argued in
+numbers. If the sim can't produce realistic NFL stats, none of those arguments
+hold up.
+
+## Principles
+
+### Stats are sim output, never hand-authored
+
+Every statistic comes from a simulated play. No baseline generation, no
+"plausible" numbers applied to unsimulated players, no synthetic league leaders.
+If a player didn't play the snap, the snap didn't happen.
+
+### Realism is measured against the real NFL
+
+League-wide season totals and distributions should sit inside historical NFL
+bands — passing yards per team, sack rates, completion percentages, rush yards
+per carry, turnover rates, etc. A season where the league leader in rushing has
+800 yards or 3,000 yards is a bug.
+
+### Stats are the primary feedback loop for GM decisions
+
+The GM cannot see true attributes. Stats are the strongest public signal
+available and must be rich enough to drive real decisions — re-sign or walk,
+extend or trade, start the rookie or the veteran.
+
+### Stats accumulate across career and league history
+
+Per-game, per-season, and career totals persist. League history retains season
+leaders, records, and all-time lists. Retired players keep their stats; traded
+players carry their stats.
+
+## Scope
+
+### Player statistics
+
+- **Offense:** passing, rushing, receiving, offensive line (sacks allowed,
+  pressures allowed, run-block grades where derivable from sim events).
+- **Defense:** tackles, sacks, TFLs, pressures, interceptions, pass defenses,
+  forced fumbles, coverage stats (targets, catches allowed, yards allowed).
+- **Special teams:** kicking, punting, return stats, coverage tackles.
+- **Availability:** games played, games started, snap counts by phase.
+
+### Team statistics
+
+- Offensive and defensive totals and per-game rates.
+- Drive-level stats: points per drive, 3rd down %, red zone %, turnover
+  differential.
+- Situational splits: home/away, division, vs. winning teams, close-and-late.
+
+### League statistics
+
+- Season leaders and leaderboards per stat.
+- All-time records (single-game, single-season, career).
+- Standings with tiebreakers.
+- Awards derived from stats (MVP, OPOY, DPOY, etc.) — stats are input, not sole
+  determinant.
+
+### Splits and context
+
+- Game-by-game logs per player and per team.
+- Home/away, month, opponent.
+- Situational: down-and-distance, red zone, third down, two-minute.
+
+## Sim requirements
+
+- The game simulation must emit per-play events rich enough to derive every
+  statistic above. No stat category added after the fact via sampling.
+- Per-play events include: participants, outcome, yardage, situation
+  (down/distance/field position), and any position-specific event (sack,
+  pressure, target, coverage assignment, etc.).
+- League-wide tuning: after any sim change, league aggregates must be validated
+  against historical NFL bands before merge.
+
+## Out of scope (for now)
+
+- Advanced analytics layered on top of base stats (EPA, DVOA-style metrics, win
+  probability added). Base stats first; analytics later.
+- Tracking data (route running charts, defender proximity, etc.).
+- User-authored custom stat formulas.
+
+## Interaction with other systems
+
+- **[Player Attributes](./player-attributes.md):** stats are the observable
+  surface; true attributes are hidden. Stats are filtered through scheme,
+  coaching, teammates, and opponents.
+- **[Coaches](./coaches.md):** team and unit stats are the primary report card
+  for coaching staffs.
+- **[Game Simulation](./game-simulation.md):** the sim is the source of truth;
+  stats are its exhaust.
+- **[Media](./media.md):** narratives, grades, and awards draw on stats but are
+  not stats themselves.


### PR DESCRIPTION
## Summary

- Adds `decisions/0001-roster-page.md` — first product decision doc, specifying the roster page as three views (Active Roster, Depth Chart, Statistics) with no overall rating or scout/attribute verdict shown on rostered players. Judgment on the page comes from stats, contract, age, and the coach's depth chart, reinforcing the GM-trusts-coach fiction.
- Adds `north-star/statistics.md` covering the previously undocumented stats domain: sim-driven player/team/league stats, NFL-realistic distributions, and stats as the primary feedback loop for GM decisions.
- Resolves a stale merge conflict in `docs/product/README.md` and wires both new docs into their indexes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)