### PR TITLE
feat(roster): combine position groups into one sortable mega table

### DIFF
--- a/client/src/components/ui/data-table.test.tsx
+++ b/client/src/components/ui/data-table.test.tsx
@@ -1,7 +1,13 @@
-import { cleanup, render, screen, within } from "@testing-library/react";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  within,
+} from "@testing-library/react";
 import type { ColumnDef } from "@tanstack/react-table";
 import { afterEach, describe, expect, it } from "vitest";
-import { DataTable } from "./data-table.tsx";
+import { DataTable, SortableHeader } from "./data-table.tsx";
 
 type Row = { id: string; name: string; value: number };
 
@@ -11,8 +17,8 @@ const columns: ColumnDef<Row>[] = [
 ];
 
 const data: Row[] = [
-  { id: "a", name: "Alpha", value: 1 },
-  { id: "b", name: "Beta", value: 2 },
+  { id: "a", name: "Alpha", value: 2 },
+  { id: "b", name: "Beta", value: 1 },
 ];
 
 afterEach(cleanup);
@@ -45,5 +51,57 @@ describe("DataTable", () => {
     );
     const row = screen.getByTestId("row-a");
     expect(within(row).getByText("Alpha")).toBeDefined();
+  });
+
+  it("sorts rows ascending then descending when a SortableHeader is clicked", () => {
+    const sortableColumns: ColumnDef<Row>[] = [
+      {
+        accessorKey: "value",
+        header: ({ column }) => (
+          <SortableHeader column={column}>Value</SortableHeader>
+        ),
+      },
+      { accessorKey: "name", header: "Name" },
+    ];
+    render(
+      <DataTable
+        columns={sortableColumns}
+        data={data}
+        getRowTestId={(row) => `row-${row.id}`}
+      />,
+    );
+    const orderedIds = () =>
+      Array.from(document.querySelectorAll("tbody tr"))
+        .map((r) => r.getAttribute("data-testid"));
+
+    expect(orderedIds()).toEqual(["row-a", "row-b"]);
+    fireEvent.click(screen.getByRole("button", { name: /value/i }));
+    expect(orderedIds()).toEqual(["row-b", "row-a"]);
+    fireEvent.click(screen.getByRole("button", { name: /value/i }));
+    expect(orderedIds()).toEqual(["row-a", "row-b"]);
+  });
+
+  it("renders a toolbar and filters rows via the global filter", () => {
+    render(
+      <DataTable
+        columns={columns}
+        data={data}
+        getRowTestId={(row) => `row-${row.id}`}
+        toolbar={(table) => (
+          <input
+            aria-label="search"
+            value={(table.getState().globalFilter as string) ?? ""}
+            onChange={(e) => table.setGlobalFilter(e.target.value)}
+          />
+        )}
+      />,
+    );
+    expect(screen.getByTestId("row-a")).toBeDefined();
+    expect(screen.getByTestId("row-b")).toBeDefined();
+    fireEvent.change(screen.getByLabelText("search"), {
+      target: { value: "Alpha" },
+    });
+    expect(screen.getByTestId("row-a")).toBeDefined();
+    expect(screen.queryByTestId("row-b")).toBeNull();
   });
 });

--- a/client/src/components/ui/data-table.tsx
+++ b/client/src/components/ui/data-table.tsx
@@ -1,10 +1,21 @@
+import { type ReactNode, useState } from "react";
 import {
+  type Column,
   type ColumnDef,
+  type ColumnFiltersState,
   flexRender,
   getCoreRowModel,
+  getFacetedRowModel,
+  getFacetedUniqueValues,
+  getFilteredRowModel,
+  getSortedRowModel,
+  type SortingState,
+  type Table as ReactTable,
   useReactTable,
 } from "@tanstack/react-table";
+import { ArrowDown, ArrowUp, ArrowUpDown } from "lucide-react";
 
