### PR TITLE
ci: run client vitest via node to prevent CI hangs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,14 @@ jobs:
       - uses: denoland/setup-deno@v2
         with:
           deno-version: v2.7.11
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: client/package-lock.json
       - run: deno install
+      - name: Install client npm deps
+        run: npm ci --prefix client
       - name: Run migrations
         run: deno task db:migrate
         env:

--- a/deno.json
+++ b/deno.json
@@ -30,7 +30,7 @@
     "test": "deno task test:server && deno task test:packages && deno task test:client",
     "test:server": "deno test server/ --env=.env --allow-env --allow-net --allow-read --allow-sys --coverage",
     "test:packages": "deno test packages/shared/ packages/simulation/ packages/ai/ --coverage",
-    "test:client": "cd client && deno run -A npm:vitest run --coverage",
+    "test:client": "cd client && npm exec -- vitest run --coverage",
     "test:coverage": "./bin/check-coverage",
     "test:e2e": "./bin/test-e2e",
     "build": "cd client && deno task build",


### PR DESCRIPTION
## Summary

- CI Test job has been timing out at 10m on main since #77 landed. Tests all pass (90 deno + 114 vitest), coverage prints, then `deno run -A npm:vitest` fails to exit — orphan esbuild/vitest/deno processes get killed when the runner cancels the job. Reproduces 2/2 on post-merge runs; does not reproduce on PR CI.
- Switches client tests to `npm exec -- vitest` so vitest runs as a plain Node process without the Deno↔npm subprocess wrapper keeping the event loop alive. Adds `setup-node` + `npm ci --prefix client` to CI so the node-based binary is available.
- Verified locally: `deno task test:client` now exits cleanly in ~3.5s.