### PR TITLE
feat(headshot): add placeholder NPC silhouette component

### DIFF
--- a/client/src/components/headshot.test.tsx
+++ b/client/src/components/headshot.test.tsx
@@ -1,0 +1,47 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import { Headshot } from "./headshot.tsx";
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("Headshot", () => {
+  it("renders an svg element", () => {
+    const { container } = render(<Headshot name="Jane Doe" />);
+    expect(container.querySelector("svg")).not.toBeNull();
+  });
+
+  it("labels the portrait with the subject's name for assistive tech", () => {
+    render(<Headshot name="Jane Doe" />);
+    expect(screen.getByLabelText("Headshot of Jane Doe")).toBeDefined();
+  });
+
+  it("exposes an img role when a name is provided", () => {
+    render(<Headshot name="Jane Doe" />);
+    expect(screen.getByRole("img", { name: "Headshot of Jane Doe" }))
+      .toBeDefined();
+  });
+
+  it("hides the portrait from assistive tech when decorative", () => {
+    const { container } = render(<Headshot decorative />);
+    const svg = container.querySelector("svg");
+    expect(svg?.getAttribute("aria-hidden")).toBe("true");
+    expect(svg?.getAttribute("aria-label")).toBeNull();
+  });
+
+  it("forwards className to the svg for sizing and theming", () => {
+    const { container } = render(
+      <Headshot name="Jane Doe" className="size-10 text-muted-foreground" />,
+    );
+    const svg = container.querySelector("svg");
+    expect(svg?.getAttribute("class")).toContain("size-10");
+    expect(svg?.getAttribute("class")).toContain("text-muted-foreground");
+  });
+
+  it("uses currentColor so the silhouette inherits the parent text color", () => {
+    const { container } = render(<Headshot name="Jane Doe" />);
+    const svg = container.querySelector("svg");
+    expect(svg?.innerHTML).toContain("currentColor");
+  });
+});

--- a/client/src/components/headshot.tsx
+++ b/client/src/components/headshot.tsx
@@ -1,0 +1,27 @@
+type HeadshotProps =
+  & { className?: string }
+  & (
+    | { name: string; decorative?: false }
+    | { name?: undefined; decorative: true }
+  );
+
+export function Headshot({ name, decorative, className }: HeadshotProps) {
+  const a11y = decorative
+    ? { "aria-hidden": true as const }
+    : { role: "img" as const, "aria-label": `Headshot of ${name}` };
+
+  return (
+    <svg
+      viewBox="0 0 64 64"
+      xmlns="http://www.w3.org/2000/svg"
+      className={className}
+      {...a11y}
+    >
+      <circle cx="32" cy="22" r="12" fill="currentColor" />
+      <path
+        d="M8 60c0-12 10.75-20 24-20s24 8 24 20z"
+        fill="currentColor"
+      />
+    </svg>
+  );
+}

