### PR TITLE
docs(claude): reference backlog and session follow-up guidance

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,6 +38,11 @@
   React SPA structure, feature/flow/component organization, shadcn/ui usage.
 - **Incidents:** [`docs/incidents/`](./docs/incidents/) — postmortems with root
   cause analysis and action items.
+- **Backlog:** [`docs/backlog.md`](./docs/backlog.md) — lightweight list of
+  follow-ups and small ideas. Promote entries to issues or full docs once they
+  outgrow a one-liner. When you notice a follow-up during a session (deferred
+  cleanup, a rough edge spotted in passing, a decision we punted on), append a
+  dated bullet here rather than letting it drop.
 
 ## Testing
 


### PR DESCRIPTION
## Summary
- Add `docs/backlog.md` to the Documentation section in `CLAUDE.md`.
- Instruct Claude to append dated bullets to the backlog when follow-ups surface mid-session, so deferred cleanup and rough edges aren't dropped.