### PR TITLE
chore(db): add db:studio task for Drizzle Studio

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -27,6 +27,7 @@
     "db:stop": "docker compose down",
     "db:migrate": "cd server && deno run --env=../.env --allow-net --allow-env --allow-read --allow-sys db/migrate.ts",
     "db:seed": "cd server && deno run --env=../.env --allow-net --allow-env --allow-read --allow-sys db/seed.ts",
+    "db:studio": "cd server && deno run --env=../.env -A npm:drizzle-kit studio",
     "test": "deno task test:server && deno task test:packages && deno task test:client",
     "test:server": "deno test server/ --env=.env --allow-env --allow-net --allow-read --allow-sys --coverage",
     "test:packages": "deno test packages/shared/ packages/simulation/ packages/ai/ --coverage",


### PR DESCRIPTION
## Summary
- Adds `deno task db:studio` which runs `drizzle-kit studio` from `server/` with the root `.env` loaded.
- Gives a live, browser-based view of the schema and data (https://local.drizzle.studio) for ad-hoc inspection and schema visualization during development.