### PR TITLE
refactor(league): use TransactionRunner instead of raw Database

### DIFF
--- a/server/db/transaction-runner.test.ts
+++ b/server/db/transaction-runner.test.ts
@@ -1,0 +1,46 @@
+import { assertEquals, assertRejects } from "@std/assert";
+import { createTransactionRunner } from "./transaction-runner.ts";
+import type { Database } from "./connection.ts";
+
+function createFakeDb(): {
+  db: Database;
+  calls: Array<(tx: unknown) => Promise<unknown>>;
+  txMarker: object;
+} {
+  const calls: Array<(tx: unknown) => Promise<unknown>> = [];
+  const txMarker = { __tx: true };
+  const db = {
+    transaction: <T>(fn: (tx: unknown) => Promise<T>) => {
+      calls.push(fn);
+      return fn(txMarker);
+    },
+  } as unknown as Database;
+  return { db, calls, txMarker };
+}
+
+Deno.test("transaction-runner", async (t) => {
+  await t.step("run passes the tx handle into the callback", async () => {
+    const { db, txMarker } = createFakeDb();
+    const runner = createTransactionRunner(db);
+
+    let receivedTx: unknown;
+    const result = await runner.run((tx) => {
+      receivedTx = tx;
+      return Promise.resolve("ok");
+    });
+
+    assertEquals(receivedTx, txMarker);
+    assertEquals(result, "ok");
+  });
+
+  await t.step("run propagates rejections from the callback", async () => {
+    const { db } = createFakeDb();
+    const runner = createTransactionRunner(db);
+
+    await assertRejects(
+      () => runner.run(() => Promise.reject(new Error("boom"))),
+      Error,
+      "boom",
+    );
+  });
+});

--- a/server/db/transaction-runner.ts
+++ b/server/db/transaction-runner.ts
@@ -1,0 +1,11 @@
+import type { Database, Executor } from "./connection.ts";
+
+export interface TransactionRunner {
+  run<T>(fn: (tx: Executor) => Promise<T>): Promise<T>;
+}
+
+export function createTransactionRunner(db: Database): TransactionRunner {
+  return {
+    run: (fn) => db.transaction(fn),
+  };
+}

--- a/server/features/league/league.service.integration.test.ts
+++ b/server/features/league/league.service.integration.test.ts
@@ -8,6 +8,7 @@ import { leagues } from "./league.schema.ts";
 import { seasons } from "../season/season.schema.ts";
 import { createLeagueRepository } from "./league.repository.ts";
 import { createLeagueService } from "./league.service.ts";
+import { createTransactionRunner } from "../../db/transaction-runner.ts";
 import { createSeasonRepository } from "../season/season.repository.ts";
 import { createSeasonService } from "../season/season.service.ts";
 import type { PersonnelService } from "../personnel/personnel.service.interface.ts";
@@ -91,7 +92,7 @@ Deno.test({
 
     const leagueName = `Rollback Test ${crypto.randomUUID()}`;
     const service = createLeagueService({
-      db,
+      txRunner: createTransactionRunner(db),
       leagueRepo,
       seasonService,
       teamService,

--- a/server/features/league/league.service.test.ts
+++ b/server/features/league/league.service.test.ts
@@ -3,7 +3,8 @@ import { createLeagueService } from "./league.service.ts";
 import { DomainError } from "@zone-blitz/shared";
 import pino from "pino";
 import type { League } from "@zone-blitz/shared";
-import type { Database } from "../../db/connection.ts";
+import type { Executor } from "../../db/connection.ts";
+import type { TransactionRunner } from "../../db/transaction-runner.ts";
 import type { LeagueRepository } from "./league.repository.interface.ts";
 import type { SeasonService } from "../season/season.service.interface.ts";
 import type { TeamService } from "../team/team.service.interface.ts";
@@ -12,10 +13,10 @@ import type { ScheduleService } from "../schedule/schedule.service.interface.ts"
 
 const TX_MARKER = { __tx: true };
 
-function createMockDb(): Database {
+function createMockTxRunner(): TransactionRunner {
   return {
-    transaction: <T>(cb: (tx: unknown) => Promise<T>) => cb(TX_MARKER),
-  } as unknown as Database;
+    run: (fn) => fn(TX_MARKER as unknown as Executor),
+  };
 }
 
 function createTestLogger() {
@@ -124,7 +125,7 @@ function createMockScheduleService(
 }
 
 function createService(overrides: {
-  db?: Database;
+  txRunner?: TransactionRunner;
   leagueRepo?: Partial<LeagueRepository>;
   seasonService?: Partial<SeasonService>;
   teamService?: Partial<TeamService>;
@@ -132,7 +133,7 @@ function createService(overrides: {
   scheduleService?: Partial<ScheduleService>;
 } = {}) {
   return createLeagueService({
-    db: overrides.db ?? createMockDb(),
+    txRunner: overrides.txRunner ?? createMockTxRunner(),
     leagueRepo: createMockRepo(overrides.leagueRepo),
     seasonService: createMockSeasonService(overrides.seasonService),
     teamService: createMockTeamService(overrides.teamService),

--- a/server/features/league/league.service.ts
+++ b/server/features/league/league.service.ts
@@ -1,6 +1,6 @@
 import { DomainError } from "@zone-blitz/shared";
 import type pino from "pino";
-import type { Database } from "../../db/connection.ts";
+import type { TransactionRunner } from "../../db/transaction-runner.ts";
 import type { LeagueRepository } from "./league.repository.interface.ts";
 import type { LeagueService } from "./league.service.interface.ts";
 import type { SeasonService } from "../season/season.service.interface.ts";
@@ -9,7 +9,7 @@ import type { PersonnelService } from "../personnel/personnel.service.interface.
 import type { ScheduleService } from "../schedule/schedule.service.interface.ts";
 
 export function createLeagueService(deps: {
-  db: Database;
+  txRunner: TransactionRunner;
   leagueRepo: LeagueRepository;
   seasonService: SeasonService;
   teamService: TeamService;
@@ -61,7 +61,7 @@ export function createLeagueService(deps: {
         );
       }
 
-      return await deps.db.transaction(async (tx) => {
+      return await deps.txRunner.run(async (tx) => {
         const league = await deps.leagueRepo.create(input, tx);
 
         const season = await deps.seasonService.create(

--- a/server/features/mod.ts
+++ b/server/features/mod.ts
@@ -42,6 +42,7 @@ import {
   createScheduleService,
   createStubScheduleGenerator,
 } from "./schedule/mod.ts";
+import { createTransactionRunner } from "../db/transaction-runner.ts";
 
 export function createFeatureRouters(
   deps: {
@@ -116,8 +117,9 @@ export function createFeatureRouters(
     db,
     log,
   });
+  const txRunner = createTransactionRunner(db);
   const leagueService = createLeagueService({
-    db,
+    txRunner,
     leagueRepo,
     seasonService,
     teamService,


### PR DESCRIPTION
## Summary

- Introduces a small `TransactionRunner` abstraction in `server/db/` with one method: `run<T>(fn: (tx: Executor) => Promise<T>): Promise<T>`. The implementation wraps `db.transaction`.
- `leagueService` now takes `txRunner: TransactionRunner` instead of `db: Database` — it was only holding `db` to open a transaction, which leaked drizzle into the orchestration layer.
- Leaf services and repositories still accept a drizzle `Executor` for query-builder calls; that's a separate, bigger seam. This PR only cleans up the orchestration seam, which had the weakest reason to know about drizzle.
- Unit tests become a hair lighter: the mock is a `TransactionRunner` whose `run()` invokes the callback with a marker, instead of faking `Database.transaction`.