### PR TITLE
feat(personnel): forward optional tx to all sub-services

### DIFF
--- a/server/features/personnel/personnel.service.interface.ts
+++ b/server/features/personnel/personnel.service.interface.ts
@@ -1,3 +1,5 @@
+import type { Executor } from "../../db/connection.ts";
+
 export interface PersonnelGenerateInput {
   leagueId: string;
   seasonId: string;
@@ -18,5 +20,6 @@ export interface PersonnelGenerateResult {
 export interface PersonnelService {
   generate(
     input: PersonnelGenerateInput,
+    tx?: Executor,
   ): Promise<PersonnelGenerateResult>;
 }

--- a/server/features/personnel/personnel.service.test.ts
+++ b/server/features/personnel/personnel.service.test.ts
@@ -154,6 +154,61 @@ Deno.test("personnel.service", async (t) => {
   );
 
   await t.step(
+    "generate forwards tx to every downstream service",
+    async () => {
+      const marker = { __tx: true };
+      const received: Record<string, unknown> = {};
+      const service = createPersonnelService({
+        playersService: createMockPlayersService({
+          generate: (_input, tx) => {
+            received.players = tx;
+            return Promise.resolve({
+              playerCount: 0,
+              draftProspectCount: 0,
+              contractCount: 0,
+            });
+          },
+        }),
+        coachesService: createMockCoachesService({
+          generate: (_input, tx) => {
+            received.coaches = tx;
+            return Promise.resolve({ coachCount: 0 });
+          },
+        }),
+        scoutsService: createMockScoutsService({
+          generate: (_input, tx) => {
+            received.scouts = tx;
+            return Promise.resolve({ scoutCount: 0 });
+          },
+        }),
+        frontOfficeService: createMockFrontOfficeService({
+          generate: (_input, tx) => {
+            received.frontOffice = tx;
+            return Promise.resolve({ frontOfficeCount: 0 });
+          },
+        }),
+        log: createTestLogger(),
+      });
+
+      await service.generate(
+        {
+          leagueId: "l1",
+          seasonId: "s1",
+          teamIds: ["t1"],
+          rosterSize: 1,
+          salaryCap: 1,
+        },
+        marker as unknown as import("../../db/connection.ts").Executor,
+      );
+
+      assertEquals(received.players, marker);
+      assertEquals(received.coaches, marker);
+      assertEquals(received.scouts, marker);
+      assertEquals(received.frontOffice, marker);
+    },
+  );
+
+  await t.step(
     "generate returns zero counts when all services return zero",
     async () => {
       const service = createPersonnelService({

--- a/server/features/personnel/personnel.service.ts
+++ b/server/features/personnel/personnel.service.ts
@@ -15,7 +15,7 @@ export function createPersonnelService(deps: {
   const log = deps.log.child({ module: "personnel.service" });
 
   return {
-    async generate(input) {
+    async generate(input, tx) {
       log.info(
         { leagueId: input.leagueId, seasonId: input.seasonId },
         "generating personnel",
@@ -27,23 +27,23 @@ export function createPersonnelService(deps: {
         teamIds: input.teamIds,
         rosterSize: input.rosterSize,
         salaryCap: input.salaryCap,
-      });
+      }, tx);
 
       const coachesResult = await deps.coachesService.generate({
         leagueId: input.leagueId,
         teamIds: input.teamIds,
-      });
+      }, tx);
 
       const scoutsResult = await deps.scoutsService.generate({
         leagueId: input.leagueId,
         teamIds: input.teamIds,
-      });
+      }, tx);
 
       const frontOfficeResult = await deps.frontOfficeService
         .generate({
           leagueId: input.leagueId,
           teamIds: input.teamIds,
-        });
+        }, tx);
 
       return {
         playerCount: playersResult.playerCount,


### PR DESCRIPTION
## Summary

- Thread optional `tx?: Executor` through `personnelService.generate` and forward it to all four downstream services (players, coaches, scouts, front office).
- Bridges PR 2 (leaf services accept `tx`) with PR 4 (`leagueService.create` opens the root `db.transaction`). On its own this PR is a no-op — no caller passes a `tx` yet — but it completes the wiring needed for personnel generation to enlist in the league-creation transaction.
- New test verifies personnel passes the same `tx` marker to every downstream service.