### PR TITLE
feat(roster): add server roster feature with active/depth-chart/stats endpoints

### DIFF
--- a/packages/shared/mod.ts
+++ b/packages/shared/mod.ts
@@ -28,6 +28,17 @@ export type {
 } from "./types/coach.ts";
 export type { Scout } from "./types/scout.ts";
 export type {
+  ActiveRoster,
+  DepthChart,
+  DepthChartInactive,
+  DepthChartSlot,
+  PlayerPositionGroup,
+  RosterPlayer,
+  RosterPositionGroupSummary,
+  RosterStatistics,
+  RosterStatisticsRow,
+} from "./types/roster.ts";
+export type {
   Contract,
   DraftProspect,
   Player,

--- a/packages/shared/types/roster.ts
+++ b/packages/shared/types/roster.ts
@@ -1,0 +1,74 @@
+import type { CoachSummary } from "./coach.ts";
+import type { PlayerInjuryStatus, PlayerPosition } from "./player.ts";
+
+export type PlayerPositionGroup = "offense" | "defense" | "special_teams";
+
+export interface RosterPlayer {
+  id: string;
+  firstName: string;
+  lastName: string;
+  position: PlayerPosition;
+  positionGroup: PlayerPositionGroup;
+  age: number;
+  capHit: number;
+  contractYearsRemaining: number;
+  injuryStatus: PlayerInjuryStatus;
+}
+
+export interface RosterPositionGroupSummary {
+  group: PlayerPositionGroup;
+  headcount: number;
+  totalCap: number;
+}
+
+export interface ActiveRoster {
+  leagueId: string;
+  teamId: string;
+  players: RosterPlayer[];
+  positionGroups: RosterPositionGroupSummary[];
+  totalCap: number;
+  salaryCap: number;
+  capSpace: number;
+}
+
+export interface DepthChartSlot {
+  playerId: string;
+  firstName: string;
+  lastName: string;
+  position: PlayerPosition;
+  slotOrdinal: number;
+  injuryStatus: PlayerInjuryStatus;
+}
+
+export interface DepthChartInactive {
+  playerId: string;
+  firstName: string;
+  lastName: string;
+  position: PlayerPosition;
+  injuryStatus: PlayerInjuryStatus;
+}
+
+export interface DepthChart {
+  leagueId: string;
+  teamId: string;
+  slots: DepthChartSlot[];
+  inactives: DepthChartInactive[];
+  lastUpdatedAt: string | null;
+  lastUpdatedBy: CoachSummary | null;
+}
+
+export interface RosterStatisticsRow {
+  playerId: string;
+  firstName: string;
+  lastName: string;
+  position: PlayerPosition;
+  positionGroup: PlayerPositionGroup;
+  gamesPlayed: number;
+}
+
+export interface RosterStatistics {
+  leagueId: string;
+  teamId: string;
+  seasonId: string | null;
+  rows: RosterStatisticsRow[];
+}

--- a/server/features/mod.ts
+++ b/server/features/mod.ts
@@ -31,6 +31,11 @@ import {
   createStubCoachesGenerator,
 } from "./coaches/mod.ts";
 import {
+  createRosterRepository,
+  createRosterRouter,
+  createRosterService,
+} from "./roster/mod.ts";
+import {
   createScoutsService,
   createStubScoutsGenerator,
 } from "./scouts/mod.ts";
@@ -79,6 +84,7 @@ export function createFeatureRouters(
   const teamRepo = createTeamRepository({ db, log });
   const seasonRepo = createSeasonRepository({ db, log });
   const coachesRepo = createCoachesRepository({ db, log });
+  const rosterRepo = createRosterRepository({ db, log });
 
   // Services
   const userService = createUserService({ userRepo, log });
@@ -133,6 +139,8 @@ export function createFeatureRouters(
   const userRouter = createUserRouter(userService);
   const teamRouter = createTeamRouter(teamService);
   const coachesRouter = createCoachesRouter(coachesService);
+  const rosterService = createRosterService({ repo: rosterRepo, log });
+  const rosterRouter = createRosterRouter(rosterService);
 
   return {
     auth,
@@ -142,5 +150,6 @@ export function createFeatureRouters(
     userRouter,
     teamRouter,
     coachesRouter,
+    rosterRouter,
   };
 }

--- a/server/features/roster/mod.ts
+++ b/server/features/roster/mod.ts
@@ -1,0 +1,5 @@
+export { createRosterRepository } from "./roster.repository.ts";
+export { createRosterRouter } from "./roster.router.ts";
+export { createRosterService } from "./roster.service.ts";
+export type { RosterRepository } from "./roster.repository.interface.ts";
+export type { RosterService } from "./roster.service.interface.ts";

--- a/server/features/roster/roster.repository.interface.ts
+++ b/server/features/roster/roster.repository.interface.ts
@@ -1,0 +1,33 @@
+import type {
+  ActiveRoster,
+  DepthChart,
+  RosterStatistics,
+} from "@zone-blitz/shared";
+
+export interface RosterRepository {
+  /**
+   * Active 53-man roster for a team within a league. Returns player
+   * identity + contract-derived cap, injury status, contract years,
+   * and per-position-group + total cap aggregates. Scoped by league
+   * so the same team in a different universe isn't mixed in.
+   */
+  getActiveRoster(leagueId: string, teamId: string): Promise<ActiveRoster>;
+
+  /**
+   * Coach-owned depth chart snapshot for a team. Read-only: the
+   * coach sim is the only writer. Missing publish produces an empty
+   * slot list and null timestamps.
+   */
+  getDepthChart(leagueId: string, teamId: string): Promise<DepthChart>;
+
+  /**
+   * Per-player season statistics for a team. Returns an empty rows
+   * array today because the sim does not yet emit stats — the page
+   * renders an empty state until stats are produced.
+   */
+  getStatistics(
+    leagueId: string,
+    teamId: string,
+    seasonId: string | null,
+  ): Promise<RosterStatistics>;
+}

--- a/server/features/roster/roster.repository.test.ts
+++ b/server/features/roster/roster.repository.test.ts
@@ -1,0 +1,419 @@
+import { assertEquals, assertRejects } from "@std/assert";
+import { drizzle } from "drizzle-orm/postgres-js";
+import { eq, inArray } from "drizzle-orm";
+import postgres from "postgres";
+import pino from "pino";
+import { DomainError, PLAYER_ATTRIBUTE_KEYS } from "@zone-blitz/shared";
+import * as schema from "../../db/schema.ts";
+import { players } from "../players/player.schema.ts";
+import { playerAttributes } from "../players/attributes.schema.ts";
+import { contracts } from "../players/contract.schema.ts";
+import { depthChartEntries } from "../players/depth-chart.schema.ts";
+import { coaches } from "../coaches/coach.schema.ts";
+import { leagues } from "../league/league.schema.ts";
+import { teams } from "../team/team.schema.ts";
+import { cities } from "../cities/city.schema.ts";
+import { states } from "../states/state.schema.ts";
+import { createRosterRepository } from "./roster.repository.ts";
+
+function createTestDb() {
+  const connectionString = Deno.env.get("DATABASE_URL");
+  if (!connectionString) {
+    throw new Error("DATABASE_URL is required for integration tests");
+  }
+  const client = postgres(connectionString);
+  const db = drizzle(client, { schema });
+  return { db, client };
+}
+
+function createTestLogger() {
+  return pino({ level: "silent" });
+}
+
+async function setupFixtures(db: ReturnType<typeof createTestDb>["db"]) {
+  const [league] = await db
+    .insert(leagues)
+    .values({ name: `League ${crypto.randomUUID()}`, salaryCap: 255_000_000 })
+    .returning();
+  const [state] = await db
+    .insert(states)
+    .values({
+      code: `test-${crypto.randomUUID()}`,
+      name: `TestState-${crypto.randomUUID()}`,
+      region: "West",
+    })
+    .returning();
+  const [city] = await db
+    .insert(cities)
+    .values({
+      name: `TestCity-${crypto.randomUUID()}`,
+      stateId: state.id,
+    })
+    .returning();
+  const [team] = await db
+    .insert(teams)
+    .values({
+      name: "Test Team",
+      cityId: city.id,
+      abbreviation: `T${crypto.randomUUID().slice(0, 2).toUpperCase()}`,
+      primaryColor: "#000000",
+      secondaryColor: "#FFFFFF",
+      accentColor: "#FF0000",
+      conference: "AFC",
+      division: "AFC East",
+    })
+    .returning();
+  return { league, team, state, city };
+}
+
+function stubAttributeColumns(): Record<string, number> {
+  const row: Record<string, number> = {};
+  for (const key of PLAYER_ATTRIBUTE_KEYS) {
+    row[key] = 50;
+    row[`${key}Potential`] = 60;
+  }
+  return row;
+}
+
+async function cleanup(
+  db: ReturnType<typeof createTestDb>["db"],
+  ids: {
+    players?: string[];
+    teams?: string[];
+    cities?: string[];
+    states?: string[];
+    leagues?: string[];
+  },
+) {
+  if (ids.players?.length) {
+    await db.delete(players).where(inArray(players.id, ids.players));
+  }
+  for (const id of ids.teams ?? []) {
+    await db.delete(teams).where(eq(teams.id, id));
+  }
+  for (const id of ids.cities ?? []) {
+    await db.delete(cities).where(eq(cities.id, id));
+  }
+  for (const id of ids.states ?? []) {
+    await db.delete(states).where(eq(states.id, id));
+  }
+  for (const id of ids.leagues ?? []) {
+    await db.delete(leagues).where(eq(leagues.id, id));
+  }
+}
+
+Deno.test({
+  name:
+    "rosterRepository.getActiveRoster: returns players with cap, age, and contract years",
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    const { db, client } = createTestDb();
+    const repo = createRosterRepository({
+      db,
+      log: createTestLogger(),
+      now: () => new Date("2030-06-15T00:00:00Z"),
+    });
+    const playersCreated: string[] = [];
+    const teamsCreated: string[] = [];
+    const leaguesCreated: string[] = [];
+    const citiesCreated: string[] = [];
+    const statesCreated: string[] = [];
+
+    try {
+      const { league, team, state, city } = await setupFixtures(db);
+      leaguesCreated.push(league.id);
+      teamsCreated.push(team.id);
+      citiesCreated.push(city.id);
+      statesCreated.push(state.id);
+
+      const qbId = crypto.randomUUID();
+      const dlId = crypto.randomUUID();
+      await db.insert(players).values([
+        {
+          id: qbId,
+          leagueId: league.id,
+          teamId: team.id,
+          firstName: "Sam",
+          lastName: "Stone",
+          position: "QB",
+          injuryStatus: "healthy",
+          heightInches: 75,
+          weightPounds: 220,
+          birthDate: "2000-01-01",
+        },
+        {
+          id: dlId,
+          leagueId: league.id,
+          teamId: team.id,
+          firstName: "Dan",
+          lastName: "Line",
+          position: "DL",
+          injuryStatus: "questionable",
+          heightInches: 76,
+          weightPounds: 280,
+          birthDate: "1998-08-01",
+        },
+      ]);
+      playersCreated.push(qbId, dlId);
+
+      await db.insert(playerAttributes).values([
+        { playerId: qbId, ...stubAttributeColumns() },
+        { playerId: dlId, ...stubAttributeColumns() },
+      ]);
+
+      await db.insert(contracts).values([
+        {
+          playerId: qbId,
+          teamId: team.id,
+          totalYears: 4,
+          currentYear: 2,
+          totalSalary: 40_000_000,
+          annualSalary: 10_000_000,
+          guaranteedMoney: 20_000_000,
+          signingBonus: 5_000_000,
+        },
+        {
+          playerId: dlId,
+          teamId: team.id,
+          totalYears: 3,
+          currentYear: 1,
+          totalSalary: 15_000_000,
+          annualSalary: 5_000_000,
+          guaranteedMoney: 5_000_000,
+          signingBonus: 0,
+        },
+      ]);
+
+      const roster = await repo.getActiveRoster(league.id, team.id);
+
+      assertEquals(roster.leagueId, league.id);
+      assertEquals(roster.teamId, team.id);
+      assertEquals(roster.players.length, 2);
+      assertEquals(roster.totalCap, 15_000_000);
+      assertEquals(roster.salaryCap, 255_000_000);
+      assertEquals(roster.capSpace, 240_000_000);
+
+      const qb = roster.players.find((p) => p.id === qbId);
+      assertEquals(qb?.position, "QB");
+      assertEquals(qb?.positionGroup, "offense");
+      assertEquals(qb?.capHit, 10_000_000);
+      assertEquals(qb?.contractYearsRemaining, 3);
+      assertEquals(qb?.age, 30);
+      assertEquals(qb?.injuryStatus, "healthy");
+
+      const dl = roster.players.find((p) => p.id === dlId);
+      assertEquals(dl?.positionGroup, "defense");
+      assertEquals(dl?.injuryStatus, "questionable");
+
+      const offense = roster.positionGroups.find((g) => g.group === "offense");
+      assertEquals(offense?.headcount, 1);
+      assertEquals(offense?.totalCap, 10_000_000);
+      const defense = roster.positionGroups.find((g) => g.group === "defense");
+      assertEquals(defense?.headcount, 1);
+      assertEquals(defense?.totalCap, 5_000_000);
+      const st = roster.positionGroups.find((g) => g.group === "special_teams");
+      assertEquals(st?.headcount, 0);
+    } finally {
+      await cleanup(db, {
+        players: playersCreated,
+        teams: teamsCreated,
+        cities: citiesCreated,
+        states: statesCreated,
+        leagues: leaguesCreated,
+      });
+      await client.end();
+    }
+  },
+});
+
+Deno.test({
+  name:
+    "rosterRepository.getActiveRoster: throws NOT_FOUND when league missing",
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    const { db, client } = createTestDb();
+    const repo = createRosterRepository({ db, log: createTestLogger() });
+    try {
+      await assertRejects(
+        () => repo.getActiveRoster(crypto.randomUUID(), crypto.randomUUID()),
+        DomainError,
+      );
+    } finally {
+      await client.end();
+    }
+  },
+});
+
+Deno.test({
+  name:
+    "rosterRepository.getDepthChart: returns slots, inactives, and latest publisher",
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    const { db, client } = createTestDb();
+    const repo = createRosterRepository({ db, log: createTestLogger() });
+    const playersCreated: string[] = [];
+    const teamsCreated: string[] = [];
+    const leaguesCreated: string[] = [];
+    const citiesCreated: string[] = [];
+    const statesCreated: string[] = [];
+    const coachesCreated: string[] = [];
+
+    try {
+      const { league, team, state, city } = await setupFixtures(db);
+      leaguesCreated.push(league.id);
+      teamsCreated.push(team.id);
+      citiesCreated.push(city.id);
+      statesCreated.push(state.id);
+
+      const coachId = crypto.randomUUID();
+      await db.insert(coaches).values({
+        id: coachId,
+        leagueId: league.id,
+        teamId: team.id,
+        firstName: "Alex",
+        lastName: "Stone",
+        role: "HC",
+        age: 50,
+        hiredAt: new Date("2028-01-01T00:00:00Z"),
+        contractYears: 3,
+        contractSalary: 1,
+        contractBuyout: 1,
+      });
+      coachesCreated.push(coachId);
+
+      const starterId = crypto.randomUUID();
+      const inactiveId = crypto.randomUUID();
+      await db.insert(players).values([
+        {
+          id: starterId,
+          leagueId: league.id,
+          teamId: team.id,
+          firstName: "Sam",
+          lastName: "Stone",
+          position: "QB",
+          injuryStatus: "healthy",
+          heightInches: 75,
+          weightPounds: 220,
+          birthDate: "2000-01-01",
+        },
+        {
+          id: inactiveId,
+          leagueId: league.id,
+          teamId: team.id,
+          firstName: "Ben",
+          lastName: "Bench",
+          position: "RB",
+          injuryStatus: "out",
+          heightInches: 70,
+          weightPounds: 210,
+          birthDate: "2001-01-01",
+        },
+      ]);
+      playersCreated.push(starterId, inactiveId);
+
+      await db.insert(playerAttributes).values([
+        { playerId: starterId, ...stubAttributeColumns() },
+        { playerId: inactiveId, ...stubAttributeColumns() },
+      ]);
+
+      await db.insert(depthChartEntries).values([
+        {
+          teamId: team.id,
+          playerId: starterId,
+          position: "QB",
+          slotOrdinal: 1,
+          isInactive: false,
+          publishedByCoachId: coachId,
+        },
+        {
+          teamId: team.id,
+          playerId: inactiveId,
+          position: "RB",
+          slotOrdinal: 1,
+          isInactive: true,
+          publishedByCoachId: coachId,
+        },
+      ]);
+
+      const chart = await repo.getDepthChart(league.id, team.id);
+      assertEquals(chart.slots.length, 1);
+      assertEquals(chart.slots[0].playerId, starterId);
+      assertEquals(chart.slots[0].slotOrdinal, 1);
+      assertEquals(chart.inactives.length, 1);
+      assertEquals(chart.inactives[0].playerId, inactiveId);
+      assertEquals(chart.lastUpdatedBy?.id, coachId);
+      assertEquals(typeof chart.lastUpdatedAt, "string");
+    } finally {
+      if (coachesCreated.length) {
+        await db.delete(coaches).where(inArray(coaches.id, coachesCreated));
+      }
+      await cleanup(db, {
+        players: playersCreated,
+        teams: teamsCreated,
+        cities: citiesCreated,
+        states: statesCreated,
+        leagues: leaguesCreated,
+      });
+      await client.end();
+    }
+  },
+});
+
+Deno.test({
+  name:
+    "rosterRepository.getDepthChart: returns empty chart when no entries exist",
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    const { db, client } = createTestDb();
+    const repo = createRosterRepository({ db, log: createTestLogger() });
+    const teamsCreated: string[] = [];
+    const leaguesCreated: string[] = [];
+    const citiesCreated: string[] = [];
+    const statesCreated: string[] = [];
+    try {
+      const { league, team, state, city } = await setupFixtures(db);
+      leaguesCreated.push(league.id);
+      teamsCreated.push(team.id);
+      citiesCreated.push(city.id);
+      statesCreated.push(state.id);
+
+      const chart = await repo.getDepthChart(league.id, team.id);
+      assertEquals(chart.slots, []);
+      assertEquals(chart.inactives, []);
+      assertEquals(chart.lastUpdatedAt, null);
+      assertEquals(chart.lastUpdatedBy, null);
+    } finally {
+      await cleanup(db, {
+        teams: teamsCreated,
+        cities: citiesCreated,
+        states: statesCreated,
+        leagues: leaguesCreated,
+      });
+      await client.end();
+    }
+  },
+});
+
+Deno.test({
+  name: "rosterRepository.getStatistics: returns empty rows (stub)",
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    const { db, client } = createTestDb();
+    const repo = createRosterRepository({ db, log: createTestLogger() });
+    try {
+      const stats = await repo.getStatistics("lg-1", "tm-1", "season-1");
+      assertEquals(stats.rows, []);
+      assertEquals(stats.seasonId, "season-1");
+
+      const statsNoSeason = await repo.getStatistics("lg-1", "tm-1", null);
+      assertEquals(statsNoSeason.seasonId, null);
+    } finally {
+      await client.end();
+    }
+  },
+});

