### PR TITLE
feat(coaches): read API for staff tree and coach detail

### DIFF
--- a/packages/shared/mod.ts
+++ b/packages/shared/mod.ts
@@ -11,9 +11,19 @@ export type { NewSeason, Season, SeasonPhase } from "./types/season.ts";
 export type { FrontOfficeStaff } from "./types/front-office.ts";
 export type {
   Coach,
+  CoachAccolade,
+  CoachCareerStop,
+  CoachCollege,
+  CoachConnection,
+  CoachDepthChartNote,
+  CoachDetail,
+  CoachNode,
   CoachPlayCaller,
   CoachRole,
   CoachSpecialty,
+  CoachSummary,
+  CoachTenurePlayerDev,
+  CoachTenureUnitSeason,
 } from "./types/coach.ts";
 export type { Scout } from "./types/scout.ts";
 export type { Contract, DraftProspect, Player } from "./types/player.ts";

--- a/packages/shared/types/coach.ts
+++ b/packages/shared/types/coach.ts
@@ -29,6 +29,121 @@ export type CoachSpecialty =
   | "defensive_backs"
   | "ceo";
 
+/**
+ * Minimal coach reference used where a full Coach would be overkill —
+ * e.g. a mentor stub, a connection target, or a coaching-tree lineage
+ * node. Contains nothing the ADR's non-goals forbid (no OVR, no grade,
+ * no attribute reveals).
+ */
+export interface CoachSummary {
+  id: string;
+  firstName: string;
+  lastName: string;
+  role: CoachRole;
+}
+
+export interface CoachCollege {
+  id: string;
+  shortName: string;
+  nickname: string;
+  conference: string;
+}
+
+/**
+ * A node in the staff tree. Flat shape with `reportsToId`; the client
+ * assembles the tree. No numeric rating, grade, tier, or OVR.
+ */
+export interface CoachNode {
+  id: string;
+  firstName: string;
+  lastName: string;
+  role: CoachRole;
+  reportsToId: string | null;
+  playCaller: CoachPlayCaller | null;
+  specialty: CoachSpecialty | null;
+  age: number;
+  yearsWithTeam: number;
+  contractYearsRemaining: number;
+  isVacancy: boolean;
+}
+
+export interface CoachCareerStop {
+  id: string;
+  teamName: string;
+  role: string;
+  startYear: number;
+  endYear: number | null;
+  teamWins: number | null;
+  teamLosses: number | null;
+  teamTies: number | null;
+  unitRank: number | null;
+  unitSide: "offense" | "defense" | "special_teams" | null;
+}
+
+export interface CoachTenureUnitSeason {
+  season: number;
+  unitSide: "offense" | "defense" | "special_teams";
+  rank: number;
+  metrics: Record<string, unknown> | null;
+}
+
+export interface CoachTenurePlayerDev {
+  playerId: string;
+  season: number;
+  delta: "improved" | "stagnated" | "regressed";
+  note: string | null;
+}
+
+export interface CoachAccolade {
+  id: string;
+  season: number;
+  type: "coy_vote" | "championship" | "position_pro_bowl" | "other";
+  detail: string;
+}
+
+export interface CoachDepthChartNote {
+  id: string;
+  season: number;
+  note: string;
+}
+
+export interface CoachConnection {
+  relation: "mentor" | "mentee" | "peer";
+  coach: CoachSummary;
+}
+
+/**
+ * The full coach detail payload. Purely public record: bio fields,
+ * resume, reputation labels (strings, never numeric), tenure results,
+ * accolades, connections. Hidden-attribute tables must never be joined
+ * into this aggregate.
+ */
+export interface CoachDetail {
+  id: string;
+  leagueId: string;
+  teamId: string;
+  firstName: string;
+  lastName: string;
+  role: CoachRole;
+  specialty: CoachSpecialty | null;
+  playCaller: CoachPlayCaller | null;
+  age: number;
+  yearsWithTeam: number;
+  contractYearsRemaining: number;
+  contractSalary: number;
+  contractBuyout: number;
+  isVacancy: boolean;
+  college: CoachCollege | null;
+  mentor: CoachSummary | null;
+  reputationLabels: string[];
+  careerStops: CoachCareerStop[];
+  tenureUnitPerformance: CoachTenureUnitSeason[];
+  tenurePlayerDev: CoachTenurePlayerDev[];
+  accolades: CoachAccolade[];
+  depthChartNotes: CoachDepthChartNote[];
+  connections: CoachConnection[];
+}
+
 export interface Coach {
   id: string;
   leagueId: string;

--- a/server/features/coaches/coaches.repository.interface.ts
+++ b/server/features/coaches/coaches.repository.interface.ts
@@ -1,0 +1,16 @@
+import type { CoachDetail, CoachNode } from "@zone-blitz/shared";
+
+export interface CoachesRepository {
+  /**
+   * Returns every coach on a team as a flat list of staff-tree nodes.
+   * The client builds the hierarchy from `reportsToId`.
+   */
+  getStaffTreeByTeam(teamId: string): Promise<CoachNode[]>;
+
+  /**
+   * Returns the full public-record detail view for a single coach,
+   * aggregating resume, reputation, tenure results, accolades, and
+   * connections. Resolves to `undefined` when no coach has the given id.
+   */
+  getCoachDetailById(id: string): Promise<CoachDetail | undefined>;
+}

--- a/server/features/coaches/coaches.repository.test.ts
+++ b/server/features/coaches/coaches.repository.test.ts
@@ -1,0 +1,299 @@
+import { assertEquals } from "@std/assert";
+import { drizzle } from "drizzle-orm/postgres-js";
+import { eq, inArray } from "drizzle-orm";
+import postgres from "postgres";
+import pino from "pino";
+import * as schema from "../../db/schema.ts";
+import { coaches } from "./coach.schema.ts";
+import {
+  coachAccolades,
+  coachCareerStops,
+  coachConnections,
+  coachDepthChartNotes,
+  coachReputationLabels,
+  coachTenureUnitPerformance,
+} from "./coach-history.schema.ts";
+import { colleges } from "../colleges/college.schema.ts";
+import { leagues } from "../league/league.schema.ts";
+import { teams } from "../team/team.schema.ts";
+import { createCoachesRepository } from "./coaches.repository.ts";
+
+function createTestDb() {
+  const connectionString = Deno.env.get("DATABASE_URL");
+  if (!connectionString) {
+    throw new Error("DATABASE_URL is required for integration tests");
+  }
+  const client = postgres(connectionString);
+  const db = drizzle(client, { schema });
+  return { db, client };
+}
+
+function createTestLogger() {
+  return pino({ level: "silent" });
+}
+
+async function setupFixtures(db: ReturnType<typeof createTestDb>["db"]) {
+  const [league] = await db
+    .insert(leagues)
+    .values({ name: `League ${crypto.randomUUID()}` })
+    .returning();
+  const [team] = await db
+    .insert(teams)
+    .values({
+      name: "Test Team",
+      city: "Testville",
+      abbreviation: `T${crypto.randomUUID().slice(0, 2).toUpperCase()}`,
+      primaryColor: "#000000",
+      secondaryColor: "#FFFFFF",
+      accentColor: "#FF0000",
+      conference: "AFC",
+      division: "AFC East",
+    })
+    .returning();
+  return { league, team };
+}
+
+Deno.test({
+  name: "coachesRepository.getStaffTreeByTeam: returns flat nodes for the team",
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    const { db, client } = createTestDb();
+    const repo = createCoachesRepository({
+      db,
+      log: createTestLogger(),
+      now: () => new Date("2030-01-01T00:00:00Z"),
+    });
+    const created: string[] = [];
+    const teamsCreated: string[] = [];
+    const leaguesCreated: string[] = [];
+
+    try {
+      const { league, team } = await setupFixtures(db);
+      leaguesCreated.push(league.id);
+      teamsCreated.push(team.id);
+
+      const hcId = crypto.randomUUID();
+      const ocId = crypto.randomUUID();
+      await db.insert(coaches).values([
+        {
+          id: hcId,
+          leagueId: league.id,
+          teamId: team.id,
+          firstName: "Head",
+          lastName: "Coach",
+          role: "HC",
+          reportsToId: null,
+          playCaller: "offense",
+          age: 50,
+          hiredAt: new Date("2027-01-01T00:00:00Z"),
+          contractYears: 3,
+          contractSalary: 10_000_000,
+          contractBuyout: 20_000_000,
+          specialty: "ceo",
+        },
+        {
+          id: ocId,
+          leagueId: league.id,
+          teamId: team.id,
+          firstName: "Off",
+          lastName: "Coord",
+          role: "OC",
+          reportsToId: hcId,
+          age: 45,
+          hiredAt: new Date("2028-01-01T00:00:00Z"),
+          contractYears: 2,
+          contractSalary: 3_000_000,
+          contractBuyout: 4_000_000,
+          specialty: "offense",
+        },
+      ]);
+      created.push(hcId, ocId);
+
+      const tree = await repo.getStaffTreeByTeam(team.id);
+      assertEquals(tree.length, 2);
+
+      const hc = tree.find((c) => c.id === hcId);
+      assertEquals(hc?.role, "HC");
+      assertEquals(hc?.reportsToId, null);
+      assertEquals(hc?.yearsWithTeam, 3);
+
+      const oc = tree.find((c) => c.id === ocId);
+      assertEquals(oc?.role, "OC");
+      assertEquals(oc?.reportsToId, hcId);
+      assertEquals(oc?.yearsWithTeam, 2);
+    } finally {
+      if (created.length > 0) {
+        await db.delete(coaches).where(inArray(coaches.id, created));
+      }
+      for (const id of teamsCreated) {
+        await db.delete(teams).where(eq(teams.id, id));
+      }
+      for (const id of leaguesCreated) {
+        await db.delete(leagues).where(eq(leagues.id, id));
+      }
+      await client.end();
+    }
+  },
+});
+
+Deno.test({
+  name:
+    "coachesRepository.getCoachDetailById: aggregates college, reputation, resume, tenure, accolades, depth-chart notes, and connections",
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    const { db, client } = createTestDb();
+    const repo = createCoachesRepository({
+      db,
+      log: createTestLogger(),
+      now: () => new Date("2030-01-01T00:00:00Z"),
+    });
+    const coachesCreated: string[] = [];
+    const teamsCreated: string[] = [];
+    const leaguesCreated: string[] = [];
+
+    try {
+      const { league, team } = await setupFixtures(db);
+      leaguesCreated.push(league.id);
+      teamsCreated.push(team.id);
+
+      const [college] = await db
+        .select()
+        .from(colleges)
+        .limit(1);
+
+      const mentorId = crypto.randomUUID();
+      const coachId = crypto.randomUUID();
+      const peerId = crypto.randomUUID();
+
+      await db.insert(coaches).values([
+        {
+          id: mentorId,
+          leagueId: league.id,
+          teamId: team.id,
+          firstName: "Mentor",
+          lastName: "Sr",
+          role: "HC",
+          age: 65,
+          hiredAt: new Date("2020-01-01T00:00:00Z"),
+          contractYears: 1,
+          contractSalary: 5_000_000,
+          contractBuyout: 0,
+        },
+        {
+          id: coachId,
+          leagueId: league.id,
+          teamId: team.id,
+          firstName: "Under",
+          lastName: "Study",
+          role: "OC",
+          age: 42,
+          hiredAt: new Date("2028-01-01T00:00:00Z"),
+          contractYears: 2,
+          contractSalary: 2_500_000,
+          contractBuyout: 3_000_000,
+          specialty: "offense",
+          collegeId: college?.id,
+          mentorCoachId: mentorId,
+        },
+        {
+          id: peerId,
+          leagueId: league.id,
+          teamId: team.id,
+          firstName: "Peer",
+          lastName: "Buddy",
+          role: "DC",
+          age: 43,
+          hiredAt: new Date("2028-01-01T00:00:00Z"),
+          contractYears: 2,
+          contractSalary: 2_500_000,
+          contractBuyout: 3_000_000,
+        },
+      ]);
+      coachesCreated.push(mentorId, coachId, peerId);
+
+      await db.insert(coachReputationLabels).values([
+        { coachId, label: "offensive innovator" },
+        { coachId, label: "players' coach" },
+      ]);
+      await db.insert(coachCareerStops).values({
+        coachId,
+        teamName: "State Tech",
+        role: "QB Coach",
+        startYear: 2018,
+        endYear: 2022,
+        teamWins: 42,
+        teamLosses: 20,
+        teamTies: 0,
+        unitRank: 7,
+        unitSide: "offense",
+      });
+      await db.insert(coachTenureUnitPerformance).values({
+        coachId,
+        season: 1,
+        unitSide: "offense",
+        rank: 3,
+        metrics: { runPassSplit: 0.42 },
+      });
+      await db.insert(coachAccolades).values({
+        coachId,
+        season: 1,
+        type: "coy_vote",
+        detail: "finished 3rd in COY voting",
+      });
+      await db.insert(coachDepthChartNotes).values({
+        coachId,
+        season: 1,
+        note: "started rookie over veteran for last 6 games",
+      });
+      await db.insert(coachConnections).values({
+        coachId,
+        otherCoachId: peerId,
+        relation: "peer",
+      });
+
+      const detail = await repo.getCoachDetailById(coachId);
+      assertEquals(detail?.id, coachId);
+      assertEquals(detail?.yearsWithTeam, 2);
+      assertEquals(detail?.mentor?.id, mentorId);
+      assertEquals(detail?.college?.id, college?.id);
+      assertEquals(detail?.reputationLabels.length, 2);
+      assertEquals(detail?.careerStops.length, 1);
+      assertEquals(detail?.careerStops[0].teamName, "State Tech");
+      assertEquals(detail?.tenureUnitPerformance.length, 1);
+      assertEquals(detail?.accolades.length, 1);
+      assertEquals(detail?.depthChartNotes.length, 1);
+      assertEquals(detail?.connections.length, 1);
+      assertEquals(detail?.connections[0].coach.id, peerId);
+    } finally {
+      if (coachesCreated.length > 0) {
+        await db.delete(coaches).where(inArray(coaches.id, coachesCreated));
+      }
+      for (const id of teamsCreated) {
+        await db.delete(teams).where(eq(teams.id, id));
+      }
+      for (const id of leaguesCreated) {
+        await db.delete(leagues).where(eq(leagues.id, id));
+      }
+      await client.end();
+    }
+  },
+});
+
+Deno.test({
+  name:
+    "coachesRepository.getCoachDetailById: returns undefined when not found",
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    const { db, client } = createTestDb();
+    const repo = createCoachesRepository({ db, log: createTestLogger() });
+    try {
+      const result = await repo.getCoachDetailById(crypto.randomUUID());
+      assertEquals(result, undefined);
+    } finally {
+      await client.end();
+    }
+  },
+});

