### PR TITLE
feat(roster): add read-only depth chart view with tabbed navigation

### DIFF
--- a/client/src/components/ui/tabs.tsx
+++ b/client/src/components/ui/tabs.tsx
@@ -1,0 +1,80 @@
+import { Tabs as TabsPrimitive } from "@base-ui/react/tabs";
+import { cva, type VariantProps } from "class-variance-authority";
+
+import { cn } from "@/lib/utils";
+
+function Tabs({
+  className,
+  orientation = "horizontal",
+  ...props
+}: TabsPrimitive.Root.Props) {
+  return (
+    <TabsPrimitive.Root
+      data-slot="tabs"
+      data-orientation={orientation}
+      className={cn(
+        "group/tabs flex gap-2 data-horizontal:flex-col",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+const tabsListVariants = cva(
+  "group/tabs-list inline-flex w-fit items-center justify-center rounded-lg p-[3px] text-muted-foreground group-data-horizontal/tabs:h-8 group-data-vertical/tabs:h-fit group-data-vertical/tabs:flex-col data-[variant=line]:rounded-none",
+  {
+    variants: {
+      variant: {
+        default: "bg-muted",
+        line: "gap-1 bg-transparent",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+    },
+  },
+);
+
+function TabsList({
+  className,
+  variant = "default",
+  ...props
+}: TabsPrimitive.List.Props & VariantProps<typeof tabsListVariants>) {
+  return (
+    <TabsPrimitive.List
+      data-slot="tabs-list"
+      data-variant={variant}
+      className={cn(tabsListVariants({ variant }), className)}
+      {...props}
+    />
+  );
+}
+
+function TabsTrigger({ className, ...props }: TabsPrimitive.Tab.Props) {
+  return (
+    <TabsPrimitive.Tab
+      data-slot="tabs-trigger"
+      className={cn(
+        "relative inline-flex h-[calc(100%-1px)] flex-1 items-center justify-center gap-1.5 rounded-md border border-transparent px-1.5 py-0.5 text-sm font-medium whitespace-nowrap text-foreground/60 transition-all group-data-vertical/tabs:w-full group-data-vertical/tabs:justify-start hover:text-foreground focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 focus-visible:outline-1 focus-visible:outline-ring disabled:pointer-events-none disabled:opacity-50 has-data-[icon=inline-end]:pr-1 has-data-[icon=inline-start]:pl-1 aria-disabled:pointer-events-none aria-disabled:opacity-50 dark:text-muted-foreground dark:hover:text-foreground group-data-[variant=default]/tabs-list:data-active:shadow-sm group-data-[variant=line]/tabs-list:data-active:shadow-none [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        "group-data-[variant=line]/tabs-list:bg-transparent group-data-[variant=line]/tabs-list:data-active:bg-transparent dark:group-data-[variant=line]/tabs-list:data-active:border-transparent dark:group-data-[variant=line]/tabs-list:data-active:bg-transparent",
+        "data-active:bg-background data-active:text-foreground dark:data-active:border-input dark:data-active:bg-input/30 dark:data-active:text-foreground",
+        "after:absolute after:bg-foreground after:opacity-0 after:transition-opacity group-data-horizontal/tabs:after:inset-x-0 group-data-horizontal/tabs:after:bottom-[-5px] group-data-horizontal/tabs:after:h-0.5 group-data-vertical/tabs:after:inset-y-0 group-data-vertical/tabs:after:-right-1 group-data-vertical/tabs:after:w-0.5 group-data-[variant=line]/tabs-list:data-active:after:opacity-100",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function TabsContent({ className, ...props }: TabsPrimitive.Panel.Props) {
+  return (
+    <TabsPrimitive.Panel
+      data-slot="tabs-content"
+      className={cn("flex-1 text-sm outline-none", className)}
+      {...props}
+    />
+  );
+}
+
+export { Tabs, TabsContent, TabsList, tabsListVariants, TabsTrigger };

--- a/client/src/features/league/roster.test.tsx
+++ b/client/src/features/league/roster.test.tsx
@@ -1,4 +1,10 @@
-import { cleanup, render, screen, within } from "@testing-library/react";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  within,
+} from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { Roster } from "./roster.tsx";
@@ -6,6 +12,7 @@ import { Roster } from "./roster.tsx";
 const mockUseParams = vi.fn();
 const mockUseLeague = vi.fn();
 const mockUseActiveRoster = vi.fn();
+const mockUseDepthChart = vi.fn();
 
 vi.mock("@tanstack/react-router", () => ({
   useParams: (...args: unknown[]) => mockUseParams(...args),
@@ -17,6 +24,10 @@ vi.mock("../../hooks/use-league.ts", () => ({
 
 vi.mock("../../hooks/use-active-roster.ts", () => ({
   useActiveRoster: (...args: unknown[]) => mockUseActiveRoster(...args),
+}));
+
+vi.mock("../../hooks/use-depth-chart.ts", () => ({
+  useDepthChart: (...args: unknown[]) => mockUseDepthChart(...args),
 }));
 
 function renderRoster() {
@@ -78,6 +89,77 @@ const baseRoster = {
   capSpace: 190_000_000,
 };
 
+const baseDepthChart = {
+  leagueId: "L1",
+  teamId: "T1",
+  slots: [
+    {
+      playerId: "p1",
+      firstName: "Patrick",
+      lastName: "Quarterback",
+      position: "QB",
+      slotOrdinal: 1,
+      injuryStatus: "healthy",
+    },
+    {
+      playerId: "p4",
+      firstName: "Backup",
+      lastName: "Qb",
+      position: "QB",
+      slotOrdinal: 2,
+      injuryStatus: "questionable",
+    },
+    {
+      playerId: "p2",
+      firstName: "Derrick",
+      lastName: "Runback",
+      position: "RB",
+      slotOrdinal: 1,
+      injuryStatus: "questionable",
+    },
+    {
+      playerId: "p5",
+      firstName: "Third",
+      lastName: "String",
+      position: "RB",
+      slotOrdinal: 3,
+      injuryStatus: "healthy",
+    },
+    {
+      playerId: "p6",
+      firstName: "Fourth",
+      lastName: "Back",
+      position: "RB",
+      slotOrdinal: 4,
+      injuryStatus: "healthy",
+    },
+    {
+      playerId: "p7",
+      firstName: "Deep",
+      lastName: "Reserve",
+      position: "RB",
+      slotOrdinal: 11,
+      injuryStatus: "healthy",
+    },
+  ],
+  inactives: [
+    {
+      playerId: "p3",
+      firstName: "Aaron",
+      lastName: "Rusher",
+      position: "EDGE",
+      injuryStatus: "out",
+    },
+  ],
+  lastUpdatedAt: "2026-04-10T12:00:00.000Z",
+  lastUpdatedBy: {
+    id: "c1",
+    firstName: "Andy",
+    lastName: "Coach",
+    role: "head_coach",
+  },
+};
+
 afterEach(() => {
   cleanup();
   vi.clearAllMocks();
@@ -93,14 +175,35 @@ beforeEach(() => {
     isLoading: false,
     isError: false,
   });
+  mockUseDepthChart.mockReturnValue({
+    data: baseDepthChart,
+    isLoading: false,
+    isError: false,
+  });
 });
 
-describe("Roster", () => {
+describe("Roster — page", () => {
   it("renders the Roster heading", () => {
     renderRoster();
     expect(screen.getByRole("heading", { name: "Roster" })).toBeDefined();
   });
 
+  it("shows tabs for Active Roster and Depth Chart", () => {
+    renderRoster();
+    expect(screen.getByRole("tab", { name: /active roster/i })).toBeDefined();
+    expect(screen.getByRole("tab", { name: /depth chart/i })).toBeDefined();
+  });
+
+  it("shows a message when the league has no selected team", () => {
+    mockUseLeague.mockReturnValue({
+      data: { id: "L1", userTeamId: null, name: "Test League" },
+    });
+    renderRoster();
+    expect(screen.getByText(/select a team/i)).toBeDefined();
+  });
+});
+
+describe("Roster — active roster tab (default)", () => {
   it("shows a loading skeleton while data is fetching", () => {
     mockUseActiveRoster.mockReturnValue({
       data: undefined,
@@ -108,7 +211,7 @@ describe("Roster", () => {
       isError: false,
     });
     renderRoster();
-    expect(screen.getByTestId("roster-loading")).toBeDefined();
+    expect(screen.getByTestId("active-roster-loading")).toBeDefined();
   });
 
   it("shows an error message when the roster fails to load", () => {
@@ -121,20 +224,7 @@ describe("Roster", () => {
     expect(screen.getByText(/failed to load roster/i)).toBeDefined();
   });
 
-  it("shows a message when the league has no selected team", () => {
-    mockUseLeague.mockReturnValue({
-      data: { id: "L1", userTeamId: null, name: "Test League" },
-    });
-    mockUseActiveRoster.mockReturnValue({
-      data: undefined,
-      isLoading: false,
-      isError: false,
-    });
-    renderRoster();
-    expect(screen.getByText(/select a team/i)).toBeDefined();
-  });
-
-  it("renders the cap summary with total cap, salary cap, and cap space", () => {
+  it("renders the cap summary", () => {
     renderRoster();
     const summary = screen.getByTestId("roster-cap-summary");
     expect(within(summary).getByText("$65,000,000")).toBeDefined();
@@ -142,7 +232,7 @@ describe("Roster", () => {
     expect(within(summary).getByText("$190,000,000")).toBeDefined();
   });
 
-  it("renders a section per position group with headcount and group cap", () => {
+  it("renders position group headers with headcount and cap", () => {
     renderRoster();
     const offense = screen.getByTestId("position-group-header-offense");
     expect(within(offense).getByText(/offense/i)).toBeDefined();
@@ -154,7 +244,7 @@ describe("Roster", () => {
     expect(within(defense).getByText("$8,000,000")).toBeDefined();
   });
 
-  it("renders a player row with name, position, age, cap hit, contract years, and injury status", () => {
+  it("renders a player row with all visible fields", () => {
     renderRoster();
     const row = screen.getByTestId("roster-row-p1");
     expect(within(row).getByText("Patrick Quarterback")).toBeDefined();
@@ -165,7 +255,7 @@ describe("Roster", () => {
     expect(within(row).getByText(/healthy/i)).toBeDefined();
   });
 
-  it("does not render overall rating, grade, or attribute columns", () => {
+  it("does not render overall rating or grade", () => {
     renderRoster();
     expect(screen.queryByText(/overall/i)).toBeNull();
     expect(screen.queryByText(/^grade$/i)).toBeNull();
@@ -174,5 +264,88 @@ describe("Roster", () => {
   it("omits empty position groups", () => {
     renderRoster();
     expect(screen.queryByTestId("position-group-special_teams")).toBeNull();
+  });
+});
+
+describe("Roster — depth chart tab", () => {
+  function activateDepthChartTab() {
+    fireEvent.click(screen.getByRole("tab", { name: /depth chart/i }));
+  }
+
+  it("shows a loading skeleton while the chart is fetching", () => {
+    mockUseDepthChart.mockReturnValue({
+      data: undefined,
+      isLoading: true,
+      isError: false,
+    });
+    renderRoster();
+    activateDepthChartTab();
+    expect(screen.getByTestId("depth-chart-loading")).toBeDefined();
+  });
+
+  it("shows an error message when the chart fails to load", () => {
+    mockUseDepthChart.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      isError: true,
+    });
+    renderRoster();
+    activateDepthChartTab();
+    expect(screen.getByText(/failed to load depth chart/i)).toBeDefined();
+  });
+
+  it("renders position cards with ordinal slots and no overall rating", () => {
+    renderRoster();
+    activateDepthChartTab();
+    const qb = screen.getByTestId("depth-chart-position-QB");
+    const qbSlots = within(qb).getAllByTestId(/depth-chart-slot-/);
+    expect(qbSlots.length).toBe(2);
+    expect(within(qbSlots[0]).getByText("1st")).toBeDefined();
+    expect(within(qbSlots[0]).getByText("Patrick Quarterback")).toBeDefined();
+    expect(within(qbSlots[1]).getByText("2nd")).toBeDefined();
+    expect(within(qbSlots[1]).getByText("Backup Qb")).toBeDefined();
+    expect(within(qbSlots[1]).getByText(/questionable/i)).toBeDefined();
+    expect(within(qb).queryByText(/overall/i)).toBeNull();
+
+    const rb = screen.getByTestId("depth-chart-position-RB");
+    expect(within(rb).getByText("3rd")).toBeDefined();
+    expect(within(rb).getByText("4th")).toBeDefined();
+    expect(within(rb).getByText("11th")).toBeDefined();
+  });
+
+  it("renders inactives in their own list", () => {
+    renderRoster();
+    activateDepthChartTab();
+    const inactives = screen.getByTestId("depth-chart-inactives");
+    expect(within(inactives).getByText("Aaron Rusher")).toBeDefined();
+    expect(within(inactives).getByText("EDGE")).toBeDefined();
+  });
+
+  it("shows the last-updated timestamp and owning coach", () => {
+    renderRoster();
+    activateDepthChartTab();
+    const meta = screen.getByTestId("depth-chart-meta");
+    expect(within(meta).getByText(/andy coach/i)).toBeDefined();
+    expect(within(meta).getByText(/2026/)).toBeDefined();
+  });
+
+  it("shows an empty state when the coach has not published a chart", () => {
+    mockUseDepthChart.mockReturnValue({
+      data: {
+        leagueId: "L1",
+        teamId: "T1",
+        slots: [],
+        inactives: [],
+        lastUpdatedAt: null,
+        lastUpdatedBy: null,
+      },
+      isLoading: false,
+      isError: false,
+    });
+    renderRoster();
+    activateDepthChartTab();
+    expect(
+      screen.getByText(/coaching staff hasn't published a depth chart/i),
+    ).toBeDefined();
   });
 });

--- a/client/src/features/league/roster.tsx
+++ b/client/src/features/league/roster.tsx
@@ -16,13 +16,17 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/table";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import type {
+  ActiveRoster,
+  DepthChart,
   PlayerPositionGroup,
   RosterPlayer,
-  RosterPositionGroupSummary,
 } from "@zone-blitz/shared/types/roster.ts";
+import type { PlayerInjuryStatus } from "@zone-blitz/shared/types/player.ts";
 import { useLeague } from "../../hooks/use-league.ts";
 import { useActiveRoster } from "../../hooks/use-active-roster.ts";
+import { useDepthChart } from "../../hooks/use-depth-chart.ts";
 
 const groupLabels: Record<PlayerPositionGroup, string> = {
   offense: "Offense",
@@ -42,31 +46,53 @@ const currency = new Intl.NumberFormat("en-US", {
   maximumFractionDigits: 0,
 });
 
+const dateFormatter = new Intl.DateTimeFormat("en-US", {
+  dateStyle: "medium",
+  timeStyle: "short",
+});
+
 function formatCurrency(value: number) {
   return currency.format(value);
 }
 
 function injuryBadgeVariant(
-  status: RosterPlayer["injuryStatus"],
+  status: PlayerInjuryStatus,
 ): "secondary" | "destructive" | "outline" {
   if (status === "healthy") return "secondary";
   if (status === "out" || status === "ir") return "destructive";
   return "outline";
 }
 
-function formatInjury(status: RosterPlayer["injuryStatus"]) {
+function formatInjury(status: PlayerInjuryStatus) {
   return status.replace(/_/g, " ");
+}
+
+function ordinal(n: number): string {
+  const mod100 = n % 100;
+  if (mod100 >= 11 && mod100 <= 13) return `${n}th`;
+  switch (n % 10) {
+    case 1:
+      return `${n}st`;
+    case 2:
+      return `${n}nd`;
+    case 3:
+      return `${n}rd`;
+    default:
+      return `${n}th`;
+  }
+}
+
+function formatCoachRole(role: string) {
+  return role
+    .split("_")
+    .map((segment) => segment.charAt(0).toUpperCase() + segment.slice(1))
+    .join(" ");
 }
 
 export function Roster() {
   const { leagueId } = useParams({ strict: false }) as { leagueId: string };
   const { data: league } = useLeague(leagueId);
   const teamId = league?.userTeamId ?? null;
-  const {
-    data: roster,
-    isLoading,
-    isError,
-  } = useActiveRoster(leagueId, teamId);
 
   return (
     <div className="flex flex-col gap-6 p-6">
@@ -84,39 +110,51 @@ export function Roster() {
             Select a team for this league to view its roster.
           </p>
         )
-        : isLoading
-        ? <RosterLoading />
-        : isError || !roster
-        ? (
-          <p className="text-destructive">
-            Failed to load roster. Try again in a moment.
-          </p>
-        )
-        : <RosterContent roster={roster} />}
+        : (
+          <Tabs defaultValue="active" className="gap-6">
+            <TabsList>
+              <TabsTrigger value="active">Active Roster</TabsTrigger>
+              <TabsTrigger value="depth-chart">Depth Chart</TabsTrigger>
+            </TabsList>
+            <TabsContent value="active" className="flex flex-col gap-6">
+              <ActiveRosterView leagueId={leagueId} teamId={teamId} />
+            </TabsContent>
+            <TabsContent value="depth-chart" className="flex flex-col gap-6">
+              <DepthChartView leagueId={leagueId} teamId={teamId} />
+            </TabsContent>
+          </Tabs>
+        )}
     </div>
   );
 }
 
-function RosterLoading() {
-  return (
-    <div data-testid="roster-loading" className="flex flex-col gap-4">
-      <Skeleton className="h-24 w-full" />
-      <Skeleton className="h-64 w-full" />
-    </div>
+function ActiveRosterView(
+  { leagueId, teamId }: { leagueId: string; teamId: string },
+) {
+  const { data: roster, isLoading, isError } = useActiveRoster(
+    leagueId,
+    teamId,
   );
+
+  if (isLoading) {
+    return (
+      <div data-testid="active-roster-loading" className="flex flex-col gap-4">
+        <Skeleton className="h-24 w-full" />
+        <Skeleton className="h-64 w-full" />
+      </div>
+    );
+  }
+  if (isError || !roster) {
+    return (
+      <p className="text-destructive">
+        Failed to load roster. Try again in a moment.
+      </p>
+    );
+  }
+  return <ActiveRosterContent roster={roster} />;
 }
 
-function RosterContent({
-  roster,
-}: {
-  roster: {
-    players: RosterPlayer[];
-    positionGroups: RosterPositionGroupSummary[];
-    totalCap: number;
-    salaryCap: number;
-    capSpace: number;
-  };
-}) {
+function ActiveRosterContent({ roster }: { roster: ActiveRoster }) {
   const playersByGroup: Record<PlayerPositionGroup, RosterPlayer[]> = {
     offense: [],
     defense: [],
@@ -215,6 +253,164 @@ function RosterContent({
         );
       })}
     </>
+  );
+}
+
+function DepthChartView(
+  { leagueId, teamId }: { leagueId: string; teamId: string },
+) {
+  const { data: chart, isLoading, isError } = useDepthChart(leagueId, teamId);
+
+  if (isLoading) {
+    return (
+      <div data-testid="depth-chart-loading" className="flex flex-col gap-4">
+        <Skeleton className="h-24 w-full" />
+        <Skeleton className="h-64 w-full" />
+      </div>
+    );
+  }
+  if (isError || !chart) {
+    return (
+      <p className="text-destructive">
+        Failed to load depth chart. Try again in a moment.
+      </p>
+    );
+  }
+  return <DepthChartContent chart={chart} />;
+}
+
+function DepthChartContent({ chart }: { chart: DepthChart }) {
+  if (chart.slots.length === 0 && chart.inactives.length === 0) {
+    return (
+      <Card>
+        <CardContent className="py-8 text-center text-muted-foreground">
+          <p>The coaching staff hasn't published a depth chart yet.</p>
+          <p className="text-sm">
+            Once the coach sets the chart, you'll see it here. You can't edit it
+            — the coach owns the lineup.
+          </p>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  const byPosition = new Map<string, typeof chart.slots>();
+  for (const slot of chart.slots) {
+    const existing = byPosition.get(slot.position) ?? [];
+    existing.push(slot);
+    byPosition.set(slot.position, existing);
+  }
+  const positions = [...byPosition.keys()].sort();
+
+  return (
+    <>
+      <DepthChartMeta
+        lastUpdatedAt={chart.lastUpdatedAt}
+        lastUpdatedBy={chart.lastUpdatedBy}
+      />
+
+      <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 xl:grid-cols-3">
+        {positions.map((position) => {
+          const slots = [...byPosition.get(position)!].sort(
+            (a, b) => a.slotOrdinal - b.slotOrdinal,
+          );
+          return (
+            <Card
+              key={position}
+              data-testid={`depth-chart-position-${position}`}
+            >
+              <CardHeader>
+                <CardTitle>{position}</CardTitle>
+              </CardHeader>
+              <CardContent className="flex flex-col gap-2">
+                {slots.map((slot) => (
+                  <div
+                    key={slot.playerId}
+                    data-testid={`depth-chart-slot-${slot.playerId}`}
+                    className="flex items-center justify-between gap-3 rounded-md border px-3 py-2"
+                  >
+                    <div className="flex items-baseline gap-3">
+                      <span className="w-8 text-sm font-semibold text-muted-foreground">
+                        {ordinal(slot.slotOrdinal)}
+                      </span>
+                      <span className="font-medium">
+                        {slot.firstName} {slot.lastName}
+                      </span>
+                    </div>
+                    <Badge variant={injuryBadgeVariant(slot.injuryStatus)}>
+                      {formatInjury(slot.injuryStatus)}
+                    </Badge>
+                  </div>
+                ))}
+              </CardContent>
+            </Card>
+          );
+        })}
+      </div>
+
+      {chart.inactives.length > 0 && (
+        <Card data-testid="depth-chart-inactives">
+          <CardHeader>
+            <CardTitle>Game-Day Inactives</CardTitle>
+            <CardDescription>
+              Not dressing this week. Set by the coaching staff.
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Player</TableHead>
+                  <TableHead>Pos</TableHead>
+                  <TableHead>Status</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {chart.inactives.map((player) => (
+                  <TableRow key={player.playerId}>
+                    <TableCell className="font-medium">
+                      {player.firstName} {player.lastName}
+                    </TableCell>
+                    <TableCell>{player.position}</TableCell>
+                    <TableCell>
+                      <Badge
+                        variant={injuryBadgeVariant(player.injuryStatus)}
+                      >
+                        {formatInjury(player.injuryStatus)}
+                      </Badge>
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          </CardContent>
+        </Card>
+      )}
+    </>
+  );
+}
+
+function DepthChartMeta(
+  { lastUpdatedAt, lastUpdatedBy }: {
+    lastUpdatedAt: DepthChart["lastUpdatedAt"];
+    lastUpdatedBy: DepthChart["lastUpdatedBy"];
+  },
+) {
+  const timestamp = lastUpdatedAt
+    ? `Last updated ${dateFormatter.format(new Date(lastUpdatedAt))}`
+    : null;
+  const author = lastUpdatedBy
+    ? `by ${lastUpdatedBy.firstName} ${lastUpdatedBy.lastName} (${
+      formatCoachRole(lastUpdatedBy.role)
+    })`
+    : null;
+  return (
+    <p
+      data-testid="depth-chart-meta"
+      className="text-sm text-muted-foreground"
+    >
+      {[timestamp, author].filter(Boolean).join(" ")}
+    </p>
   );
 }
 

--- a/client/src/hooks/use-depth-chart.test.ts
+++ b/client/src/hooks/use-depth-chart.test.ts
@@ -1,0 +1,72 @@
+import { renderHook, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { describe, expect, it, vi } from "vitest";
+import { createElement } from "react";
+import { useDepthChart } from "./use-depth-chart.ts";
+
+const mockGet = vi.fn();
+
+vi.mock("../api.ts", () => ({
+  api: {
+    api: {
+      roster: {
+        leagues: {
+          [":leagueId"]: {
+            teams: {
+              [":teamId"]: {
+                "depth-chart": {
+                  $get: (...args: unknown[]) => mockGet(...args),
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+  },
+}));
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return ({ children }: { children: React.ReactNode }) =>
+    createElement(QueryClientProvider, { client: queryClient }, children);
+}
+
+describe("useDepthChart", () => {
+  it("fetches a depth chart for a league and team", async () => {
+    const chart = {
+      leagueId: "L1",
+      teamId: "T1",
+      slots: [],
+      inactives: [],
+      lastUpdatedAt: null,
+      lastUpdatedBy: null,
+    };
+    mockGet.mockResolvedValue({ json: () => Promise.resolve(chart) });
+
+    const { result } = renderHook(() => useDepthChart("L1", "T1"), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+
+    expect(result.current.data).toEqual(chart);
+    expect(mockGet).toHaveBeenCalledWith({
+      param: { leagueId: "L1", teamId: "T1" },
+    });
+  });
+
+  it("does not fetch when teamId is missing", () => {
+    mockGet.mockClear();
+    const { result } = renderHook(() => useDepthChart("L1", null), {
+      wrapper: createWrapper(),
+    });
+
+    expect(result.current.fetchStatus).toBe("idle");
+    expect(mockGet).not.toHaveBeenCalled();
+  });
+});

--- a/client/src/hooks/use-depth-chart.ts
+++ b/client/src/hooks/use-depth-chart.ts
@@ -1,0 +1,15 @@
+import { useQuery } from "@tanstack/react-query";
+import { api } from "../api.ts";
+
+export function useDepthChart(leagueId: string, teamId: string | null) {
+  return useQuery({
+    queryKey: ["roster", "depth-chart", leagueId, teamId],
+    enabled: Boolean(leagueId) && Boolean(teamId),
+    queryFn: async () => {
+      const res = await api.api.roster.leagues[":leagueId"].teams[":teamId"][
+        "depth-chart"
+      ].$get({ param: { leagueId, teamId: teamId! } });
+      return res.json();
+    },
+  });
+}


### PR DESCRIPTION
## Summary

- Turns the Roster page into a tabbed layout (**Active Roster** / **Depth Chart**) and adds the coach-owned Depth Chart view described in [ADR 0001](docs/product/decisions/0001-roster-page.md): slots grouped by position with ordinal labels, a separate game-day inactives table, and a "last updated by {coach}" line.
- Strictly read-only — no drag-to-reorder, no "set as starter" affordance, no overall rating. Coach autonomy is the core fiction; editing lives on the coaches page when/if it ships.
- Adds `useDepthChart` (TanStack Query + Hono RPC) gated on the selected team, and pulls in shadcn `Tabs` to host the two views. The empty state calls out that the coaching staff hasn't published a chart yet.