### PR TITLE
fix(db): chunk bulk inserts to avoid drizzle stack overflow

### DIFF
--- a/server/db/chunked-insert.test.ts
+++ b/server/db/chunked-insert.test.ts
@@ -1,0 +1,118 @@
+import { assertEquals } from "@std/assert";
+import {
+  chunkedInsert,
+  chunkedInsertReturning,
+  DEFAULT_CHUNK_SIZE,
+} from "./chunked-insert.ts";
+
+interface Call {
+  rows: unknown[];
+  returning?: unknown;
+}
+
+function createMockExec(
+  onReturning?: (rows: unknown[]) => unknown[],
+): {
+  exec: Parameters<typeof chunkedInsert>[0];
+  calls: Call[];
+} {
+  const calls: Call[] = [];
+  const exec = {
+    insert() {
+      return {
+        values(rows: unknown[]) {
+          const call: Call = { rows };
+          calls.push(call);
+          const base = Promise.resolve([]);
+          return Object.assign(base, {
+            returning(spec: unknown) {
+              call.returning = spec;
+              return Promise.resolve(onReturning?.(rows) ?? []);
+            },
+          });
+        },
+      };
+    },
+  } as unknown as Parameters<typeof chunkedInsert>[0];
+  return { exec, calls };
+}
+
+Deno.test("chunkedInsert", async (t) => {
+  await t.step("default chunk size is 100", () => {
+    assertEquals(DEFAULT_CHUNK_SIZE, 100);
+  });
+
+  await t.step("splits rows into batches of the default size", async () => {
+    const { exec, calls } = createMockExec();
+    const rows = Array.from({ length: 250 }, (_, i) => ({ id: i }));
+
+    // deno-lint-ignore no-explicit-any
+    await chunkedInsert(exec, {} as any, rows);
+
+    assertEquals(calls.length, 3);
+    assertEquals(calls[0].rows.length, 100);
+    assertEquals(calls[1].rows.length, 100);
+    assertEquals(calls[2].rows.length, 50);
+  });
+
+  await t.step("respects a custom chunk size", async () => {
+    const { exec, calls } = createMockExec();
+    const rows = Array.from({ length: 10 }, (_, i) => ({ id: i }));
+
+    // deno-lint-ignore no-explicit-any
+    await chunkedInsert(exec, {} as any, rows, 3);
+
+    assertEquals(calls.length, 4);
+    assertEquals(calls[3].rows.length, 1);
+  });
+
+  await t.step("does nothing when rows are empty", async () => {
+    const { exec, calls } = createMockExec();
+
+    // deno-lint-ignore no-explicit-any
+    await chunkedInsert(exec, {} as any, []);
+
+    assertEquals(calls.length, 0);
+  });
+});
+
+Deno.test("chunkedInsertReturning", async (t) => {
+  await t.step(
+    "concatenates returned rows across batches preserving order",
+    async () => {
+      const { exec, calls } = createMockExec((batch) =>
+        (batch as { id: number }[]).map((r) => ({ id: r.id }))
+      );
+      const rows = Array.from({ length: 250 }, (_, i) => ({ id: i }));
+
+      const result = await chunkedInsertReturning<{ id: number }>(
+        exec,
+        // deno-lint-ignore no-explicit-any
+        {} as any,
+        rows,
+        { id: "id" },
+      );
+
+      assertEquals(calls.length, 3);
+      assertEquals(result.length, 250);
+      assertEquals(result[0].id, 0);
+      assertEquals(result[249].id, 249);
+      assertEquals(calls[0].returning, { id: "id" });
+    },
+  );
+
+  await t.step("returns empty array when rows are empty", async () => {
+    const { exec, calls } = createMockExec();
+
+    const result = await chunkedInsertReturning<{ id: number }>(
+      exec,
+      // deno-lint-ignore no-explicit-any
+      {} as any,
+      [],
+      { id: "id" },
+    );
+
+    assertEquals(result, []);
+    assertEquals(calls.length, 0);
+  });
+});

