### PR TITLE
docs(backlog): note multi-user leagues need a user_leagues join table

### DIFF
--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -32,6 +32,13 @@ entry when it's resolved or superseded.
   attribute insert, narrow the attribute row shape, or build the SQL
   iteratively. Split attribute rows into columns-per-table is overkill; chunked
   inserts are the cheapest fix.
+- **2026-04-14 — Multi-user leagues would need a `user_leagues` join table.**
+  The `last_played_at` column added in PR #105 lives directly on `leagues`,
+  matching today's single-user-per-league assumption (each league has one
+  `user_team_id`). If leagues ever become shared between multiple users, we'd
+  need to move `last_played_at` (and anything else that's actually per-user)
+  onto a `user_leagues` junction table keyed by `(user_id, league_id)` and join
+  it into the list query.
 - **2026-04-13 — Finer-grained league phase sub-states.** The `season.phase`
   enum only tracks `preseason | regular_season | playoffs | offseason`. Product
   docs (`docs/product/league-management.md`) describe sub-steps during the


### PR DESCRIPTION
## Summary

- Adds a backlog entry capturing the design flag from PR #105: \`last_played_at\` is per-league today, which matches the single-user-per-league model. If leagues ever become shared, we'd need a \`user_leagues\` junction table for per-user fields.