--- a/server/features/roster/roster.repository.ts
+++ b/server/features/roster/roster.repository.ts
@@ -1,0 +1,229 @@
+import { and, desc, eq } from "drizzle-orm";
+import type pino from "pino";
+import {
+  type DepthChartInactive,
+  type DepthChartSlot,
+  DomainError,
+  PLAYER_POSITION_GROUPS,
+  type PlayerPosition,
+  type PlayerPositionGroup,
+  type RosterPlayer,
+  type RosterPositionGroupSummary,
+  type RosterStatistics,
+} from "@zone-blitz/shared";
+import type { Database } from "../../db/connection.ts";
+import { players } from "../players/player.schema.ts";
+import { contracts } from "../players/contract.schema.ts";
+import { depthChartEntries } from "../players/depth-chart.schema.ts";
+import { leagues } from "../league/league.schema.ts";
+import { coaches } from "../coaches/coach.schema.ts";
+import type { RosterRepository } from "./roster.repository.interface.ts";
+
+function positionGroupOf(position: PlayerPosition): PlayerPositionGroup {
+  for (const group of ["offense", "defense", "special_teams"] as const) {
+    if (PLAYER_POSITION_GROUPS[group].includes(position)) return group;
+  }
+  throw new Error(`Unknown position group for ${position}`);
+}
+
+function ageFromBirthDate(birthDate: string, today: Date): number {
+  const birth = new Date(birthDate);
+  let age = today.getUTCFullYear() - birth.getUTCFullYear();
+  const monthDelta = today.getUTCMonth() - birth.getUTCMonth();
+  if (
+    monthDelta < 0 ||
+    (monthDelta === 0 && today.getUTCDate() < birth.getUTCDate())
+  ) {
+    age -= 1;
+  }
+  return Math.max(0, age);
+}
+
+function summarizeGroups(
+  rosterPlayers: RosterPlayer[],
+): RosterPositionGroupSummary[] {
+  const groups: PlayerPositionGroup[] = [
+    "offense",
+    "defense",
+    "special_teams",
+  ];
+  return groups.map((group) => {
+    const members = rosterPlayers.filter((p) => p.positionGroup === group);
+    return {
+      group,
+      headcount: members.length,
+      totalCap: members.reduce((sum, p) => sum + p.capHit, 0),
+    };
+  });
+}
+
+export function createRosterRepository(deps: {
+  db: Database;
+  log: pino.Logger;
+  now?: () => Date;
+}): RosterRepository {
+  const log = deps.log.child({ module: "roster.repository" });
+  const now = deps.now ?? (() => new Date());
+
+  return {
+    async getActiveRoster(leagueId, teamId) {
+      log.debug({ leagueId, teamId }, "fetching active roster");
+
+      const [league] = await deps.db
+        .select({ salaryCap: leagues.salaryCap })
+        .from(leagues)
+        .where(eq(leagues.id, leagueId))
+        .limit(1);
+      if (!league) {
+        throw new DomainError("NOT_FOUND", `League ${leagueId} not found`);
+      }
+
+      const rows = await deps.db
+        .select({
+          id: players.id,
+          firstName: players.firstName,
+          lastName: players.lastName,
+          position: players.position,
+          birthDate: players.birthDate,
+          injuryStatus: players.injuryStatus,
+          annualSalary: contracts.annualSalary,
+          totalYears: contracts.totalYears,
+          currentYear: contracts.currentYear,
+        })
+        .from(players)
+        .leftJoin(contracts, eq(contracts.playerId, players.id))
+        .where(
+          and(eq(players.leagueId, leagueId), eq(players.teamId, teamId)),
+        );
+
+      const today = now();
+      const rosterPlayers: RosterPlayer[] = rows.map((row) => ({
+        id: row.id,
+        firstName: row.firstName,
+        lastName: row.lastName,
+        position: row.position,
+        positionGroup: positionGroupOf(row.position),
+        age: ageFromBirthDate(row.birthDate, today),
+        capHit: row.annualSalary ?? 0,
+        contractYearsRemaining: row.totalYears !== null &&
+            row.currentYear !== null
+          ? Math.max(0, row.totalYears - row.currentYear + 1)
+          : 0,
+        injuryStatus: row.injuryStatus,
+      }));
+
+      const totalCap = rosterPlayers.reduce((sum, p) => sum + p.capHit, 0);
+
+      return {
+        leagueId,
+        teamId,
+        players: rosterPlayers,
+        positionGroups: summarizeGroups(rosterPlayers),
+        totalCap,
+        salaryCap: league.salaryCap,
+        capSpace: league.salaryCap - totalCap,
+      };
+    },
+
+    async getDepthChart(leagueId, teamId) {
+      log.debug({ leagueId, teamId }, "fetching depth chart");
+
+      const entryRows = await deps.db
+        .select({
+          playerId: depthChartEntries.playerId,
+          position: depthChartEntries.position,
+          slotOrdinal: depthChartEntries.slotOrdinal,
+          isInactive: depthChartEntries.isInactive,
+          publishedAt: depthChartEntries.publishedAt,
+          publishedByCoachId: depthChartEntries.publishedByCoachId,
+          firstName: players.firstName,
+          lastName: players.lastName,
+          injuryStatus: players.injuryStatus,
+        })
+        .from(depthChartEntries)
+        .innerJoin(players, eq(players.id, depthChartEntries.playerId))
+        .where(
+          and(
+            eq(depthChartEntries.teamId, teamId),
+            eq(players.leagueId, leagueId),
+          ),
+        );
+
+      const slots: DepthChartSlot[] = [];
+      const inactives: DepthChartInactive[] = [];
+
+      for (const row of entryRows) {
+        if (row.isInactive) {
+          inactives.push({
+            playerId: row.playerId,
+            firstName: row.firstName,
+            lastName: row.lastName,
+            position: row.position,
+            injuryStatus: row.injuryStatus,
+          });
+        } else {
+          slots.push({
+            playerId: row.playerId,
+            firstName: row.firstName,
+            lastName: row.lastName,
+            position: row.position,
+            slotOrdinal: row.slotOrdinal,
+            injuryStatus: row.injuryStatus,
+          });
+        }
+      }
+
+      slots.sort((a, b) =>
+        a.position.localeCompare(b.position) || a.slotOrdinal - b.slotOrdinal
+      );
+
+      const [latest] = await deps.db
+        .select({
+          publishedAt: depthChartEntries.publishedAt,
+          publishedByCoachId: depthChartEntries.publishedByCoachId,
+        })
+        .from(depthChartEntries)
+        .where(eq(depthChartEntries.teamId, teamId))
+        .orderBy(desc(depthChartEntries.publishedAt))
+        .limit(1);
+
+      let lastUpdatedBy = null;
+      if (latest?.publishedByCoachId) {
+        const [coach] = await deps.db
+          .select({
+            id: coaches.id,
+            firstName: coaches.firstName,
+            lastName: coaches.lastName,
+            role: coaches.role,
+          })
+          .from(coaches)
+          .where(eq(coaches.id, latest.publishedByCoachId))
+          .limit(1);
+        if (coach) lastUpdatedBy = coach;
+      }
+
+      return {
+        leagueId,
+        teamId,
+        slots,
+        inactives,
+        lastUpdatedAt: latest?.publishedAt?.toISOString() ?? null,
+        lastUpdatedBy,
+      };
+    },
+
+    getStatistics(leagueId, teamId, seasonId) {
+      log.debug(
+        { leagueId, teamId, seasonId },
+        "fetching roster statistics (stub)",
+      );
+      const empty: RosterStatistics = {
+        leagueId,
+        teamId,
+        seasonId,
+        rows: [],
+      };
+      return Promise.resolve(empty);
+    },
+  };
+}