--- a/server/features/coaches/coaches.repository.ts
+++ b/server/features/coaches/coaches.repository.ts
@@ -1,0 +1,244 @@
+import { eq } from "drizzle-orm";
+import type pino from "pino";
+import type {
+  CoachAccolade,
+  CoachCareerStop,
+  CoachConnection,
+  CoachDepthChartNote,
+  CoachDetail,
+  CoachNode,
+  CoachSummary,
+  CoachTenurePlayerDev,
+  CoachTenureUnitSeason,
+} from "@zone-blitz/shared";
+import type { Database } from "../../db/connection.ts";
+import { coaches } from "./coach.schema.ts";
+import {
+  coachAccolades,
+  coachCareerStops,
+  coachConnections,
+  coachDepthChartNotes,
+  coachReputationLabels,
+  coachTenurePlayerDev,
+  coachTenureUnitPerformance,
+} from "./coach-history.schema.ts";
+import { colleges } from "../colleges/college.schema.ts";
+import type { CoachesRepository } from "./coaches.repository.interface.ts";
+
+function yearsBetween(from: Date, to: Date): number {
+  const ms = to.getTime() - from.getTime();
+  const years = ms / (365.25 * 24 * 60 * 60 * 1000);
+  return Math.max(0, Math.floor(years));
+}
+
+export function createCoachesRepository(deps: {
+  db: Database;
+  log: pino.Logger;
+  /**
+   * Override for `now` in tests so `yearsWithTeam` is deterministic.
+   * Defaults to `() => new Date()`.
+   */
+  now?: () => Date;
+}): CoachesRepository {
+  const log = deps.log.child({ module: "coaches.repository" });
+  const now = deps.now ?? (() => new Date());
+
+  return {
+    async getStaffTreeByTeam(teamId) {
+      log.debug({ teamId }, "fetching staff tree");
+      const rows = await deps.db
+        .select()
+        .from(coaches)
+        .where(eq(coaches.teamId, teamId));
+      const today = now();
+      return rows.map((row): CoachNode => ({
+        id: row.id,
+        firstName: row.firstName,
+        lastName: row.lastName,
+        role: row.role,
+        reportsToId: row.reportsToId,
+        playCaller: row.playCaller,
+        specialty: row.specialty,
+        age: row.age,
+        yearsWithTeam: yearsBetween(row.hiredAt, today),
+        contractYearsRemaining: row.contractYears,
+        isVacancy: row.isVacancy,
+      }));
+    },
+
+    async getCoachDetailById(id) {
+      log.debug({ id }, "fetching coach detail");
+      const [row] = await deps.db
+        .select()
+        .from(coaches)
+        .where(eq(coaches.id, id))
+        .limit(1);
+      if (!row) return undefined;
+
+      const [
+        collegeRow,
+        mentorRow,
+        reputationRows,
+        careerStopRows,
+        tenurePerfRows,
+        tenureDevRows,
+        accoladeRows,
+        depthChartRows,
+        connectionRows,
+      ] = await Promise.all([
+        row.collegeId
+          ? deps.db
+            .select()
+            .from(colleges)
+            .where(eq(colleges.id, row.collegeId))
+            .limit(1)
+          : Promise.resolve([]),
+        row.mentorCoachId
+          ? deps.db
+            .select()
+            .from(coaches)
+            .where(eq(coaches.id, row.mentorCoachId))
+            .limit(1)
+          : Promise.resolve([]),
+        deps.db
+          .select()
+          .from(coachReputationLabels)
+          .where(eq(coachReputationLabels.coachId, id)),
+        deps.db
+          .select()
+          .from(coachCareerStops)
+          .where(eq(coachCareerStops.coachId, id)),
+        deps.db
+          .select()
+          .from(coachTenureUnitPerformance)
+          .where(eq(coachTenureUnitPerformance.coachId, id)),
+        deps.db
+          .select()
+          .from(coachTenurePlayerDev)
+          .where(eq(coachTenurePlayerDev.coachId, id)),
+        deps.db
+          .select()
+          .from(coachAccolades)
+          .where(eq(coachAccolades.coachId, id)),
+        deps.db
+          .select()
+          .from(coachDepthChartNotes)
+          .where(eq(coachDepthChartNotes.coachId, id)),
+        deps.db
+          .select({
+            relation: coachConnections.relation,
+            id: coaches.id,
+            firstName: coaches.firstName,
+            lastName: coaches.lastName,
+            role: coaches.role,
+          })
+          .from(coachConnections)
+          .innerJoin(coaches, eq(coachConnections.otherCoachId, coaches.id))
+          .where(eq(coachConnections.coachId, id)),
+      ]);
+
+      const today = now();
+      const college = collegeRow[0];
+      const mentor = mentorRow[0];
+
+      const careerStops: CoachCareerStop[] = careerStopRows.map((stop) => ({
+        id: stop.id,
+        teamName: stop.teamName,
+        role: stop.role,
+        startYear: stop.startYear,
+        endYear: stop.endYear,
+        teamWins: stop.teamWins,
+        teamLosses: stop.teamLosses,
+        teamTies: stop.teamTies,
+        unitRank: stop.unitRank,
+        unitSide: stop.unitSide,
+      }));
+
+      const tenureUnitPerformance: CoachTenureUnitSeason[] = tenurePerfRows
+        .map((p) => ({
+          season: p.season,
+          unitSide: p.unitSide,
+          rank: p.rank,
+          metrics: p.metrics as Record<string, unknown> | null,
+        }));
+
+      const tenurePlayerDev: CoachTenurePlayerDev[] = tenureDevRows.map(
+        (d) => ({
+          playerId: d.playerId,
+          season: d.season,
+          delta: d.delta,
+          note: d.note,
+        }),
+      );
+
+      const accolades: CoachAccolade[] = accoladeRows.map((a) => ({
+        id: a.id,
+        season: a.season,
+        type: a.type,
+        detail: a.detail,
+      }));
+
+      const depthChartNotes: CoachDepthChartNote[] = depthChartRows.map((
+        n,
+      ) => ({
+        id: n.id,
+        season: n.season,
+        note: n.note,
+      }));
+
+      const connections: CoachConnection[] = connectionRows.map((c) => ({
+        relation: c.relation,
+        coach: {
+          id: c.id,
+          firstName: c.firstName,
+          lastName: c.lastName,
+          role: c.role,
+        },
+      }));
+
+      const mentorSummary: CoachSummary | null = mentor
+        ? {
+          id: mentor.id,
+          firstName: mentor.firstName,
+          lastName: mentor.lastName,
+          role: mentor.role,
+        }
+        : null;
+
+      const detail: CoachDetail = {
+        id: row.id,
+        leagueId: row.leagueId,
+        teamId: row.teamId,
+        firstName: row.firstName,
+        lastName: row.lastName,
+        role: row.role,
+        specialty: row.specialty,
+        playCaller: row.playCaller,
+        age: row.age,
+        yearsWithTeam: yearsBetween(row.hiredAt, today),
+        contractYearsRemaining: row.contractYears,
+        contractSalary: row.contractSalary,
+        contractBuyout: row.contractBuyout,
+        isVacancy: row.isVacancy,
+        college: college
+          ? {
+            id: college.id,
+            shortName: college.shortName,
+            nickname: college.nickname,
+            conference: college.conference,
+          }
+          : null,
+        mentor: mentorSummary,
+        reputationLabels: reputationRows.map((r) => r.label),
+        careerStops,
+        tenureUnitPerformance,
+        tenurePlayerDev,
+        accolades,
+        depthChartNotes,
+        connections,
+      };
+
+      return detail;
+    },
+  };
+}

