### PR TITLE
refactor(services): rename generateAndPersist to generate

### DIFF
--- a/server/features/coaches/coaches.service.interface.ts
+++ b/server/features/coaches/coaches.service.interface.ts
@@ -8,7 +8,7 @@ export interface CoachesGenerateResult {
 }
 
 export interface CoachesService {
-  generateAndPersist(
+  generate(
     input: CoachesGenerateInput,
   ): Promise<CoachesGenerateResult>;
 }

--- a/server/features/coaches/coaches.service.test.ts
+++ b/server/features/coaches/coaches.service.test.ts
@@ -46,7 +46,7 @@ function createMockDb(): {
 
 Deno.test("coaches.service", async (t) => {
   await t.step(
-    "generateAndPersist inserts generated coaches and returns count",
+    "generate inserts generated coaches and returns count",
     async () => {
       const { db, calls } = createMockDb();
       const generator = createMockGenerator({
@@ -62,7 +62,7 @@ Deno.test("coaches.service", async (t) => {
         log: createTestLogger(),
       });
 
-      const result = await service.generateAndPersist({
+      const result = await service.generate({
         leagueId: "l1",
         teamIds: ["t1"],
       });
@@ -73,7 +73,7 @@ Deno.test("coaches.service", async (t) => {
   );
 
   await t.step(
-    "generateAndPersist skips insert when generator returns empty",
+    "generate skips insert when generator returns empty",
     async () => {
       const { db, calls } = createMockDb();
       const generator = createMockGenerator();
@@ -84,7 +84,7 @@ Deno.test("coaches.service", async (t) => {
         log: createTestLogger(),
       });
 
-      const result = await service.generateAndPersist({
+      const result = await service.generate({
         leagueId: "l1",
         teamIds: [],
       });

--- a/server/features/coaches/coaches.service.ts
+++ b/server/features/coaches/coaches.service.ts
@@ -12,7 +12,7 @@ export function createCoachesService(deps: {
   const log = deps.log.child({ module: "coaches.service" });
 
   return {
-    async generateAndPersist(input) {
+    async generate(input) {
       log.info({ leagueId: input.leagueId }, "generating coaches");
 
       const generated = deps.generator.generate({

--- a/server/features/front-office/front-office.service.interface.ts
+++ b/server/features/front-office/front-office.service.interface.ts
@@ -8,7 +8,7 @@ export interface FrontOfficeGenerateResult {
 }
 
 export interface FrontOfficeService {
-  generateAndPersist(
+  generate(
     input: FrontOfficeGenerateInput,
   ): Promise<FrontOfficeGenerateResult>;
 }

--- a/server/features/front-office/front-office.service.test.ts
+++ b/server/features/front-office/front-office.service.test.ts
@@ -46,7 +46,7 @@ function createMockDb(): {
 
 Deno.test("front-office.service", async (t) => {
   await t.step(
-    "generateAndPersist inserts generated staff and returns count",
+    "generate inserts generated staff and returns count",
     async () => {
       const { db, calls } = createMockDb();
       const generator = createMockGenerator({
@@ -62,7 +62,7 @@ Deno.test("front-office.service", async (t) => {
         log: createTestLogger(),
       });
 
-      const result = await service.generateAndPersist({
+      const result = await service.generate({
         leagueId: "l1",
         teamIds: ["t1"],
       });
@@ -73,7 +73,7 @@ Deno.test("front-office.service", async (t) => {
   );
 
   await t.step(
-    "generateAndPersist skips insert when generator returns empty",
+    "generate skips insert when generator returns empty",
     async () => {
       const { db, calls } = createMockDb();
       const generator = createMockGenerator();
@@ -84,7 +84,7 @@ Deno.test("front-office.service", async (t) => {
         log: createTestLogger(),
       });
 
-      const result = await service.generateAndPersist({
+      const result = await service.generate({
         leagueId: "l1",
         teamIds: [],
       });

--- a/server/features/front-office/front-office.service.ts
+++ b/server/features/front-office/front-office.service.ts
@@ -12,7 +12,7 @@ export function createFrontOfficeService(deps: {
   const log = deps.log.child({ module: "front-office.service" });
 
   return {
-    async generateAndPersist(input) {
+    async generate(input) {
       log.info({ leagueId: input.leagueId }, "generating front office staff");
 
       const generated = deps.generator.generate({

--- a/server/features/league/league.service.test.ts
+++ b/server/features/league/league.service.test.ts
@@ -90,7 +90,7 @@ function createMockPersonnelService(
   overrides: Partial<PersonnelService> = {},
 ): PersonnelService {
   return {
-    generateAndPersist: () =>
+    generate: () =>
       Promise.resolve({
         playerCount: 0,
         coachCount: 0,
@@ -107,7 +107,7 @@ function createMockScheduleService(
   overrides: Partial<ScheduleService> = {},
 ): ScheduleService {
   return {
-    generateAndPersist: () => Promise.resolve({ gameCount: 0 }),
+    generate: () => Promise.resolve({ gameCount: 0 }),
     ...overrides,
   };
 }
@@ -234,7 +234,7 @@ Deno.test("league.service", async (t) => {
         },
       },
       personnelService: {
-        generateAndPersist: (input) => {
+        generate: (input) => {
           personnelCalled = true;
           assertEquals(input.leagueId, "new-id");
           assertEquals(input.seasonId, "season-1");
@@ -251,7 +251,7 @@ Deno.test("league.service", async (t) => {
         },
       },
       scheduleService: {
-        generateAndPersist: (input) => {
+        generate: (input) => {
           scheduleCalled = true;
           assertEquals(input.seasonId, "season-1");
           assertEquals(input.seasonLength, 17);

--- a/server/features/league/league.service.ts
+++ b/server/features/league/league.service.ts
@@ -61,7 +61,7 @@ export function createLeagueService(deps: {
 
       const teams = await deps.teamService.getAll();
 
-      await deps.personnelService.generateAndPersist({
+      await deps.personnelService.generate({
         leagueId: league.id,
         seasonId: season.id,
         teamIds: teams.map((t) => t.id),
@@ -69,7 +69,7 @@ export function createLeagueService(deps: {
         salaryCap: league.salaryCap,
       });
 
-      await deps.scheduleService.generateAndPersist({
+      await deps.scheduleService.generate({
         seasonId: season.id,
         teams: teams.map((t) => ({
           teamId: t.id,

--- a/server/features/personnel/personnel.service.interface.ts
+++ b/server/features/personnel/personnel.service.interface.ts
@@ -16,7 +16,7 @@ export interface PersonnelGenerateResult {
 }
 
 export interface PersonnelService {
-  generateAndPersist(
+  generate(
     input: PersonnelGenerateInput,
   ): Promise<PersonnelGenerateResult>;
 }

--- a/server/features/personnel/personnel.service.test.ts
+++ b/server/features/personnel/personnel.service.test.ts
@@ -19,7 +19,7 @@ function createMockPlayersService(
   overrides: Partial<PlayersService> = {},
 ): PlayersService {
   return {
-    generateAndPersist: () =>
+    generate: () =>
       Promise.resolve({
         playerCount: 0,
         draftProspectCount: 0,
@@ -33,7 +33,7 @@ function createMockCoachesService(
   overrides: Partial<CoachesService> = {},
 ): CoachesService {
   return {
-    generateAndPersist: () => Promise.resolve({ coachCount: 0 }),
+    generate: () => Promise.resolve({ coachCount: 0 }),
     ...overrides,
   };
 }
@@ -42,7 +42,7 @@ function createMockScoutsService(
   overrides: Partial<ScoutsService> = {},
 ): ScoutsService {
   return {
-    generateAndPersist: () => Promise.resolve({ scoutCount: 0 }),
+    generate: () => Promise.resolve({ scoutCount: 0 }),
     ...overrides,
   };
 }
@@ -51,14 +51,14 @@ function createMockFrontOfficeService(
   overrides: Partial<FrontOfficeService> = {},
 ): FrontOfficeService {
   return {
-    generateAndPersist: () => Promise.resolve({ frontOfficeCount: 0 }),
+    generate: () => Promise.resolve({ frontOfficeCount: 0 }),
     ...overrides,
   };
 }
 
 Deno.test("personnel.service", async (t) => {
   await t.step(
-    "generateAndPersist delegates to all four services and aggregates counts",
+    "generate delegates to all four services and aggregates counts",
     async () => {
       let playersServiceInput:
         | {
@@ -70,7 +70,7 @@ Deno.test("personnel.service", async (t) => {
         }
         | undefined;
       const playersService = createMockPlayersService({
-        generateAndPersist: (input) => {
+        generate: (input) => {
           playersServiceInput = input;
           return Promise.resolve({
             playerCount: 2,
@@ -84,7 +84,7 @@ Deno.test("personnel.service", async (t) => {
         | { leagueId: string; teamIds: string[] }
         | undefined;
       const coachesService = createMockCoachesService({
-        generateAndPersist: (input) => {
+        generate: (input) => {
           coachesServiceInput = input;
           return Promise.resolve({ coachCount: 5 });
         },
@@ -94,7 +94,7 @@ Deno.test("personnel.service", async (t) => {
         | { leagueId: string; teamIds: string[] }
         | undefined;
       const scoutsService = createMockScoutsService({
-        generateAndPersist: (input) => {
+        generate: (input) => {
           scoutsServiceInput = input;
           return Promise.resolve({ scoutCount: 3 });
         },
@@ -104,7 +104,7 @@ Deno.test("personnel.service", async (t) => {
         | { leagueId: string; teamIds: string[] }
         | undefined;
       const frontOfficeService = createMockFrontOfficeService({
-        generateAndPersist: (input) => {
+        generate: (input) => {
           frontOfficeServiceInput = input;
           return Promise.resolve({ frontOfficeCount: 2 });
         },
@@ -118,7 +118,7 @@ Deno.test("personnel.service", async (t) => {
         log: createTestLogger(),
       });
 
-      const result = await service.generateAndPersist({
+      const result = await service.generate({
         leagueId: "l1",
         seasonId: "s1",
         teamIds: ["t1"],
@@ -151,7 +151,7 @@ Deno.test("personnel.service", async (t) => {
   );
 
   await t.step(
-    "generateAndPersist returns zero counts when all services return zero",
+    "generate returns zero counts when all services return zero",
     async () => {
       const service = createPersonnelService({
         playersService: createMockPlayersService(),
@@ -161,7 +161,7 @@ Deno.test("personnel.service", async (t) => {
         log: createTestLogger(),
       });
 
-      const result = await service.generateAndPersist({
+      const result = await service.generate({
         leagueId: "l1",
         seasonId: "s1",
         teamIds: [],

--- a/server/features/personnel/personnel.service.ts
+++ b/server/features/personnel/personnel.service.ts
@@ -15,13 +15,13 @@ export function createPersonnelService(deps: {
   const log = deps.log.child({ module: "personnel.service" });
 
   return {
-    async generateAndPersist(input) {
+    async generate(input) {
       log.info(
         { leagueId: input.leagueId, seasonId: input.seasonId },
         "generating personnel",
       );
 
-      const playersResult = await deps.playersService.generateAndPersist({
+      const playersResult = await deps.playersService.generate({
         leagueId: input.leagueId,
         seasonId: input.seasonId,
         teamIds: input.teamIds,
@@ -29,18 +29,18 @@ export function createPersonnelService(deps: {
         salaryCap: input.salaryCap,
       });
 
-      const coachesResult = await deps.coachesService.generateAndPersist({
+      const coachesResult = await deps.coachesService.generate({
         leagueId: input.leagueId,
         teamIds: input.teamIds,
       });
 
-      const scoutsResult = await deps.scoutsService.generateAndPersist({
+      const scoutsResult = await deps.scoutsService.generate({
         leagueId: input.leagueId,
         teamIds: input.teamIds,
       });
 
       const frontOfficeResult = await deps.frontOfficeService
-        .generateAndPersist({
+        .generate({
           leagueId: input.leagueId,
           teamIds: input.teamIds,
         });

--- a/server/features/players/players.service.interface.ts
+++ b/server/features/players/players.service.interface.ts
@@ -13,7 +13,7 @@ export interface PlayersGenerateResult {
 }
 
 export interface PlayersService {
-  generateAndPersist(
+  generate(
     input: PlayersGenerateInput,
   ): Promise<PlayersGenerateResult>;
 }

--- a/server/features/players/players.service.test.ts
+++ b/server/features/players/players.service.test.ts
@@ -69,7 +69,7 @@ function createMockDb(rosteredPlayerIds: string[] = []): {
 
 Deno.test("players.service", async (t) => {
   await t.step(
-    "generateAndPersist inserts players, draft prospects, contracts and returns counts",
+    "generate inserts players, draft prospects, contracts and returns counts",
     async () => {
       const { db, calls } = createMockDb(["p1", "p2"]);
       const generator = createMockGenerator({
@@ -102,7 +102,7 @@ Deno.test("players.service", async (t) => {
         log: createTestLogger(),
       });
 
-      const result = await service.generateAndPersist({
+      const result = await service.generate({
         leagueId: "l1",
         seasonId: "s1",
         teamIds: ["t1"],
@@ -120,7 +120,7 @@ Deno.test("players.service", async (t) => {
   );
 
   await t.step(
-    "generateAndPersist skips inserts for empty generator output",
+    "generate skips inserts for empty generator output",
     async () => {
       const { db, calls } = createMockDb();
       const generator = createMockGenerator();
@@ -131,7 +131,7 @@ Deno.test("players.service", async (t) => {
         log: createTestLogger(),
       });
 
-      const result = await service.generateAndPersist({
+      const result = await service.generate({
         leagueId: "l1",
         seasonId: "s1",
         teamIds: [],
@@ -147,7 +147,7 @@ Deno.test("players.service", async (t) => {
   );
 
   await t.step(
-    "generateAndPersist passes inserted players to contract generator",
+    "generate passes inserted players to contract generator",
     async () => {
       const { db } = createMockDb(["player-1"]);
       let contractsGeneratorReceivedPlayers:
@@ -173,7 +173,7 @@ Deno.test("players.service", async (t) => {
         log: createTestLogger(),
       });
 
-      await service.generateAndPersist({
+      await service.generate({
         leagueId: "l1",
         seasonId: "s1",
         teamIds: ["t1"],

--- a/server/features/players/players.service.ts
+++ b/server/features/players/players.service.ts
@@ -13,7 +13,7 @@ export function createPlayersService(deps: {
   const log = deps.log.child({ module: "players.service" });
 
   return {
-    async generateAndPersist(input) {
+    async generate(input) {
       log.info(
         { leagueId: input.leagueId, seasonId: input.seasonId },
         "generating players",

--- a/server/features/schedule/schedule.service.interface.ts
+++ b/server/features/schedule/schedule.service.interface.ts
@@ -11,7 +11,7 @@ export interface ScheduleGenerateResult {
 }
 
 export interface ScheduleService {
-  generateAndPersist(
+  generate(
     input: ScheduleGenerateInput,
   ): Promise<ScheduleGenerateResult>;
 }

--- a/server/features/schedule/schedule.service.test.ts
+++ b/server/features/schedule/schedule.service.test.ts
@@ -45,7 +45,7 @@ const TEAMS: TeamDivisionInfo[] = [
 
 Deno.test("schedule.service", async (t) => {
   await t.step(
-    "generateAndPersist inserts generated games and returns count",
+    "generate inserts generated games and returns count",
     async () => {
       const { db, calls } = createMockDb();
       const generator: ScheduleGenerator = {
@@ -71,7 +71,7 @@ Deno.test("schedule.service", async (t) => {
         log: createTestLogger(),
       });
 
-      const result = await service.generateAndPersist({
+      const result = await service.generate({
         seasonId: "s1",
         teams: TEAMS,
         seasonLength: 17,
@@ -84,7 +84,7 @@ Deno.test("schedule.service", async (t) => {
   );
 
   await t.step(
-    "generateAndPersist skips insert when generator returns no games",
+    "generate skips insert when generator returns no games",
     async () => {
       const { db, calls } = createMockDb();
       const generator: ScheduleGenerator = {
@@ -97,7 +97,7 @@ Deno.test("schedule.service", async (t) => {
         log: createTestLogger(),
       });
 
-      const result = await service.generateAndPersist({
+      const result = await service.generate({
         seasonId: "s1",
         teams: TEAMS,
         seasonLength: 17,
@@ -108,7 +108,7 @@ Deno.test("schedule.service", async (t) => {
     },
   );
 
-  await t.step("generateAndPersist forwards input to generator", async () => {
+  await t.step("generate forwards input to generator", async () => {
     const { db } = createMockDb();
     let receivedInput:
       | { seasonId: string; teams: TeamDivisionInfo[]; seasonLength: number }
@@ -126,7 +126,7 @@ Deno.test("schedule.service", async (t) => {
       log: createTestLogger(),
     });
 
-    await service.generateAndPersist({
+    await service.generate({
       seasonId: "s1",
       teams: TEAMS,
       seasonLength: 17,

--- a/server/features/schedule/schedule.service.ts
+++ b/server/features/schedule/schedule.service.ts
@@ -12,7 +12,7 @@ export function createScheduleService(deps: {
   const log = deps.log.child({ module: "schedule.service" });
 
   return {
-    async generateAndPersist(input) {
+    async generate(input) {
       log.info({ seasonId: input.seasonId }, "generating schedule");
 
       const generatedGames = deps.generator.generate({

--- a/server/features/scouts/scouts.service.interface.ts
+++ b/server/features/scouts/scouts.service.interface.ts
@@ -8,5 +8,5 @@ export interface ScoutsGenerateResult {
 }
 
 export interface ScoutsService {
-  generateAndPersist(input: ScoutsGenerateInput): Promise<ScoutsGenerateResult>;
+  generate(input: ScoutsGenerateInput): Promise<ScoutsGenerateResult>;
 }

--- a/server/features/scouts/scouts.service.test.ts
+++ b/server/features/scouts/scouts.service.test.ts
@@ -46,7 +46,7 @@ function createMockDb(): {
 
 Deno.test("scouts.service", async (t) => {
   await t.step(
-    "generateAndPersist inserts generated scouts and returns count",
+    "generate inserts generated scouts and returns count",
     async () => {
       const { db, calls } = createMockDb();
       const generator = createMockGenerator({
@@ -62,7 +62,7 @@ Deno.test("scouts.service", async (t) => {
         log: createTestLogger(),
       });
 
-      const result = await service.generateAndPersist({
+      const result = await service.generate({
         leagueId: "l1",
         teamIds: ["t1"],
       });
@@ -73,7 +73,7 @@ Deno.test("scouts.service", async (t) => {
   );
 
   await t.step(
-    "generateAndPersist skips insert when generator returns empty",
+    "generate skips insert when generator returns empty",
     async () => {
       const { db, calls } = createMockDb();
       const generator = createMockGenerator();
@@ -84,7 +84,7 @@ Deno.test("scouts.service", async (t) => {
         log: createTestLogger(),
       });
 
-      const result = await service.generateAndPersist({
+      const result = await service.generate({
         leagueId: "l1",
         teamIds: [],
       });

--- a/server/features/scouts/scouts.service.ts
+++ b/server/features/scouts/scouts.service.ts
@@ -12,7 +12,7 @@ export function createScoutsService(deps: {
   const log = deps.log.child({ module: "scouts.service" });
 
   return {
-    async generateAndPersist(input) {
+    async generate(input) {
       log.info({ leagueId: input.leagueId }, "generating scouts");
 
       const generated = deps.generator.generate({


### PR DESCRIPTION
## Summary
- Renames `generateAndPersist` → `generate` across all seven services (players, coaches, scouts, front-office, personnel, schedule, league) plus their interfaces and tests.
- Motivation: the old name leaked the persistence mechanism into the public contract and the `And` signaled a method doing two things. Services should name *intent*, not *mechanics* — callers don't need to know whether the result is backed by a DB, an event log, or memory. Persistence stays inside the service where it belongs.
- Chose `generate` over `create` because this is procedural/sim generation (scouts, schedules, coaches produced algorithmically), which matches the domain's ubiquitous language better than user-initiated creation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)