--- a/server/db/chunked-insert.ts
+++ b/server/db/chunked-insert.ts
@@ -1,0 +1,35 @@
+import type { Executor } from "./connection.ts";
+
+export const DEFAULT_CHUNK_SIZE = 100;
+
+export async function chunkedInsert(
+  exec: Executor,
+  // deno-lint-ignore no-explicit-any
+  table: any,
+  rows: readonly Record<string, unknown>[],
+  chunkSize: number = DEFAULT_CHUNK_SIZE,
+): Promise<void> {
+  for (let i = 0; i < rows.length; i += chunkSize) {
+    // deno-lint-ignore no-explicit-any
+    await (exec.insert as any)(table).values(rows.slice(i, i + chunkSize));
+  }
+}
+
+export async function chunkedInsertReturning<R>(
+  exec: Executor,
+  // deno-lint-ignore no-explicit-any
+  table: any,
+  rows: readonly Record<string, unknown>[],
+  returning: Record<string, unknown>,
+  chunkSize: number = DEFAULT_CHUNK_SIZE,
+): Promise<R[]> {
+  const results: R[] = [];
+  for (let i = 0; i < rows.length; i += chunkSize) {
+    // deno-lint-ignore no-explicit-any
+    const batch = await (exec.insert as any)(table)
+      .values(rows.slice(i, i + chunkSize))
+      .returning(returning);
+    results.push(...(batch as R[]));
+  }
+  return results;
+}

--- a/server/features/coaches/coaches.service.ts
+++ b/server/features/coaches/coaches.service.ts
@@ -1,6 +1,7 @@
 import { DomainError } from "@zone-blitz/shared";
 import type pino from "pino";
 import type { Database } from "../../db/connection.ts";
+import { chunkedInsert } from "../../db/chunked-insert.ts";
 import { coaches } from "./coach.schema.ts";
 import type { CoachesGenerator } from "./coaches.generator.interface.ts";
 import type { CoachesRepository } from "./coaches.repository.interface.ts";
