### PR TITLE
feat(db): export DrizzleTx and Executor types

### DIFF
--- a/server/db/connection.ts
+++ b/server/db/connection.ts
@@ -11,3 +11,7 @@ const client = postgres(databaseUrl);
 export const db = drizzle(client, { schema });
 
 export type Database = typeof db;
+
+export type DrizzleTx = Parameters<Parameters<Database["transaction"]>[0]>[0];
+
+export type Executor = Database | DrizzleTx;


### PR DESCRIPTION
## Summary

- Export `DrizzleTx` (the transaction handle type from `db.transaction`) and `Executor` (union of `Database | DrizzleTx`) from `server/db/connection.ts`.
- Foundation for making league creation transactional — upcoming PRs will add an optional `tx?: Executor` parameter to the write-side services currently invoked by `leagueService.create` (season, personnel, players, coaches, scouts, front office, schedule), then wrap the whole flow in `db.transaction` so partial failures roll back.
- No behavior change, no caller updated.