### PR TITLE
fix(client): surface server errors from league create mutation

### DIFF
--- a/client/src/features/league-select/index.test.tsx
+++ b/client/src/features/league-select/index.test.tsx
@@ -242,6 +242,8 @@ describe("LeagueSelect", () => {
     );
     mockPost.mockReturnValue(
       Promise.resolve({
+        ok: true,
+        status: 201,
         json: () => Promise.resolve({ id: 3, name: "New League" }),
       }),
     );

--- a/client/src/hooks/use-leagues.test.ts
+++ b/client/src/hooks/use-leagues.test.ts
@@ -1,0 +1,68 @@
+import { renderHook, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { describe, expect, it, vi } from "vitest";
+import { useCreateLeague } from "./use-leagues.ts";
+import { createElement } from "react";
+
+const mockPost = vi.fn();
+
+vi.mock("../api.ts", () => ({
+  api: {
+    api: {
+      leagues: {
+        $post: (...args: unknown[]) => mockPost(...args),
+      },
+    },
+  },
+}));
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  return ({ children }: { children: React.ReactNode }) =>
+    createElement(QueryClientProvider, { client: queryClient }, children);
+}
+
+describe("useCreateLeague", () => {
+  it("returns the created league on success", async () => {
+    const league = { id: "abc", name: "Test League" };
+    mockPost.mockResolvedValue({
+      ok: true,
+      status: 201,
+      json: () => Promise.resolve(league),
+    });
+
+    const { result } = renderHook(() => useCreateLeague(), {
+      wrapper: createWrapper(),
+    });
+
+    result.current.mutate({ name: "Test League" });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+
+    expect(result.current.data).toEqual(league);
+  });
+
+  it("rejects when the server responds with a non-ok status", async () => {
+    mockPost.mockResolvedValue({
+      ok: false,
+      status: 500,
+      json: () => Promise.resolve({ error: "boom" }),
+    });
+
+    const { result } = renderHook(() => useCreateLeague(), {
+      wrapper: createWrapper(),
+    });
+
+    result.current.mutate({ name: "Test League" });
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true);
+    });
+
+    expect(result.current.error).toBeInstanceOf(Error);
+  });
+});

--- a/client/src/hooks/use-leagues.ts
+++ b/client/src/hooks/use-leagues.ts
@@ -16,6 +16,9 @@ export function useCreateLeague() {
   return useMutation({
     mutationFn: async (input: { name: string }) => {
       const res = await api.api.leagues.$post({ json: input });
+      if (!res.ok) {
+        throw new Error(`Failed to create league (${res.status})`);
+      }
       return res.json();
     },
     onSuccess: () => {


### PR DESCRIPTION
## Summary

- Follow-up to #92 and the production `/leagues/undefined` report. `useCreateLeague` was calling `res.json()` without checking `res.ok`, so a 500 from the create endpoint would silently resolve the mutation with `{error: "..."}` and the UI would navigate to `/leagues/undefined` (because `league.id` was absent).
- Throw on non-ok responses so the mutation enters its error state and only genuine successes trigger the `onSuccess` navigation. Adds a dedicated `useCreateLeague` test covering both paths.