### PR TITLE
test(e2e): verify created league shows on home page table

### DIFF
--- a/e2e/tests/leagues-table.spec.ts
+++ b/e2e/tests/leagues-table.spec.ts
@@ -1,0 +1,28 @@
+import { expect, test } from "../fixtures/auth.ts";
+
+test("created league appears in the home page leagues table", async ({ authenticatedPage: page }) => {
+  const leagueName = `Table Test League ${Date.now()}`;
+
+  await page.goto("/leagues/new");
+  await page.getByLabel("League name").fill(leagueName);
+  await page.getByRole("button", { name: "Create league" }).click();
+
+  await expect(
+    page.getByRole("heading", { name: "Choose Your Team" }),
+  ).toBeVisible({ timeout: 30_000 });
+
+  await page.goto("/");
+
+  await expect(
+    page.getByRole("heading", { name: "Leagues" }),
+  ).toBeVisible();
+
+  const row = page.getByRole("row", { name: new RegExp(leagueName) });
+  await expect(row).toBeVisible();
+  await expect(row.getByRole("cell", { name: leagueName, exact: true }))
+    .toBeVisible();
+  await expect(row.getByRole("cell", { name: "32", exact: true }))
+    .toBeVisible();
+  await expect(row.getByRole("cell", { name: "17", exact: true }))
+    .toBeVisible();
+});


### PR DESCRIPTION
## Summary
- Adds an E2E test that creates a league via the UI, returns to \`/\`, and asserts the new league row appears in the leagues table with its name, team count (32), and season length (17).
- Closes the gap between league creation (covered up to team-select) and the authenticated home page table rendering.