### PR TITLE
refactor(league-select): rename "Assigned Team" column to "Team"

### DIFF
--- a/client/src/features/league-select/index.test.tsx
+++ b/client/src/features/league-select/index.test.tsx
@@ -145,7 +145,7 @@ describe("LeagueSelect", () => {
     });
     expect(screen.getByText("XFL League")).toBeDefined();
     expect(screen.getByRole("columnheader", { name: "Name" })).toBeDefined();
-    expect(screen.getByRole("columnheader", { name: "Assigned Team" }))
+    expect(screen.getByRole("columnheader", { name: "Team" }))
       .toBeDefined();
     expect(screen.getByRole("columnheader", { name: "Status" })).toBeDefined();
     expect(screen.getByRole("columnheader", { name: "Created" })).toBeDefined();

--- a/client/src/features/league-select/index.tsx
+++ b/client/src/features/league-select/index.tsx
@@ -121,7 +121,7 @@ export function LeagueSelect() {
               <TableHeader>
                 <TableRow>
                   <TableHead>Name</TableHead>
-                  <TableHead>Assigned Team</TableHead>
+                  <TableHead>Team</TableHead>
                   <TableHead>Status</TableHead>
                   <TableHead className="text-right">Created</TableHead>
                   <TableHead className="w-10">


### PR DESCRIPTION
## Summary

- Rename the `Assigned Team` column header on the home-page leagues table to just `Team`. The table is already scoped to the user's leagues, so the `Assigned` qualifier is redundant.
- Updates the matching test assertion.