--- a/server/features/roster/roster.router.test.ts
+++ b/server/features/roster/roster.router.test.ts
@@ -1,0 +1,157 @@
+import { assertEquals } from "@std/assert";
+import type { ActiveRoster, DepthChart } from "@zone-blitz/shared";
+import { createRosterRouter } from "./roster.router.ts";
+import type { RosterService } from "./roster.service.interface.ts";
+
+function createMockService(
+  overrides: Partial<RosterService> = {},
+): RosterService {
+  const emptyActive: ActiveRoster = {
+    leagueId: "l",
+    teamId: "t",
+    players: [],
+    positionGroups: [],
+    totalCap: 0,
+    salaryCap: 0,
+    capSpace: 0,
+  };
+  const emptyChart: DepthChart = {
+    leagueId: "l",
+    teamId: "t",
+    slots: [],
+    inactives: [],
+    lastUpdatedAt: null,
+    lastUpdatedBy: null,
+  };
+  return {
+    getActiveRoster: () => Promise.resolve(emptyActive),
+    getDepthChart: () => Promise.resolve(emptyChart),
+    getStatistics: () =>
+      Promise.resolve({
+        leagueId: "l",
+        teamId: "t",
+        seasonId: null,
+        rows: [],
+      }),
+    ...overrides,
+  };
+}
+
+Deno.test("roster.router", async (t) => {
+  await t.step(
+    "GET /leagues/:leagueId/teams/:teamId/active returns the active roster",
+    async () => {
+      let receivedLeague: string | undefined;
+      let receivedTeam: string | undefined;
+      const router = createRosterRouter(
+        createMockService({
+          getActiveRoster: (leagueId, teamId) => {
+            receivedLeague = leagueId;
+            receivedTeam = teamId;
+            return Promise.resolve({
+              leagueId,
+              teamId,
+              players: [
+                {
+                  id: "p1",
+                  firstName: "Sam",
+                  lastName: "Stone",
+                  position: "QB",
+                  positionGroup: "offense",
+                  age: 25,
+                  capHit: 10_000_000,
+                  contractYearsRemaining: 3,
+                  injuryStatus: "healthy",
+                },
+              ],
+              positionGroups: [
+                { group: "offense", headcount: 1, totalCap: 10_000_000 },
+                { group: "defense", headcount: 0, totalCap: 0 },
+                { group: "special_teams", headcount: 0, totalCap: 0 },
+              ],
+              totalCap: 10_000_000,
+              salaryCap: 255_000_000,
+              capSpace: 245_000_000,
+            });
+          },
+        }),
+      );
+
+      const res = await router.request("/leagues/lg-1/teams/tm-1/active");
+      assertEquals(res.status, 200);
+      assertEquals(receivedLeague, "lg-1");
+      assertEquals(receivedTeam, "tm-1");
+
+      const body = await res.json();
+      assertEquals(body.players.length, 1);
+      assertEquals(body.players[0].id, "p1");
+      assertEquals(body.totalCap, 10_000_000);
+    },
+  );
+
+  await t.step(
+    "GET /leagues/:leagueId/teams/:teamId/depth-chart returns slots + inactives",
+    async () => {
+      const router = createRosterRouter(
+        createMockService({
+          getDepthChart: (leagueId, teamId) =>
+            Promise.resolve({
+              leagueId,
+              teamId,
+              slots: [
+                {
+                  playerId: "p1",
+                  firstName: "Sam",
+                  lastName: "Stone",
+                  position: "QB",
+                  slotOrdinal: 1,
+                  injuryStatus: "healthy",
+                },
+              ],
+              inactives: [],
+              lastUpdatedAt: "2026-04-13T00:00:00.000Z",
+              lastUpdatedBy: {
+                id: "c1",
+                firstName: "Alex",
+                lastName: "Stone",
+                role: "HC",
+              },
+            }),
+        }),
+      );
+      const res = await router.request("/leagues/lg-1/teams/tm-1/depth-chart");
+      assertEquals(res.status, 200);
+      const body = await res.json();
+      assertEquals(body.slots.length, 1);
+      assertEquals(body.lastUpdatedBy.role, "HC");
+    },
+  );
+
+  await t.step(
+    "GET /leagues/:leagueId/teams/:teamId/statistics passes season query",
+    async () => {
+      let receivedSeason: string | null | undefined;
+      const router = createRosterRouter(
+        createMockService({
+          getStatistics: (leagueId, teamId, seasonId) => {
+            receivedSeason = seasonId;
+            return Promise.resolve({
+              leagueId,
+              teamId,
+              seasonId,
+              rows: [],
+            });
+          },
+        }),
+      );
+      const res = await router.request(
+        "/leagues/lg-1/teams/tm-1/statistics?season=s-42",
+      );
+      assertEquals(res.status, 200);
+      assertEquals(receivedSeason, "s-42");
+
+      await router.request("/leagues/lg-1/teams/tm-1/statistics");
+      assertEquals(receivedSeason, null);
+    },
+  );
+});

