### PR TITLE
fix(dev): seed teams on dev startup and guard empty-teams league create

### DIFF
--- a/bin/dev
+++ b/bin/dev
@@ -5,6 +5,7 @@ cd "$(dirname "$0")/.."
 deno task setup
 deno task db:start
 deno task db:migrate
+deno task db:seed
 
 deno run -A npm:concurrently -n server,client -c blue,green \
   "deno task dev:server" \

--- a/server/features/league/league.service.test.ts
+++ b/server/features/league/league.service.test.ts
@@ -269,6 +269,21 @@ Deno.test("league.service", async (t) => {
     assertEquals(scheduleCalled, true);
   });
 
+  await t.step(
+    "create throws PRECONDITION_FAILED when no teams are seeded",
+    async () => {
+      const service = createService({
+        teamService: { getAll: () => Promise.resolve([]) },
+      });
+
+      await assertRejects(
+        () => service.create({ name: "New League" }),
+        DomainError,
+        "no teams",
+      );
+    },
+  );
+
   await t.step("create returns the league", async () => {
     const service = createService();
     const result = await service.create({ name: "New League" });

--- a/server/features/league/league.service.ts
+++ b/server/features/league/league.service.ts
@@ -51,6 +51,14 @@ export function createLeagueService(deps: {
     async create(input) {
       log.info({ name: input.name }, "creating league");
 
+      const teams = await deps.teamService.getAll();
+      if (teams.length === 0) {
+        throw new DomainError(
+          "PRECONDITION_FAILED",
+          "Cannot create a league with no teams. Run `deno task db:seed` to seed default teams.",
+        );
+      }
+
       const league = await deps.leagueRepo.create(input);
 
       const season = await deps.seasonService.create({ leagueId: league.id });
@@ -58,8 +66,6 @@ export function createLeagueService(deps: {
         { leagueId: league.id, seasonId: season.id },
         "created season 1",
       );
-
-      const teams = await deps.teamService.getAll();
 
       await deps.personnelService.generate({
         leagueId: league.id,


### PR DESCRIPTION
## Summary

- Fresh dev builds ran migrations but not the seed script, so creating a league hit an empty `teams` table and crashed deep inside the stub schedule generator with `Cannot read properties of undefined (reading 'length')` at `stub-schedule-generator.ts:103`.
- `bin/dev` now runs `deno task db:seed` after migrations so default states/cities/teams/colleges are always present locally.
- `league.service.create` fails fast with a `PRECONDITION_FAILED` `DomainError` when no teams exist, pointing the operator at `deno task db:seed` instead of surfacing a `TypeError`. The team fetch is moved ahead of league/season creation so the guard does not leave orphan rows behind.