### PR TITLE
feat(scouts): render staff tree and scout detail views

### DIFF
--- a/client/src/features/league/scouts/build-tree.test.ts
+++ b/client/src/features/league/scouts/build-tree.test.ts
@@ -1,0 +1,82 @@
+import type { ScoutNode, ScoutRole } from "@zone-blitz/shared";
+import { describe, expect, it } from "vitest";
+import { buildStaffTree } from "./build-tree.ts";
+
+function node(overrides: Partial<ScoutNode> & { id: string }): ScoutNode {
+  return {
+    id: overrides.id,
+    firstName: overrides.firstName ?? "First",
+    lastName: overrides.lastName ?? overrides.id,
+    role: (overrides.role ?? "AREA_SCOUT") as ScoutRole,
+    reportsToId: overrides.reportsToId ?? null,
+    coverage: overrides.coverage ?? null,
+    age: overrides.age ?? 45,
+    yearsWithTeam: overrides.yearsWithTeam ?? 2,
+    contractYearsRemaining: overrides.contractYearsRemaining ?? 2,
+    workCapacity: overrides.workCapacity ?? 120,
+    isVacancy: overrides.isVacancy ?? false,
+  };
+}
+
+describe("buildStaffTree", () => {
+  it("returns an empty list when there are no scouts", () => {
+    expect(buildStaffTree([])).toEqual([]);
+  });
+
+  it("roots the tree at the director", () => {
+    const tree = buildStaffTree([
+      node({ id: "dir", role: "DIRECTOR" }),
+      node({ id: "cc", role: "NATIONAL_CROSS_CHECKER", reportsToId: "dir" }),
+    ]);
+
+    expect(tree).toHaveLength(1);
+    expect(tree[0].id).toBe("dir");
+    expect(tree[0].reports.map((r) => r.id)).toEqual(["cc"]);
+  });
+
+  it("nests area scouts under their cross-checker three levels deep", () => {
+    const tree = buildStaffTree([
+      node({ id: "dir", role: "DIRECTOR" }),
+      node({ id: "east", role: "NATIONAL_CROSS_CHECKER", reportsToId: "dir" }),
+      node({ id: "west", role: "NATIONAL_CROSS_CHECKER", reportsToId: "dir" }),
+      node({ id: "ne", role: "AREA_SCOUT", reportsToId: "east" }),
+      node({ id: "se", role: "AREA_SCOUT", reportsToId: "east" }),
+      node({ id: "mw", role: "AREA_SCOUT", reportsToId: "west" }),
+    ]);
+
+    expect(tree).toHaveLength(1);
+    const director = tree[0];
+    expect(director.reports.map((r) => r.id).sort()).toEqual(["east", "west"]);
+    const east = director.reports.find((r) => r.id === "east")!;
+    expect(east.reports.map((r) => r.id).sort()).toEqual(["ne", "se"]);
+    const west = director.reports.find((r) => r.id === "west")!;
+    expect(west.reports.map((r) => r.id)).toEqual(["mw"]);
+  });
+
+  it("treats scouts whose reportsToId is missing as additional roots", () => {
+    const tree = buildStaffTree([
+      node({ id: "dir", role: "DIRECTOR" }),
+      node({
+        id: "orphan",
+        role: "AREA_SCOUT",
+        reportsToId: "non-existent",
+      }),
+    ]);
+
+    const rootIds = tree.map((r) => r.id).sort();
+    expect(rootIds).toEqual(["dir", "orphan"]);
+  });
+
+  it("sorts direct reports by canonical role order", () => {
+    const tree = buildStaffTree([
+      node({ id: "dir", role: "DIRECTOR" }),
+      node({ id: "area", role: "AREA_SCOUT", reportsToId: "dir" }),
+      node({ id: "cc", role: "NATIONAL_CROSS_CHECKER", reportsToId: "dir" }),
+    ]);
+
+    expect(tree[0].reports.map((r) => r.role)).toEqual([
+      "NATIONAL_CROSS_CHECKER",
+      "AREA_SCOUT",
+    ]);
+  });
+});

--- a/client/src/features/league/scouts/build-tree.ts
+++ b/client/src/features/league/scouts/build-tree.ts
@@ -1,0 +1,53 @@
+import type { ScoutNode } from "@zone-blitz/shared";
+
+/**
+ * A scout in tree form: the flat `ScoutNode` plus an ordered list of
+ * direct reports. `reports` is always present, possibly empty.
+ */
+export interface StaffTreeNode extends ScoutNode {
+  reports: StaffTreeNode[];
+}
+
+const ROLE_ORDER: Record<string, number> = {
+  DIRECTOR: 0,
+  NATIONAL_CROSS_CHECKER: 1,
+  AREA_SCOUT: 2,
+};
+
+function compareByRole(a: ScoutNode, b: ScoutNode) {
+  const aOrder = ROLE_ORDER[a.role] ?? 99;
+  const bOrder = ROLE_ORDER[b.role] ?? 99;
+  if (aOrder !== bOrder) return aOrder - bOrder;
+  return a.lastName.localeCompare(b.lastName);
+}
+
+/**
+ * Builds the staff tree from the flat `ScoutNode` list returned by the
+ * API. Nodes with `reportsToId === null` become roots; a node whose
+ * `reportsToId` does not resolve to any sibling is treated as a root so
+ * the staff is never silently hidden. Children are sorted by canonical
+ * role order (Director → National Cross-checker → Area Scout).
+ */
+export function buildStaffTree(nodes: ScoutNode[]): StaffTreeNode[] {
+  const byId = new Map<string, StaffTreeNode>();
+  for (const node of nodes) {
+    byId.set(node.id, { ...node, reports: [] });
+  }
+
+  const roots: StaffTreeNode[] = [];
+  for (const node of byId.values()) {
+    const parent = node.reportsToId ? byId.get(node.reportsToId) : undefined;
+    if (parent) {
+      parent.reports.push(node);
+    } else {
+      roots.push(node);
+    }
+  }
+
+  for (const node of byId.values()) {
+    node.reports.sort(compareByRole);
+  }
+  roots.sort(compareByRole);
+
+  return roots;
+}