--- a/server/features/roster/roster.router.ts
+++ b/server/features/roster/roster.router.ts
@@ -1,0 +1,30 @@
+import { Hono } from "hono";
+import type { RosterService } from "./roster.service.interface.ts";
+import type { AppEnv } from "../../env.ts";
+
+export function createRosterRouter(rosterService: RosterService) {
+  return new Hono<AppEnv>()
+    .get("/leagues/:leagueId/teams/:teamId/active", async (c) => {
+      const leagueId = c.req.param("leagueId");
+      const teamId = c.req.param("teamId");
+      const roster = await rosterService.getActiveRoster(leagueId, teamId);
+      return c.json(roster);
+    })
+    .get("/leagues/:leagueId/teams/:teamId/depth-chart", async (c) => {
+      const leagueId = c.req.param("leagueId");
+      const teamId = c.req.param("teamId");
+      const chart = await rosterService.getDepthChart(leagueId, teamId);
+      return c.json(chart);
+    })
+    .get("/leagues/:leagueId/teams/:teamId/statistics", async (c) => {
+      const leagueId = c.req.param("leagueId");
+      const teamId = c.req.param("teamId");
+      const seasonId = c.req.query("season") ?? null;
+      const stats = await rosterService.getStatistics(
+        leagueId,
+        teamId,
+        seasonId,
+      );
+      return c.json(stats);
+    });
+}

