### PR TITLE
feat(league-select): add per-row delete action to league grid

### DIFF
--- a/client/src/features/league-select/index.test.tsx
+++ b/client/src/features/league-select/index.test.tsx
@@ -11,6 +11,7 @@ import { LeagueSelect } from "./index.tsx";
 
 const mockGet = vi.fn();
 const mockPost = vi.fn();
+const mockDelete = vi.fn();
 const mockNavigate = vi.fn();
 
 vi.mock("../../api.ts", () => ({
@@ -19,6 +20,9 @@ vi.mock("../../api.ts", () => ({
       leagues: {
         $get: (...args: unknown[]) => mockGet(...args),
         $post: (...args: unknown[]) => mockPost(...args),
+        ":id": {
+          $delete: (...args: unknown[]) => mockDelete(...args),
+        },
       },
       users: {
         me: {
@@ -329,4 +333,80 @@ describe("LeagueSelect", () => {
       expect(screen.getByText("Creating...")).toBeDefined();
     });
   });
+
+  it(
+    "confirms and deletes a league when the row delete action is used",
+    async () => {
+      mockGet.mockReturnValue(
+        Promise.resolve({
+          json: () =>
+            Promise.resolve([
+              {
+                id: 7,
+                name: "Doomed League",
+                numberOfTeams: 32,
+                seasonLength: 17,
+                createdAt: "2026-01-15T00:00:00Z",
+                currentSeason: { year: 1, phase: "preseason", week: 1 },
+              },
+            ]),
+        }),
+      );
+      mockDelete.mockReturnValue(Promise.resolve({}));
+      renderWithProviders();
+
+      await waitFor(() => {
+        expect(screen.getByText("Doomed League")).toBeDefined();
+      });
+
+      fireEvent.click(
+        screen.getByRole("button", { name: "Delete Doomed League" }),
+      );
+
+      expect(mockNavigate).not.toHaveBeenCalled();
+
+      const confirm = await screen.findByRole("button", {
+        name: "Confirm Delete",
+      });
+      fireEvent.click(confirm);
+
+      await waitFor(() => {
+        expect(mockDelete).toHaveBeenCalledWith({ param: { id: "7" } });
+      });
+    },
+  );
+
+  it(
+    "does not delete when the delete dialog is cancelled",
+    async () => {
+      mockGet.mockReturnValue(
+        Promise.resolve({
+          json: () =>
+            Promise.resolve([
+              {
+                id: 7,
+                name: "Safe League",
+                numberOfTeams: 32,
+                seasonLength: 17,
+                createdAt: "2026-01-15T00:00:00Z",
+                currentSeason: { year: 1, phase: "preseason", week: 1 },
+              },
+            ]),
+        }),
+      );
+      renderWithProviders();
+
+      await waitFor(() => {
+        expect(screen.getByText("Safe League")).toBeDefined();
+      });
+
+      fireEvent.click(
+        screen.getByRole("button", { name: "Delete Safe League" }),
+      );
+      const cancel = await screen.findByRole("button", { name: "Cancel" });
+      fireEvent.click(cancel);
+
+      expect(mockDelete).not.toHaveBeenCalled();
+    },
+  );
 });

--- a/client/src/features/league-select/index.tsx
+++ b/client/src/features/league-select/index.tsx
@@ -1,7 +1,12 @@
 import { useState } from "react";
 import { useNavigate } from "@tanstack/react-router";
+import { Trash2Icon } from "lucide-react";
 import type { SeasonPhase } from "@zone-blitz/shared";
-import { useCreateLeague, useLeagues } from "../../hooks/use-leagues.ts";
+import {
+  useCreateLeague,
+  useDeleteLeague,
+  useLeagues,
+} from "../../hooks/use-leagues.ts";
 import { UserMenu } from "../../components/user-menu.tsx";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -15,6 +20,17 @@ import {
 } from "@/components/ui/table";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from "@/components/ui/alert-dialog";
 
 const PHASE_LABELS: Record<SeasonPhase, string> = {
   preseason: "Preseason",
@@ -44,6 +60,7 @@ function formatDate(value: string | Date): string {
 export function LeagueSelect() {
   const { data: leagues, isLoading, error } = useLeagues();
   const createLeague = useCreateLeague();
+  const deleteLeague = useDeleteLeague();
   const navigate = useNavigate();
   const [newName, setNewName] = useState("");
 
@@ -138,6 +155,9 @@ export function LeagueSelect() {
                   <TableHead className="text-right">Season Length</TableHead>
                   <TableHead>Status</TableHead>
                   <TableHead className="text-right">Created</TableHead>
+                  <TableHead className="w-10">
+                    <span className="sr-only">Actions</span>
+                  </TableHead>
                 </TableRow>
               </TableHeader>
               <TableBody>
@@ -182,6 +202,50 @@ export function LeagueSelect() {
                       </TableCell>
                       <TableCell className="text-right text-muted-foreground">
                         {formatDate(league.createdAt)}
+                      </TableCell>
+                      <TableCell
+                        className="text-right"
+                        onClick={(e) => e.stopPropagation()}
+                      >
+                        <AlertDialog>
+                          <AlertDialogTrigger
+                            render={
+                              <Button
+                                variant="ghost"
+                                size="icon"
+                                aria-label={`Delete ${league.name}`}
+                                className="text-muted-foreground hover:text-destructive"
+                              />
+                            }
+                          >
+                            <Trash2Icon className="size-4" />
+                          </AlertDialogTrigger>
+                          <AlertDialogContent>
+                            <AlertDialogHeader>
+                              <AlertDialogTitle>
+                                Delete {league.name}?
+                              </AlertDialogTitle>
+                              <AlertDialogDescription>
+                                This action cannot be undone. All league data
+                                including teams, players, and seasons will be
+                                permanently deleted.
+                              </AlertDialogDescription>
+                            </AlertDialogHeader>
+                            <AlertDialogFooter>
+                              <AlertDialogCancel>Cancel</AlertDialogCancel>
+                              <AlertDialogAction
+                                variant="destructive"
+                                onClick={() =>
+                                  deleteLeague.mutate(String(league.id))}
+                                disabled={deleteLeague.isPending}
+                              >
+                                {deleteLeague.isPending
+                                  ? "Deleting..."
+                                  : "Confirm Delete"}
+                              </AlertDialogAction>
+                            </AlertDialogFooter>
+                          </AlertDialogContent>
+                        </AlertDialog>
                       </TableCell>
                     </TableRow>
                   );


### PR DESCRIPTION
## Summary

- Adds a trash-icon button on each row of the home page league grid that opens a confirm-before-destroy `AlertDialog` — mirrors the existing Danger Zone pattern from `features/league/settings.tsx`.
- The action cell stops click propagation so the delete control no longer double-fires into the row's navigate-to-league handler.
- Reuses the existing `useDeleteLeague` mutation; no API changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)