### PR TITLE
feat(roster): build active roster view on league Roster page

### DIFF
--- a/client/src/features/league/roster.test.tsx
+++ b/client/src/features/league/roster.test.tsx
@@ -1,14 +1,178 @@
-import { cleanup, render, screen } from "@testing-library/react";
-import { afterEach, describe, expect, it } from "vitest";
+import { cleanup, render, screen, within } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { Roster } from "./roster.tsx";
+
+const mockUseParams = vi.fn();
+const mockUseLeague = vi.fn();
+const mockUseActiveRoster = vi.fn();
+
+vi.mock("@tanstack/react-router", () => ({
+  useParams: (...args: unknown[]) => mockUseParams(...args),
+}));
+
+vi.mock("../../hooks/use-league.ts", () => ({
+  useLeague: (...args: unknown[]) => mockUseLeague(...args),
+}));
+
+vi.mock("../../hooks/use-active-roster.ts", () => ({
+  useActiveRoster: (...args: unknown[]) => mockUseActiveRoster(...args),
+}));
+
+function renderRoster() {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={client}>
+      <Roster />
+    </QueryClientProvider>,
+  );
+}
+
+const baseRoster = {
+  leagueId: "L1",
+  teamId: "T1",
+  players: [
+    {
+      id: "p1",
+      firstName: "Patrick",
+      lastName: "Quarterback",
+      position: "QB",
+      positionGroup: "offense",
+      age: 28,
+      capHit: 45_000_000,
+      contractYearsRemaining: 3,
+      injuryStatus: "healthy",
+    },
+    {
+      id: "p2",
+      firstName: "Derrick",
+      lastName: "Runback",
+      position: "RB",
+      positionGroup: "offense",
+      age: 26,
+      capHit: 12_000_000,
+      contractYearsRemaining: 2,
+      injuryStatus: "questionable",
+    },
+    {
+      id: "p3",
+      firstName: "Aaron",
+      lastName: "Rusher",
+      position: "EDGE",
+      positionGroup: "defense",
+      age: 24,
+      capHit: 8_000_000,
+      contractYearsRemaining: 4,
+      injuryStatus: "out",
+    },
+  ],
+  positionGroups: [
+    { group: "offense", headcount: 2, totalCap: 57_000_000 },
+    { group: "defense", headcount: 1, totalCap: 8_000_000 },
+    { group: "special_teams", headcount: 0, totalCap: 0 },
+  ],
+  totalCap: 65_000_000,
+  salaryCap: 255_000_000,
+  capSpace: 190_000_000,
+};
 
 afterEach(() => {
   cleanup();
+  vi.clearAllMocks();
+});
+
+beforeEach(() => {
+  mockUseParams.mockReturnValue({ leagueId: "L1" });
+  mockUseLeague.mockReturnValue({
+    data: { id: "L1", userTeamId: "T1", name: "Test League" },
+  });
+  mockUseActiveRoster.mockReturnValue({
+    data: baseRoster,
+    isLoading: false,
+    isError: false,
+  });
 });
 
 describe("Roster", () => {
   it("renders the Roster heading", () => {
-    render(<Roster />);
+    renderRoster();
     expect(screen.getByRole("heading", { name: "Roster" })).toBeDefined();
+  });
+
+  it("shows a loading skeleton while data is fetching", () => {
+    mockUseActiveRoster.mockReturnValue({
+      data: undefined,
+      isLoading: true,
+      isError: false,
+    });
+    renderRoster();
+    expect(screen.getByTestId("roster-loading")).toBeDefined();
+  });
+
+  it("shows an error message when the roster fails to load", () => {
+    mockUseActiveRoster.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      isError: true,
+    });
+    renderRoster();
+    expect(screen.getByText(/failed to load roster/i)).toBeDefined();
+  });
+
+  it("shows a message when the league has no selected team", () => {
+    mockUseLeague.mockReturnValue({
+      data: { id: "L1", userTeamId: null, name: "Test League" },
+    });
+    mockUseActiveRoster.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      isError: false,
+    });
+    renderRoster();
+    expect(screen.getByText(/select a team/i)).toBeDefined();
+  });
+
+  it("renders the cap summary with total cap, salary cap, and cap space", () => {
+    renderRoster();
+    const summary = screen.getByTestId("roster-cap-summary");
+    expect(within(summary).getByText("$65,000,000")).toBeDefined();
+    expect(within(summary).getByText("$255,000,000")).toBeDefined();
+    expect(within(summary).getByText("$190,000,000")).toBeDefined();
+  });
+
+  it("renders a section per position group with headcount and group cap", () => {
+    renderRoster();
+    const offense = screen.getByTestId("position-group-header-offense");
+    expect(within(offense).getByText(/offense/i)).toBeDefined();
+    expect(within(offense).getByText("2 players")).toBeDefined();
+    expect(within(offense).getByText("$57,000,000")).toBeDefined();
+
+    const defense = screen.getByTestId("position-group-header-defense");
+    expect(within(defense).getByText("1 player")).toBeDefined();
+    expect(within(defense).getByText("$8,000,000")).toBeDefined();
+  });
+
+  it("renders a player row with name, position, age, cap hit, contract years, and injury status", () => {
+    renderRoster();
+    const row = screen.getByTestId("roster-row-p1");
+    expect(within(row).getByText("Patrick Quarterback")).toBeDefined();
+    expect(within(row).getByText("QB")).toBeDefined();
+    expect(within(row).getByText("28")).toBeDefined();
+    expect(within(row).getByText("$45,000,000")).toBeDefined();
+    expect(within(row).getByText("3 yrs")).toBeDefined();
+    expect(within(row).getByText(/healthy/i)).toBeDefined();
+  });
+
+  it("does not render overall rating, grade, or attribute columns", () => {
+    renderRoster();
+    expect(screen.queryByText(/overall/i)).toBeNull();
+    expect(screen.queryByText(/^grade$/i)).toBeNull();
+  });
+
+  it("omits empty position groups", () => {
+    renderRoster();
+    expect(screen.queryByTestId("position-group-special_teams")).toBeNull();
   });
 });

