### PR TITLE
feat(server): thread optional tx through leaf services/repos

### DIFF
--- a/server/features/coaches/coaches.service.interface.ts
+++ b/server/features/coaches/coaches.service.interface.ts
@@ -1,4 +1,5 @@
 import type { CoachDetail, CoachNode } from "@zone-blitz/shared";
+import type { Executor } from "../../db/connection.ts";
 
 export interface CoachesGenerateInput {
   leagueId: string;
@@ -12,6 +13,7 @@ export interface CoachesGenerateResult {
 export interface CoachesService {
   generate(
     input: CoachesGenerateInput,
+    tx?: Executor,
   ): Promise<CoachesGenerateResult>;
 
   /**

--- a/server/features/coaches/coaches.service.test.ts
+++ b/server/features/coaches/coaches.service.test.ts
@@ -212,6 +212,45 @@ Deno.test("coaches.service", async (t) => {
   });
 
   await t.step(
+    "generate routes inserts through tx when provided",
+    async () => {
+      const { db, calls: dbCalls } = createMockDb();
+      const { db: tx, calls: txCalls } = createMockDb();
+      const base = {
+        leagueId: "l1",
+        teamId: "t1",
+        role: "HC" as const,
+        reportsToId: null,
+        playCaller: "offense" as const,
+        age: 50,
+        hiredAt: new Date(),
+        contractYears: 3,
+        contractSalary: 1_000_000,
+        contractBuyout: 1_000_000,
+        collegeId: null,
+        specialty: "ceo" as const,
+        isVacancy: false,
+        mentorCoachId: null,
+      };
+      const generator = createMockGenerator({
+        generate: () => [{ ...base, id: "c1", firstName: "A", lastName: "B" }],
+      });
+
+      const service = createCoachesService({
+        generator,
+        repo: createMockRepo(),
+        db,
+        log: createTestLogger(),
+      });
+
+      await service.generate({ leagueId: "l1", teamIds: ["t1"] }, tx);
+
+      assertEquals(dbCalls.length, 0);
+      assertEquals(txCalls.length, 1);
+    },
+  );
+
+  await t.step(
     "getCoachDetail throws NOT_FOUND when repository returns undefined",
     async () => {
       const { db } = createMockDb();

--- a/server/features/coaches/coaches.service.ts
+++ b/server/features/coaches/coaches.service.ts
@@ -15,7 +15,7 @@ export function createCoachesService(deps: {
   const log = deps.log.child({ module: "coaches.service" });
 
   return {
-    async generate(input) {
+    async generate(input, tx) {
       log.info({ leagueId: input.leagueId }, "generating coaches");
 
       const generated = deps.generator.generate({
@@ -24,7 +24,7 @@ export function createCoachesService(deps: {
       });
 
       if (generated.length > 0) {
-        await deps.db.insert(coaches).values(generated);
+        await (tx ?? deps.db).insert(coaches).values(generated);
       }
 
       log.info(

--- a/server/features/front-office/front-office.service.interface.ts
+++ b/server/features/front-office/front-office.service.interface.ts
@@ -1,3 +1,5 @@
+import type { Executor } from "../../db/connection.ts";
+
 export interface FrontOfficeGenerateInput {
   leagueId: string;
   teamIds: string[];
@@ -10,5 +12,6 @@ export interface FrontOfficeGenerateResult {
 export interface FrontOfficeService {
   generate(
     input: FrontOfficeGenerateInput,
+    tx?: Executor,
   ): Promise<FrontOfficeGenerateResult>;
 }

--- a/server/features/front-office/front-office.service.test.ts
+++ b/server/features/front-office/front-office.service.test.ts
@@ -73,6 +73,30 @@ Deno.test("front-office.service", async (t) => {
   );
 
   await t.step(
+    "generate routes inserts through tx when provided",
+    async () => {
+      const { db, calls: dbCalls } = createMockDb();
+      const { db: tx, calls: txCalls } = createMockDb();
+      const generator = createMockGenerator({
+        generate: () => [
+          { leagueId: "l1", teamId: "t1", firstName: "A", lastName: "B" },
+        ],
+      });
+
+      const service = createFrontOfficeService({
+        generator,
+        db,
+        log: createTestLogger(),
+      });
+
+      await service.generate({ leagueId: "l1", teamIds: ["t1"] }, tx);
+
+      assertEquals(dbCalls.length, 0);
+      assertEquals(txCalls.length, 1);
+    },
+  );
+
+  await t.step(
     "generate skips insert when generator returns empty",
     async () => {
       const { db, calls } = createMockDb();

--- a/server/features/front-office/front-office.service.ts
+++ b/server/features/front-office/front-office.service.ts
@@ -12,7 +12,7 @@ export function createFrontOfficeService(deps: {
   const log = deps.log.child({ module: "front-office.service" });
 
   return {
-    async generate(input) {
+    async generate(input, tx) {
       log.info({ leagueId: input.leagueId }, "generating front office staff");
 
       const generated = deps.generator.generate({
@@ -21,7 +21,7 @@ export function createFrontOfficeService(deps: {
       });
 
       if (generated.length > 0) {
-        await deps.db.insert(frontOfficeStaff).values(generated);
+        await (tx ?? deps.db).insert(frontOfficeStaff).values(generated);
       }
 
       log.info(

--- a/server/features/league/league.repository.interface.ts
+++ b/server/features/league/league.repository.interface.ts
@@ -1,8 +1,9 @@
 import type { League, NewLeague } from "@zone-blitz/shared";
+import type { Executor } from "../../db/connection.ts";
 
 export interface LeagueRepository {
   getAll(): Promise<League[]>;
   getById(id: string): Promise<League | undefined>;
-  create(league: NewLeague): Promise<League>;
+  create(league: NewLeague, tx?: Executor): Promise<League>;
   deleteById(id: string): Promise<void>;
 }

--- a/server/features/league/league.repository.ts
+++ b/server/features/league/league.repository.ts
@@ -26,9 +26,9 @@ export function createLeagueRepository(deps: {
       return league;
     },
 
-    async create(input) {
+    async create(input, tx) {
       log.debug({ name: input.name }, "creating league");
-      const [league] = await deps.db
+      const [league] = await (tx ?? deps.db)
         .insert(leagues)
         .values({ name: input.name })
         .returning();

--- a/server/features/players/players.service.interface.ts
+++ b/server/features/players/players.service.interface.ts
@@ -1,3 +1,5 @@
+import type { Executor } from "../../db/connection.ts";
+
 export interface PlayersGenerateInput {
   leagueId: string;
   seasonId: string;
@@ -15,5 +17,6 @@ export interface PlayersGenerateResult {
 export interface PlayersService {
   generate(
     input: PlayersGenerateInput,
+    tx?: Executor,
   ): Promise<PlayersGenerateResult>;
 }

--- a/server/features/players/players.service.test.ts
+++ b/server/features/players/players.service.test.ts
@@ -208,6 +208,56 @@ Deno.test("players.service", async (t) => {
   );
 
   await t.step(
+    "generate routes inserts through tx when provided",
+    async () => {
+      const { db, calls: dbCalls } = createMockDb(["p1"]);
+      const { db: tx, calls: txCalls } = createMockDb(["p1"]);
+      const generator = createMockGenerator({
+        generate: () => ({
+          players: [
+            {
+              player: {
+                leagueId: "l1",
+                teamId: "t1",
+                firstName: "A",
+                lastName: "B",
+                heightInches: 72,
+                weightPounds: 220,
+                college: null,
+                birthDate: "2000-01-01",
+              },
+              attributes: stubAttrs(),
+            },
+          ],
+          draftProspects: [],
+        }),
+        generateContracts: () => [],
+      });
+
+      const service = createPlayersService({
+        generator,
+        db,
+        log: createTestLogger(),
+      });
+
+      await service.generate(
+        {
+          leagueId: "l1",
+          seasonId: "s1",
+          teamIds: ["t1"],
+          rosterSize: 1,
+          salaryCap: 100_000,
+        },
+        tx,
+      );
+
+      assertEquals(dbCalls.length, 0);
+      // players + player_attributes writes routed through tx
+      assertEquals(txCalls.length, 2);
+    },
+  );
+
+  await t.step(
     "generate passes inserted players to contract generator",
     async () => {
       const { db } = createMockDb(["player-1"]);

--- a/server/features/players/players.service.ts
+++ b/server/features/players/players.service.ts
@@ -17,7 +17,8 @@ export function createPlayersService(deps: {
   const log = deps.log.child({ module: "players.service" });
 
   return {
-    async generate(input) {
+    async generate(input, tx) {
+      const exec = tx ?? deps.db;
       log.info(
         { leagueId: input.leagueId, seasonId: input.seasonId },
         "generating players",
@@ -33,7 +34,7 @@ export function createPlayersService(deps: {
       let insertedPlayers: { id: string; teamId: string | null }[] = [];
 
       if (generated.players.length > 0) {
-        insertedPlayers = await deps.db
+        insertedPlayers = await exec
           .insert(players)
           .values(generated.players.map((entry) => entry.player))
           .returning({ id: players.id, teamId: players.teamId });
@@ -42,11 +43,11 @@ export function createPlayersService(deps: {
           playerId: row.id,
           ...generated.players[index].attributes,
         }));
-        await deps.db.insert(playerAttributes).values(attributeRows);
+        await exec.insert(playerAttributes).values(attributeRows);
       }
 
       if (generated.draftProspects.length > 0) {
-        const insertedProspects = await deps.db
+        const insertedProspects = await exec
           .insert(draftProspects)
           .values(generated.draftProspects.map((entry) => entry.prospect))
           .returning({ id: draftProspects.id });
@@ -55,7 +56,7 @@ export function createPlayersService(deps: {
           draftProspectId: row.id,
           ...generated.draftProspects[index].attributes,
         }));
-        await deps.db
+        await exec
           .insert(draftProspectAttributes)
           .values(prospectAttributeRows);
       }
@@ -75,7 +76,7 @@ export function createPlayersService(deps: {
       });
 
       if (generatedContracts.length > 0) {
-        await deps.db.insert(contracts).values(generatedContracts);
+        await exec.insert(contracts).values(generatedContracts);
       }
 
       log.info(

--- a/server/features/schedule/schedule.service.interface.ts
+++ b/server/features/schedule/schedule.service.interface.ts
@@ -1,4 +1,5 @@
 import type { TeamDivisionInfo } from "./schedule.generator.interface.ts";
+import type { Executor } from "../../db/connection.ts";
 
 export interface ScheduleGenerateInput {
   seasonId: string;
@@ -13,5 +14,6 @@ export interface ScheduleGenerateResult {
 export interface ScheduleService {
   generate(
     input: ScheduleGenerateInput,
+    tx?: Executor,
   ): Promise<ScheduleGenerateResult>;
 }

--- a/server/features/schedule/schedule.service.test.ts
+++ b/server/features/schedule/schedule.service.test.ts
@@ -108,6 +108,33 @@ Deno.test("schedule.service", async (t) => {
     },
   );
 
+  await t.step(
+    "generate routes inserts through tx when provided",
+    async () => {
+      const { db, calls: dbCalls } = createMockDb();
+      const { db: tx, calls: txCalls } = createMockDb();
+      const generator: ScheduleGenerator = {
+        generate: () => [
+          { seasonId: "s1", week: 1, homeTeamId: "t1", awayTeamId: "t2" },
+        ],
+      };
+
+      const service = createScheduleService({
+        generator,
+        db,
+        log: createTestLogger(),
+      });
+
+      await service.generate(
+        { seasonId: "s1", teams: TEAMS, seasonLength: 17 },
+        tx,
+      );
+
+      assertEquals(dbCalls.length, 0);
+      assertEquals(txCalls.length, 1);
+    },
+  );
+
   await t.step("generate forwards input to generator", async () => {
     const { db } = createMockDb();
     let receivedInput:

--- a/server/features/schedule/schedule.service.ts
+++ b/server/features/schedule/schedule.service.ts
@@ -12,7 +12,7 @@ export function createScheduleService(deps: {
   const log = deps.log.child({ module: "schedule.service" });
 
   return {
-    async generate(input) {
+    async generate(input, tx) {
       log.info({ seasonId: input.seasonId }, "generating schedule");
 
       const generatedGames = deps.generator.generate({
@@ -22,7 +22,7 @@ export function createScheduleService(deps: {
       });
 
       if (generatedGames.length > 0) {
-        await deps.db.insert(games).values(generatedGames);
+        await (tx ?? deps.db).insert(games).values(generatedGames);
       }
 
       log.info(

--- a/server/features/scouts/scouts.service.interface.ts
+++ b/server/features/scouts/scouts.service.interface.ts
@@ -1,3 +1,5 @@
+import type { Executor } from "../../db/connection.ts";
+
 export interface ScoutsGenerateInput {
   leagueId: string;
   teamIds: string[];
@@ -8,5 +10,8 @@ export interface ScoutsGenerateResult {
 }
 
 export interface ScoutsService {
-  generate(input: ScoutsGenerateInput): Promise<ScoutsGenerateResult>;
+  generate(
+    input: ScoutsGenerateInput,
+    tx?: Executor,
+  ): Promise<ScoutsGenerateResult>;
 }

--- a/server/features/scouts/scouts.service.test.ts
+++ b/server/features/scouts/scouts.service.test.ts
@@ -73,6 +73,30 @@ Deno.test("scouts.service", async (t) => {
   );
 
   await t.step(
+    "generate routes inserts through tx when provided",
+    async () => {
+      const { db, calls: dbCalls } = createMockDb();
+      const { db: tx, calls: txCalls } = createMockDb();
+      const generator = createMockGenerator({
+        generate: () => [
+          { leagueId: "l1", teamId: "t1", firstName: "A", lastName: "B" },
+        ],
+      });
+
+      const service = createScoutsService({
+        generator,
+        db,
+        log: createTestLogger(),
+      });
+
+      await service.generate({ leagueId: "l1", teamIds: ["t1"] }, tx);
+
+      assertEquals(dbCalls.length, 0);
+      assertEquals(txCalls.length, 1);
+    },
+  );
+
+  await t.step(
     "generate skips insert when generator returns empty",
     async () => {
       const { db, calls } = createMockDb();

--- a/server/features/scouts/scouts.service.ts
+++ b/server/features/scouts/scouts.service.ts
@@ -12,7 +12,7 @@ export function createScoutsService(deps: {
   const log = deps.log.child({ module: "scouts.service" });
 
   return {
-    async generate(input) {
+    async generate(input, tx) {
       log.info({ leagueId: input.leagueId }, "generating scouts");
 
       const generated = deps.generator.generate({
@@ -21,7 +21,7 @@ export function createScoutsService(deps: {
       });
 
       if (generated.length > 0) {
-        await deps.db.insert(scouts).values(generated);
+        await (tx ?? deps.db).insert(scouts).values(generated);
       }
 
       log.info(

--- a/server/features/season/season.repository.interface.ts
+++ b/server/features/season/season.repository.interface.ts
@@ -1,7 +1,8 @@
 import type { NewSeason, Season } from "@zone-blitz/shared";
+import type { Executor } from "../../db/connection.ts";
 
 export interface SeasonRepository {
   getByLeagueId(leagueId: string): Promise<Season[]>;
   getById(id: string): Promise<Season | undefined>;
-  create(season: NewSeason): Promise<Season>;
+  create(season: NewSeason, tx?: Executor): Promise<Season>;
 }

--- a/server/features/season/season.repository.ts
+++ b/server/features/season/season.repository.ts
@@ -29,9 +29,9 @@ export function createSeasonRepository(deps: {
       return season;
     },
 
-    async create(input) {
+    async create(input, tx) {
       log.debug({ leagueId: input.leagueId }, "creating season");
-      const [season] = await deps.db
+      const [season] = await (tx ?? deps.db)
         .insert(seasons)
         .values({
           leagueId: input.leagueId,

--- a/server/features/season/season.service.interface.ts
+++ b/server/features/season/season.service.interface.ts
@@ -1,7 +1,8 @@
 import type { NewSeason, Season } from "@zone-blitz/shared";
+import type { Executor } from "../../db/connection.ts";
 
 export interface SeasonService {
   getByLeagueId(leagueId: string): Promise<Season[]>;
   getById(id: string): Promise<Season | undefined>;
-  create(season: NewSeason): Promise<Season>;
+  create(season: NewSeason, tx?: Executor): Promise<Season>;
 }

--- a/server/features/season/season.service.test.ts
+++ b/server/features/season/season.service.test.ts
@@ -115,4 +115,24 @@ Deno.test("season.service", async (t) => {
       "league-1",
     );
   });
+
+  await t.step("create forwards tx to repository when provided", async () => {
+    let receivedTx: unknown;
+    const marker = { __tx: true };
+    const service = createSeasonService({
+      seasonRepo: createMockSeasonRepo({
+        create: (_input, tx) => {
+          receivedTx = tx;
+          return Promise.resolve(createMockSeason());
+        },
+      }),
+      log: createTestLogger(),
+    });
+
+    await service.create(
+      { leagueId: "league-1" },
+      marker as unknown as import("../../db/connection.ts").Executor,
+    );
+    assertEquals(receivedTx, marker);
+  });
 });

--- a/server/features/season/season.service.ts
+++ b/server/features/season/season.service.ts
@@ -19,9 +19,9 @@ export function createSeasonService(deps: {
       return await deps.seasonRepo.getById(id);
     },
 
-    async create(input) {
+    async create(input, tx) {
       log.debug({ leagueId: input.leagueId }, "creating season");
-      return await deps.seasonRepo.create(input);
+      return await deps.seasonRepo.create(input, tx);
     },
   };
 }


### PR DESCRIPTION
## Summary

- Adds optional trailing `tx?: Executor` to every write-side service and repository used by league creation: players/coaches/scouts/front-office/schedule services, season service + repo, and the league repo.
- Each write resolves `(tx ?? deps.db)` so existing callers (no tx) keep working identically while a future caller inside `db.transaction` can pass the `tx` to enlist the writes.
- No caller threads `tx` yet — that arrives in the next PR (personnel forwards) and PR 4 (league.service opens the transaction).
- Adds a "routes inserts through tx when provided" unit test per leaf service covering the new branch.