--- a/server/features/coaches/coaches.router.test.ts
+++ b/server/features/coaches/coaches.router.test.ts
@@ -1,0 +1,113 @@
+import { assertEquals } from "@std/assert";
+import { DomainError } from "@zone-blitz/shared";
+import type { CoachDetail, CoachNode } from "@zone-blitz/shared";
+import { createCoachesRouter } from "./coaches.router.ts";
+import type { CoachesService } from "./coaches.service.interface.ts";
+
+function createMockService(
+  overrides: Partial<CoachesService> = {},
+): CoachesService {
+  return {
+    generate: () => Promise.resolve({ coachCount: 0 }),
+    getStaffTree: () => Promise.resolve([]),
+    getCoachDetail: () =>
+      Promise.reject(new DomainError("NOT_FOUND", "Coach missing not found")),
+    ...overrides,
+  };
+}
+
+function createNode(overrides: Partial<CoachNode> = {}): CoachNode {
+  return {
+    id: "c1",
+    firstName: "Alex",
+    lastName: "Stone",
+    role: "HC",
+    reportsToId: null,
+    playCaller: "offense",
+    specialty: "ceo",
+    age: 52,
+    yearsWithTeam: 3,
+    contractYearsRemaining: 4,
+    isVacancy: false,
+    ...overrides,
+  };
+}
+
+function createDetail(overrides: Partial<CoachDetail> = {}): CoachDetail {
+  return {
+    id: "c1",
+    leagueId: "l1",
+    teamId: "t1",
+    firstName: "Alex",
+    lastName: "Stone",
+    role: "HC",
+    specialty: "ceo",
+    playCaller: "offense",
+    age: 52,
+    yearsWithTeam: 3,
+    contractYearsRemaining: 4,
+    contractSalary: 10_000_000,
+    contractBuyout: 20_000_000,
+    isVacancy: false,
+    college: null,
+    mentor: null,
+    reputationLabels: [],
+    careerStops: [],
+    tenureUnitPerformance: [],
+    tenurePlayerDev: [],
+    accolades: [],
+    depthChartNotes: [],
+    connections: [],
+    ...overrides,
+  };
+}
+
+Deno.test("coaches.router", async (t) => {
+  await t.step(
+    "GET /teams/:teamId/staff returns the staff tree for the team",
+    async () => {
+      let received: string | undefined;
+      const nodes = [
+        createNode({ id: "hc", role: "HC" }),
+        createNode({ id: "oc", role: "OC", reportsToId: "hc" }),
+      ];
+      const router = createCoachesRouter(
+        createMockService({
+          getStaffTree: (teamId) => {
+            received = teamId;
+            return Promise.resolve(nodes);
+          },
+        }),
+      );
+
+      const res = await router.request("/teams/team-123/staff");
+      assertEquals(res.status, 200);
+      assertEquals(received, "team-123");
+
+      const body = await res.json();
+      assertEquals(body.length, 2);
+      assertEquals(body[0].id, "hc");
+    },
+  );
+
+  await t.step("GET /:coachId returns the coach detail", async () => {
+    let received: string | undefined;
+    const detail = createDetail({ id: "coach-42", firstName: "Sam" });
+    const router = createCoachesRouter(
+      createMockService({
+        getCoachDetail: (id) => {
+          received = id;
+          return Promise.resolve(detail);
+        },
+      }),
+    );
+
+    const res = await router.request("/coach-42");
+    assertEquals(res.status, 200);
+    assertEquals(received, "coach-42");
+
+    const body = await res.json();
+    assertEquals(body.id, "coach-42");
+    assertEquals(body.firstName, "Sam");
+  });
+});