--- a/client/src/features/league/roster.tsx
+++ b/client/src/features/league/roster.tsx
@@ -1,10 +1,228 @@
-import { StubPage } from "./stub-page.tsx";
+import { useParams } from "@tanstack/react-router";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { Skeleton } from "@/components/ui/skeleton";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import type {
+  PlayerPositionGroup,
+  RosterPlayer,
+  RosterPositionGroupSummary,
+} from "@zone-blitz/shared/types/roster.ts";
+import { useLeague } from "../../hooks/use-league.ts";
+import { useActiveRoster } from "../../hooks/use-active-roster.ts";
+
+const groupLabels: Record<PlayerPositionGroup, string> = {
+  offense: "Offense",
+  defense: "Defense",
+  special_teams: "Special Teams",
+};
+
+const groupOrder: PlayerPositionGroup[] = [
+  "offense",
+  "defense",
+  "special_teams",
+];
+
+const currency = new Intl.NumberFormat("en-US", {
+  style: "currency",
+  currency: "USD",
+  maximumFractionDigits: 0,
+});
+
+function formatCurrency(value: number) {
+  return currency.format(value);
+}
+
+function injuryBadgeVariant(
+  status: RosterPlayer["injuryStatus"],
+): "secondary" | "destructive" | "outline" {
+  if (status === "healthy") return "secondary";
+  if (status === "out" || status === "ir") return "destructive";
+  return "outline";
+}
+
+function formatInjury(status: RosterPlayer["injuryStatus"]) {
+  return status.replace(/_/g, " ");
+}
 
 export function Roster() {
+  const { leagueId } = useParams({ strict: false }) as { leagueId: string };
+  const { data: league } = useLeague(leagueId);
+  const teamId = league?.userTeamId ?? null;
+  const {
+    data: roster,
+    isLoading,
+    isError,
+  } = useActiveRoster(leagueId, teamId);
+
   return (
-    <StubPage
-      title="Roster"
-      description="Your active roster, depth chart, and player development."
-    />
+    <div className="flex flex-col gap-6 p-6">
+      <div className="flex flex-col gap-2">
+        <h1 className="text-3xl font-bold tracking-tight">Roster</h1>
+        <p className="max-w-2xl text-muted-foreground">
+          The 53-man active roster. You control who's on the team; the coaching
+          staff sets the depth chart.
+        </p>
+      </div>
+
+      {!teamId
+        ? (
+          <p className="text-muted-foreground">
+            Select a team for this league to view its roster.
+          </p>
+        )
+        : isLoading
+        ? <RosterLoading />
+        : isError || !roster
+        ? (
+          <p className="text-destructive">
+            Failed to load roster. Try again in a moment.
+          </p>
+        )
+        : <RosterContent roster={roster} />}
+    </div>
+  );
+}
+
+function RosterLoading() {
+  return (
+    <div data-testid="roster-loading" className="flex flex-col gap-4">
+      <Skeleton className="h-24 w-full" />
+      <Skeleton className="h-64 w-full" />
+    </div>
+  );
+}
+
+function RosterContent({
+  roster,
+}: {
+  roster: {
+    players: RosterPlayer[];
+    positionGroups: RosterPositionGroupSummary[];
+    totalCap: number;
+    salaryCap: number;
+    capSpace: number;
+  };
+}) {
+  const playersByGroup: Record<PlayerPositionGroup, RosterPlayer[]> = {
+    offense: [],
+    defense: [],
+    special_teams: [],
+  };
+  for (const player of roster.players) {
+    playersByGroup[player.positionGroup].push(player);
+  }
+
+  return (
+    <>
+      <Card data-testid="roster-cap-summary">
+        <CardHeader>
+          <CardTitle>Cap Summary</CardTitle>
+          <CardDescription>
+            Roster spend against the league salary cap.
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <dl className="grid grid-cols-1 gap-4 sm:grid-cols-3">
+            <CapStat
+              label="Total Cap"
+              value={formatCurrency(roster.totalCap)}
+            />
+            <CapStat
+              label="Salary Cap"
+              value={formatCurrency(roster.salaryCap)}
+            />
+            <CapStat
+              label="Cap Space"
+              value={formatCurrency(roster.capSpace)}
+            />
+          </dl>
+        </CardContent>
+      </Card>
+
+      {groupOrder.map((group) => {
+        const summary = roster.positionGroups.find((g) => g.group === group);
+        const players = playersByGroup[group];
+        if (!summary || summary.headcount === 0) return null;
+        return (
+          <Card key={group} data-testid={`position-group-${group}`}>
+            <CardHeader
+              className="flex flex-col gap-1 sm:flex-row sm:items-baseline sm:justify-between"
+              data-testid={`position-group-header-${group}`}
+            >
+              <CardTitle>{groupLabels[group]}</CardTitle>
+              <div className="flex gap-4 text-sm text-muted-foreground">
+                <span>
+                  {summary.headcount}{" "}
+                  {summary.headcount === 1 ? "player" : "players"}
+                </span>
+                <span>{formatCurrency(summary.totalCap)}</span>
+              </div>
+            </CardHeader>
+            <CardContent>
+              <Table>
+                <TableHeader>
+                  <TableRow>
+                    <TableHead>Player</TableHead>
+                    <TableHead>Pos</TableHead>
+                    <TableHead>Age</TableHead>
+                    <TableHead>Cap Hit</TableHead>
+                    <TableHead>Contract</TableHead>
+                    <TableHead>Status</TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {players.map((player) => (
+                    <TableRow
+                      key={player.id}
+                      data-testid={`roster-row-${player.id}`}
+                    >
+                      <TableCell className="font-medium">
+                        {player.firstName} {player.lastName}
+                      </TableCell>
+                      <TableCell>{player.position}</TableCell>
+                      <TableCell>{player.age}</TableCell>
+                      <TableCell>{formatCurrency(player.capHit)}</TableCell>
+                      <TableCell>
+                        {player.contractYearsRemaining} yrs
+                      </TableCell>
+                      <TableCell>
+                        <Badge
+                          variant={injuryBadgeVariant(player.injuryStatus)}
+                        >
+                          {formatInjury(player.injuryStatus)}
+                        </Badge>
+                      </TableCell>
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
+            </CardContent>
+          </Card>
+        );
+      })}
+    </>
+  );
+}
+
+function CapStat({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="flex flex-col gap-1">
+      <dt className="text-sm text-muted-foreground">{label}</dt>
+      <dd className="text-2xl font-semibold">{value}</dd>
+    </div>
   );
 }

--- a/client/src/hooks/use-active-roster.test.ts
+++ b/client/src/hooks/use-active-roster.test.ts
@@ -1,0 +1,73 @@
+import { renderHook, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { describe, expect, it, vi } from "vitest";
+import { createElement } from "react";
+import { useActiveRoster } from "./use-active-roster.ts";
+
+const mockGet = vi.fn();
+
+vi.mock("../api.ts", () => ({
+  api: {
+    api: {
+      roster: {
+        leagues: {
+          [":leagueId"]: {
+            teams: {
+              [":teamId"]: {
+                active: {
+                  $get: (...args: unknown[]) => mockGet(...args),
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+  },
+}));
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return ({ children }: { children: React.ReactNode }) =>
+    createElement(QueryClientProvider, { client: queryClient }, children);
+}
+
+describe("useActiveRoster", () => {
+  it("fetches an active roster for a league and team", async () => {
+    const roster = {
+      leagueId: "L1",
+      teamId: "T1",
+      players: [],
+      positionGroups: [],
+      totalCap: 0,
+      salaryCap: 255_000_000,
+      capSpace: 255_000_000,
+    };
+    mockGet.mockResolvedValue({ json: () => Promise.resolve(roster) });
+
+    const { result } = renderHook(() => useActiveRoster("L1", "T1"), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+
+    expect(result.current.data).toEqual(roster);
+    expect(mockGet).toHaveBeenCalledWith({
+      param: { leagueId: "L1", teamId: "T1" },
+    });
+  });
+
+  it("does not fetch when teamId is missing", () => {
+    mockGet.mockClear();
+    const { result } = renderHook(() => useActiveRoster("L1", null), {
+      wrapper: createWrapper(),
+    });
+
+    expect(result.current.fetchStatus).toBe("idle");
+    expect(mockGet).not.toHaveBeenCalled();
+  });
+});

--- a/client/src/hooks/use-active-roster.ts
+++ b/client/src/hooks/use-active-roster.ts
@@ -1,0 +1,14 @@
+import { useQuery } from "@tanstack/react-query";
+import { api } from "../api.ts";
+
+export function useActiveRoster(leagueId: string, teamId: string | null) {
+  return useQuery({
+    queryKey: ["roster", "active", leagueId, teamId],
+    enabled: Boolean(leagueId) && Boolean(teamId),
+    queryFn: async () => {
+      const res = await api.api.roster.leagues[":leagueId"].teams[":teamId"]
+        .active.$get({ param: { leagueId, teamId: teamId! } });
+      return res.json();
+    },
+  });
+}


### PR DESCRIPTION
## Summary

- Replaces the Roster page stub with a real Active Roster view driven by the roster service from #101: cap summary (total / salary / space) plus a per-position-group breakdown with headcount, group cap, and a player table showing name, position, age, cap hit, contract years, and injury status.
- Per ADR [0001-roster-page](docs/product/decisions/0001-roster-page.md), deliberately omits overall rating / grade / scout verdict — judgment lives in stats, contract, age, and the coach's depth chart, not a number on the page.
- Adds `useActiveRoster` hook (TanStack Query + Hono RPC) gated on the league's selected team, with clear fallbacks for loading, error, and no-team-selected states. Depth chart and statistics views follow in later PRs.