+import { Button } from "@/components/ui/button";
 import {
   Table,
   TableBody,
@@ -18,65 +29,111 @@ interface DataTableProps<TData, TValue> {
   columns: ColumnDef<TData, TValue>[];
   data: TData[];
   getRowTestId?: (row: TData) => string;
+  toolbar?: (table: ReactTable<TData>) => ReactNode;
 }
 
 export function DataTable<TData, TValue>({
   columns,
   data,
   getRowTestId,
+  toolbar,
 }: DataTableProps<TData, TValue>) {
+  const [sorting, setSorting] = useState<SortingState>([]);
+  const [columnFilters, setColumnFilters] = useState<ColumnFiltersState>([]);
+  const [globalFilter, setGlobalFilter] = useState("");
+
   const table = useReactTable({
     data,
     columns,
+    state: { sorting, columnFilters, globalFilter },
+    onSortingChange: setSorting,
+    onColumnFiltersChange: setColumnFilters,
+    onGlobalFilterChange: setGlobalFilter,
     getCoreRowModel: getCoreRowModel(),
+    getSortedRowModel: getSortedRowModel(),
+    getFilteredRowModel: getFilteredRowModel(),
+    getFacetedRowModel: getFacetedRowModel(),
+    getFacetedUniqueValues: getFacetedUniqueValues(),
   });
 
   const rows = table.getRowModel().rows;
 
   return (
-    <div className="overflow-hidden rounded-md border">
-      <Table>
-        <TableHeader>
-          {table.getHeaderGroups().map((headerGroup) => (
-            <TableRow key={headerGroup.id}>
-              {headerGroup.headers.map((header) => (
-                <TableHead key={header.id}>
-                  {header.isPlaceholder ? null : flexRender(
-                    header.column.columnDef.header,
-                    header.getContext(),
-                  )}
-                </TableHead>
-              ))}
-            </TableRow>
-          ))}
-        </TableHeader>
-        <TableBody>
-          {rows.length
-            ? rows.map((row) => (
-              <TableRow
-                key={row.id}
-                data-state={row.getIsSelected() && "selected"}
-                data-testid={getRowTestId?.(row.original)}
-              >
-                {row.getVisibleCells().map((cell) => (
-                  <TableCell key={cell.id}>
-                    {flexRender(cell.column.columnDef.cell, cell.getContext())}
-                  </TableCell>
+    <div className="flex flex-col gap-3">
+      {toolbar ? toolbar(table) : null}
+      <div className="overflow-hidden rounded-md border">
+        <Table>
+          <TableHeader>
+            {table.getHeaderGroups().map((headerGroup) => (
+              <TableRow key={headerGroup.id}>
+                {headerGroup.headers.map((header) => (
+                  <TableHead key={header.id}>
+                    {header.isPlaceholder ? null : flexRender(
+                      header.column.columnDef.header,
+                      header.getContext(),
+                    )}
+                  </TableHead>
                 ))}
               </TableRow>
-            ))
-            : (
-              <TableRow>
-                <TableCell
-                  colSpan={columns.length}
-                  className="h-24 text-center"
+            ))}
+          </TableHeader>
+          <TableBody>
+            {rows.length
+              ? rows.map((row) => (
+                <TableRow
+                  key={row.id}
+                  data-state={row.getIsSelected() && "selected"}
+                  data-testid={getRowTestId?.(row.original)}
                 >
-                  No results.
-                </TableCell>
-              </TableRow>
-            )}
-        </TableBody>
-      </Table>
+                  {row.getVisibleCells().map((cell) => (
+                    <TableCell key={cell.id}>
+                      {flexRender(
+                        cell.column.columnDef.cell,
+                        cell.getContext(),
+                      )}
+                    </TableCell>
+                  ))}
+                </TableRow>
+              ))
+              : (
+                <TableRow>
+                  <TableCell
+                    colSpan={columns.length}
+                    className="h-24 text-center"
+                  >
+                    No results.
+                  </TableCell>
+                </TableRow>
+              )}
+          </TableBody>
+        </Table>
+      </div>
     </div>
+  );
+}
+
+export function SortableHeader<TData, TValue>({
+  column,
+  children,
+}: {
+  column: Column<TData, TValue>;
+  children: ReactNode;
+}) {
+  const sorted = column.getIsSorted();
+  const Icon = sorted === "asc"
+    ? ArrowUp
+    : sorted === "desc"
+    ? ArrowDown
+    : ArrowUpDown;
+  return (
+    <Button
+      variant="ghost"
+      size="sm"
+      className="-ml-2.5 h-7 px-2"
+      onClick={() => column.toggleSorting(sorted === "asc")}
+    >
+      {children}
+      <Icon className="ml-1 size-3.5 opacity-70" />
+    </Button>
   );
 }

--- a/client/src/features/league/roster.test.tsx
+++ b/client/src/features/league/roster.test.tsx
@@ -1,4 +1,10 @@
-import { cleanup, render, screen, within } from "@testing-library/react";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  within,
+} from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { Roster } from "./roster.tsx";
@@ -67,15 +73,26 @@ const baseRoster = {
       contractYearsRemaining: 4,
       injuryStatus: "out",
     },
+    {
+      id: "p4",
+      firstName: "Kyle",
+      lastName: "Kicker",
+      position: "K",
+      positionGroup: "special_teams",
+      age: 30,
+      capHit: 3_000_000,
+      contractYearsRemaining: 1,
+      injuryStatus: "healthy",
+    },
   ],
   positionGroups: [
     { group: "offense", headcount: 2, totalCap: 57_000_000 },
     { group: "defense", headcount: 1, totalCap: 8_000_000 },
-    { group: "special_teams", headcount: 0, totalCap: 0 },
+    { group: "special_teams", headcount: 1, totalCap: 3_000_000 },
   ],
-  totalCap: 65_000_000,
+  totalCap: 68_000_000,
   salaryCap: 255_000_000,
-  capSpace: 190_000_000,
+  capSpace: 187_000_000,
 };
 
 afterEach(() => {
@@ -94,6 +111,12 @@ beforeEach(() => {
     isError: false,
   });
 });
+
+function rosterRowIds() {
+  return Array.from(document.querySelectorAll("tbody tr"))
+    .map((row) => row.getAttribute("data-testid"))
+    .filter((id): id is string => Boolean(id));
+}
 
 describe("Roster", () => {
   it("renders the Roster heading", () => {
@@ -137,42 +160,66 @@ describe("Roster", () => {
   it("renders the cap summary with total cap, salary cap, and cap space", () => {
     renderRoster();
     const summary = screen.getByTestId("roster-cap-summary");
-    expect(within(summary).getByText("$65,000,000")).toBeDefined();
+    expect(within(summary).getByText("$68,000,000")).toBeDefined();
     expect(within(summary).getByText("$255,000,000")).toBeDefined();
-    expect(within(summary).getByText("$190,000,000")).toBeDefined();
+    expect(within(summary).getByText("$187,000,000")).toBeDefined();
   });
 
-  it("renders a section per position group with headcount and group cap", () => {
+  it("renders every player in a single combined table", () => {
     renderRoster();
-    const offense = screen.getByTestId("position-group-header-offense");
-    expect(within(offense).getByText(/offense/i)).toBeDefined();
-    expect(within(offense).getByText("2 players")).toBeDefined();
-    expect(within(offense).getByText("$57,000,000")).toBeDefined();
-
-    const defense = screen.getByTestId("position-group-header-defense");
-    expect(within(defense).getByText("1 player")).toBeDefined();
-    expect(within(defense).getByText("$8,000,000")).toBeDefined();
+    expect(screen.queryByTestId("position-group-offense")).toBeNull();
+    expect(screen.queryByTestId("position-group-defense")).toBeNull();
+    expect(rosterRowIds()).toEqual([
+      "roster-row-p1",
+      "roster-row-p2",
+      "roster-row-p3",
+      "roster-row-p4",
+    ]);
   });
 
-  it("renders a player row with name, position, age, cap hit, contract years, and injury status", () => {
+  it("renders a player row with name, position, group, age, cap hit, contract years, and injury status", () => {
     renderRoster();
     const row = screen.getByTestId("roster-row-p1");
     expect(within(row).getByText("Patrick Quarterback")).toBeDefined();
     expect(within(row).getByText("QB")).toBeDefined();
+    expect(within(row).getByText("Offense")).toBeDefined();
     expect(within(row).getByText("28")).toBeDefined();
     expect(within(row).getByText("$45,000,000")).toBeDefined();
     expect(within(row).getByText("3 yrs")).toBeDefined();
     expect(within(row).getByText(/healthy/i)).toBeDefined();
   });
 
-  it("does not render overall rating, grade, or attribute columns", () => {
+  it("filters rows by the position group filter", () => {
     renderRoster();
-    expect(screen.queryByText(/overall/i)).toBeNull();
-    expect(screen.queryByText(/^grade$/i)).toBeNull();
+    fireEvent.click(screen.getByTestId("roster-group-filter-defense"));
+    expect(rosterRowIds()).toEqual(["roster-row-p3"]);
+    fireEvent.click(screen.getByTestId("roster-group-filter-all"));
+    expect(rosterRowIds()).toHaveLength(4);
   });
 
-  it("omits empty position groups", () => {
+  it("filters rows by the global search input", () => {
     renderRoster();
-    expect(screen.queryByTestId("position-group-special_teams")).toBeNull();
+    fireEvent.change(screen.getByLabelText("Search roster"), {
+      target: { value: "Kicker" },
+    });
+    expect(rosterRowIds()).toEqual(["roster-row-p4"]);
+  });
+
+  it("sorts rows when the Cap Hit header is clicked", () => {
+    renderRoster();
+    fireEvent.click(screen.getByRole("button", { name: /cap hit/i }));
+    expect(rosterRowIds()).toEqual([
+      "roster-row-p4",
+      "roster-row-p3",
+      "roster-row-p2",
+      "roster-row-p1",
+    ]);
+    fireEvent.click(screen.getByRole("button", { name: /cap hit/i }));
+    expect(rosterRowIds()).toEqual([
+      "roster-row-p1",
+      "roster-row-p2",
+      "roster-row-p3",
+      "roster-row-p4",
+    ]);
   });
 });

--- a/client/src/features/league/roster.tsx
+++ b/client/src/features/league/roster.tsx
@@ -1,5 +1,5 @@
 import { useParams } from "@tanstack/react-router";
-import type { ColumnDef } from "@tanstack/react-table";
+import type { ColumnDef, Row } from "@tanstack/react-table";
 import {
   Card,
   CardContent,
@@ -8,12 +8,13 @@ import {
   CardTitle,
 } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
 import { Skeleton } from "@/components/ui/skeleton";
-import { DataTable } from "@/components/ui/data-table";
+import { DataTable, SortableHeader } from "@/components/ui/data-table";
 import type {
   PlayerPositionGroup,
   RosterPlayer,
-  RosterPositionGroupSummary,
 } from "@zone-blitz/shared/types/roster.ts";
 import { useLeague } from "../../hooks/use-league.ts";
 import { useActiveRoster } from "../../hooks/use-active-roster.ts";
@@ -24,7 +25,8 @@ const groupLabels: Record<PlayerPositionGroup, string> = {
   special_teams: "Special Teams",
 };
 
-const groupOrder: PlayerPositionGroup[] = [
+const groupFilterOptions: (PlayerPositionGroup | "all")[] = [
+  "all",
   "offense",
   "defense",
   "special_teams",
@@ -55,7 +57,10 @@ function formatInjury(status: RosterPlayer["injuryStatus"]) {
 const rosterColumns: ColumnDef<RosterPlayer>[] = [
   {
     id: "player",
-    header: "Player",
+    accessorFn: (p) => `${p.firstName} ${p.lastName}`,
+    header: ({ column }) => (
+      <SortableHeader column={column}>Player</SortableHeader>
+    ),
     cell: ({ row }) => (
       <span className="font-medium">
         {row.original.firstName} {row.original.lastName}
@@ -64,25 +69,48 @@ const rosterColumns: ColumnDef<RosterPlayer>[] = [
   },
   {
     accessorKey: "position",
-    header: "Pos",
+    header: ({ column }) => (
+      <SortableHeader column={column}>
+        Pos
+      </SortableHeader>
+    ),
+  },
+  {
+    accessorKey: "positionGroup",
+    header: ({ column }) => (
+      <SortableHeader column={column}>Group</SortableHeader>
+    ),
+    cell: ({ row }) => groupLabels[row.original.positionGroup],
+    filterFn: (row: Row<RosterPlayer>, _id, value) =>
+      value === "all" || row.original.positionGroup === value,
   },
   {
     accessorKey: "age",
-    header: "Age",
+    header: ({ column }) => (
+      <SortableHeader column={column}>
+        Age
+      </SortableHeader>
+    ),
   },
   {
-    id: "capHit",
-    header: "Cap Hit",
+    accessorKey: "capHit",
+    header: ({ column }) => (
+      <SortableHeader column={column}>Cap Hit</SortableHeader>
+    ),
     cell: ({ row }) => formatCurrency(row.original.capHit),
   },
   {
-    id: "contract",
-    header: "Contract",
+    accessorKey: "contractYearsRemaining",
+    header: ({ column }) => (
+      <SortableHeader column={column}>Contract</SortableHeader>
+    ),
     cell: ({ row }) => `${row.original.contractYearsRemaining} yrs`,
   },
   {
-    id: "status",
-    header: "Status",
+    accessorKey: "injuryStatus",
+    header: ({ column }) => (
+      <SortableHeader column={column}>Status</SortableHeader>
+    ),
     cell: ({ row }) => (
       <Badge variant={injuryBadgeVariant(row.original.injuryStatus)}>
         {formatInjury(row.original.injuryStatus)}
@@ -144,21 +172,11 @@ function RosterContent({
 }: {
   roster: {
     players: RosterPlayer[];
-    positionGroups: RosterPositionGroupSummary[];
     totalCap: number;
     salaryCap: number;
     capSpace: number;
   };
 }) {
-  const playersByGroup: Record<PlayerPositionGroup, RosterPlayer[]> = {
-    offense: [],
-    defense: [],
-    special_teams: [],
-  };
-  for (const player of roster.players) {
-    playersByGroup[player.positionGroup].push(player);
-  }
-
   return (
     <>
       <Card data-testid="roster-cap-summary">
@@ -186,35 +204,57 @@ function RosterContent({
         </CardContent>
       </Card>
 
-      {groupOrder.map((group) => {
-        const summary = roster.positionGroups.find((g) => g.group === group);
-        const players = playersByGroup[group];
-        if (!summary || summary.headcount === 0) return null;
-        return (
-          <Card key={group} data-testid={`position-group-${group}`}>
-            <CardHeader
-              className="flex flex-col gap-1 sm:flex-row sm:items-baseline sm:justify-between"
-              data-testid={`position-group-header-${group}`}
+      <DataTable
+        columns={rosterColumns}
+        data={roster.players}
+        getRowTestId={(player) => `roster-row-${player.id}`}
+        toolbar={(table) => {
+          const groupFilter =
+            (table.getColumn("positionGroup")?.getFilterValue() as
+              | PlayerPositionGroup
+              | "all"
+              | undefined) ?? "all";
+          return (
+            <div
+              className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between"
+              data-testid="roster-toolbar"
             >
-              <CardTitle>{groupLabels[group]}</CardTitle>
-              <div className="flex gap-4 text-sm text-muted-foreground">
-                <span>
-                  {summary.headcount}{" "}
-                  {summary.headcount === 1 ? "player" : "players"}
-                </span>
-                <span>{formatCurrency(summary.totalCap)}</span>
-              </div>
-            </CardHeader>
-            <CardContent>
-              <DataTable
-                columns={rosterColumns}
-                data={players}
-                getRowTestId={(player) => `roster-row-${player.id}`}
+              <Input
+                aria-label="Search roster"
+                placeholder="Search players…"
+                className="sm:max-w-xs"
+                value={(table.getState().globalFilter as string) ?? ""}
+                onChange={(event) => table.setGlobalFilter(event.target.value)}
               />
-            </CardContent>
-          </Card>
-        );
-      })}
+              <div
+                className="flex flex-wrap gap-1"
+                role="group"
+                aria-label="Filter by position group"
+              >
+                {groupFilterOptions.map((option) => {
+                  const active = groupFilter === option;
+                  return (
+                    <Button
+                      key={option}
+                      type="button"
+                      size="sm"
+                      variant={active ? "secondary" : "ghost"}
+                      data-testid={`roster-group-filter-${option}`}
+                      aria-pressed={active}
+                      onClick={() =>
+                        table
+                          .getColumn("positionGroup")
+                          ?.setFilterValue(option)}
+                    >
+                      {option === "all" ? "All" : groupLabels[option]}
+                    </Button>
+                  );
+                })}
+              </div>
+            </div>
+          );
+        }}
+      />
     </>
   );
 }


### PR DESCRIPTION
## Summary

- Collapses Offense/Defense/Special Teams cards into a single shadcn `DataTable` on the Roster page — the table no longer sits inside a `Card` wrapper and gains a `positionGroup` column plus a toolbar with a global search input and position-group filter buttons.
- Extends the shared `DataTable` with TanStack Table sorting, column filtering, and global filtering; adds a `toolbar` render prop that hands the table instance to the caller so feature pages can compose their own filter controls.
- Introduces a `SortableHeader` helper so any column header can be clicked to cycle asc/desc sorting, and wires each roster column through it.