### PR TITLE
feat(roster): render position group tables via shadcn DataTable

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -10,6 +10,7 @@
         "@fontsource-variable/geist": "^5.2.8",
         "@tanstack/react-query": "^5",
         "@tanstack/react-router": "^1.168.18",
+        "@tanstack/react-table": "^8.21.3",
         "better-auth": "^1",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
@@ -2446,6 +2447,26 @@
         "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
+    "node_modules/@tanstack/react-table": {
+      "version": "8.21.3",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-table/-/react-table-8.21.3.tgz",
+      "integrity": "sha512-5nNMTSETP4ykGegmVkhjcS8tTLW6Vl4axfEGQN3v0zdHYbK4UfoqfPChclTrJ4EoK9QynqAu9oUf8VEmrpZ5Ww==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/table-core": "8.21.3"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
+      }
+    },
     "node_modules/@tanstack/router-core": {
       "version": "1.168.14",
       "resolved": "https://registry.npmjs.org/@tanstack/router-core/-/router-core-1.168.14.tgz",
@@ -2473,6 +2494,19 @@
       "resolved": "https://registry.npmjs.org/@tanstack/store/-/store-0.9.3.tgz",
       "integrity": "sha512-8reSzl/qGWGGVKhBoxXPMWzATSbZLZFWhwBAFO9NAyp0TxzfBP0mIrGb8CP8KrQTmvzXlR/vFPPUrHTLBGyFyw==",
       "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/table-core": {
+      "version": "8.21.3",
+      "resolved": "https://registry.npmjs.org/@tanstack/table-core/-/table-core-8.21.3.tgz",
+      "integrity": "sha512-ldZXEhOBb8Is7xLs01fR3YEc3DERiz5silj8tnGkFZytt1abEvl/GhUmCE0PMLaMPTa3Jk4HbKmRlHmu+gCftg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/tannerlinsley"

--- a/client/package.json
+++ b/client/package.json
@@ -7,6 +7,7 @@
     "@fontsource-variable/geist": "^5.2.8",
     "@tanstack/react-query": "^5",
     "@tanstack/react-router": "^1.168.18",
+    "@tanstack/react-table": "^8.21.3",
     "better-auth": "^1",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",

--- a/client/src/components/ui/data-table.test.tsx
+++ b/client/src/components/ui/data-table.test.tsx
@@ -1,0 +1,49 @@
+import { cleanup, render, screen, within } from "@testing-library/react";
+import type { ColumnDef } from "@tanstack/react-table";
+import { afterEach, describe, expect, it } from "vitest";
+import { DataTable } from "./data-table.tsx";
+
+type Row = { id: string; name: string; value: number };
+
+const columns: ColumnDef<Row>[] = [
+  { accessorKey: "name", header: "Name" },
+  { accessorKey: "value", header: "Value" },
+];
+
+const data: Row[] = [
+  { id: "a", name: "Alpha", value: 1 },
+  { id: "b", name: "Beta", value: 2 },
+];
+
+afterEach(cleanup);
+
+describe("DataTable", () => {
+  it("renders a header cell per column", () => {
+    render(<DataTable columns={columns} data={data} />);
+    expect(screen.getByRole("columnheader", { name: "Name" })).toBeDefined();
+    expect(screen.getByRole("columnheader", { name: "Value" })).toBeDefined();
+  });
+
+  it("renders a row per data entry with cell values", () => {
+    render(<DataTable columns={columns} data={data} />);
+    expect(screen.getByText("Alpha")).toBeDefined();
+    expect(screen.getByText("Beta")).toBeDefined();
+  });
+
+  it("shows an empty-state row when data is empty", () => {
+    render(<DataTable columns={columns} data={[]} />);
+    expect(screen.getByText(/no results/i)).toBeDefined();
+  });
+
+  it("applies a row data-testid from the getRowTestId prop", () => {
+    render(
+      <DataTable
+        columns={columns}
+        data={data}
+        getRowTestId={(row) => `row-${row.id}`}
+      />,
+    );
+    const row = screen.getByTestId("row-a");
+    expect(within(row).getByText("Alpha")).toBeDefined();
+  });
+});

--- a/client/src/components/ui/data-table.tsx
+++ b/client/src/components/ui/data-table.tsx
@@ -1,0 +1,82 @@
+import {
+  type ColumnDef,
+  flexRender,
+  getCoreRowModel,
+  useReactTable,
+} from "@tanstack/react-table";
+
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+
+interface DataTableProps<TData, TValue> {
+  columns: ColumnDef<TData, TValue>[];
+  data: TData[];
+  getRowTestId?: (row: TData) => string;
+}
+
+export function DataTable<TData, TValue>({
+  columns,
+  data,
+  getRowTestId,
+}: DataTableProps<TData, TValue>) {
+  const table = useReactTable({
+    data,
+    columns,
+    getCoreRowModel: getCoreRowModel(),
+  });
+
+  const rows = table.getRowModel().rows;
+
+  return (
+    <div className="overflow-hidden rounded-md border">
+      <Table>
+        <TableHeader>
+          {table.getHeaderGroups().map((headerGroup) => (
+            <TableRow key={headerGroup.id}>
+              {headerGroup.headers.map((header) => (
+                <TableHead key={header.id}>
+                  {header.isPlaceholder ? null : flexRender(
+                    header.column.columnDef.header,
+                    header.getContext(),
+                  )}
+                </TableHead>
+              ))}
+            </TableRow>
+          ))}
+        </TableHeader>
+        <TableBody>
+          {rows.length
+            ? rows.map((row) => (
+              <TableRow
+                key={row.id}
+                data-state={row.getIsSelected() && "selected"}
+                data-testid={getRowTestId?.(row.original)}
+              >
+                {row.getVisibleCells().map((cell) => (
+                  <TableCell key={cell.id}>
+                    {flexRender(cell.column.columnDef.cell, cell.getContext())}
+                  </TableCell>
+                ))}
+              </TableRow>
+            ))
+            : (
+              <TableRow>
+                <TableCell
+                  colSpan={columns.length}
+                  className="h-24 text-center"
+                >
+                  No results.
+                </TableCell>
+              </TableRow>
+            )}
+        </TableBody>
+      </Table>
+    </div>
+  );
+}

--- a/client/src/features/league/roster.tsx
+++ b/client/src/features/league/roster.tsx
@@ -1,4 +1,5 @@
 import { useParams } from "@tanstack/react-router";
+import type { ColumnDef } from "@tanstack/react-table";
 import {
   Card,
   CardContent,
@@ -8,14 +9,7 @@ import {
 } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Skeleton } from "@/components/ui/skeleton";
-import {
-  Table,
-  TableBody,
-  TableCell,
-  TableHead,
-  TableHeader,
-  TableRow,
-} from "@/components/ui/table";
+import { DataTable } from "@/components/ui/data-table";
 import type {
   PlayerPositionGroup,
   RosterPlayer,
@@ -57,6 +51,45 @@ function injuryBadgeVariant(
 function formatInjury(status: RosterPlayer["injuryStatus"]) {
   return status.replace(/_/g, " ");
 }
+
+const rosterColumns: ColumnDef<RosterPlayer>[] = [
+  {
+    id: "player",
+    header: "Player",
+    cell: ({ row }) => (
+      <span className="font-medium">
+        {row.original.firstName} {row.original.lastName}
+      </span>
+    ),
+  },
+  {
+    accessorKey: "position",
+    header: "Pos",
+  },
+  {
+    accessorKey: "age",
+    header: "Age",
+  },
+  {
+    id: "capHit",
+    header: "Cap Hit",
+    cell: ({ row }) => formatCurrency(row.original.capHit),
+  },
+  {
+    id: "contract",
+    header: "Contract",
+    cell: ({ row }) => `${row.original.contractYearsRemaining} yrs`,
+  },
+  {
+    id: "status",
+    header: "Status",
+    cell: ({ row }) => (
+      <Badge variant={injuryBadgeVariant(row.original.injuryStatus)}>
+        {formatInjury(row.original.injuryStatus)}
+      </Badge>
+    ),
+  },
+];
 
 export function Roster() {
   const { leagueId } = useParams({ strict: false }) as { leagueId: string };
@@ -173,43 +206,11 @@ function RosterContent({
               </div>
             </CardHeader>
             <CardContent>
-              <Table>
-                <TableHeader>
-                  <TableRow>
-                    <TableHead>Player</TableHead>
-                    <TableHead>Pos</TableHead>
-                    <TableHead>Age</TableHead>
-                    <TableHead>Cap Hit</TableHead>
-                    <TableHead>Contract</TableHead>
-                    <TableHead>Status</TableHead>
-                  </TableRow>
-                </TableHeader>
-                <TableBody>
-                  {players.map((player) => (
-                    <TableRow
-                      key={player.id}
-                      data-testid={`roster-row-${player.id}`}
-                    >
-                      <TableCell className="font-medium">
-                        {player.firstName} {player.lastName}
-                      </TableCell>
-                      <TableCell>{player.position}</TableCell>
-                      <TableCell>{player.age}</TableCell>
-                      <TableCell>{formatCurrency(player.capHit)}</TableCell>
-                      <TableCell>
-                        {player.contractYearsRemaining} yrs
-                      </TableCell>
-                      <TableCell>
-                        <Badge
-                          variant={injuryBadgeVariant(player.injuryStatus)}
-                        >
-                          {formatInjury(player.injuryStatus)}
-                        </Badge>
-                      </TableCell>
-                    </TableRow>
-                  ))}
-                </TableBody>
-              </Table>
+              <DataTable
+                columns={rosterColumns}
+                data={players}
+                getRowTestId={(player) => `roster-row-${player.id}`}
+              />
             </CardContent>
           </Card>
         );


### PR DESCRIPTION
## Summary
- Adds a reusable `DataTable` component at `client/src/components/ui/data-table.tsx` that follows the shadcn data-table pattern (https://ui.shadcn.com/docs/components/radix/data-table), built on `@tanstack/react-table` and composed from the existing shadcn `Table` primitives.
- Refactors the Roster page's per-position-group tables to use `DataTable` with `ColumnDef`s, so we have one shared table primitive ready to grow into sorting / filtering / pagination as other tabular views (free agency, standings, etc.) adopt it.
- Preserves existing UI test contracts (`roster-row-<id>`) via a small `getRowTestId` prop on `DataTable`.