--- a/docs/product/decisions/0004-npc-portraits.md
+++ b/docs/product/decisions/0004-npc-portraits.md
@@ -1,0 +1,98 @@
+# 0004 — NPC portraits: generic silhouette placeholder
+
+- **Date:** 2026-04-13
+- **Status:** Accepted
+- **Area:** cross-cutting — applies to any surface that renders a person
+  (players, coaches, scouts, owners). See
+  [`../north-star/player-attributes.md`](../north-star/player-attributes.md),
+  [`../north-star/coaches.md`](../north-star/coaches.md).
+
+## Context
+
+Roster, coach, and scout surfaces all render rows of NPCs. Right now those rows
+are text-only, which reads as a spreadsheet rather than a league full of people.
+A portrait slot — even a placeholder — changes the feel of every inspection
+surface we've shipped (0001, 0002, 0003) from "data table" to "dossier."
+
+We also don't yet know the right art direction. The realistic options range from
+stylized SVG layer compositing (OOTP/Football Manager aesthetic) to a
+pre-generated photoreal headshot pool (AI-generated once, assigned by seed) to
+full on-demand AI generation. Each has a different art and cost profile, and
+we'd be guessing at the answer before we've seen portraits in place on a real
+surface.
+
+## Decision
+
+Ship a single, generic **head-and-shoulders silhouette** SVG as the portrait for
+every NPC, everywhere a portrait slot exists. Same asset for every person — no
+per-NPC variation yet. The component accepts a size and themes via
+`currentColor`; it takes no player/coach data as input beyond what's needed for
+the accessible label (name, role).
+
+This is a deliberate placeholder. It establishes the portrait slot in the UI
+without committing to an art direction or spending art/AI budget before we know
+where portraits pull their weight.
+
+## Requirements
+
+- A reusable `Headshot` component in `client/src/components/`.
+- Renders a filled bust silhouette (head + shoulders, no features) via inline
+  SVG with `viewBox` so it scales cleanly.
+- Uses `currentColor` for the silhouette fill so it inherits theme/team accent
+  colors from its parent.
+- Accepts a size prop (or className pass-through) to render at roster-row size,
+  detail-page-header size, and anywhere in between.
+- Ships with an accessible label derived from the subject's name (e.g.
+  `aria-label="Headshot of {name}"`), or `aria-hidden` when rendered purely
+  decoratively alongside a visible name.
+- Same silhouette for every NPC. No seeding, no variation, no
+  male/female/position differentiation yet.
+- No network calls, no external image URLs, no build-time asset pipeline. The
+  SVG is inline in the component.
+
+## Out of scope
+
+- Per-NPC variation of any kind (procedural, seeded, AI-generated, or
+  hand-authored).
+- Gender, ethnicity, age, or position-based portrait differentiation.
+- Uploading or customizing portraits (not a feature we've scoped).
+- A portrait for team logos, stadiums, or non-person entities — those have their
+  own visual identity decisions.
+- Deciding the eventual real portrait system (layered SVG vs. pre-generated AI
+  pool vs. on-demand generation). That is a separate future decision informed by
+  what we learn with the placeholder in place.
+
+## Alternatives considered
+
+- **Ship nothing, keep text-only rows** — rejected. Leaves roster/coach/scout
+  surfaces feeling like spreadsheets and delays learning where portraits matter.
+  A placeholder is cheap enough that "wait until we have real portraits" is the
+  wrong tradeoff.
+- **Use a DiceBear style (Personas, Micah) as the placeholder** — rejected for
+  now. DiceBear styles are biased toward young, slim, hipster-leaning aesthetics
+  that read wrong on a 34-year-old nose tackle or a grizzled DC. If we seed
+  per-NPC portraits with a style that's visibly off, the placeholder stops
+  reading as a placeholder and starts making design claims we haven't made. A
+  single neutral silhouette reads unambiguously as "not yet filled in."
+- **Layered SVG compositing with AI-generated layer assets** — rejected as
+  premature. This is a plausible eventual direction, but committing art
+  direction and generation pipeline before we've validated the surface value of
+  portraits is backwards.
+- **Pre-generated AI headshot pool, assigned by seed** — rejected as premature
+  for the same reason. Likely the right answer for photoreal, but the
+  placeholder decision shouldn't presuppose the final one.
+
+## Consequences
+
+- Every inspection surface (roster, coach detail, scout detail, opponent roster,
+  player detail) can add a portrait slot today without waiting on art.
+- The UI will have identical silhouettes repeated across every row. That is the
+  correct signal — it makes the "we haven't shipped real portraits yet" state
+  obvious instead of hiding it behind procedural variety that looks
+  almost-but-not-quite right.
+- When we revisit real portraits, the component boundary is already in place:
+  swap the SVG contents (or accept a seed/URL prop) without touching call sites.
+- Future PRD will decide the real portrait system. Inputs to that decision:
+  which surfaces actually benefit from per-NPC identity (likely player detail
+  and coach detail first), what art budget we're willing to spend, and whether
+  we want stylized-custom or photoreal-pooled as the aesthetic.

--- a/docs/product/decisions/README.md
+++ b/docs/product/decisions/README.md
@@ -24,3 +24,5 @@ as superseded.
 - [0003 — Scouts page: org chart tree + scout detail view](./0003-scouts-page.md)
   — rename "Scouting" nav to "Scouts"; staff inspection surface, no accuracy
   numbers
+- [0004 — NPC portraits: generic silhouette placeholder](./0004-npc-portraits.md)
+  — one shared head-and-shoulders SVG for every NPC; defer real portrait system


### PR DESCRIPTION
## Summary

- Adds a reusable `Headshot` component that renders a single generic head-and-shoulders SVG silhouette for every NPC. Themes via `currentColor`, sized via `className`.
- Records the decision in [`docs/product/decisions/0004-npc-portraits.md`](./docs/product/decisions/0004-npc-portraits.md) — deliberate placeholder so inspection surfaces can add a portrait slot now without committing to an art direction (layered SVG vs. pre-generated AI pool vs. on-demand generation) before we see portraits in place.
- Component-only PR. Wiring into coach/roster/scout surfaces will follow in separate PRs per the one-logical-change rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)