--- a/server/features/roster/roster.service.interface.ts
+++ b/server/features/roster/roster.service.interface.ts
@@ -1,0 +1,15 @@
+import type {
+  ActiveRoster,
+  DepthChart,
+  RosterStatistics,
+} from "@zone-blitz/shared";
+
+export interface RosterService {
+  getActiveRoster(leagueId: string, teamId: string): Promise<ActiveRoster>;
+  getDepthChart(leagueId: string, teamId: string): Promise<DepthChart>;
+  getStatistics(
+    leagueId: string,
+    teamId: string,
+    seasonId: string | null,
+  ): Promise<RosterStatistics>;
+}

--- a/server/features/roster/roster.service.test.ts
+++ b/server/features/roster/roster.service.test.ts
@@ -1,0 +1,131 @@
+import { assertEquals } from "@std/assert";
+import type {
+  ActiveRoster,
+  DepthChart,
+  RosterStatistics,
+} from "@zone-blitz/shared";
+import { createRosterService } from "./roster.service.ts";
+import type { RosterRepository } from "./roster.repository.interface.ts";
+
+function createTestLogger() {
+  return {
+    child: () => createTestLogger(),
+    debug: () => {},
+    info: () => {},
+    warn: () => {},
+    error: () => {},
+  } as unknown as import("pino").Logger;
+}
+
+function createMockRepo(
+  overrides: Partial<RosterRepository> = {},
+): RosterRepository {
+  const emptyActive: ActiveRoster = {
+    leagueId: "l",
+    teamId: "t",
+    players: [],
+    positionGroups: [],
+    totalCap: 0,
+    salaryCap: 0,
+    capSpace: 0,
+  };
+  const emptyChart: DepthChart = {
+    leagueId: "l",
+    teamId: "t",
+    slots: [],
+    inactives: [],
+    lastUpdatedAt: null,
+    lastUpdatedBy: null,
+  };
+  const emptyStats: RosterStatistics = {
+    leagueId: "l",
+    teamId: "t",
+    seasonId: null,
+    rows: [],
+  };
+  return {
+    getActiveRoster: () => Promise.resolve(emptyActive),
+    getDepthChart: () => Promise.resolve(emptyChart),
+    getStatistics: () => Promise.resolve(emptyStats),
+    ...overrides,
+  };
+}
+
+Deno.test("roster.service", async (t) => {
+  await t.step(
+    "getActiveRoster forwards leagueId and teamId to repository",
+    async () => {
+      let receivedLeague: string | undefined;
+      let receivedTeam: string | undefined;
+      const service = createRosterService({
+        repo: createMockRepo({
+          getActiveRoster: (leagueId, teamId) => {
+            receivedLeague = leagueId;
+            receivedTeam = teamId;
+            return Promise.resolve({
+              leagueId,
+              teamId,
+              players: [],
+              positionGroups: [],
+              totalCap: 0,
+              salaryCap: 1,
+              capSpace: 1,
+            });
+          },
+        }),
+        log: createTestLogger(),
+      });
+
+      const result = await service.getActiveRoster("lg-1", "tm-1");
+      assertEquals(receivedLeague, "lg-1");
+      assertEquals(receivedTeam, "tm-1");
+      assertEquals(result.salaryCap, 1);
+    },
+  );
+
+  await t.step("getDepthChart delegates to repository", async () => {
+    let called = false;
+    const service = createRosterService({
+      repo: createMockRepo({
+        getDepthChart: (leagueId, teamId) => {
+          called = true;
+          return Promise.resolve({
+            leagueId,
+            teamId,
+            slots: [],
+            inactives: [],
+            lastUpdatedAt: null,
+            lastUpdatedBy: null,
+          });
+        },
+      }),
+      log: createTestLogger(),
+    });
+    const result = await service.getDepthChart("lg-1", "tm-1");
+    assertEquals(called, true);
+    assertEquals(result.slots, []);
+  });
+
+  await t.step("getStatistics passes seasonId through", async () => {
+    let receivedSeason: string | null | undefined;
+    const service = createRosterService({
+      repo: createMockRepo({
+        getStatistics: (leagueId, teamId, seasonId) => {
+          receivedSeason = seasonId;
+          return Promise.resolve({
+            leagueId,
+            teamId,
+            seasonId,
+            rows: [],
+          });
+        },
+      }),
+      log: createTestLogger(),
+    });
+    await service.getStatistics("lg-1", "tm-1", "season-42");
+    assertEquals(receivedSeason, "season-42");
+
+    await service.getStatistics("lg-1", "tm-1", null);
+    assertEquals(receivedSeason, null);
+  });
+});

