### PR TITLE
fix(coaches): scope staff tree by league to prevent cross-league leakage

### DIFF
--- a/client/src/features/league/coaches/coaches.test.tsx
+++ b/client/src/features/league/coaches/coaches.test.tsx
@@ -19,10 +19,14 @@ vi.mock("../../../api.ts", () => ({
         $get: (...args: unknown[]) => mockTeamsGet(...args),
       },
       coaches: {
-        teams: {
-          [":teamId"]: {
-            staff: {
-              $get: (...args: unknown[]) => mockStaffGet(...args),
+        leagues: {
+          [":leagueId"]: {
+            teams: {
+              [":teamId"]: {
+                staff: {
+                  $get: (...args: unknown[]) => mockStaffGet(...args),
+                },
+              },
             },
           },
         },
@@ -119,7 +123,7 @@ describe("Coaches page", () => {
     });
 
     expect(mockStaffGet).toHaveBeenCalledWith({
-      param: { teamId: "team-1" },
+      param: { leagueId: "1", teamId: "team-1" },
     });
   });
 

--- a/client/src/features/league/coaches/index.tsx
+++ b/client/src/features/league/coaches/index.tsx
@@ -14,7 +14,7 @@ export function Coaches() {
   // so the page has data to render end-to-end.
   const { data: teams, isLoading: teamsLoading } = useTeams();
   const teamId = (teams?.[0]?.id as string | undefined) ?? "";
-  const { data, isLoading, error } = useStaffTree(teamId);
+  const { data, isLoading, error } = useStaffTree(leagueId ?? "", teamId);
 
   const loading = teamsLoading || isLoading;
 

--- a/client/src/features/league/coaches/index.tsx
+++ b/client/src/features/league/coaches/index.tsx
@@ -8,13 +8,14 @@ import { buildStaffTree } from "./build-tree.ts";
 import { StaffTreeNode } from "./staff-tree-node.tsx";
 
 export function Coaches() {
-  const { leagueId } = useParams({ strict: false });
+  const { leagueId: rawLeagueId } = useParams({ strict: false });
+  const leagueId = rawLeagueId ?? "";
   // TODO: wire a proper "current team" selection once persisted. For now
   // the staff tree renders the first team returned by the teams endpoint
   // so the page has data to render end-to-end.
   const { data: teams, isLoading: teamsLoading } = useTeams();
   const teamId = (teams?.[0]?.id as string | undefined) ?? "";
-  const { data, isLoading, error } = useStaffTree(leagueId ?? "", teamId);
+  const { data, isLoading, error } = useStaffTree(leagueId, teamId);
 
   const loading = teamsLoading || isLoading;
 
@@ -45,7 +46,7 @@ export function Coaches() {
       {!loading && !error && data && (
         <StaffTree
           nodes={data as CoachNode[]}
-          leagueId={leagueId ?? ""}
+          leagueId={leagueId}
         />
       )}
     </div>

--- a/client/src/hooks/use-staff-tree.test.ts
+++ b/client/src/hooks/use-staff-tree.test.ts
@@ -10,10 +10,14 @@ vi.mock("../api.ts", () => ({
   api: {
     api: {
       coaches: {
-        teams: {
-          [":teamId"]: {
-            staff: {
-              $get: (...args: unknown[]) => mockGet(...args),
+        leagues: {
+          [":leagueId"]: {
+            teams: {
+              [":teamId"]: {
+                staff: {
+                  $get: (...args: unknown[]) => mockGet(...args),
+                },
+              },
             },
           },
         },
@@ -31,11 +35,11 @@ function createWrapper() {
 }
 
 describe("useStaffTree", () => {
-  it("fetches the staff tree for a team", async () => {
+  it("fetches the staff tree for a team scoped to a league", async () => {
     const staff = [{ id: "c1", firstName: "A", lastName: "B", role: "HC" }];
     mockGet.mockResolvedValue({ json: () => Promise.resolve(staff) });
 
-    const { result } = renderHook(() => useStaffTree("team-1"), {
+    const { result } = renderHook(() => useStaffTree("league-1", "team-1"), {
       wrapper: createWrapper(),
     });
 
@@ -44,12 +48,23 @@ describe("useStaffTree", () => {
     });
 
     expect(result.current.data).toEqual(staff);
-    expect(mockGet).toHaveBeenCalledWith({ param: { teamId: "team-1" } });
+    expect(mockGet).toHaveBeenCalledWith({
+      param: { leagueId: "league-1", teamId: "team-1" },
+    });
   });
 
   it("skips fetching when teamId is empty", () => {
     mockGet.mockClear();
-    const { result } = renderHook(() => useStaffTree(""), {
+    const { result } = renderHook(() => useStaffTree("league-1", ""), {
+      wrapper: createWrapper(),
+    });
+    expect(result.current.isFetching).toBe(false);
+    expect(mockGet).not.toHaveBeenCalled();
+  });
+
+  it("skips fetching when leagueId is empty", () => {
+    mockGet.mockClear();
+    const { result } = renderHook(() => useStaffTree("", "team-1"), {
       wrapper: createWrapper(),
     });
     expect(result.current.isFetching).toBe(false);

--- a/client/src/hooks/use-staff-tree.ts
+++ b/client/src/hooks/use-staff-tree.ts
@@ -1,15 +1,16 @@
 import { useQuery } from "@tanstack/react-query";
 import { api } from "../api.ts";
 
-export function useStaffTree(teamId: string) {
+export function useStaffTree(leagueId: string, teamId: string) {
   return useQuery({
-    queryKey: ["coaches", "staff-tree", teamId],
+    queryKey: ["coaches", "staff-tree", leagueId, teamId],
     queryFn: async () => {
-      const res = await api.api.coaches.teams[":teamId"].staff.$get({
-        param: { teamId },
-      });
+      const res = await api.api.coaches.leagues[":leagueId"].teams[":teamId"]
+        .staff.$get({
+          param: { leagueId, teamId },
+        });
       return res.json();
     },
-    enabled: teamId.length > 0,
+    enabled: leagueId.length > 0 && teamId.length > 0,
   });
 }

--- a/client/src/router.test.tsx
+++ b/client/src/router.test.tsx
@@ -20,10 +20,14 @@ vi.mock("./api.ts", () => ({
         $get: (...args: unknown[]) => mockTeamsGet(...args),
       },
       coaches: {
-        teams: {
-          [":teamId"]: {
-            staff: {
-              $get: (...args: unknown[]) => mockStaffGet(...args),
+        leagues: {
+          [":leagueId"]: {
+            teams: {
+              [":teamId"]: {
+                staff: {
+                  $get: (...args: unknown[]) => mockStaffGet(...args),
+                },
+              },
             },
           },
         },

--- a/server/features/coaches/coaches.repository.interface.ts
+++ b/server/features/coaches/coaches.repository.interface.ts
@@ -3,9 +3,11 @@ import type { CoachDetail, CoachNode } from "@zone-blitz/shared";
 export interface CoachesRepository {
   /**
    * Returns every coach on a team as a flat list of staff-tree nodes.
-   * The client builds the hierarchy from `reportsToId`.
+   * Scoped to a league so teams that exist in multiple leagues do not
+   * leak coaching staff across universes. The client builds the
+   * hierarchy from `reportsToId`.
    */
-  getStaffTreeByTeam(teamId: string): Promise<CoachNode[]>;
+  getStaffTreeByTeam(leagueId: string, teamId: string): Promise<CoachNode[]>;
 
   /**
    * Returns the full public-record detail view for a single coach,

--- a/server/features/coaches/coaches.repository.test.ts
+++ b/server/features/coaches/coaches.repository.test.ts
@@ -131,7 +131,7 @@ Deno.test({
       ]);
       created.push(hcId, ocId);
 
-      const tree = await repo.getStaffTreeByTeam(team.id);
+      const tree = await repo.getStaffTreeByTeam(league.id, team.id);
       assertEquals(tree.length, 2);
 
       const hc = tree.find((c) => c.id === hcId);

--- a/server/features/coaches/coaches.repository.ts
+++ b/server/features/coaches/coaches.repository.ts
@@ -1,4 +1,4 @@
-import { eq } from "drizzle-orm";
+import { and, eq } from "drizzle-orm";
 import type pino from "pino";
 import type {
   CoachAccolade,
@@ -44,12 +44,14 @@ export function createCoachesRepository(deps: {
   const now = deps.now ?? (() => new Date());
 
   return {
-    async getStaffTreeByTeam(teamId) {
-      log.debug({ teamId }, "fetching staff tree");
+    async getStaffTreeByTeam(leagueId, teamId) {
+      log.debug({ leagueId, teamId }, "fetching staff tree");
       const rows = await deps.db
         .select()
         .from(coaches)
-        .where(eq(coaches.teamId, teamId));
+        .where(
+          and(eq(coaches.leagueId, leagueId), eq(coaches.teamId, teamId)),
+        );
       const today = now();
       return rows.map((row): CoachNode => ({
         id: row.id,

--- a/server/features/coaches/coaches.router.test.ts
+++ b/server/features/coaches/coaches.router.test.ts
@@ -64,25 +64,30 @@ function createDetail(overrides: Partial<CoachDetail> = {}): CoachDetail {
 
 Deno.test("coaches.router", async (t) => {
   await t.step(
-    "GET /teams/:teamId/staff returns the staff tree for the team",
+    "GET /leagues/:leagueId/teams/:teamId/staff returns the staff tree",
     async () => {
-      let received: string | undefined;
+      let receivedLeague: string | undefined;
+      let receivedTeam: string | undefined;
       const nodes = [
         createNode({ id: "hc", role: "HC" }),
         createNode({ id: "oc", role: "OC", reportsToId: "hc" }),
       ];
       const router = createCoachesRouter(
         createMockService({
-          getStaffTree: (teamId) => {
-            received = teamId;
+          getStaffTree: (leagueId, teamId) => {
+            receivedLeague = leagueId;
+            receivedTeam = teamId;
             return Promise.resolve(nodes);
           },
         }),
       );
 
-      const res = await router.request("/teams/team-123/staff");
+      const res = await router.request(
+        "/leagues/league-1/teams/team-123/staff",
+      );
       assertEquals(res.status, 200);
-      assertEquals(received, "team-123");
+      assertEquals(receivedLeague, "league-1");
+      assertEquals(receivedTeam, "team-123");
 
       const body = await res.json();
       assertEquals(body.length, 2);

--- a/server/features/coaches/coaches.router.ts
+++ b/server/features/coaches/coaches.router.ts
@@ -4,9 +4,10 @@ import type { AppEnv } from "../../env.ts";
 
 export function createCoachesRouter(coachesService: CoachesService) {
   return new Hono<AppEnv>()
-    .get("/teams/:teamId/staff", async (c) => {
+    .get("/leagues/:leagueId/teams/:teamId/staff", async (c) => {
+      const leagueId = c.req.param("leagueId");
       const teamId = c.req.param("teamId");
-      const staff = await coachesService.getStaffTree(teamId);
+      const staff = await coachesService.getStaffTree(leagueId, teamId);
       return c.json(staff);
     })
     .get("/:coachId", async (c) => {

--- a/server/features/coaches/coaches.service.interface.ts
+++ b/server/features/coaches/coaches.service.interface.ts
@@ -17,10 +17,12 @@ export interface CoachesService {
   ): Promise<CoachesGenerateResult>;
 
   /**
-   * Staff tree for a team — flat list of nodes; the client builds the
-   * hierarchy from `reportsToId`.
+   * Staff tree for a team in a given league — flat list of nodes; the
+   * client builds the hierarchy from `reportsToId`. Scoping by league
+   * prevents staff from other universes leaking through when the same
+   * team id is reused across leagues.
    */
-  getStaffTree(teamId: string): Promise<CoachNode[]>;
+  getStaffTree(leagueId: string, teamId: string): Promise<CoachNode[]>;
 
   /**
    * Full public-record detail for a single coach. Throws `DomainError`

--- a/server/features/coaches/coaches.service.test.ts
+++ b/server/features/coaches/coaches.service.test.ts
@@ -176,24 +176,28 @@ Deno.test("coaches.service", async (t) => {
     },
   );
 
-  await t.step("getStaffTree delegates to repository", async () => {
-    const { db } = createMockDb();
-    const nodes = [createNode()];
-    const service = createCoachesService({
-      generator: createMockGenerator(),
-      repo: createMockRepo({
-        getStaffTreeByTeam: (teamId) => {
-          assertEquals(teamId, "t1");
-          return Promise.resolve(nodes);
-        },
-      }),
-      db,
-      log: createTestLogger(),
-    });
+  await t.step(
+    "getStaffTree delegates to repository with league and team",
+    async () => {
+      const { db } = createMockDb();
+      const nodes = [createNode()];
+      const service = createCoachesService({
+        generator: createMockGenerator(),
+        repo: createMockRepo({
+          getStaffTreeByTeam: (leagueId, teamId) => {
+            assertEquals(leagueId, "l1");
+            assertEquals(teamId, "t1");
+            return Promise.resolve(nodes);
+          },
+        }),
+        db,
+        log: createTestLogger(),
+      });
 
-    const result = await service.getStaffTree("t1");
-    assertEquals(result, nodes);
-  });
+      const result = await service.getStaffTree("l1", "t1");
+      assertEquals(result, nodes);
+    },
+  );
 
   await t.step("getCoachDetail returns the detail when found", async () => {
     const { db } = createMockDb();

--- a/server/features/coaches/coaches.service.ts
+++ b/server/features/coaches/coaches.service.ts
@@ -36,9 +36,9 @@ export function createCoachesService(deps: {
       return { coachCount: generated.length };
     },
 
-    async getStaffTree(teamId) {
-      log.debug({ teamId }, "fetching staff tree");
-      return await deps.repo.getStaffTreeByTeam(teamId);
+    async getStaffTree(leagueId, teamId) {
+      log.debug({ leagueId, teamId }, "fetching staff tree");
+      return await deps.repo.getStaffTreeByTeam(leagueId, teamId);
     },
 
     async getCoachDetail(id) {


### PR DESCRIPTION
## Summary

- Teams are global but coaches are per `(leagueId, teamId)`. The staff tree endpoint filtered on `teamId` alone, which meant creating a second league would start blending coaches from every league that shared that team id — a correctness bug for the multi-universe gameplay the app supports.
- Thread `leagueId` through the repository, service, route (`GET /coaches/leagues/:leagueId/teams/:teamId/staff`), and `useStaffTree` hook; the coaches page now sources `leagueId` from the league-layout route params.