### PR TITLE
fix(db): wipe players and draft_prospects before NOT NULL identity cols

### DIFF
--- a/server/db/migrations/0011_wonderful_wendigo.sql
+++ b/server/db/migrations/0011_wonderful_wendigo.sql
@@ -1,3 +1,10 @@
+-- The new player/draft-prospect shape adds NOT NULL identity columns
+-- (height_inches, weight_pounds, birth_date) that the prior stub rows
+-- did not carry. Wipe existing records so the ALTER TABLE statements
+-- below can enforce NOT NULL safely; leagues regenerate their rosters
+-- and draft classes under the new shape on next seed.
+DELETE FROM "players";--> statement-breakpoint
+DELETE FROM "draft_prospects";--> statement-breakpoint
 CREATE TABLE "draft_prospect_attributes" (
 	"draft_prospect_id" uuid PRIMARY KEY NOT NULL,
 	"speed" smallint NOT NULL,


### PR DESCRIPTION
## Summary

- Migration 0011 (from #78) adds `height_inches`, `weight_pounds`, and `birth_date` as NOT NULL to both `players` and `draft_prospects`, but existing stub rows carry no values for those columns — Postgres aborts the ALTER TABLE with `column contains null values`. Prod has been in a crash loop for every deploy since #78, masked until #83 fixed the CI hang and the deploy step finally got to run end-to-end.
- Prepends `DELETE FROM "players"` and `DELETE FROM "draft_prospects"` to the migration, matching the pattern #77 used for coaches. Stub rows regenerate on next seed; the new shape isn't backfill-compatible with the prior stub-only schema anyway.
- Verified locally by applying 0000–0010 to a fresh DB, inserting a players row, then running the edited 0011 — ALTER TABLE now succeeds and the new NOT NULL columns are in place.