### PR TITLE
feat(coaches): model full staff hierarchy, bio, and career-history tables

### DIFF
--- a/packages/shared/mod.ts
+++ b/packages/shared/mod.ts
@@ -9,7 +9,12 @@ export type {
 export type { Team } from "./types/team.ts";
 export type { NewSeason, Season, SeasonPhase } from "./types/season.ts";
 export type { FrontOfficeStaff } from "./types/front-office.ts";
-export type { Coach } from "./types/coach.ts";
+export type {
+  Coach,
+  CoachPlayCaller,
+  CoachRole,
+  CoachSpecialty,
+} from "./types/coach.ts";
 export type { Scout } from "./types/scout.ts";
 export type { Contract, DraftProspect, Player } from "./types/player.ts";
 export type { Game } from "./types/game.ts";

--- a/packages/shared/types/coach.ts
+++ b/packages/shared/types/coach.ts
@@ -1,9 +1,52 @@
+export type CoachRole =
+  | "HC"
+  | "OC"
+  | "DC"
+  | "STC"
+  | "QB"
+  | "RB"
+  | "WR"
+  | "TE"
+  | "OL"
+  | "DL"
+  | "LB"
+  | "DB"
+  | "ST_ASSISTANT";
+
+export type CoachPlayCaller = "offense" | "defense" | "ceo";
+
+export type CoachSpecialty =
+  | "offense"
+  | "defense"
+  | "special_teams"
+  | "quarterbacks"
+  | "running_backs"
+  | "wide_receivers"
+  | "tight_ends"
+  | "offensive_line"
+  | "defensive_line"
+  | "linebackers"
+  | "defensive_backs"
+  | "ceo";
+
 export interface Coach {
   id: string;
   leagueId: string;
   teamId: string;
   firstName: string;
   lastName: string;
+  role: CoachRole;
+  reportsToId: string | null;
+  playCaller: CoachPlayCaller | null;
+  age: number;
+  hiredAt: Date;
+  contractYears: number;
+  contractSalary: number;
+  contractBuyout: number;
+  collegeId: string | null;
+  specialty: CoachSpecialty | null;
+  isVacancy: boolean;
+  mentorCoachId: string | null;
   createdAt: Date;
   updatedAt: Date;
 }

--- a/server/db/migrations/0010_huge_jean_grey.sql
+++ b/server/db/migrations/0010_huge_jean_grey.sql
@@ -1,0 +1,108 @@
+-- The new coach shape is not backfill-compatible with the stub-generator
+-- rows from the previous schema (no role, no hierarchy, no contract data).
+-- Wipe existing records so NOT NULL columns can be added safely; leagues
+-- will regenerate their staff under the new shape on next seed.
+DELETE FROM "coaches";--> statement-breakpoint
+CREATE TYPE "public"."coach_accolade_type" AS ENUM('coy_vote', 'championship', 'position_pro_bowl', 'other');--> statement-breakpoint
+CREATE TYPE "public"."coach_play_caller" AS ENUM('offense', 'defense', 'ceo');--> statement-breakpoint
+CREATE TYPE "public"."coach_role" AS ENUM('HC', 'OC', 'DC', 'STC', 'QB', 'RB', 'WR', 'TE', 'OL', 'DL', 'LB', 'DB', 'ST_ASSISTANT');--> statement-breakpoint
+CREATE TYPE "public"."coach_specialty" AS ENUM('offense', 'defense', 'special_teams', 'quarterbacks', 'running_backs', 'wide_receivers', 'tight_ends', 'offensive_line', 'defensive_line', 'linebackers', 'defensive_backs', 'ceo');--> statement-breakpoint
+CREATE TYPE "public"."coach_connection_relation" AS ENUM('mentor', 'mentee', 'peer');--> statement-breakpoint
+CREATE TYPE "public"."coach_player_dev_delta" AS ENUM('improved', 'stagnated', 'regressed');--> statement-breakpoint
+CREATE TYPE "public"."coach_tenure_unit_side" AS ENUM('offense', 'defense', 'special_teams');--> statement-breakpoint
+CREATE TABLE "coach_accolades" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"coach_id" uuid NOT NULL,
+	"season" integer NOT NULL,
+	"type" "coach_accolade_type" NOT NULL,
+	"detail" text NOT NULL,
+	"created_at" timestamp DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "coach_career_stops" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"coach_id" uuid NOT NULL,
+	"team_id" uuid,
+	"team_name" text NOT NULL,
+	"role" text NOT NULL,
+	"start_year" integer NOT NULL,
+	"end_year" integer,
+	"team_wins" integer,
+	"team_losses" integer,
+	"team_ties" integer,
+	"unit_rank" integer,
+	"unit_side" "coach_tenure_unit_side",
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"updated_at" timestamp DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "coach_connections" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"coach_id" uuid NOT NULL,
+	"other_coach_id" uuid NOT NULL,
+	"relation" "coach_connection_relation" NOT NULL,
+	"created_at" timestamp DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "coach_depth_chart_notes" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"coach_id" uuid NOT NULL,
+	"season" integer NOT NULL,
+	"note" text NOT NULL,
+	"created_at" timestamp DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "coach_reputation_labels" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"coach_id" uuid NOT NULL,
+	"label" text NOT NULL,
+	"created_at" timestamp DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "coach_tenure_player_dev" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"coach_id" uuid NOT NULL,
+	"player_id" uuid NOT NULL,
+	"season" integer NOT NULL,
+	"delta" "coach_player_dev_delta" NOT NULL,
+	"note" text,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"updated_at" timestamp DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "coach_tenure_unit_performance" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"coach_id" uuid NOT NULL,
+	"season" integer NOT NULL,
+	"unit_side" "coach_tenure_unit_side" NOT NULL,
+	"rank" integer NOT NULL,
+	"metrics" jsonb,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"updated_at" timestamp DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "coaches" ADD COLUMN "role" "coach_role" NOT NULL;--> statement-breakpoint
+ALTER TABLE "coaches" ADD COLUMN "reports_to_id" uuid;--> statement-breakpoint
+ALTER TABLE "coaches" ADD COLUMN "play_caller" "coach_play_caller";--> statement-breakpoint
+ALTER TABLE "coaches" ADD COLUMN "age" integer NOT NULL;--> statement-breakpoint
+ALTER TABLE "coaches" ADD COLUMN "hired_at" timestamp NOT NULL;--> statement-breakpoint
+ALTER TABLE "coaches" ADD COLUMN "contract_years" integer NOT NULL;--> statement-breakpoint
+ALTER TABLE "coaches" ADD COLUMN "contract_salary" integer NOT NULL;--> statement-breakpoint
+ALTER TABLE "coaches" ADD COLUMN "contract_buyout" integer NOT NULL;--> statement-breakpoint
+ALTER TABLE "coaches" ADD COLUMN "college_id" uuid;--> statement-breakpoint
+ALTER TABLE "coaches" ADD COLUMN "specialty" "coach_specialty";--> statement-breakpoint
+ALTER TABLE "coaches" ADD COLUMN "is_vacancy" boolean DEFAULT false NOT NULL;--> statement-breakpoint
+ALTER TABLE "coaches" ADD COLUMN "mentor_coach_id" uuid;--> statement-breakpoint
+ALTER TABLE "coach_accolades" ADD CONSTRAINT "coach_accolades_coach_id_coaches_id_fk" FOREIGN KEY ("coach_id") REFERENCES "public"."coaches"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "coach_career_stops" ADD CONSTRAINT "coach_career_stops_coach_id_coaches_id_fk" FOREIGN KEY ("coach_id") REFERENCES "public"."coaches"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "coach_career_stops" ADD CONSTRAINT "coach_career_stops_team_id_teams_id_fk" FOREIGN KEY ("team_id") REFERENCES "public"."teams"("id") ON DELETE set null ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "coach_connections" ADD CONSTRAINT "coach_connections_coach_id_coaches_id_fk" FOREIGN KEY ("coach_id") REFERENCES "public"."coaches"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "coach_connections" ADD CONSTRAINT "coach_connections_other_coach_id_coaches_id_fk" FOREIGN KEY ("other_coach_id") REFERENCES "public"."coaches"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "coach_depth_chart_notes" ADD CONSTRAINT "coach_depth_chart_notes_coach_id_coaches_id_fk" FOREIGN KEY ("coach_id") REFERENCES "public"."coaches"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "coach_reputation_labels" ADD CONSTRAINT "coach_reputation_labels_coach_id_coaches_id_fk" FOREIGN KEY ("coach_id") REFERENCES "public"."coaches"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "coach_tenure_player_dev" ADD CONSTRAINT "coach_tenure_player_dev_coach_id_coaches_id_fk" FOREIGN KEY ("coach_id") REFERENCES "public"."coaches"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "coach_tenure_player_dev" ADD CONSTRAINT "coach_tenure_player_dev_player_id_players_id_fk" FOREIGN KEY ("player_id") REFERENCES "public"."players"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "coach_tenure_unit_performance" ADD CONSTRAINT "coach_tenure_unit_performance_coach_id_coaches_id_fk" FOREIGN KEY ("coach_id") REFERENCES "public"."coaches"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "coaches" ADD CONSTRAINT "coaches_reports_to_id_coaches_id_fk" FOREIGN KEY ("reports_to_id") REFERENCES "public"."coaches"("id") ON DELETE set null ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "coaches" ADD CONSTRAINT "coaches_college_id_colleges_id_fk" FOREIGN KEY ("college_id") REFERENCES "public"."colleges"("id") ON DELETE set null ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "coaches" ADD CONSTRAINT "coaches_mentor_coach_id_coaches_id_fk" FOREIGN KEY ("mentor_coach_id") REFERENCES "public"."coaches"("id") ON DELETE set null ON UPDATE no action;

--- a/server/db/migrations/meta/0010_snapshot.json
+++ b/server/db/migrations/meta/0010_snapshot.json
@@ -1,0 +1,2067 @@
+{
+  "id": "5ced0229-b93c-4f02-aa56-b6fd0839ea29",
+  "prevId": "443bc676-facd-4870-a50d-ad291c2e1239",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.accounts": {
+      "name": "accounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "accounts_user_id_users_id_fk": {
+          "name": "accounts_user_id_users_id_fk",
+          "tableFrom": "accounts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.coach_accolades": {
+      "name": "coach_accolades",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "coach_id": {
+          "name": "coach_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "season": {
+          "name": "season",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "coach_accolade_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "detail": {
+          "name": "detail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "coach_accolades_coach_id_coaches_id_fk": {
+          "name": "coach_accolades_coach_id_coaches_id_fk",
+          "tableFrom": "coach_accolades",
+          "tableTo": "coaches",
+          "columnsFrom": [
+            "coach_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.coach_career_stops": {
+      "name": "coach_career_stops",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "coach_id": {
+          "name": "coach_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "team_name": {
+          "name": "team_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_year": {
+          "name": "start_year",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_year": {
+          "name": "end_year",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "team_wins": {
+          "name": "team_wins",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "team_losses": {
+          "name": "team_losses",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "team_ties": {
+          "name": "team_ties",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "unit_rank": {
+          "name": "unit_rank",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "unit_side": {
+          "name": "unit_side",
+          "type": "coach_tenure_unit_side",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "coach_career_stops_coach_id_coaches_id_fk": {
+          "name": "coach_career_stops_coach_id_coaches_id_fk",
+          "tableFrom": "coach_career_stops",
+          "tableTo": "coaches",
+          "columnsFrom": [
+            "coach_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "coach_career_stops_team_id_teams_id_fk": {
+          "name": "coach_career_stops_team_id_teams_id_fk",
+          "tableFrom": "coach_career_stops",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.coach_connections": {
+      "name": "coach_connections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "coach_id": {
+          "name": "coach_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "other_coach_id": {
+          "name": "other_coach_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "relation": {
+          "name": "relation",
+          "type": "coach_connection_relation",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "coach_connections_coach_id_coaches_id_fk": {
+          "name": "coach_connections_coach_id_coaches_id_fk",
+          "tableFrom": "coach_connections",
+          "tableTo": "coaches",
+          "columnsFrom": [
+            "coach_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "coach_connections_other_coach_id_coaches_id_fk": {
+          "name": "coach_connections_other_coach_id_coaches_id_fk",
+          "tableFrom": "coach_connections",
+          "tableTo": "coaches",
+          "columnsFrom": [
+            "other_coach_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.coach_depth_chart_notes": {
+      "name": "coach_depth_chart_notes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "coach_id": {
+          "name": "coach_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "season": {
+          "name": "season",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "coach_depth_chart_notes_coach_id_coaches_id_fk": {
+          "name": "coach_depth_chart_notes_coach_id_coaches_id_fk",
+          "tableFrom": "coach_depth_chart_notes",
+          "tableTo": "coaches",
+          "columnsFrom": [
+            "coach_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.coach_reputation_labels": {
+      "name": "coach_reputation_labels",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "coach_id": {
+          "name": "coach_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "coach_reputation_labels_coach_id_coaches_id_fk": {
+          "name": "coach_reputation_labels_coach_id_coaches_id_fk",
+          "tableFrom": "coach_reputation_labels",
+          "tableTo": "coaches",
+          "columnsFrom": [
+            "coach_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.coach_tenure_player_dev": {
+      "name": "coach_tenure_player_dev",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "coach_id": {
+          "name": "coach_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "player_id": {
+          "name": "player_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "season": {
+          "name": "season",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "delta": {
+          "name": "delta",
+          "type": "coach_player_dev_delta",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "coach_tenure_player_dev_coach_id_coaches_id_fk": {
+          "name": "coach_tenure_player_dev_coach_id_coaches_id_fk",
+          "tableFrom": "coach_tenure_player_dev",
+          "tableTo": "coaches",
+          "columnsFrom": [
+            "coach_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "coach_tenure_player_dev_player_id_players_id_fk": {
+          "name": "coach_tenure_player_dev_player_id_players_id_fk",
+          "tableFrom": "coach_tenure_player_dev",
+          "tableTo": "players",
+          "columnsFrom": [
+            "player_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.coach_tenure_unit_performance": {
+      "name": "coach_tenure_unit_performance",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "coach_id": {
+          "name": "coach_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "season": {
+          "name": "season",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "unit_side": {
+          "name": "unit_side",
+          "type": "coach_tenure_unit_side",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rank": {
+          "name": "rank",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metrics": {
+          "name": "metrics",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "coach_tenure_unit_performance_coach_id_coaches_id_fk": {
+          "name": "coach_tenure_unit_performance_coach_id_coaches_id_fk",
+          "tableFrom": "coach_tenure_unit_performance",
+          "tableTo": "coaches",
+          "columnsFrom": [
+            "coach_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.coaches": {
+      "name": "coaches",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "league_id": {
+          "name": "league_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "coach_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reports_to_id": {
+          "name": "reports_to_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "play_caller": {
+          "name": "play_caller",
+          "type": "coach_play_caller",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "age": {
+          "name": "age",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hired_at": {
+          "name": "hired_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contract_years": {
+          "name": "contract_years",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contract_salary": {
+          "name": "contract_salary",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contract_buyout": {
+          "name": "contract_buyout",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "college_id": {
+          "name": "college_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "specialty": {
+          "name": "specialty",
+          "type": "coach_specialty",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_vacancy": {
+          "name": "is_vacancy",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "mentor_coach_id": {
+          "name": "mentor_coach_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "coaches_league_id_leagues_id_fk": {
+          "name": "coaches_league_id_leagues_id_fk",
+          "tableFrom": "coaches",
+          "tableTo": "leagues",
+          "columnsFrom": [
+            "league_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "coaches_team_id_teams_id_fk": {
+          "name": "coaches_team_id_teams_id_fk",
+          "tableFrom": "coaches",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "coaches_reports_to_id_coaches_id_fk": {
+          "name": "coaches_reports_to_id_coaches_id_fk",
+          "tableFrom": "coaches",
+          "tableTo": "coaches",
+          "columnsFrom": [
+            "reports_to_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "coaches_college_id_colleges_id_fk": {
+          "name": "coaches_college_id_colleges_id_fk",
+          "tableFrom": "coaches",
+          "tableTo": "colleges",
+          "columnsFrom": [
+            "college_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "coaches_mentor_coach_id_coaches_id_fk": {
+          "name": "coaches_mentor_coach_id_coaches_id_fk",
+          "tableFrom": "coaches",
+          "tableTo": "coaches",
+          "columnsFrom": [
+            "mentor_coach_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.colleges": {
+      "name": "colleges",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "short_name": {
+          "name": "short_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "nickname": {
+          "name": "nickname",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "city": {
+          "name": "city",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conference": {
+          "name": "conference",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subdivision": {
+          "name": "subdivision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "colleges_name_unique": {
+          "name": "colleges_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.contracts": {
+      "name": "contracts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "player_id": {
+          "name": "player_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_years": {
+          "name": "total_years",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "current_year": {
+          "name": "current_year",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "total_salary": {
+          "name": "total_salary",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "annual_salary": {
+          "name": "annual_salary",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "guaranteed_money": {
+          "name": "guaranteed_money",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "signing_bonus": {
+          "name": "signing_bonus",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "contracts_player_id_players_id_fk": {
+          "name": "contracts_player_id_players_id_fk",
+          "tableFrom": "contracts",
+          "tableTo": "players",
+          "columnsFrom": [
+            "player_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "contracts_team_id_teams_id_fk": {
+          "name": "contracts_team_id_teams_id_fk",
+          "tableFrom": "contracts",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.draft_prospects": {
+      "name": "draft_prospects",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "season_id": {
+          "name": "season_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "draft_prospects_season_id_seasons_id_fk": {
+          "name": "draft_prospects_season_id_seasons_id_fk",
+          "tableFrom": "draft_prospects",
+          "tableTo": "seasons",
+          "columnsFrom": [
+            "season_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.front_office_staff": {
+      "name": "front_office_staff",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "league_id": {
+          "name": "league_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "front_office_staff_league_id_leagues_id_fk": {
+          "name": "front_office_staff_league_id_leagues_id_fk",
+          "tableFrom": "front_office_staff",
+          "tableTo": "leagues",
+          "columnsFrom": [
+            "league_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "front_office_staff_team_id_teams_id_fk": {
+          "name": "front_office_staff_team_id_teams_id_fk",
+          "tableFrom": "front_office_staff",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.games": {
+      "name": "games",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "season_id": {
+          "name": "season_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "week": {
+          "name": "week",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "home_team_id": {
+          "name": "home_team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "away_team_id": {
+          "name": "away_team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "games_season_id_seasons_id_fk": {
+          "name": "games_season_id_seasons_id_fk",
+          "tableFrom": "games",
+          "tableTo": "seasons",
+          "columnsFrom": [
+            "season_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "games_home_team_id_teams_id_fk": {
+          "name": "games_home_team_id_teams_id_fk",
+          "tableFrom": "games",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "home_team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "games_away_team_id_teams_id_fk": {
+          "name": "games_away_team_id_teams_id_fk",
+          "tableFrom": "games",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "away_team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.health_checks": {
+      "name": "health_checks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "checked_at": {
+          "name": "checked_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.leagues": {
+      "name": "leagues",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "number_of_teams": {
+          "name": "number_of_teams",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 32
+        },
+        "season_length": {
+          "name": "season_length",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 17
+        },
+        "salary_cap": {
+          "name": "salary_cap",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 255000000
+        },
+        "cap_floor_percent": {
+          "name": "cap_floor_percent",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 89
+        },
+        "cap_growth_rate": {
+          "name": "cap_growth_rate",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 5
+        },
+        "roster_size": {
+          "name": "roster_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 53
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.players": {
+      "name": "players",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "league_id": {
+          "name": "league_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "players_league_id_leagues_id_fk": {
+          "name": "players_league_id_leagues_id_fk",
+          "tableFrom": "players",
+          "tableTo": "leagues",
+          "columnsFrom": [
+            "league_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "players_team_id_teams_id_fk": {
+          "name": "players_team_id_teams_id_fk",
+          "tableFrom": "players",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.scouts": {
+      "name": "scouts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "league_id": {
+          "name": "league_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "scouts_league_id_leagues_id_fk": {
+          "name": "scouts_league_id_leagues_id_fk",
+          "tableFrom": "scouts",
+          "tableTo": "leagues",
+          "columnsFrom": [
+            "league_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "scouts_team_id_teams_id_fk": {
+          "name": "scouts_team_id_teams_id_fk",
+          "tableFrom": "scouts",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.seasons": {
+      "name": "seasons",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "league_id": {
+          "name": "league_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "year": {
+          "name": "year",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "phase": {
+          "name": "phase",
+          "type": "season_phase",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'preseason'"
+        },
+        "week": {
+          "name": "week",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "seasons_league_id_leagues_id_fk": {
+          "name": "seasons_league_id_leagues_id_fk",
+          "tableFrom": "seasons",
+          "tableTo": "leagues",
+          "columnsFrom": [
+            "league_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "sessions_token_unique": {
+          "name": "sessions_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.teams": {
+      "name": "teams",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "city": {
+          "name": "city",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "abbreviation": {
+          "name": "abbreviation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "primary_color": {
+          "name": "primary_color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "secondary_color": {
+          "name": "secondary_color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "accent_color": {
+          "name": "accent_color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conference": {
+          "name": "conference",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "division": {
+          "name": "division",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "teams_abbreviation_unique": {
+          "name": "teams_abbreviation_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "abbreviation"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verifications": {
+      "name": "verifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.coach_accolade_type": {
+      "name": "coach_accolade_type",
+      "schema": "public",
+      "values": [
+        "coy_vote",
+        "championship",
+        "position_pro_bowl",
+        "other"
+      ]
+    },
+    "public.coach_play_caller": {
+      "name": "coach_play_caller",
+      "schema": "public",
+      "values": [
+        "offense",
+        "defense",
+        "ceo"
+      ]
+    },
+    "public.coach_role": {
+      "name": "coach_role",
+      "schema": "public",
+      "values": [
+        "HC",
+        "OC",
+        "DC",
+        "STC",
+        "QB",
+        "RB",
+        "WR",
+        "TE",
+        "OL",
+        "DL",
+        "LB",
+        "DB",
+        "ST_ASSISTANT"
+      ]
+    },
+    "public.coach_specialty": {
+      "name": "coach_specialty",
+      "schema": "public",
+      "values": [
+        "offense",
+        "defense",
+        "special_teams",
+        "quarterbacks",
+        "running_backs",
+        "wide_receivers",
+        "tight_ends",
+        "offensive_line",
+        "defensive_line",
+        "linebackers",
+        "defensive_backs",
+        "ceo"
+      ]
+    },
+    "public.coach_connection_relation": {
+      "name": "coach_connection_relation",
+      "schema": "public",
+      "values": [
+        "mentor",
+        "mentee",
+        "peer"
+      ]
+    },
+    "public.coach_player_dev_delta": {
+      "name": "coach_player_dev_delta",
+      "schema": "public",
+      "values": [
+        "improved",
+        "stagnated",
+        "regressed"
+      ]
+    },
+    "public.season_phase": {
+      "name": "season_phase",
+      "schema": "public",
+      "values": [
+        "preseason",
+        "regular_season",
+        "playoffs",
+        "offseason"
+      ]
+    },
+    "public.coach_tenure_unit_side": {
+      "name": "coach_tenure_unit_side",
+      "schema": "public",
+      "values": [
+        "offense",
+        "defense",
+        "special_teams"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/server/db/migrations/meta/_journal.json
+++ b/server/db/migrations/meta/_journal.json
@@ -71,6 +71,13 @@
       "when": 1776128690160,
       "tag": "0009_numerous_starjammers",
       "breakpoints": true
+    },
+    {
+      "idx": 10,
+      "version": "7",
+      "when": 1776129271101,
+      "tag": "0010_huge_jean_grey",
+      "breakpoints": true
     }
   ]
 }

--- a/server/db/schema.ts
+++ b/server/db/schema.ts
@@ -12,7 +12,25 @@ export { teams } from "../features/team/team.schema.ts";
 export { colleges } from "../features/colleges/college.schema.ts";
 export { seasonPhaseEnum, seasons } from "../features/season/season.schema.ts";
 export { frontOfficeStaff } from "../features/front-office/front-office.schema.ts";
-export { coaches } from "../features/coaches/coach.schema.ts";
+export {
+  coaches,
+  coachPlayCallerEnum,
+  coachRoleEnum,
+  coachSpecialtyEnum,
+} from "../features/coaches/coach.schema.ts";
+export {
+  accoladeTypeEnum,
+  coachAccolades,
+  coachCareerStops,
+  coachConnections,
+  coachDepthChartNotes,
+  coachReputationLabels,
+  coachTenurePlayerDev,
+  coachTenureUnitPerformance,
+  connectionRelationEnum,
+  playerDevDeltaEnum,
+  tenureUnitSideEnum,
+} from "../features/coaches/coach-history.schema.ts";
 export { scouts } from "../features/scouts/scout.schema.ts";
 export { draftProspects, players } from "../features/players/player.schema.ts";
 export { contracts } from "../features/players/contract.schema.ts";

--- a/server/features/coaches/coach-history.schema.ts
+++ b/server/features/coaches/coach-history.schema.ts
@@ -1,0 +1,162 @@
+import type { AnyPgColumn } from "drizzle-orm/pg-core";
+import {
+  integer,
+  jsonb,
+  pgEnum,
+  pgTable,
+  text,
+  timestamp,
+  uuid,
+} from "drizzle-orm/pg-core";
+import { coaches } from "./coach.schema.ts";
+import { players } from "../players/player.schema.ts";
+import { teams } from "../team/team.schema.ts";
+
+export const tenureUnitSideEnum = pgEnum("coach_tenure_unit_side", [
+  "offense",
+  "defense",
+  "special_teams",
+]);
+
+export const playerDevDeltaEnum = pgEnum("coach_player_dev_delta", [
+  "improved",
+  "stagnated",
+  "regressed",
+]);
+
+export const accoladeTypeEnum = pgEnum("coach_accolade_type", [
+  "coy_vote",
+  "championship",
+  "position_pro_bowl",
+  "other",
+]);
+
+export const connectionRelationEnum = pgEnum("coach_connection_relation", [
+  "mentor",
+  "mentee",
+  "peer",
+]);
+
+/**
+ * A stop on a coach's career resume — previous (or current) team, role,
+ * years, and the team's record or unit rank during his tenure where
+ * applicable. Public-record data only.
+ */
+export const coachCareerStops = pgTable("coach_career_stops", {
+  id: uuid("id").defaultRandom().primaryKey(),
+  coachId: uuid("coach_id")
+    .notNull()
+    .references(() => coaches.id, { onDelete: "cascade" }),
+  teamId: uuid("team_id").references(() => teams.id, {
+    onDelete: "set null",
+  }),
+  teamName: text("team_name").notNull(),
+  role: text("role").notNull(),
+  startYear: integer("start_year").notNull(),
+  endYear: integer("end_year"),
+  teamWins: integer("team_wins"),
+  teamLosses: integer("team_losses"),
+  teamTies: integer("team_ties"),
+  unitRank: integer("unit_rank"),
+  unitSide: tenureUnitSideEnum("unit_side"),
+  createdAt: timestamp("created_at").defaultNow().notNull(),
+  updatedAt: timestamp("updated_at").defaultNow().notNull(),
+});
+
+/**
+ * League-generated reputation labels (e.g. "offensive innovator",
+ * "players' coach"). Labels only, no numeric backing.
+ */
+export const coachReputationLabels = pgTable("coach_reputation_labels", {
+  id: uuid("id").defaultRandom().primaryKey(),
+  coachId: uuid("coach_id")
+    .notNull()
+    .references(() => coaches.id, { onDelete: "cascade" }),
+  label: text("label").notNull(),
+  createdAt: timestamp("created_at").defaultNow().notNull(),
+});
+
+/**
+ * Season-by-season unit performance for a coach under his current team.
+ * `metrics` holds scheme tendencies (run-pass split, blitz rate, formation
+ * usage — whatever applies to the role).
+ */
+export const coachTenureUnitPerformance = pgTable(
+  "coach_tenure_unit_performance",
+  {
+    id: uuid("id").defaultRandom().primaryKey(),
+    coachId: uuid("coach_id")
+      .notNull()
+      .references(() => coaches.id, { onDelete: "cascade" }),
+    season: integer("season").notNull(),
+    unitSide: tenureUnitSideEnum("unit_side").notNull(),
+    rank: integer("rank").notNull(),
+    metrics: jsonb("metrics"),
+    createdAt: timestamp("created_at").defaultNow().notNull(),
+    updatedAt: timestamp("updated_at").defaultNow().notNull(),
+  },
+);
+
+/**
+ * Per-player development trajectory under a coach for a given season —
+ * improved / stagnated / regressed, with optional flavor note.
+ */
+export const coachTenurePlayerDev = pgTable("coach_tenure_player_dev", {
+  id: uuid("id").defaultRandom().primaryKey(),
+  coachId: uuid("coach_id")
+    .notNull()
+    .references(() => coaches.id, { onDelete: "cascade" }),
+  playerId: uuid("player_id")
+    .notNull()
+    .references(() => players.id, { onDelete: "cascade" }),
+  season: integer("season").notNull(),
+  delta: playerDevDeltaEnum("delta").notNull(),
+  note: text("note"),
+  createdAt: timestamp("created_at").defaultNow().notNull(),
+  updatedAt: timestamp("updated_at").defaultNow().notNull(),
+});
+
+/**
+ * Awards, votes, championships, Pro Bowl selections attributable to a
+ * coach's position group.
+ */
+export const coachAccolades = pgTable("coach_accolades", {
+  id: uuid("id").defaultRandom().primaryKey(),
+  coachId: uuid("coach_id")
+    .notNull()
+    .references(() => coaches.id, { onDelete: "cascade" }),
+  season: integer("season").notNull(),
+  type: accoladeTypeEnum("type").notNull(),
+  detail: text("detail").notNull(),
+  createdAt: timestamp("created_at").defaultNow().notNull(),
+});
+
+/**
+ * Flavor notes about notable depth-chart decisions (e.g. "started the
+ * veteran over the rookie for N games").
+ */
+export const coachDepthChartNotes = pgTable("coach_depth_chart_notes", {
+  id: uuid("id").defaultRandom().primaryKey(),
+  coachId: uuid("coach_id")
+    .notNull()
+    .references(() => coaches.id, { onDelete: "cascade" }),
+  season: integer("season").notNull(),
+  note: text("note").notNull(),
+  createdAt: timestamp("created_at").defaultNow().notNull(),
+});
+
+/**
+ * Coach-to-coach connections: mentor / mentee / peer. Powers the
+ * "coaching tree lineage" and "connections" sections on the detail page.
+ */
+export const coachConnections = pgTable("coach_connections", {
+  id: uuid("id").defaultRandom().primaryKey(),
+  coachId: uuid("coach_id")
+    .notNull()
+    .references(() => coaches.id, { onDelete: "cascade" }),
+  otherCoachId: uuid("other_coach_id")
+    .notNull()
+    .references((): AnyPgColumn => coaches.id, { onDelete: "cascade" }),
+  relation: connectionRelationEnum("relation").notNull(),
+  createdAt: timestamp("created_at").defaultNow().notNull(),
+});

--- a/server/features/coaches/coach.schema.ts
+++ b/server/features/coaches/coach.schema.ts
@@ -1,6 +1,53 @@
-import { pgTable, text, timestamp, uuid } from "drizzle-orm/pg-core";
+import type { AnyPgColumn } from "drizzle-orm/pg-core";
+import {
+  boolean,
+  integer,
+  pgEnum,
+  pgTable,
+  text,
+  timestamp,
+  uuid,
+} from "drizzle-orm/pg-core";
 import { leagues } from "../league/league.schema.ts";
 import { teams } from "../team/team.schema.ts";
+import { colleges } from "../colleges/college.schema.ts";
+
+export const coachRoleEnum = pgEnum("coach_role", [
+  "HC",
+  "OC",
+  "DC",
+  "STC",
+  "QB",
+  "RB",
+  "WR",
+  "TE",
+  "OL",
+  "DL",
+  "LB",
+  "DB",
+  "ST_ASSISTANT",
+]);
+
+export const coachPlayCallerEnum = pgEnum("coach_play_caller", [
+  "offense",
+  "defense",
+  "ceo",
+]);
+
+export const coachSpecialtyEnum = pgEnum("coach_specialty", [
+  "offense",
+  "defense",
+  "special_teams",
+  "quarterbacks",
+  "running_backs",
+  "wide_receivers",
+  "tight_ends",
+  "offensive_line",
+  "defensive_line",
+  "linebackers",
+  "defensive_backs",
+  "ceo",
+]);
 
 export const coaches = pgTable("coaches", {
   id: uuid("id").defaultRandom().primaryKey(),
@@ -12,6 +59,26 @@ export const coaches = pgTable("coaches", {
     .references(() => teams.id, { onDelete: "cascade" }),
   firstName: text("first_name").notNull(),
   lastName: text("last_name").notNull(),
+  role: coachRoleEnum("role").notNull(),
+  reportsToId: uuid("reports_to_id").references(
+    (): AnyPgColumn => coaches.id,
+    { onDelete: "set null" },
+  ),
+  playCaller: coachPlayCallerEnum("play_caller"),
+  age: integer("age").notNull(),
+  hiredAt: timestamp("hired_at").notNull(),
+  contractYears: integer("contract_years").notNull(),
+  contractSalary: integer("contract_salary").notNull(),
+  contractBuyout: integer("contract_buyout").notNull(),
+  collegeId: uuid("college_id").references(() => colleges.id, {
+    onDelete: "set null",
+  }),
+  specialty: coachSpecialtyEnum("specialty"),
+  isVacancy: boolean("is_vacancy").notNull().default(false),
+  mentorCoachId: uuid("mentor_coach_id").references(
+    (): AnyPgColumn => coaches.id,
+    { onDelete: "set null" },
+  ),
   createdAt: timestamp("created_at").defaultNow().notNull(),
   updatedAt: timestamp("updated_at").defaultNow().notNull(),
 });

--- a/server/features/coaches/coaches.generator.interface.ts
+++ b/server/features/coaches/coaches.generator.interface.ts
@@ -3,9 +3,20 @@ import type { Coach } from "@zone-blitz/shared";
 export interface CoachesGeneratorInput {
   leagueId: string;
   teamIds: string[];
+  /**
+   * Optional pool of college ids used to assign `collegeId` to generated
+   * coaches. When empty, coaches are generated with `collegeId: null`.
+   */
+  collegeIds?: string[];
 }
 
-export type GeneratedCoach = Omit<Coach, "id" | "createdAt" | "updatedAt">;
+/**
+ * A coach record as produced by the generator — the shape of a row ready
+ * for insertion into the `coaches` table. `id` is pre-assigned so that
+ * `reportsToId` and `mentorCoachId` can reference siblings without a
+ * post-insert stitching pass.
+ */
+export type GeneratedCoach = Omit<Coach, "createdAt" | "updatedAt">;
 
 export interface CoachesGenerator {
   generate(input: CoachesGeneratorInput): GeneratedCoach[];

--- a/server/features/coaches/coaches.service.test.ts
+++ b/server/features/coaches/coaches.service.test.ts
@@ -49,10 +49,26 @@ Deno.test("coaches.service", async (t) => {
     "generate inserts generated coaches and returns count",
     async () => {
       const { db, calls } = createMockDb();
+      const base = {
+        leagueId: "l1",
+        teamId: "t1",
+        role: "HC" as const,
+        reportsToId: null,
+        playCaller: "offense" as const,
+        age: 50,
+        hiredAt: new Date(),
+        contractYears: 3,
+        contractSalary: 1_000_000,
+        contractBuyout: 1_000_000,
+        collegeId: null,
+        specialty: "ceo" as const,
+        isVacancy: false,
+        mentorCoachId: null,
+      };
       const generator = createMockGenerator({
         generate: () => [
-          { leagueId: "l1", teamId: "t1", firstName: "A", lastName: "B" },
-          { leagueId: "l1", teamId: "t1", firstName: "C", lastName: "D" },
+          { ...base, id: "c1", firstName: "A", lastName: "B" },
+          { ...base, id: "c2", firstName: "C", lastName: "D" },
         ],
       });
 

--- a/server/features/coaches/stub-coaches-generator.test.ts
+++ b/server/features/coaches/stub-coaches-generator.test.ts
@@ -1,4 +1,5 @@
-import { assertEquals } from "@std/assert";
+import { assertEquals, assertNotEquals } from "@std/assert";
+import type { CoachRole } from "@zone-blitz/shared";
 import { createStubCoachesGenerator } from "./stub-coaches-generator.ts";
 
 const TEAM_IDS = ["team-1", "team-2", "team-3"];
@@ -7,25 +8,148 @@ const INPUT = {
   teamIds: TEAM_IDS,
 };
 
-Deno.test("generates coaches for each team", () => {
+const COACHES_PER_TEAM = 13;
+
+const EXPECTED_ROLES: CoachRole[] = [
+  "HC",
+  "OC",
+  "DC",
+  "STC",
+  "QB",
+  "RB",
+  "WR",
+  "TE",
+  "OL",
+  "DL",
+  "LB",
+  "DB",
+  "ST_ASSISTANT",
+];
+
+Deno.test("generates a full staff per team", () => {
   const generator = createStubCoachesGenerator();
   const result = generator.generate(INPUT);
 
-  assertEquals(result.length, TEAM_IDS.length * 5);
+  assertEquals(result.length, TEAM_IDS.length * COACHES_PER_TEAM);
   for (const teamId of TEAM_IDS) {
     const teamCoaches = result.filter((c) => c.teamId === teamId);
-    assertEquals(teamCoaches.length, 5);
+    assertEquals(teamCoaches.length, COACHES_PER_TEAM);
+    const roles = new Set(teamCoaches.map((c) => c.role));
+    for (const role of EXPECTED_ROLES) {
+      assertEquals(roles.has(role), true, `team ${teamId} missing ${role}`);
+    }
   }
 });
 
-Deno.test("all coaches have the correct leagueId and non-empty names", () => {
+Deno.test("each team has exactly one head coach", () => {
   const generator = createStubCoachesGenerator();
   const result = generator.generate(INPUT);
+  for (const teamId of TEAM_IDS) {
+    const hcs = result.filter((c) => c.teamId === teamId && c.role === "HC");
+    assertEquals(hcs.length, 1);
+  }
+});
 
+Deno.test("head coach has no reportsTo and non-null play caller", () => {
+  const generator = createStubCoachesGenerator();
+  const result = generator.generate(INPUT);
+  const hcs = result.filter((c) => c.role === "HC");
+  for (const hc of hcs) {
+    assertEquals(hc.reportsToId, null);
+    assertNotEquals(hc.playCaller, null);
+  }
+});
+
+Deno.test("coordinators report to their head coach", () => {
+  const generator = createStubCoachesGenerator();
+  const result = generator.generate(INPUT);
+  for (const teamId of TEAM_IDS) {
+    const teamCoaches = result.filter((c) => c.teamId === teamId);
+    const hc = teamCoaches.find((c) => c.role === "HC");
+    const coordinators = teamCoaches.filter((c) =>
+      c.role === "OC" || c.role === "DC" || c.role === "STC"
+    );
+    assertEquals(coordinators.length, 3);
+    for (const coord of coordinators) {
+      assertEquals(coord.reportsToId, hc?.id);
+      assertEquals(coord.playCaller, null);
+    }
+  }
+});
+
+Deno.test("offensive position coaches report to OC", () => {
+  const generator = createStubCoachesGenerator();
+  const result = generator.generate(INPUT);
+  const offensiveRoles: CoachRole[] = ["QB", "RB", "WR", "TE", "OL"];
+  for (const teamId of TEAM_IDS) {
+    const teamCoaches = result.filter((c) => c.teamId === teamId);
+    const oc = teamCoaches.find((c) => c.role === "OC");
+    for (const role of offensiveRoles) {
+      const coach = teamCoaches.find((c) => c.role === role);
+      assertEquals(coach?.reportsToId, oc?.id);
+    }
+  }
+});
+
+Deno.test("defensive position coaches report to DC", () => {
+  const generator = createStubCoachesGenerator();
+  const result = generator.generate(INPUT);
+  const defensiveRoles: CoachRole[] = ["DL", "LB", "DB"];
+  for (const teamId of TEAM_IDS) {
+    const teamCoaches = result.filter((c) => c.teamId === teamId);
+    const dc = teamCoaches.find((c) => c.role === "DC");
+    for (const role of defensiveRoles) {
+      const coach = teamCoaches.find((c) => c.role === role);
+      assertEquals(coach?.reportsToId, dc?.id);
+    }
+  }
+});
+
+Deno.test("special teams assistant reports to STC", () => {
+  const generator = createStubCoachesGenerator();
+  const result = generator.generate(INPUT);
+  for (const teamId of TEAM_IDS) {
+    const teamCoaches = result.filter((c) => c.teamId === teamId);
+    const stc = teamCoaches.find((c) => c.role === "STC");
+    const sta = teamCoaches.find((c) => c.role === "ST_ASSISTANT");
+    assertEquals(sta?.reportsToId, stc?.id);
+  }
+});
+
+Deno.test("all coaches have the correct leagueId, non-empty names, plausible age", () => {
+  const generator = createStubCoachesGenerator();
+  const result = generator.generate(INPUT);
   for (const coach of result) {
     assertEquals(coach.leagueId, INPUT.leagueId);
     assertEquals(coach.firstName.length > 0, true);
     assertEquals(coach.lastName.length > 0, true);
+    assertEquals(coach.age >= 30 && coach.age <= 75, true);
+    assertEquals(coach.contractYears >= 1, true);
+    assertEquals(coach.isVacancy, false);
+  }
+});
+
+Deno.test("coaches have unique ids", () => {
+  const generator = createStubCoachesGenerator();
+  const result = generator.generate(INPUT);
+  const ids = new Set(result.map((c) => c.id));
+  assertEquals(ids.size, result.length);
+});
+
+Deno.test("coaches get a college when a pool is provided", () => {
+  const generator = createStubCoachesGenerator();
+  const collegeIds = ["college-a", "college-b"];
+  const result = generator.generate({ ...INPUT, collegeIds });
+  for (const coach of result) {
+    assertEquals(collegeIds.includes(coach.collegeId ?? ""), true);
+  }
+});
+
+Deno.test("coaches have null college when no pool is provided", () => {
+  const generator = createStubCoachesGenerator();
+  const result = generator.generate(INPUT);
+  for (const coach of result) {
+    assertEquals(coach.collegeId, null);
   }
 });
 

--- a/server/features/coaches/stub-coaches-generator.ts
+++ b/server/features/coaches/stub-coaches-generator.ts
@@ -1,3 +1,4 @@
+import type { CoachRole, CoachSpecialty } from "@zone-blitz/shared";
 import type {
   CoachesGenerator,
   CoachesGeneratorInput,
@@ -30,7 +31,135 @@ const LAST_NAMES = [
   "Martinez",
 ];
 
-const COACHES_PER_TEAM = 5;
+interface RoleSpec {
+  role: CoachRole;
+  specialty: CoachSpecialty;
+  age: number;
+  contractYears: number;
+  contractSalary: number;
+  contractBuyout: number;
+  reportsTo: "HC" | "OC" | "DC" | "STC" | null;
+}
+
+const STAFF_BLUEPRINT: RoleSpec[] = [
+  {
+    role: "HC",
+    specialty: "ceo",
+    age: 52,
+    contractYears: 4,
+    contractSalary: 10_000_000,
+    contractBuyout: 20_000_000,
+    reportsTo: null,
+  },
+  {
+    role: "OC",
+    specialty: "offense",
+    age: 48,
+    contractYears: 3,
+    contractSalary: 3_500_000,
+    contractBuyout: 5_000_000,
+    reportsTo: "HC",
+  },
+  {
+    role: "DC",
+    specialty: "defense",
+    age: 49,
+    contractYears: 3,
+    contractSalary: 3_500_000,
+    contractBuyout: 5_000_000,
+    reportsTo: "HC",
+  },
+  {
+    role: "STC",
+    specialty: "special_teams",
+    age: 47,
+    contractYears: 2,
+    contractSalary: 1_500_000,
+    contractBuyout: 2_000_000,
+    reportsTo: "HC",
+  },
+  {
+    role: "QB",
+    specialty: "quarterbacks",
+    age: 42,
+    contractYears: 2,
+    contractSalary: 1_200_000,
+    contractBuyout: 1_500_000,
+    reportsTo: "OC",
+  },
+  {
+    role: "RB",
+    specialty: "running_backs",
+    age: 41,
+    contractYears: 2,
+    contractSalary: 900_000,
+    contractBuyout: 1_000_000,
+    reportsTo: "OC",
+  },
+  {
+    role: "WR",
+    specialty: "wide_receivers",
+    age: 43,
+    contractYears: 2,
+    contractSalary: 900_000,
+    contractBuyout: 1_000_000,
+    reportsTo: "OC",
+  },
+  {
+    role: "TE",
+    specialty: "tight_ends",
+    age: 40,
+    contractYears: 2,
+    contractSalary: 800_000,
+    contractBuyout: 900_000,
+    reportsTo: "OC",
+  },
+  {
+    role: "OL",
+    specialty: "offensive_line",
+    age: 50,
+    contractYears: 3,
+    contractSalary: 1_400_000,
+    contractBuyout: 1_800_000,
+    reportsTo: "OC",
+  },
+  {
+    role: "DL",
+    specialty: "defensive_line",
+    age: 46,
+    contractYears: 2,
+    contractSalary: 1_100_000,
+    contractBuyout: 1_300_000,
+    reportsTo: "DC",
+  },
+  {
+    role: "LB",
+    specialty: "linebackers",
+    age: 44,
+    contractYears: 2,
+    contractSalary: 1_000_000,
+    contractBuyout: 1_200_000,
+    reportsTo: "DC",
+  },
+  {
+    role: "DB",
+    specialty: "defensive_backs",
+    age: 45,
+    contractYears: 2,
+    contractSalary: 1_000_000,
+    contractBuyout: 1_200_000,
+    reportsTo: "DC",
+  },
+  {
+    role: "ST_ASSISTANT",
+    specialty: "special_teams",
+    age: 38,
+    contractYears: 1,
+    contractSalary: 450_000,
+    contractBuyout: 450_000,
+    reportsTo: "STC",
+  },
+];
 
 function randomName(index: number) {
   const firstName = FIRST_NAMES[index % FIRST_NAMES.length];
@@ -42,19 +171,52 @@ function randomName(index: number) {
 export function createStubCoachesGenerator(): CoachesGenerator {
   return {
     generate(input: CoachesGeneratorInput): GeneratedCoach[] {
-      let nameIndex = 0;
       const coaches: GeneratedCoach[] = [];
+      const now = new Date();
+      let nameIndex = 0;
+      let collegeIndex = 0;
+      const pool = input.collegeIds ?? [];
+
       for (const teamId of input.teamIds) {
-        for (let i = 0; i < COACHES_PER_TEAM; i++) {
+        const idsByRole = new Map<CoachRole, string>();
+        for (const spec of STAFF_BLUEPRINT) {
+          idsByRole.set(spec.role, crypto.randomUUID());
+        }
+
+        for (const spec of STAFF_BLUEPRINT) {
           const { firstName, lastName } = randomName(nameIndex++);
+          const id = idsByRole.get(spec.role)!;
+          const reportsToId = spec.reportsTo === null
+            ? null
+            : idsByRole.get(spec.reportsTo)!;
+          const hiredAt = new Date(now);
+          hiredAt.setFullYear(hiredAt.getFullYear() - spec.contractYears + 1);
+          const collegeId = pool.length > 0
+            ? pool[collegeIndex++ % pool.length]
+            : null;
+
           coaches.push({
+            id,
             leagueId: input.leagueId,
             teamId,
             firstName,
             lastName,
+            role: spec.role,
+            reportsToId,
+            playCaller: spec.role === "HC" ? "offense" : null,
+            age: spec.age,
+            hiredAt,
+            contractYears: spec.contractYears,
+            contractSalary: spec.contractSalary,
+            contractBuyout: spec.contractBuyout,
+            collegeId,
+            specialty: spec.specialty,
+            isVacancy: false,
+            mentorCoachId: null,
           });
         }
       }
+
       return coaches;
     },
   };


### PR DESCRIPTION
## Summary

- Extends the `coaches` table with role, reports-to self-FK, play-caller, age, hired-at, contract terms, college FK, specialty, vacancy flag, and mentor self-FK — the fields the coaches page (ADR 0002) needs to render a staff tree and coach detail view.
- Adds seven per-coach history tables (career stops, reputation labels, tenure unit performance, tenure player dev, accolades, depth-chart notes, coach connections) so the sim has a place to publish the career artifacts the detail page will surface.
- Enhances the stub generator to produce a full 13-person staff per team with correct reporting relationships (HC → coordinators → position coaches).
- Migration wipes existing coach rows before adding NOT NULL columns — the new shape is not backfill-compatible with the prior stub-only rows.
- Pure schema + generator work; no routes yet. Read API comes in the next PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)