--- a/client/src/features/league/scouts/detail.test.tsx
+++ b/client/src/features/league/scouts/detail.test.tsx
@@ -1,17 +1,200 @@
-import { cleanup, render, screen } from "@testing-library/react";
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { ScoutDetail } from "./detail.tsx";
 
+const mockDetailGet = vi.fn();
+
 vi.mock("@tanstack/react-router", () => ({
-  useParams: () => ({ scoutId: "abc" }),
+  useParams: () => ({ scoutId: "s1", leagueId: "1" }),
+  Link: ({
+    children,
+    params,
+  }: {
+    children: React.ReactNode;
+    to?: string;
+    params?: { leagueId: string; scoutId: string };
+    className?: string;
+  }) => (
+    <a
+      href={params
+        ? `/leagues/${params.leagueId}/scouts/${params.scoutId}`
+        : "#"}
+    >
+      {children}
+    </a>
+  ),
 }));
 
-afterEach(() => cleanup());
+vi.mock("../../../api.ts", () => ({
+  api: {
+    api: {
+      scouts: {
+        [":scoutId"]: {
+          $get: (...args: unknown[]) => mockDetailGet(...args),
+        },
+      },
+    },
+  },
+}));
 
-describe("ScoutDetail placeholder", () => {
-  it("renders the scout id as a placeholder message", () => {
-    render(<ScoutDetail />);
-    expect(screen.getByRole("heading", { name: "Scout" })).toBeDefined();
-    expect(screen.getByText(/scout abc/)).toBeDefined();
+function renderDetail() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <ScoutDetail />
+    </QueryClientProvider>,
+  );
+}
+
+const baseDetail = {
+  id: "s1",
+  leagueId: "1",
+  teamId: "t1",
+  firstName: "Alex",
+  lastName: "Stone",
+  role: "DIRECTOR",
+  coverage: null as string | null,
+  age: 58,
+  yearsWithTeam: 3,
+  contractYearsRemaining: 4,
+  contractSalary: 1_500_000,
+  contractBuyout: 2_000_000,
+  workCapacity: 200,
+  isVacancy: false,
+  reputationLabels: [] as string[],
+  careerStops: [] as unknown[],
+  evaluations: [] as unknown[],
+  crossChecks: [] as unknown[],
+  externalTrackRecord: [] as unknown[],
+  connections: [] as unknown[],
+};
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+describe("ScoutDetail", () => {
+  it("renders header, empty sections, and work capacity", async () => {
+    mockDetailGet.mockResolvedValue({
+      json: () => Promise.resolve(baseDetail),
+    });
+
+    renderDetail();
+
+    await waitFor(() => {
+      expect(screen.getByRole("heading", { name: /Alex Stone/ })).toBeDefined();
+    });
+    expect(screen.getByText(/Scouting Director/)).toBeDefined();
+    expect(screen.getByText(/200 pts \/ cycle/)).toBeDefined();
+    expect(screen.getByText(/No prior stops on record/)).toBeDefined();
+    expect(screen.getByText(/No league reputation yet/)).toBeDefined();
+    expect(screen.getByText(/No evaluations on file/)).toBeDefined();
+    expect(screen.getByText(/No secondhand record on file/)).toBeDefined();
+    expect(screen.getByText(/No known connections/)).toBeDefined();
+  });
+
+  it("renders reputation, resume, evaluations, cross-checks, external record, and connections", async () => {
+    mockDetailGet.mockResolvedValue({
+      json: () =>
+        Promise.resolve({
+          ...baseDetail,
+          coverage: "Southeast",
+          reputationLabels: ["respected ACC evaluator"],
+          careerStops: [
+            {
+              id: "cs1",
+              orgName: "Lions",
+              role: "Area Scout",
+              startYear: 2018,
+              endYear: null,
+              coverageNotes: "SEC",
+            },
+          ],
+          evaluations: [
+            {
+              id: "e1",
+              prospectId: null,
+              prospectName: "Rookie Back",
+              draftYear: 2029,
+              positionGroup: "RB",
+              roundTier: "4-5",
+              grade: "late-round flyer",
+              evaluationLevel: "standard",
+              outcome: "contributor",
+              outcomeDetail: "3rd-string RB",
+            },
+          ],
+          crossChecks: [
+            {
+              id: "cc1",
+              evaluationId: "e1",
+              otherScout: {
+                id: "s2",
+                firstName: "Peer",
+                lastName: "Buddy",
+                role: "AREA_SCOUT",
+              },
+              otherGrade: "UDFA",
+              winner: "this",
+            },
+            {
+              id: "cc2",
+              evaluationId: "e1",
+              otherScout: null,
+              otherGrade: "day 3",
+              winner: "pending",
+            },
+          ],
+          externalTrackRecord: [
+            {
+              id: "ex1",
+              orgName: "Tigers",
+              startYear: 2015,
+              endYear: null,
+              noisyHitRateLabel: "above-average on Day 3 picks",
+            },
+          ],
+          connections: [
+            {
+              relation: "peer",
+              scout: {
+                id: "s3",
+                firstName: "Pat",
+                lastName: "Friend",
+                role: "AREA_SCOUT",
+              },
+            },
+          ],
+        }),
+    });
+
+    renderDetail();
+
+    await waitFor(() => {
+      expect(screen.getByText(/respected ACC evaluator/)).toBeDefined();
+    });
+    expect(screen.getByText(/Lions — Area Scout/)).toBeDefined();
+    expect(screen.getByText(/Rookie Back/)).toBeDefined();
+    expect(screen.getByText(/late-round flyer/)).toBeDefined();
+    expect(screen.getByText(/Peer Buddy/)).toBeDefined();
+    expect(screen.getByText(/Lower confidence/)).toBeDefined();
+    expect(screen.getByText(/Tigers/)).toBeDefined();
+    const connectionLink = screen.getByRole("link", { name: /Pat Friend/ });
+    expect(connectionLink.getAttribute("href")).toBe(
+      "/leagues/1/scouts/s3",
+    );
+  });
+
+  it("shows an error alert when the request fails", async () => {
+    mockDetailGet.mockRejectedValue(new Error("boom"));
+    renderDetail();
+
+    await waitFor(() => {
+      expect(screen.getByText(/Failed to load scout detail/)).toBeDefined();
+    });
   });
 });

--- a/client/src/features/league/scouts/detail.tsx
+++ b/client/src/features/league/scouts/detail.tsx
@@ -1,13 +1,303 @@
-import { useParams } from "@tanstack/react-router";
+import { Link, useParams } from "@tanstack/react-router";
+import type {
+  ScoutConnection,
+  ScoutDetail as ScoutDetailData,
+  ScoutEvaluation,
+  ScoutRole,
+} from "@zone-blitz/shared";
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import { Badge } from "@/components/ui/badge";
+import { Card } from "@/components/ui/card";
+import { Separator } from "@/components/ui/separator";
+import { Skeleton } from "@/components/ui/skeleton";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { useScoutDetail } from "../../../hooks/use-scout-detail.ts";
+
+const ROLE_LABELS: Record<ScoutRole, string> = {
+  DIRECTOR: "Scouting Director",
+  NATIONAL_CROSS_CHECKER: "National Cross-checker",
+  AREA_SCOUT: "Area Scout",
+};
+
+const CONNECTION_LABELS: Record<ScoutConnection["relation"], string> = {
+  worked_under: "Worked under",
+  peer: "Peer",
+  mentee: "Mentee",
+};
 
 export function ScoutDetail() {
-  const { scoutId } = useParams({ strict: false });
+  const { scoutId, leagueId } = useParams({ strict: false }) as {
+    scoutId: string;
+    leagueId: string;
+  };
+  const { data, isLoading, error } = useScoutDetail(scoutId);
+
+  if (isLoading) {
+    return (
+      <div className="flex flex-col gap-3 p-6" data-testid="scout-skeleton">
+        <Skeleton className="h-10 w-2/3" />
+        <Skeleton className="h-32 w-full" />
+        <Skeleton className="h-48 w-full" />
+      </div>
+    );
+  }
+
+  if (error || !data) {
+    return (
+      <div className="p-6">
+        <Alert variant="destructive">
+          <AlertTitle>Error</AlertTitle>
+          <AlertDescription>Failed to load scout detail.</AlertDescription>
+        </Alert>
+      </div>
+    );
+  }
+
+  const detail = data as ScoutDetailData;
+
   return (
-    <div className="flex flex-col gap-2 p-6">
-      <h1 className="text-2xl font-bold tracking-tight">Scout</h1>
-      <p className="text-sm text-muted-foreground">
-        Detail view coming soon — scout {scoutId}.
-      </p>
+    <div className="flex flex-col gap-6 p-6">
+      <Header detail={detail} />
+      <Resume detail={detail} />
+      <Reputation detail={detail} />
+      <TrackRecord detail={detail} />
+      <ExternalRecord detail={detail} />
+      <Connections detail={detail} leagueId={leagueId} />
     </div>
+  );
+}
+
+function Header({ detail }: { detail: ScoutDetailData }) {
+  return (
+    <header className="flex flex-col gap-2">
+      <h1 className="text-2xl font-bold tracking-tight">
+        {detail.firstName} {detail.lastName}
+      </h1>
+      <p className="text-sm text-muted-foreground">
+        {ROLE_LABELS[detail.role]}
+        {detail.coverage && <span>· {detail.coverage}</span>}
+      </p>
+      <p className="text-sm text-muted-foreground">
+        Age {detail.age} · {detail.yearsWithTeam} yr w/ team ·{" "}
+        {detail.contractYearsRemaining} yr remaining · {detail.workCapacity}
+        {" "}
+        pts / cycle
+      </p>
+    </header>
+  );
+}
+
+function Section({
+  title,
+  children,
+}: {
+  title: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <section className="flex flex-col gap-3">
+      <div className="flex items-center gap-3">
+        <h2 className="text-lg font-semibold">{title}</h2>
+        <Separator className="flex-1" />
+      </div>
+      {children}
+    </section>
+  );
+}
+
+function Resume({ detail }: { detail: ScoutDetailData }) {
+  return (
+    <Section title="Resume">
+      {detail.careerStops.length === 0
+        ? (
+          <p className="text-sm text-muted-foreground">
+            No prior stops on record.
+          </p>
+        )
+        : (
+          <ul className="flex flex-col gap-2">
+            {detail.careerStops.map((stop) => (
+              <Card key={stop.id} className="flex flex-col gap-1 p-4">
+                <p className="text-sm font-medium">
+                  {stop.orgName} — {stop.role}
+                </p>
+                <p className="text-xs text-muted-foreground">
+                  {stop.startYear}–{stop.endYear ?? "present"}
+                  {stop.coverageNotes && <span>· {stop.coverageNotes}</span>}
+                </p>
+              </Card>
+            ))}
+          </ul>
+        )}
+    </Section>
+  );
+}
+
+function Reputation({ detail }: { detail: ScoutDetailData }) {
+  return (
+    <Section title="Reputation">
+      {detail.reputationLabels.length === 0
+        ? (
+          <p className="text-sm text-muted-foreground">
+            No league reputation yet.
+          </p>
+        )
+        : (
+          <div className="flex flex-wrap gap-2">
+            {detail.reputationLabels.map((label) => (
+              <Badge key={label} variant="secondary">
+                {label}
+              </Badge>
+            ))}
+          </div>
+        )}
+    </Section>
+  );
+}
+
+function TrackRecord({ detail }: { detail: ScoutDetailData }) {
+  return (
+    <Section title="Track record with this team">
+      <EvaluationsTable evaluations={detail.evaluations} />
+      <CrossCheckList detail={detail} />
+    </Section>
+  );
+}
+
+function EvaluationsTable({
+  evaluations,
+}: {
+  evaluations: ScoutEvaluation[];
+}) {
+  if (evaluations.length === 0) {
+    return (
+      <p className="text-sm text-muted-foreground">
+        No evaluations on file from his tenure.
+      </p>
+    );
+  }
+  return (
+    <Table>
+      <TableHeader>
+        <TableRow>
+          <TableHead>Draft year</TableHead>
+          <TableHead>Position</TableHead>
+          <TableHead>Round tier</TableHead>
+          <TableHead>Prospect</TableHead>
+          <TableHead>Grade</TableHead>
+          <TableHead>Level</TableHead>
+          <TableHead>Outcome</TableHead>
+        </TableRow>
+      </TableHeader>
+      <TableBody>
+        {evaluations.map((e) => (
+          <TableRow key={e.id}>
+            <TableCell>{e.draftYear}</TableCell>
+            <TableCell>{e.positionGroup}</TableCell>
+            <TableCell>{e.roundTier}</TableCell>
+            <TableCell>{e.prospectName}</TableCell>
+            <TableCell>{e.grade}</TableCell>
+            <TableCell>{e.evaluationLevel}</TableCell>
+            <TableCell>
+              {e.outcome}
+              {e.outcomeDetail && (
+                <span className="text-xs text-muted-foreground">
+                  {" "}
+                  · {e.outcomeDetail}
+                </span>
+              )}
+            </TableCell>
+          </TableRow>
+        ))}
+      </TableBody>
+    </Table>
+  );
+}
+
+function CrossCheckList({ detail }: { detail: ScoutDetailData }) {
+  if (detail.crossChecks.length === 0) return null;
+  return (
+    <div className="flex flex-col gap-2">
+      <h3 className="text-sm font-medium">Cross-check history</h3>
+      <ul className="flex flex-col gap-1">
+        {detail.crossChecks.map((c) => (
+          <li key={c.id} className="text-sm text-muted-foreground">
+            vs {c.otherScout
+              ? `${c.otherScout.firstName} ${c.otherScout.lastName}`
+              : "unknown scout"} · other grade:{" "}
+            <span className="font-medium">{c.otherGrade}</span> · winner:{" "}
+            <span className="font-medium">{c.winner}</span>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+function ExternalRecord({ detail }: { detail: ScoutDetailData }) {
+  return (
+    <Section title="Track record across the league">
+      {detail.externalTrackRecord.length === 0
+        ? (
+          <p className="text-sm text-muted-foreground">
+            No secondhand record on file.
+          </p>
+        )
+        : (
+          <Alert>
+            <AlertTitle>Lower confidence — secondhand data</AlertTitle>
+            <AlertDescription>
+              <ul className="mt-2 flex flex-col gap-1">
+                {detail.externalTrackRecord.map((r) => (
+                  <li key={r.id} className="text-sm">
+                    {r.orgName} ({r.startYear}–{r.endYear ?? "present"}) —{" "}
+                    {r.noisyHitRateLabel}
+                  </li>
+                ))}
+              </ul>
+            </AlertDescription>
+          </Alert>
+        )}
+    </Section>
+  );
+}
+
+function Connections({
+  detail,
+  leagueId,
+}: {
+  detail: ScoutDetailData;
+  leagueId: string;
+}) {
+  return (
+    <Section title="Connections">
+      {detail.connections.length === 0
+        ? <p className="text-sm text-muted-foreground">No known connections.</p>
+        : (
+          <ul className="flex flex-col gap-2">
+            {detail.connections.map((c) => (
+              <li key={c.scout.id} className="text-sm">
+                <span className="text-muted-foreground">
+                  {CONNECTION_LABELS[c.relation]}:
+                </span>{" "}
+                <Link
+                  to="/leagues/$leagueId/scouts/$scoutId"
+                  params={{ leagueId, scoutId: c.scout.id }}
+                  className="font-medium underline"
+                >
+                  {c.scout.firstName} {c.scout.lastName}
+                </Link>
+              </li>
+            ))}
+          </ul>
+        )}
+    </Section>
   );
 }

--- a/client/src/features/league/scouts/index.test.tsx
+++ b/client/src/features/league/scouts/index.test.tsx
@@ -1,14 +1,180 @@
-import { cleanup, render, screen } from "@testing-library/react";
-import { afterEach, describe, expect, it } from "vitest";
-import { Scouts } from "./index.tsx";
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { RouterProvider } from "@tanstack/react-router";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createTestRouter } from "../../../router.tsx";
+
+const mockLeaguesGet = vi.fn();
+const mockTeamsGet = vi.fn();
+const mockStaffGet = vi.fn();
+const mockCoachesStaffGet = vi.fn();
+
+vi.mock("../../../api.ts", () => ({
+  api: {
+    api: {
+      leagues: {
+        $get: (...args: unknown[]) => mockLeaguesGet(...args),
+        $post: vi.fn(),
+      },
+      teams: {
+        $get: (...args: unknown[]) => mockTeamsGet(...args),
+      },
+      coaches: {
+        leagues: {
+          [":leagueId"]: {
+            teams: {
+              [":teamId"]: {
+                staff: {
+                  $get: (...args: unknown[]) => mockCoachesStaffGet(...args),
+                },
+              },
+            },
+          },
+        },
+      },
+      scouts: {
+        leagues: {
+          [":leagueId"]: {
+            teams: {
+              [":teamId"]: {
+                staff: {
+                  $get: (...args: unknown[]) => mockStaffGet(...args),
+                },
+              },
+            },
+          },
+        },
+        [":scoutId"]: {
+          $get: vi.fn(),
+        },
+      },
+    },
+  },
+}));
+
+vi.mock("../../../lib/auth-client.ts", () => ({
+  authClient: {
+    useSession: () => ({
+      data: { user: { id: "1", name: "Test" }, session: { id: "s1" } },
+      isPending: false,
+    }),
+    signIn: { social: vi.fn() },
+  },
+}));
+
+function renderAt(path: string) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  const router = createTestRouter(path);
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <RouterProvider router={router} />
+    </QueryClientProvider>,
+  );
+}
+
+const baseTeam = {
+  id: "team-1",
+  name: "Team",
+  city: "City",
+  abbreviation: "TST",
+  primaryColor: "#000000",
+  secondaryColor: "#FFFFFF",
+  conference: "AFC",
+  division: "AFC East",
+};
+
+const baseScout = {
+  reportsToId: null as string | null,
+  coverage: null as string | null,
+  age: 45,
+  yearsWithTeam: 2,
+  contractYearsRemaining: 2,
+  workCapacity: 120,
+  isVacancy: false,
+};
 
 afterEach(() => {
   cleanup();
+  vi.clearAllMocks();
 });
 
-describe("Scouts", () => {
-  it("renders the Scouts heading", () => {
-    render(<Scouts />);
-    expect(screen.getByRole("heading", { name: "Scouts" })).toBeDefined();
+describe("Scouts page", () => {
+  it("renders the staff tree returned by the API", async () => {
+    mockLeaguesGet.mockResolvedValue({
+      json: () => Promise.resolve({ id: "1", name: "League" }),
+    });
+    mockTeamsGet.mockResolvedValue({
+      json: () => Promise.resolve([baseTeam]),
+    });
+    mockStaffGet.mockResolvedValue({
+      json: () =>
+        Promise.resolve([
+          {
+            ...baseScout,
+            id: "dir",
+            firstName: "Alex",
+            lastName: "Stone",
+            role: "DIRECTOR",
+            workCapacity: 200,
+          },
+          {
+            ...baseScout,
+            id: "cc",
+            firstName: "Sam",
+            lastName: "Rivers",
+            role: "NATIONAL_CROSS_CHECKER",
+            reportsToId: "dir",
+            coverage: "East",
+          },
+        ]),
+    });
+
+    renderAt("/leagues/1/scouts");
+
+    await waitFor(() => {
+      expect(screen.getByText("Alex Stone")).toBeDefined();
+      expect(screen.getByText("Sam Rivers")).toBeDefined();
+      expect(screen.getByText(/200 pts \/ cycle/)).toBeDefined();
+    });
+
+    expect(mockStaffGet).toHaveBeenCalledWith({
+      param: { leagueId: "1", teamId: "team-1" },
+    });
+  });
+
+  it("renders the empty-state message when the team has no staff", async () => {
+    mockLeaguesGet.mockResolvedValue({
+      json: () => Promise.resolve({ id: "1", name: "League" }),
+    });
+    mockTeamsGet.mockResolvedValue({
+      json: () => Promise.resolve([baseTeam]),
+    });
+    mockStaffGet.mockResolvedValue({
+      json: () => Promise.resolve([]),
+    });
+
+    renderAt("/leagues/1/scouts");
+
+    await waitFor(() => {
+      expect(screen.getByText(/No scouts on staff/i)).toBeDefined();
+    });
+  });
+
+  it("shows the error alert when the request fails", async () => {
+    mockLeaguesGet.mockResolvedValue({
+      json: () => Promise.resolve({ id: "1", name: "League" }),
+    });
+    mockTeamsGet.mockResolvedValue({
+      json: () => Promise.resolve([baseTeam]),
+    });
+    mockStaffGet.mockRejectedValue(new Error("boom"));
+
+    renderAt("/leagues/1/scouts");
+
+    await waitFor(() => {
+      expect(screen.getByText(/Failed to load scouting staff/i)).toBeDefined();
+    });
   });
 });

--- a/client/src/features/league/scouts/index.tsx
+++ b/client/src/features/league/scouts/index.tsx
@@ -1,10 +1,75 @@
-import { StubPage } from "../stub-page.tsx";
+import { useParams } from "@tanstack/react-router";
+import type { ScoutNode } from "@zone-blitz/shared";
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import { Skeleton } from "@/components/ui/skeleton";
+import { useScoutStaffTree } from "../../../hooks/use-scout-staff-tree.ts";
+import { useTeams } from "../../../hooks/use-teams.ts";
+import { buildStaffTree } from "./build-tree.ts";
+import { StaffTreeNode } from "./staff-tree-node.tsx";
 
 export function Scouts() {
+  const { leagueId: rawLeagueId } = useParams({ strict: false });
+  const leagueId = rawLeagueId ?? "";
+  const { data: teams, isLoading: teamsLoading } = useTeams();
+  const teamId = (teams?.[0]?.id as string | undefined) ?? "";
+  const { data, isLoading, error } = useScoutStaffTree(leagueId, teamId);
+
+  const loading = teamsLoading || isLoading;
+
   return (
-    <StubPage
-      title="Scouts"
-      description="Inspect your scouting department — the director, cross-checkers, and area scouts who work for you."
-    />
+    <div className="flex flex-col gap-6 p-6">
+      <header className="flex flex-col gap-1">
+        <h1 className="text-2xl font-bold tracking-tight">Scouts</h1>
+        <p className="text-sm text-muted-foreground">
+          Your scouting department — director, cross-checkers, and area scouts.
+        </p>
+      </header>
+
+      {loading && (
+        <div className="flex flex-col gap-3" data-testid="scouts-skeleton">
+          <Skeleton className="h-20 w-full" />
+          <Skeleton className="h-20 w-11/12" />
+          <Skeleton className="h-20 w-10/12" />
+        </div>
+      )}
+
+      {error && !loading && (
+        <Alert variant="destructive">
+          <AlertTitle>Error</AlertTitle>
+          <AlertDescription>Failed to load scouting staff.</AlertDescription>
+        </Alert>
+      )}
+
+      {!loading && !error && data && (
+        <StaffTree
+          nodes={data as ScoutNode[]}
+          leagueId={leagueId}
+        />
+      )}
+    </div>
+  );
+}
+
+function StaffTree({
+  nodes,
+  leagueId,
+}: {
+  nodes: ScoutNode[];
+  leagueId: string;
+}) {
+  const tree = buildStaffTree(nodes);
+  if (tree.length === 0) {
+    return (
+      <p className="text-sm text-muted-foreground">
+        No scouts on staff yet.
+      </p>
+    );
+  }
+  return (
+    <ul className="flex flex-col gap-3">
+      {tree.map((root) => (
+        <StaffTreeNode key={root.id} node={root} leagueId={leagueId} />
+      ))}
+    </ul>
   );
 }

--- a/client/src/features/league/scouts/staff-tree-node.test.tsx
+++ b/client/src/features/league/scouts/staff-tree-node.test.tsx
@@ -1,0 +1,120 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { StaffTreeNode as StaffTreeNodeData } from "./build-tree.ts";
+import { StaffTreeNode } from "./staff-tree-node.tsx";
+
+vi.mock("@tanstack/react-router", () => ({
+  Link: ({
+    children,
+    params,
+    className,
+  }: {
+    children: React.ReactNode;
+    to?: string;
+    params?: { leagueId: string; scoutId: string };
+    className?: string;
+  }) => (
+    <a
+      href={params
+        ? `/leagues/${params.leagueId}/scouts/${params.scoutId}`
+        : "#"}
+      className={className}
+    >
+      {children}
+    </a>
+  ),
+}));
+
+function treeNode(overrides: Partial<StaffTreeNodeData>): StaffTreeNodeData {
+  return {
+    id: "s1",
+    firstName: "Alex",
+    lastName: "Stone",
+    role: "DIRECTOR",
+    reportsToId: null,
+    coverage: null,
+    age: 58,
+    yearsWithTeam: 3,
+    contractYearsRemaining: 4,
+    workCapacity: 200,
+    isVacancy: false,
+    reports: [],
+    ...overrides,
+  };
+}
+
+afterEach(() => cleanup());
+
+describe("StaffTreeNode", () => {
+  it("renders the scout's name, role, coverage, and bio line", () => {
+    render(
+      <ul>
+        <StaffTreeNode
+          node={treeNode({ role: "AREA_SCOUT", coverage: "Southeast" })}
+          leagueId="1"
+        />
+      </ul>,
+    );
+    expect(screen.getByText("Alex Stone")).toBeDefined();
+    expect(screen.getByText(/Area Scout/)).toBeDefined();
+    expect(screen.getByText(/Southeast/)).toBeDefined();
+    expect(
+      screen.getByText(/Age 58 · 3 yr w\/ team · 4 yr remaining/),
+    ).toBeDefined();
+  });
+
+  it("renders the work-capacity badge", () => {
+    render(
+      <ul>
+        <StaffTreeNode
+          node={treeNode({ workCapacity: 180 })}
+          leagueId="1"
+        />
+      </ul>,
+    );
+    expect(screen.getByText(/180 pts \/ cycle/)).toBeDefined();
+  });
+
+  it("links to the scout detail route", () => {
+    render(
+      <ul>
+        <StaffTreeNode node={treeNode({ id: "abc" })} leagueId="42" />
+      </ul>,
+    );
+    const link = screen.getByRole("link");
+    expect(link.getAttribute("href")).toBe("/leagues/42/scouts/abc");
+  });
+
+  it("renders a vacancy card with a disabled Hire button", () => {
+    render(
+      <ul>
+        <StaffTreeNode
+          node={treeNode({ isVacancy: true, role: "AREA_SCOUT" })}
+          leagueId="1"
+        />
+      </ul>,
+    );
+    expect(screen.getByText("Vacant")).toBeDefined();
+    const button = screen.getByRole("button", { name: "Hire" });
+    expect(button.hasAttribute("disabled")).toBe(true);
+  });
+
+  it("recursively renders direct reports", () => {
+    const child = treeNode({
+      id: "cc",
+      firstName: "Sam",
+      lastName: "Rivers",
+      role: "NATIONAL_CROSS_CHECKER",
+    });
+    render(
+      <ul>
+        <StaffTreeNode
+          node={treeNode({ role: "DIRECTOR", reports: [child] })}
+          leagueId="1"
+        />
+      </ul>,
+    );
+    expect(screen.getByText("Alex Stone")).toBeDefined();
+    expect(screen.getByText("Sam Rivers")).toBeDefined();
+  });
+});

--- a/client/src/features/league/scouts/staff-tree-node.tsx
+++ b/client/src/features/league/scouts/staff-tree-node.tsx
@@ -1,0 +1,91 @@
+import { Link } from "@tanstack/react-router";
+import type { ScoutRole } from "@zone-blitz/shared";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card } from "@/components/ui/card";
+import type { StaffTreeNode as StaffTreeNodeData } from "./build-tree.ts";
+
+const ROLE_LABELS: Record<ScoutRole, string> = {
+  DIRECTOR: "Scouting Director",
+  NATIONAL_CROSS_CHECKER: "National Cross-checker",
+  AREA_SCOUT: "Area Scout",
+};
+
+interface StaffTreeNodeProps {
+  node: StaffTreeNodeData;
+  leagueId: string;
+  depth?: number;
+}
+
+export function StaffTreeNode(
+  { node, leagueId, depth = 0 }: StaffTreeNodeProps,
+) {
+  return (
+    <li className="flex flex-col gap-3" data-testid={`scout-${node.id}`}>
+      <ScoutCard node={node} leagueId={leagueId} />
+      {node.reports.length > 0 && (
+        <ul className="flex flex-col gap-3 border-l border-border pl-6 ml-4">
+          {node.reports.map((child) => (
+            <StaffTreeNode
+              key={child.id}
+              node={child}
+              leagueId={leagueId}
+              depth={depth + 1}
+            />
+          ))}
+        </ul>
+      )}
+    </li>
+  );
+}
+
+function ScoutCard({
+  node,
+  leagueId,
+}: {
+  node: StaffTreeNodeData;
+  leagueId: string;
+}) {
+  if (node.isVacancy) {
+    return (
+      <Card className="flex flex-row items-center justify-between gap-4 border-dashed bg-muted/30 p-4">
+        <div>
+          <p className="text-sm font-medium text-muted-foreground">
+            {ROLE_LABELS[node.role]}
+          </p>
+          <p className="text-xs text-muted-foreground">Vacant</p>
+        </div>
+        <Button size="sm" variant="outline" disabled>
+          Hire
+        </Button>
+      </Card>
+    );
+  }
+
+  return (
+    <Card className="p-0">
+      <Link
+        to="/leagues/$leagueId/scouts/$scoutId"
+        params={{ leagueId, scoutId: node.id }}
+        className="flex flex-col gap-1 p-4 transition-colors hover:bg-muted/40"
+      >
+        <div className="flex items-center justify-between gap-3">
+          <p className="text-sm font-semibold">
+            {node.firstName} {node.lastName}
+          </p>
+          <Badge variant="secondary">
+            {node.workCapacity} pts / cycle
+          </Badge>
+        </div>
+        <p className="text-xs text-muted-foreground">
+          {ROLE_LABELS[node.role]}
+          {node.coverage && <span>· {node.coverage}</span>}
+        </p>
+        <p className="text-xs text-muted-foreground">
+          Age {node.age} · {node.yearsWithTeam} yr w/ team ·{" "}
+          {node.contractYearsRemaining} yr remaining
+        </p>
+      </Link>
+    </Card>
+  );
+}

--- a/client/src/hooks/use-scout-detail.test.ts
+++ b/client/src/hooks/use-scout-detail.test.ts
@@ -1,0 +1,54 @@
+import { renderHook, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { describe, expect, it, vi } from "vitest";
+import { useScoutDetail } from "./use-scout-detail.ts";
+import { createElement } from "react";
+
+const mockGet = vi.fn();
+
+vi.mock("../api.ts", () => ({
+  api: {
+    api: {
+      scouts: {
+        [":scoutId"]: {
+          $get: (...args: unknown[]) => mockGet(...args),
+        },
+      },
+    },
+  },
+}));
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return ({ children }: { children: React.ReactNode }) =>
+    createElement(QueryClientProvider, { client: queryClient }, children);
+}
+
+describe("useScoutDetail", () => {
+  it("fetches the scout detail by id", async () => {
+    const detail = { id: "s1", firstName: "A", lastName: "B" };
+    mockGet.mockResolvedValue({ json: () => Promise.resolve(detail) });
+
+    const { result } = renderHook(() => useScoutDetail("s1"), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+
+    expect(result.current.data).toEqual(detail);
+    expect(mockGet).toHaveBeenCalledWith({ param: { scoutId: "s1" } });
+  });
+
+  it("skips fetching when scoutId is empty", () => {
+    mockGet.mockClear();
+    const { result } = renderHook(() => useScoutDetail(""), {
+      wrapper: createWrapper(),
+    });
+    expect(result.current.isFetching).toBe(false);
+    expect(mockGet).not.toHaveBeenCalled();
+  });
+});

--- a/client/src/hooks/use-scout-detail.ts
+++ b/client/src/hooks/use-scout-detail.ts
@@ -1,0 +1,15 @@
+import { useQuery } from "@tanstack/react-query";
+import { api } from "../api.ts";
+
+export function useScoutDetail(scoutId: string) {
+  return useQuery({
+    queryKey: ["scouts", "detail", scoutId],
+    queryFn: async () => {
+      const res = await api.api.scouts[":scoutId"].$get({
+        param: { scoutId },
+      });
+      return res.json();
+    },
+    enabled: scoutId.length > 0,
+  });
+}

--- a/client/src/hooks/use-scout-staff-tree.test.ts
+++ b/client/src/hooks/use-scout-staff-tree.test.ts
@@ -1,0 +1,79 @@
+import { renderHook, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { describe, expect, it, vi } from "vitest";
+import { useScoutStaffTree } from "./use-scout-staff-tree.ts";
+import { createElement } from "react";
+
+const mockGet = vi.fn();
+
+vi.mock("../api.ts", () => ({
+  api: {
+    api: {
+      scouts: {
+        leagues: {
+          [":leagueId"]: {
+            teams: {
+              [":teamId"]: {
+                staff: {
+                  $get: (...args: unknown[]) => mockGet(...args),
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+  },
+}));
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return ({ children }: { children: React.ReactNode }) =>
+    createElement(QueryClientProvider, { client: queryClient }, children);
+}
+
+describe("useScoutStaffTree", () => {
+  it("fetches the staff tree for a team scoped to a league", async () => {
+    const staff = [{
+      id: "s1",
+      firstName: "A",
+      lastName: "B",
+      role: "DIRECTOR",
+    }];
+    mockGet.mockResolvedValue({ json: () => Promise.resolve(staff) });
+
+    const { result } = renderHook(
+      () => useScoutStaffTree("league-1", "team-1"),
+      { wrapper: createWrapper() },
+    );
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+
+    expect(result.current.data).toEqual(staff);
+    expect(mockGet).toHaveBeenCalledWith({
+      param: { leagueId: "league-1", teamId: "team-1" },
+    });
+  });
+
+  it("skips fetching when teamId is empty", () => {
+    mockGet.mockClear();
+    const { result } = renderHook(() => useScoutStaffTree("league-1", ""), {
+      wrapper: createWrapper(),
+    });
+    expect(result.current.isFetching).toBe(false);
+    expect(mockGet).not.toHaveBeenCalled();
+  });
+
+  it("skips fetching when leagueId is empty", () => {
+    mockGet.mockClear();
+    const { result } = renderHook(() => useScoutStaffTree("", "team-1"), {
+      wrapper: createWrapper(),
+    });
+    expect(result.current.isFetching).toBe(false);
+    expect(mockGet).not.toHaveBeenCalled();
+  });
+});

--- a/client/src/hooks/use-scout-staff-tree.ts
+++ b/client/src/hooks/use-scout-staff-tree.ts
@@ -1,0 +1,16 @@
+import { useQuery } from "@tanstack/react-query";
+import { api } from "../api.ts";
+
+export function useScoutStaffTree(leagueId: string, teamId: string) {
+  return useQuery({
+    queryKey: ["scouts", "staff-tree", leagueId, teamId],
+    queryFn: async () => {
+      const res = await api.api.scouts.leagues[":leagueId"].teams[":teamId"]
+        .staff.$get({
+          param: { leagueId, teamId },
+        });
+      return res.json();
+    },
+    enabled: leagueId.length > 0 && teamId.length > 0,
+  });
+}


### PR DESCRIPTION
## Summary

Replaces the stub Scouts page with the two read-only surfaces decision 0003 calls for. Closes out the three-PR roll-out that began with the nav rename (#111) and the backend schema + read API (#112).

- **Staff tree** — mirrors the coaches pattern: flat \`ScoutNode\` list from the API, client-side \`buildStaffTree\`, role order Director → National Cross-checker → Area Scout, \`Link\` target to \`/leagues/\$leagueId/scouts/\$scoutId\`, dashed vacancy card with disabled Hire button. Each node shows only the public record — name, role, coverage, age, tenure, contract remaining, work capacity (the one practical constraint the north-star leaves visible).
- **Scout detail** — pulls the full aggregate from \`GET /api/scouts/:scoutId\` and renders the six sections per PRD: header, resume, reputation (string labels only), track record with this team (evaluations table + cross-check list), track record across the league (badged "lower confidence — secondhand data"), and connections (linked to other scouts).
- No accuracy / OVR / grade number anywhere. Grades are the scout's own written verdict; outcomes are retrospective fact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)