--- a/server/features/roster/roster.service.ts
+++ b/server/features/roster/roster.service.ts
@@ -1,0 +1,27 @@
+import type pino from "pino";
+import type { RosterRepository } from "./roster.repository.interface.ts";
+import type { RosterService } from "./roster.service.interface.ts";
+
+export function createRosterService(deps: {
+  repo: RosterRepository;
+  log: pino.Logger;
+}): RosterService {
+  const log = deps.log.child({ module: "roster.service" });
+
+  return {
+    async getActiveRoster(leagueId, teamId) {
+      log.debug({ leagueId, teamId }, "fetching active roster");
+      return await deps.repo.getActiveRoster(leagueId, teamId);
+    },
+
+    async getDepthChart(leagueId, teamId) {
+      log.debug({ leagueId, teamId }, "fetching depth chart");
+      return await deps.repo.getDepthChart(leagueId, teamId);
+    },
+
+    async getStatistics(leagueId, teamId, seasonId) {
+      log.debug({ leagueId, teamId, seasonId }, "fetching roster statistics");
+      return await deps.repo.getStatistics(leagueId, teamId, seasonId);
+    },
+  };
+}

--- a/server/main.ts
+++ b/server/main.ts
@@ -41,7 +41,10 @@ const app = new Hono<AppEnv>()
   .route("/api/teams", features.teamRouter)
   .use("/api/coaches/*", authGuard())
   .use("/api/coaches", authGuard())
-  .route("/api/coaches", features.coachesRouter);
+  .route("/api/coaches", features.coachesRouter)
+  .use("/api/roster/*", authGuard())
+  .use("/api/roster", authGuard())
+  .route("/api/roster", features.rosterRouter);
 
 // Domain error handler
 app.onError((err, c) => {


### PR DESCRIPTION
## Summary

- New `server/features/roster/` feature: repository + service + router wired into `/api/roster`.
- Three read endpoints scoped by league + team:
  - `GET /leagues/:leagueId/teams/:teamId/active` — 53-man roster with cap hit, age (from birthDate), contract years remaining, injury status, position-group headcount/cap totals, plus league cap and cap space.
  - `GET /leagues/:leagueId/teams/:teamId/depth-chart` — coach-published slots + game-day inactives + last-updated timestamp and publishing coach. Read-only; coach sim is the only writer.
  - `GET /leagues/:leagueId/teams/:teamId/statistics?season=<id>` — empty-rows stub. The sim does not emit per-player stats yet, so the page renders an empty state per the scope reduction in decision 0001.
- Shared types added to `@zone-blitz/shared` so the client picks them up via Hono RPC inference in later PRs.