### PR TITLE
test(e2e): cover league creation flow end-to-end

### DIFF
--- a/e2e/helpers/db.ts
+++ b/e2e/helpers/db.ts
@@ -65,7 +65,7 @@ export async function seedTestUser(): Promise<{ sessionToken: string }> {
       ${TEST_SESSION.userAgent},
       ${TEST_SESSION.userId}
     )
-    ON CONFLICT (id) DO NOTHING
+    ON CONFLICT DO NOTHING
   `;
 
   return { sessionToken: TEST_SESSION.token };

--- a/e2e/setup.ts
+++ b/e2e/setup.ts
@@ -38,3 +38,23 @@ if (code !== 0) {
   console.error("Migration failed");
   Deno.exit(code);
 }
+
+const seed = new Deno.Command("deno", {
+  args: [
+    "run",
+    "--allow-net",
+    "--allow-env",
+    "--allow-read",
+    "--allow-sys",
+    "db/seed.ts",
+  ],
+  cwd: "server",
+  env: { DATABASE_URL: migrateUrl },
+  stdout: "inherit",
+  stderr: "inherit",
+});
+const { code: seedCode } = await seed.output();
+if (seedCode !== 0) {
+  console.error("Seed failed");
+  Deno.exit(seedCode);
+}

--- a/e2e/tests/league-creation.spec.ts
+++ b/e2e/tests/league-creation.spec.ts
@@ -1,0 +1,23 @@
+import { expect, test } from "../fixtures/auth.ts";
+
+test("user can create a league, pick a team, and land on the league dashboard", async ({ authenticatedPage: page }) => {
+  await page.goto("/leagues/new");
+
+  await expect(
+    page.getByRole("heading", { name: "Create a new league" }),
+  ).toBeVisible();
+
+  await page.getByLabel("League name").fill("Test League");
+  await page.getByRole("button", { name: "Create league" }).click();
+
+  await expect(
+    page.getByRole("heading", { name: "Choose Your Team" }),
+  ).toBeVisible({ timeout: 30_000 });
+
+  const uuid = "[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}";
+  await expect(page).toHaveURL(new RegExp(`/leagues/${uuid}/team-select$`));
+
+  await page.getByRole("button").first().click();
+
+  await expect(page).toHaveURL(new RegExp(`/leagues/${uuid}$`));
+});


### PR DESCRIPTION
## Summary

- Adds a Playwright E2E test that creates a league, picks a team, and asserts the league dashboard URL with a valid UUID.
- Seeds default teams as part of `e2e/setup.ts` (league creation requires teams to exist).
- Relaxes the session seed `ON CONFLICT` so parallel workers don't collide on the `token` unique constraint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)