--- a/server/features/coaches/coaches.router.ts
+++ b/server/features/coaches/coaches.router.ts
@@ -1,0 +1,17 @@
+import { Hono } from "hono";
+import type { CoachesService } from "./coaches.service.interface.ts";
+import type { AppEnv } from "../../env.ts";
+
+export function createCoachesRouter(coachesService: CoachesService) {
+  return new Hono<AppEnv>()
+    .get("/teams/:teamId/staff", async (c) => {
+      const teamId = c.req.param("teamId");
+      const staff = await coachesService.getStaffTree(teamId);
+      return c.json(staff);
+    })
+    .get("/:coachId", async (c) => {
+      const coachId = c.req.param("coachId");
+      const detail = await coachesService.getCoachDetail(coachId);
+      return c.json(detail);
+    });
+}

--- a/server/features/coaches/coaches.service.interface.ts
+++ b/server/features/coaches/coaches.service.interface.ts
@@ -1,3 +1,5 @@
+import type { CoachDetail, CoachNode } from "@zone-blitz/shared";
+
 export interface CoachesGenerateInput {
   leagueId: string;
   teamIds: string[];
@@ -11,4 +13,16 @@ export interface CoachesService {
   generate(
     input: CoachesGenerateInput,
   ): Promise<CoachesGenerateResult>;
+
+  /**
+   * Staff tree for a team — flat list of nodes; the client builds the
+   * hierarchy from `reportsToId`.
+   */
+  getStaffTree(teamId: string): Promise<CoachNode[]>;
+
+  /**
+   * Full public-record detail for a single coach. Throws `DomainError`
+   * with code `NOT_FOUND` when no coach has the given id.
+   */
+  getCoachDetail(id: string): Promise<CoachDetail>;
 }

--- a/server/features/coaches/coaches.service.test.ts
+++ b/server/features/coaches/coaches.service.test.ts
@@ -1,6 +1,14 @@
-import { assertEquals } from "@std/assert";
+import { assertEquals, assertRejects } from "@std/assert";
+import { DomainError } from "@zone-blitz/shared";
+import type {
+  CoachDetail,
+  CoachNode,
+  CoachRole,
+  CoachSpecialty,
+} from "@zone-blitz/shared";
 import { createCoachesService } from "./coaches.service.ts";
 import type { CoachesGenerator } from "./coaches.generator.interface.ts";
+import type { CoachesRepository } from "./coaches.repository.interface.ts";
 
 function createTestLogger() {
   return {
@@ -17,6 +25,16 @@ function createMockGenerator(
 ): CoachesGenerator {
   return {
     generate: () => [],
+    ...overrides,
+  };
+}
+
+function createMockRepo(
+  overrides: Partial<CoachesRepository> = {},
+): CoachesRepository {
+  return {
+    getStaffTreeByTeam: () => Promise.resolve([]),
+    getCoachDetailById: () => Promise.resolve(undefined),
     ...overrides,
   };
 }
@@ -42,6 +60,52 @@ function createMockDb(): {
     },
   } as unknown as import("../../db/connection.ts").Database;
   return { db, calls };
+}
+
+function createNode(overrides: Partial<CoachNode> = {}): CoachNode {
+  return {
+    id: "c1",
+    firstName: "Alex",
+    lastName: "Stone",
+    role: "HC" as CoachRole,
+    reportsToId: null,
+    playCaller: "offense",
+    specialty: "ceo" as CoachSpecialty,
+    age: 52,
+    yearsWithTeam: 3,
+    contractYearsRemaining: 4,
+    isVacancy: false,
+    ...overrides,
+  };
+}
+
+function createDetail(overrides: Partial<CoachDetail> = {}): CoachDetail {
+  return {
+    id: "c1",
+    leagueId: "l1",
+    teamId: "t1",
+    firstName: "Alex",
+    lastName: "Stone",
+    role: "HC",
+    specialty: "ceo",
+    playCaller: "offense",
+    age: 52,
+    yearsWithTeam: 3,
+    contractYearsRemaining: 4,
+    contractSalary: 10_000_000,
+    contractBuyout: 20_000_000,
+    isVacancy: false,
+    college: null,
+    mentor: null,
+    reputationLabels: [],
+    careerStops: [],
+    tenureUnitPerformance: [],
+    tenurePlayerDev: [],
+    accolades: [],
+    depthChartNotes: [],
+    connections: [],
+    ...overrides,
+  };
 }
 
 Deno.test("coaches.service", async (t) => {
@@ -74,6 +138,7 @@ Deno.test("coaches.service", async (t) => {
 
       const service = createCoachesService({
         generator,
+        repo: createMockRepo(),
         db,
         log: createTestLogger(),
       });
@@ -96,6 +161,7 @@ Deno.test("coaches.service", async (t) => {
 
       const service = createCoachesService({
         generator,
+        repo: createMockRepo(),
         db,
         log: createTestLogger(),
       });
@@ -107,6 +173,60 @@ Deno.test("coaches.service", async (t) => {
 
       assertEquals(result.coachCount, 0);
       assertEquals(calls.length, 0);
+    },
+  );
+
+  await t.step("getStaffTree delegates to repository", async () => {
+    const { db } = createMockDb();
+    const nodes = [createNode()];
+    const service = createCoachesService({
+      generator: createMockGenerator(),
+      repo: createMockRepo({
+        getStaffTreeByTeam: (teamId) => {
+          assertEquals(teamId, "t1");
+          return Promise.resolve(nodes);
+        },
+      }),
+      db,
+      log: createTestLogger(),
+    });
+
+    const result = await service.getStaffTree("t1");
+    assertEquals(result, nodes);
+  });
+
+  await t.step("getCoachDetail returns the detail when found", async () => {
+    const { db } = createMockDb();
+    const detail = createDetail();
+    const service = createCoachesService({
+      generator: createMockGenerator(),
+      repo: createMockRepo({
+        getCoachDetailById: () => Promise.resolve(detail),
+      }),
+      db,
+      log: createTestLogger(),
+    });
+
+    const result = await service.getCoachDetail("c1");
+    assertEquals(result, detail);
+  });
+
+  await t.step(
+    "getCoachDetail throws NOT_FOUND when repository returns undefined",
+    async () => {
+      const { db } = createMockDb();
+      const service = createCoachesService({
+        generator: createMockGenerator(),
+        repo: createMockRepo(),
+        db,
+        log: createTestLogger(),
+      });
+
+      await assertRejects(
+        () => service.getCoachDetail("missing"),
+        DomainError,
+        "Coach missing not found",
+      );
     },
   );
 });

--- a/server/features/coaches/coaches.service.ts
+++ b/server/features/coaches/coaches.service.ts
@@ -1,11 +1,14 @@
+import { DomainError } from "@zone-blitz/shared";
 import type pino from "pino";
 import type { Database } from "../../db/connection.ts";
 import { coaches } from "./coach.schema.ts";
 import type { CoachesGenerator } from "./coaches.generator.interface.ts";
+import type { CoachesRepository } from "./coaches.repository.interface.ts";
 import type { CoachesService } from "./coaches.service.interface.ts";
 
 export function createCoachesService(deps: {
   generator: CoachesGenerator;
+  repo: CoachesRepository;
   db: Database;
   log: pino.Logger;
 }): CoachesService {
@@ -30,6 +33,20 @@ export function createCoachesService(deps: {
       );
 
       return { coachCount: generated.length };
+    },
+
+    async getStaffTree(teamId) {
+      log.debug({ teamId }, "fetching staff tree");
+      return await deps.repo.getStaffTreeByTeam(teamId);
+    },
+
+    async getCoachDetail(id) {
+      log.debug({ id }, "fetching coach detail");
+      const detail = await deps.repo.getCoachDetailById(id);
+      if (!detail) {
+        throw new DomainError("NOT_FOUND", `Coach ${id} not found`);
+      }
+      return detail;
     },
   };
 }

--- a/server/features/coaches/mod.ts
+++ b/server/features/coaches/mod.ts
@@ -1,3 +1,6 @@
 export { createStubCoachesGenerator } from "./stub-coaches-generator.ts";
+export { createCoachesRepository } from "./coaches.repository.ts";
 export { createCoachesService } from "./coaches.service.ts";
+export { createCoachesRouter } from "./coaches.router.ts";
+export type { CoachesRepository } from "./coaches.repository.interface.ts";
 export type { CoachesService } from "./coaches.service.interface.ts";

--- a/server/features/mod.ts
+++ b/server/features/mod.ts
@@ -25,6 +25,8 @@ import {
   createStubPlayersGenerator,
 } from "./players/mod.ts";
 import {
+  createCoachesRepository,
+  createCoachesRouter,
   createCoachesService,
   createStubCoachesGenerator,
 } from "./coaches/mod.ts";
@@ -75,6 +77,7 @@ export function createFeatureRouters(
   const userRepo = createUserRepository({ db, log });
   const teamRepo = createTeamRepository({ db, log });
   const seasonRepo = createSeasonRepository({ db, log });
+  const coachesRepo = createCoachesRepository({ db, log });
 
   // Services
   const userService = createUserService({ userRepo, log });
@@ -87,6 +90,7 @@ export function createFeatureRouters(
   });
   const coachesService = createCoachesService({
     generator: createStubCoachesGenerator(),
+    repo: coachesRepo,
     db,
     log,
   });
@@ -125,6 +129,7 @@ export function createFeatureRouters(
   const leagueRouter = createLeagueRouter(leagueService);
   const userRouter = createUserRouter(userService);
   const teamRouter = createTeamRouter(teamService);
+  const coachesRouter = createCoachesRouter(coachesService);
 
   return {
     auth,
@@ -133,5 +138,6 @@ export function createFeatureRouters(
     leagueRouter,
     userRouter,
     teamRouter,
+    coachesRouter,
   };
 }

--- a/server/features/personnel/personnel.service.test.ts
+++ b/server/features/personnel/personnel.service.test.ts
@@ -34,6 +34,9 @@ function createMockCoachesService(
 ): CoachesService {
   return {
     generate: () => Promise.resolve({ coachCount: 0 }),
+    getStaffTree: () => Promise.resolve([]),
+    getCoachDetail: () =>
+      Promise.reject(new Error("getCoachDetail not stubbed")),
     ...overrides,
   };
 }

--- a/server/main.ts
+++ b/server/main.ts
@@ -38,7 +38,10 @@ const app = new Hono<AppEnv>()
   .route("/api/users", features.userRouter)
   .use("/api/teams/*", authGuard())
   .use("/api/teams", authGuard())
-  .route("/api/teams", features.teamRouter);
+  .route("/api/teams", features.teamRouter)
+  .use("/api/coaches/*", authGuard())
+  .use("/api/coaches", authGuard())
+  .route("/api/coaches", features.coachesRouter);
 
 // Domain error handler
 app.onError((err, c) => {


### PR DESCRIPTION
## Summary

- Adds `GET /api/coaches/teams/:teamId/staff` returning flat `CoachNode[]` (client assembles tree from `reportsToId`).
- Adds `GET /api/coaches/:coachId` returning the full `CoachDetail` aggregate — bio, college, mentor, reputation labels, career stops, tenure unit performance, per-player dev deltas, accolades, depth-chart notes, and coach-to-coach connections.
- Shared `CoachNode` and `CoachDetail` types contain zero numeric rating/grade/tier/OVR fields, enforcing ADR 0002's non-goals at the API boundary. Router exposes only GETs — no mutation surface in this PR.
- `CoachesRepository` has real-DB integration tests; `yearsWithTeam` is derived from `hiredAt` with an injectable `now` for determinism.
- Wired into `server/features/mod.ts` and mounted at `/api/coaches` behind the auth guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)