@@ -24,7 +25,7 @@ export function createCoachesService(deps: {
       });
 
       if (generated.length > 0) {
-        await (tx ?? deps.db).insert(coaches).values(generated);
+        await chunkedInsert(tx ?? deps.db, coaches, generated);
       }
 
       log.info(

--- a/server/features/front-office/front-office.service.ts
+++ b/server/features/front-office/front-office.service.ts
@@ -1,5 +1,6 @@
 import type pino from "pino";
 import type { Database } from "../../db/connection.ts";
+import { chunkedInsert } from "../../db/chunked-insert.ts";
 import { frontOfficeStaff } from "./front-office.schema.ts";
 import type { FrontOfficeGenerator } from "./front-office.generator.interface.ts";
 import type { FrontOfficeService } from "./front-office.service.interface.ts";
@@ -21,7 +22,7 @@ export function createFrontOfficeService(deps: {
       });
 
       if (generated.length > 0) {
-        await (tx ?? deps.db).insert(frontOfficeStaff).values(generated);
+        await chunkedInsert(tx ?? deps.db, frontOfficeStaff, generated);
       }
 
       log.info(

--- a/server/features/players/players.service.ts
+++ b/server/features/players/players.service.ts
@@ -1,5 +1,9 @@
 import type pino from "pino";
 import type { Database } from "../../db/connection.ts";
+import {
+  chunkedInsert,
+  chunkedInsertReturning,
+} from "../../db/chunked-insert.ts";
 import { draftProspects, players } from "./player.schema.ts";
 import {
   draftProspectAttributes,
@@ -34,31 +38,39 @@ export function createPlayersService(deps: {
       let insertedPlayers: { id: string; teamId: string | null }[] = [];
 
       if (generated.players.length > 0) {
-        insertedPlayers = await exec
-          .insert(players)
-          .values(generated.players.map((entry) => entry.player))
-          .returning({ id: players.id, teamId: players.teamId });
+        insertedPlayers = await chunkedInsertReturning<
+          { id: string; teamId: string | null }
+        >(
+          exec,
+          players,
+          generated.players.map((entry) => entry.player),
+          { id: players.id, teamId: players.teamId },
+        );
 
         const attributeRows = insertedPlayers.map((row, index) => ({
           playerId: row.id,
           ...generated.players[index].attributes,
         }));
-        await exec.insert(playerAttributes).values(attributeRows);
+        await chunkedInsert(exec, playerAttributes, attributeRows);
       }
 
       if (generated.draftProspects.length > 0) {
-        const insertedProspects = await exec
-          .insert(draftProspects)
-          .values(generated.draftProspects.map((entry) => entry.prospect))
-          .returning({ id: draftProspects.id });
+        const insertedProspects = await chunkedInsertReturning<{ id: string }>(
+          exec,
+          draftProspects,
+          generated.draftProspects.map((entry) => entry.prospect),
+          { id: draftProspects.id },
+        );
 
         const prospectAttributeRows = insertedProspects.map((row, index) => ({
           draftProspectId: row.id,
           ...generated.draftProspects[index].attributes,
         }));
-        await exec
-          .insert(draftProspectAttributes)
-          .values(prospectAttributeRows);
+        await chunkedInsert(
+          exec,
+          draftProspectAttributes,
+          prospectAttributeRows,
+        );
       }
 
       log.info(
@@ -76,7 +88,7 @@ export function createPlayersService(deps: {
       });
 
       if (generatedContracts.length > 0) {
-        await exec.insert(contracts).values(generatedContracts);
+        await chunkedInsert(exec, contracts, generatedContracts);
       }
 
       log.info(

--- a/server/features/schedule/schedule.service.ts
+++ b/server/features/schedule/schedule.service.ts
@@ -1,5 +1,6 @@
 import type pino from "pino";
 import type { Database } from "../../db/connection.ts";
+import { chunkedInsert } from "../../db/chunked-insert.ts";
 import { games } from "./game.schema.ts";
 import type { ScheduleGenerator } from "./schedule.generator.interface.ts";
 import type { ScheduleService } from "./schedule.service.interface.ts";
@@ -22,7 +23,7 @@ export function createScheduleService(deps: {
       });
 
       if (generatedGames.length > 0) {
-        await (tx ?? deps.db).insert(games).values(generatedGames);
+        await chunkedInsert(tx ?? deps.db, games, generatedGames);
       }
 
       log.info(

--- a/server/features/scouts/scouts.service.ts
+++ b/server/features/scouts/scouts.service.ts
@@ -1,5 +1,6 @@
 import type pino from "pino";
 import type { Database } from "../../db/connection.ts";
+import { chunkedInsert } from "../../db/chunked-insert.ts";
 import { scouts } from "./scout.schema.ts";
 import type { ScoutsGenerator } from "./scouts.generator.interface.ts";
 import type { ScoutsService } from "./scouts.service.interface.ts";
@@ -21,7 +22,7 @@ export function createScoutsService(deps: {
       });
 
       if (generated.length > 0) {
-        await (tx ?? deps.db).insert(scouts).values(generated);
+        await chunkedInsert(tx ?? deps.db, scouts, generated);
       }
 
       log.info(


### PR DESCRIPTION
## Summary

- Fixes production `RangeError: Maximum call stack size exceeded` on `POST /api/leagues` (request 9c9a594c). Drizzle's SQL builder recursively merges per-row fragments when you call `.values([...])` with large arrays; league creation was passing ~1,696 player rows (plus attributes), ~416 coaches, ~544 games, and full scout/front-office staff in single inserts and blowing the V8 stack.
- Adds `server/db/chunked-insert.ts` with `chunkedInsert` and `chunkedInsertReturning` helpers (default batch size 100) and routes coaches, schedule, scouts, front-office, and all four players-service inserts through them. At most ~17 round trips for the largest payload, well below the stack limit.