### PR TITLE
feat(opponents): add opponent roster view with team picker

### DIFF
--- a/client/src/features/league/layout.tsx
+++ b/client/src/features/league/layout.tsx
@@ -72,6 +72,7 @@ const navGroups: NavGroup[] = [
     items: [
       { label: "Standings", path: "standings", Icon: TrophyIcon },
       { label: "Schedule", path: "schedule", Icon: CalendarIcon },
+      { label: "Opponents", path: "opponents", Icon: UsersIcon },
       { label: "Media", path: "media", Icon: NewspaperIcon },
       { label: "Owner", path: "owner", Icon: CrownIcon },
     ],

--- a/client/src/features/league/opponents/detail.test.tsx
+++ b/client/src/features/league/opponents/detail.test.tsx
@@ -1,0 +1,202 @@
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  within,
+} from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { OpponentRoster } from "./detail.tsx";
+
+const mockUseParams = vi.fn();
+const mockUseTeams = vi.fn();
+const mockUseActiveRoster = vi.fn();
+
+vi.mock("@tanstack/react-router", () => ({
+  useParams: (...args: unknown[]) => mockUseParams(...args),
+  Link: (
+    { to, params, children, ...rest }: {
+      to: string;
+      params: Record<string, string>;
+      children: React.ReactNode;
+    } & Record<string, unknown>,
+  ) => {
+    let href = to;
+    for (const [k, v] of Object.entries(params ?? {})) {
+      href = href.replace(`$${k}`, v);
+    }
+    return (
+      <a href={href} {...rest}>
+        {children}
+      </a>
+    );
+  },
+}));
+
+vi.mock("../../../hooks/use-teams.ts", () => ({
+  useTeams: (...args: unknown[]) => mockUseTeams(...args),
+}));
+
+vi.mock("../../../hooks/use-active-roster.ts", () => ({
+  useActiveRoster: (...args: unknown[]) => mockUseActiveRoster(...args),
+}));
+
+function renderDetail() {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={client}>
+      <OpponentRoster />
+    </QueryClientProvider>,
+  );
+}
+
+const roster = {
+  leagueId: "L1",
+  teamId: "T2",
+  players: [
+    {
+      id: "p1",
+      firstName: "Patrick",
+      lastName: "Quarterback",
+      position: "QB",
+      positionGroup: "offense",
+      age: 28,
+      capHit: 45_000_000,
+      contractYearsRemaining: 3,
+      injuryStatus: "healthy",
+    },
+    {
+      id: "p2",
+      firstName: "Aaron",
+      lastName: "Rusher",
+      position: "EDGE",
+      positionGroup: "defense",
+      age: 24,
+      capHit: 8_000_000,
+      contractYearsRemaining: 4,
+      injuryStatus: "out",
+    },
+    {
+      id: "p3",
+      firstName: "Derrick",
+      lastName: "Runback",
+      position: "RB",
+      positionGroup: "offense",
+      age: 26,
+      capHit: 12_000_000,
+      contractYearsRemaining: 2,
+      injuryStatus: "questionable",
+    },
+  ],
+  positionGroups: [
+    { group: "offense", headcount: 1, totalCap: 45_000_000 },
+    { group: "defense", headcount: 1, totalCap: 8_000_000 },
+    { group: "special_teams", headcount: 0, totalCap: 0 },
+  ],
+  totalCap: 53_000_000,
+  salaryCap: 255_000_000,
+  capSpace: 202_000_000,
+};
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+beforeEach(() => {
+  mockUseParams.mockReturnValue({ leagueId: "L1", teamId: "T2" });
+  mockUseTeams.mockReturnValue({
+    data: [
+      {
+        id: "T2",
+        name: "Bengals",
+        city: "Cincinnati",
+        conference: "AFC",
+        division: "North",
+      },
+    ],
+  });
+  mockUseActiveRoster.mockReturnValue({
+    data: roster,
+    isLoading: false,
+    isError: false,
+  });
+});
+
+describe("OpponentRoster — page", () => {
+  it("renders the opposing team's name in the heading", () => {
+    renderDetail();
+    expect(screen.getByTestId("opponent-heading").textContent).toContain(
+      "Cincinnati Bengals",
+    );
+  });
+
+  it("renders Roster and Statistics tabs", () => {
+    renderDetail();
+    expect(screen.getByRole("tab", { name: /roster/i })).toBeDefined();
+    expect(screen.getByRole("tab", { name: /statistics/i })).toBeDefined();
+  });
+
+  it("shows a loading skeleton while the roster loads", () => {
+    mockUseActiveRoster.mockReturnValue({
+      data: undefined,
+      isLoading: true,
+      isError: false,
+    });
+    renderDetail();
+    expect(screen.getByTestId("opponent-roster-loading")).toBeDefined();
+  });
+
+  it("renders the cap summary and position-group breakdown", () => {
+    renderDetail();
+    const cap = screen.getByTestId("opponent-cap-summary");
+    expect(within(cap).getByText("$53,000,000")).toBeDefined();
+    const groups = screen.getByTestId("opponent-position-groups");
+    expect(
+      within(groups).getByTestId("opponent-position-group-offense"),
+    ).toBeDefined();
+  });
+
+  it("renders player rows with public columns only (no overall)", () => {
+    renderDetail();
+    const row = screen.getByTestId("opponent-row-p1");
+    expect(within(row).getByText("Patrick Quarterback")).toBeDefined();
+    expect(within(row).getByText("QB")).toBeDefined();
+    expect(within(row).getByText("$45,000,000")).toBeDefined();
+    expect(within(row).queryByText(/overall/i)).toBeNull();
+  });
+
+  it("links each player to their detail page", () => {
+    renderDetail();
+    const link = screen.getByTestId(
+      "opponent-player-link-p1",
+    ) as HTMLAnchorElement;
+    expect(link.getAttribute("href")).toBe("/leagues/L1/players/p1");
+  });
+
+  it("filters by position group", () => {
+    renderDetail();
+    fireEvent.click(screen.getByTestId("opponent-group-filter-defense"));
+    expect(screen.queryByTestId("opponent-row-p1")).toBeNull();
+    expect(screen.getByTestId("opponent-row-p2")).toBeDefined();
+  });
+
+  it("shows a statistics placeholder since box scores aren't persisted yet", () => {
+    renderDetail();
+    fireEvent.click(screen.getByRole("tab", { name: /statistics/i }));
+    expect(screen.getByTestId("opponent-statistics-placeholder")).toBeDefined();
+  });
+
+  it("shows an error state when the roster fails to load", () => {
+    mockUseActiveRoster.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      isError: true,
+    });
+    renderDetail();
+    expect(screen.getByText(/failed to load roster/i)).toBeDefined();
+  });
+});

--- a/client/src/features/league/opponents/detail.tsx
+++ b/client/src/features/league/opponents/detail.tsx
@@ -1,0 +1,328 @@
+import { Link, useParams } from "@tanstack/react-router";
+import type { ColumnDef, Row } from "@tanstack/react-table";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Skeleton } from "@/components/ui/skeleton";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { DataTable, SortableHeader } from "@/components/ui/data-table";
+import type {
+  ActiveRoster,
+  PlayerPositionGroup,
+  RosterPlayer,
+  Team,
+} from "@zone-blitz/shared";
+import type { PlayerInjuryStatus } from "@zone-blitz/shared/types/player.ts";
+import { useActiveRoster } from "../../../hooks/use-active-roster.ts";
+import { useTeams } from "../../../hooks/use-teams.ts";
+
+const groupLabels: Record<PlayerPositionGroup, string> = {
+  offense: "Offense",
+  defense: "Defense",
+  special_teams: "Special Teams",
+};
+
+const groupFilterOptions: (PlayerPositionGroup | "all")[] = [
+  "all",
+  "offense",
+  "defense",
+  "special_teams",
+];
+
+const currency = new Intl.NumberFormat("en-US", {
+  style: "currency",
+  currency: "USD",
+  maximumFractionDigits: 0,
+});
+
+function formatCurrency(value: number) {
+  return currency.format(value);
+}
+
+function injuryBadgeVariant(
+  status: PlayerInjuryStatus,
+): "secondary" | "destructive" | "outline" {
+  if (status === "healthy") return "secondary";
+  if (status === "out" || status === "ir") return "destructive";
+  return "outline";
+}
+
+function formatInjury(status: PlayerInjuryStatus) {
+  return status.replace(/_/g, " ");
+}
+
+function createRosterColumns(leagueId: string): ColumnDef<RosterPlayer>[] {
+  return [
+    {
+      id: "player",
+      accessorFn: (p) => `${p.firstName} ${p.lastName}`,
+      header: ({ column }) => (
+        <SortableHeader column={column}>Player</SortableHeader>
+      ),
+      cell: ({ row }) => (
+        <Link
+          to="/leagues/$leagueId/players/$playerId"
+          params={{ leagueId, playerId: row.original.id }}
+          className="font-medium underline-offset-2 hover:underline"
+          data-testid={`opponent-player-link-${row.original.id}`}
+        >
+          {row.original.firstName} {row.original.lastName}
+        </Link>
+      ),
+    },
+    {
+      accessorKey: "position",
+      header: ({ column }) => (
+        <SortableHeader column={column}>Pos</SortableHeader>
+      ),
+    },
+    {
+      accessorKey: "positionGroup",
+      header: ({ column }) => (
+        <SortableHeader column={column}>Group</SortableHeader>
+      ),
+      cell: ({ row }) => groupLabels[row.original.positionGroup],
+      filterFn: (row: Row<RosterPlayer>, _id, value) =>
+        value === "all" || row.original.positionGroup === value,
+    },
+    {
+      accessorKey: "age",
+      header: ({ column }) => (
+        <SortableHeader column={column}>Age</SortableHeader>
+      ),
+    },
+    {
+      accessorKey: "capHit",
+      header: ({ column }) => (
+        <SortableHeader column={column}>Cap Hit</SortableHeader>
+      ),
+      cell: ({ row }) => formatCurrency(row.original.capHit),
+    },
+    {
+      accessorKey: "contractYearsRemaining",
+      header: ({ column }) => (
+        <SortableHeader column={column}>Contract</SortableHeader>
+      ),
+      cell: ({ row }) => `${row.original.contractYearsRemaining} yrs`,
+    },
+    {
+      accessorKey: "injuryStatus",
+      header: ({ column }) => (
+        <SortableHeader column={column}>Status</SortableHeader>
+      ),
+      cell: ({ row }) => (
+        <Badge variant={injuryBadgeVariant(row.original.injuryStatus)}>
+          {formatInjury(row.original.injuryStatus)}
+        </Badge>
+      ),
+    },
+  ];
+}
+
+export function OpponentRoster() {
+  const { leagueId, teamId } = useParams({ strict: false }) as {
+    leagueId: string;
+    teamId: string;
+  };
+  const { data: teams } = useTeams();
+  const team = teams?.find((t: Team) => t.id === teamId) ?? null;
+
+  return (
+    <div className="flex flex-col gap-6 p-6">
+      <div className="flex flex-col gap-2">
+        <h1
+          className="text-3xl font-bold tracking-tight"
+          data-testid="opponent-heading"
+        >
+          {team ? `${team.city} ${team.name}` : "Opposing Team"}
+        </h1>
+        <p className="max-w-2xl text-muted-foreground">
+          Public record only — contracts and box scores. What your scouts think
+          of this team lives in the scouting room.
+        </p>
+      </div>
+
+      <Tabs defaultValue="roster" className="gap-6">
+        <TabsList>
+          <TabsTrigger value="roster">Roster</TabsTrigger>
+          <TabsTrigger value="statistics">Statistics</TabsTrigger>
+        </TabsList>
+        <TabsContent value="roster" className="flex flex-col gap-6">
+          <OpponentRosterView leagueId={leagueId} teamId={teamId} />
+        </TabsContent>
+        <TabsContent value="statistics" className="flex flex-col gap-6">
+          <StatisticsPlaceholder />
+        </TabsContent>
+      </Tabs>
+    </div>
+  );
+}
+
+function OpponentRosterView(
+  { leagueId, teamId }: { leagueId: string; teamId: string },
+) {
+  const { data: roster, isLoading, isError } = useActiveRoster(
+    leagueId,
+    teamId,
+  );
+
+  if (isLoading) {
+    return (
+      <div
+        data-testid="opponent-roster-loading"
+        className="flex flex-col gap-4"
+      >
+        <Skeleton className="h-24 w-full" />
+        <Skeleton className="h-64 w-full" />
+      </div>
+    );
+  }
+  if (isError || !roster) {
+    return (
+      <p className="text-destructive">
+        Failed to load roster. Try again in a moment.
+      </p>
+    );
+  }
+  return <OpponentRosterContent roster={roster} leagueId={leagueId} />;
+}
+
+function OpponentRosterContent(
+  { roster, leagueId }: { roster: ActiveRoster; leagueId: string },
+) {
+  return (
+    <>
+      <Card data-testid="opponent-cap-summary">
+        <CardHeader>
+          <CardTitle>Cap Summary</CardTitle>
+          <CardDescription>
+            Roster spend against the league salary cap.
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <dl className="grid grid-cols-1 gap-4 sm:grid-cols-3">
+            <CapStat
+              label="Total Cap"
+              value={formatCurrency(roster.totalCap)}
+            />
+            <CapStat
+              label="Salary Cap"
+              value={formatCurrency(roster.salaryCap)}
+            />
+            <CapStat
+              label="Cap Space"
+              value={formatCurrency(roster.capSpace)}
+            />
+          </dl>
+        </CardContent>
+      </Card>
+
+      <Card data-testid="opponent-position-groups">
+        <CardHeader>
+          <CardTitle>Position groups</CardTitle>
+          <CardDescription>Headcount and cap spend by group.</CardDescription>
+        </CardHeader>
+        <CardContent>
+          <dl className="grid grid-cols-1 gap-4 sm:grid-cols-3">
+            {roster.positionGroups.map((group) => (
+              <div
+                key={group.group}
+                className="flex flex-col gap-1"
+                data-testid={`opponent-position-group-${group.group}`}
+              >
+                <dt className="text-sm text-muted-foreground">
+                  {groupLabels[group.group]}
+                </dt>
+                <dd className="text-lg font-semibold">
+                  {group.headcount} players · {formatCurrency(group.totalCap)}
+                </dd>
+              </div>
+            ))}
+          </dl>
+        </CardContent>
+      </Card>
+
+      <DataTable
+        columns={createRosterColumns(leagueId)}
+        data={roster.players}
+        getRowTestId={(player) => `opponent-row-${player.id}`}
+        toolbar={(table) => {
+          const groupFilter =
+            (table.getColumn("positionGroup")?.getFilterValue() as
+              | PlayerPositionGroup
+              | "all"
+              | undefined) ?? "all";
+          return (
+            <div
+              className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between"
+              data-testid="opponent-toolbar"
+            >
+              <Input
+                aria-label="Search roster"
+                placeholder="Search players…"
+                className="sm:max-w-xs"
+                value={(table.getState().globalFilter as string) ?? ""}
+                onChange={(event) => table.setGlobalFilter(event.target.value)}
+              />
+              <div
+                className="flex flex-wrap gap-1"
+                role="group"
+                aria-label="Filter by position group"
+              >
+                {groupFilterOptions.map((option) => {
+                  const active = groupFilter === option;
+                  return (
+                    <Button
+                      key={option}
+                      type="button"
+                      size="sm"
+                      variant={active ? "secondary" : "ghost"}
+                      data-testid={`opponent-group-filter-${option}`}
+                      aria-pressed={active}
+                      onClick={() =>
+                        table
+                          .getColumn("positionGroup")
+                          ?.setFilterValue(option)}
+                    >
+                      {option === "all" ? "All" : groupLabels[option]}
+                    </Button>
+                  );
+                })}
+              </div>
+            </div>
+          );
+        }}
+      />
+    </>
+  );
+}
+
+function StatisticsPlaceholder() {
+  return (
+    <Card data-testid="opponent-statistics-placeholder">
+      <CardContent className="py-8 text-center text-muted-foreground">
+        <p>Per-player statistics aren't recorded yet.</p>
+        <p className="text-sm">
+          Once games are simulated and box scores persist, current and prior
+          season stat lines will show up here.
+        </p>
+      </CardContent>
+    </Card>
+  );
+}
+
+function CapStat({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="flex flex-col gap-1">
+      <dt className="text-sm text-muted-foreground">{label}</dt>
+      <dd className="text-2xl font-semibold">{value}</dd>
+    </div>
+  );
+}

--- a/client/src/features/league/opponents/index.test.tsx
+++ b/client/src/features/league/opponents/index.test.tsx
@@ -1,0 +1,149 @@
+import { cleanup, render, screen, within } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { Opponents } from "./index.tsx";
+
+const mockUseParams = vi.fn();
+const mockUseLeague = vi.fn();
+const mockUseTeams = vi.fn();
+
+vi.mock("@tanstack/react-router", () => ({
+  useParams: (...args: unknown[]) => mockUseParams(...args),
+  Link: (
+    { to, params, children, ...rest }: {
+      to: string;
+      params: Record<string, string>;
+      children: React.ReactNode;
+    } & Record<string, unknown>,
+  ) => {
+    let href = to;
+    for (const [k, v] of Object.entries(params ?? {})) {
+      href = href.replace(`$${k}`, v);
+    }
+    return (
+      <a href={href} {...rest}>
+        {children}
+      </a>
+    );
+  },
+}));
+
+vi.mock("../../../hooks/use-league.ts", () => ({
+  useLeague: (...args: unknown[]) => mockUseLeague(...args),
+}));
+
+vi.mock("../../../hooks/use-teams.ts", () => ({
+  useTeams: (...args: unknown[]) => mockUseTeams(...args),
+}));
+
+function renderOpponents() {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={client}>
+      <Opponents />
+    </QueryClientProvider>,
+  );
+}
+
+const teams = [
+  {
+    id: "t1",
+    name: "Ravens",
+    city: "Baltimore",
+    conference: "AFC",
+    division: "North",
+    abbreviation: "BAL",
+  },
+  {
+    id: "t2",
+    name: "Bengals",
+    city: "Cincinnati",
+    conference: "AFC",
+    division: "North",
+    abbreviation: "CIN",
+  },
+  {
+    id: "t3",
+    name: "Cowboys",
+    city: "Dallas",
+    conference: "NFC",
+    division: "East",
+    abbreviation: "DAL",
+  },
+];
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+beforeEach(() => {
+  mockUseParams.mockReturnValue({ leagueId: "L1" });
+  mockUseLeague.mockReturnValue({
+    data: { id: "L1", userTeamId: "t1", name: "Test League" },
+  });
+  mockUseTeams.mockReturnValue({ data: teams, isLoading: false, error: null });
+});
+
+describe("Opponents — team picker", () => {
+  it("renders the Opponents heading", () => {
+    renderOpponents();
+    expect(screen.getByRole("heading", { name: "Opponents" })).toBeDefined();
+  });
+
+  it("shows a loading skeleton while teams load", () => {
+    mockUseTeams.mockReturnValue({
+      data: undefined,
+      isLoading: true,
+      error: null,
+    });
+    renderOpponents();
+    expect(screen.getByTestId("opponents-skeleton")).toBeDefined();
+  });
+
+  it("excludes the user's team from the picker", () => {
+    renderOpponents();
+    expect(screen.queryByTestId("opponents-team-t1")).toBeNull();
+    expect(screen.getByTestId("opponents-team-t2")).toBeDefined();
+    expect(screen.getByTestId("opponents-team-t3")).toBeDefined();
+  });
+
+  it("groups teams by conference and division", () => {
+    renderOpponents();
+    const afc = screen.getByTestId("opponents-conference-AFC");
+    expect(within(afc).getByTestId("opponents-division-AFC-North"))
+      .toBeDefined();
+    expect(within(afc).getByTestId("opponents-team-t2")).toBeDefined();
+    const nfc = screen.getByTestId("opponents-conference-NFC");
+    expect(within(nfc).getByTestId("opponents-division-NFC-East"))
+      .toBeDefined();
+  });
+
+  it("links each team to its opponent detail route", () => {
+    renderOpponents();
+    const link = screen.getByTestId("opponents-team-t2") as HTMLAnchorElement;
+    expect(link.getAttribute("href")).toBe("/leagues/L1/opponents/t2");
+  });
+
+  it("shows an empty-state message when no opposing teams exist", () => {
+    mockUseTeams.mockReturnValue({
+      data: [teams[0]],
+      isLoading: false,
+      error: null,
+    });
+    renderOpponents();
+    expect(screen.getByText(/no opposing teams found/i)).toBeDefined();
+  });
+
+  it("shows an error when teams fail to load", () => {
+    mockUseTeams.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      error: new Error("boom"),
+    });
+    renderOpponents();
+    expect(screen.getByText(/failed to load/i)).toBeDefined();
+  });
+});

--- a/client/src/features/league/opponents/index.tsx
+++ b/client/src/features/league/opponents/index.tsx
@@ -1,0 +1,128 @@
+import { Link, useParams } from "@tanstack/react-router";
+import type { Team } from "@zone-blitz/shared";
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import { Card, CardContent } from "@/components/ui/card";
+import { Skeleton } from "@/components/ui/skeleton";
+import { useLeague } from "../../../hooks/use-league.ts";
+import { useTeams } from "../../../hooks/use-teams.ts";
+
+export function Opponents() {
+  const { leagueId: rawLeagueId } = useParams({ strict: false });
+  const leagueId = rawLeagueId ?? "";
+  const { data: league } = useLeague(leagueId);
+  const { data: teams, isLoading, error } = useTeams();
+  const userTeamId = league?.userTeamId ?? null;
+
+  return (
+    <div className="flex flex-col gap-6 p-6">
+      <header className="flex flex-col gap-1">
+        <h1 className="text-3xl font-bold tracking-tight">Opponents</h1>
+        <p className="max-w-2xl text-muted-foreground">
+          How the rest of the league is built. Contracts and public box scores —
+          nothing your scouts haven't already put on the record.
+        </p>
+      </header>
+
+      {isLoading && (
+        <div className="flex flex-col gap-3" data-testid="opponents-skeleton">
+          <Skeleton className="h-24 w-full" />
+          <Skeleton className="h-24 w-full" />
+        </div>
+      )}
+
+      {error && !isLoading && (
+        <Alert variant="destructive">
+          <AlertTitle>Error</AlertTitle>
+          <AlertDescription>Failed to load the league.</AlertDescription>
+        </Alert>
+      )}
+
+      {!isLoading && !error && teams && (
+        <TeamPicker
+          teams={teams}
+          leagueId={leagueId}
+          userTeamId={userTeamId}
+        />
+      )}
+    </div>
+  );
+}
+
+function TeamPicker(
+  { teams, leagueId, userTeamId }: {
+    teams: Team[];
+    leagueId: string;
+    userTeamId: string | null;
+  },
+) {
+  const opponents = teams.filter((t) => t.id !== userTeamId);
+  if (opponents.length === 0) {
+    return (
+      <p className="text-sm text-muted-foreground">
+        No opposing teams found.
+      </p>
+    );
+  }
+
+  const byConference = new Map<string, Map<string, Team[]>>();
+  for (const team of opponents) {
+    const conf = byConference.get(team.conference) ??
+      new Map<string, Team[]>();
+    const div = conf.get(team.division) ?? [];
+    div.push(team);
+    conf.set(team.division, div);
+    byConference.set(team.conference, conf);
+  }
+
+  const conferences = [...byConference.keys()].sort();
+
+  return (
+    <div className="flex flex-col gap-6">
+      {conferences.map((conference) => {
+        const divisions = [...byConference.get(conference)!.keys()].sort();
+        return (
+          <section
+            key={conference}
+            className="flex flex-col gap-3"
+            data-testid={`opponents-conference-${conference}`}
+          >
+            <h2 className="text-xl font-semibold">{conference}</h2>
+            <div className="grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-4">
+              {divisions.map((division) => {
+                const divisionTeams = [
+                  ...byConference.get(conference)!.get(division)!,
+                ].sort((a, b) => a.name.localeCompare(b.name));
+                return (
+                  <Card
+                    key={division}
+                    data-testid={`opponents-division-${conference}-${division}`}
+                  >
+                    <CardContent className="flex flex-col gap-2 pt-4">
+                      <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                        {division}
+                      </p>
+                      <ul className="flex flex-col gap-1">
+                        {divisionTeams.map((team) => (
+                          <li key={team.id}>
+                            <Link
+                              to="/leagues/$leagueId/opponents/$teamId"
+                              params={{ leagueId, teamId: team.id }}
+                              className="text-sm font-medium underline-offset-2 hover:underline"
+                              data-testid={`opponents-team-${team.id}`}
+                            >
+                              {team.city} {team.name}
+                            </Link>
+                          </li>
+                        ))}
+                      </ul>
+                    </CardContent>
+                  </Card>
+                );
+              })}
+            </div>
+          </section>
+        );
+      })}
+    </div>
+  );
+}

--- a/client/src/features/league/players/detail.test.tsx
+++ b/client/src/features/league/players/detail.test.tsx
@@ -1,0 +1,25 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { PlayerDetail } from "./detail.tsx";
+
+vi.mock("@tanstack/react-router", () => ({
+  useParams: () => ({ leagueId: "L1", playerId: "p1" }),
+}));
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+describe("PlayerDetail — placeholder", () => {
+  it("renders the Player heading", () => {
+    render(<PlayerDetail />);
+    expect(screen.getByRole("heading", { name: "Player" })).toBeDefined();
+  });
+
+  it("renders a coming-soon placeholder with the player id", () => {
+    render(<PlayerDetail />);
+    expect(screen.getByTestId("player-detail-placeholder")).toBeDefined();
+    expect(screen.getByTestId("player-detail-id-p1")).toBeDefined();
+  });
+});

--- a/client/src/features/league/players/detail.tsx
+++ b/client/src/features/league/players/detail.tsx
@@ -1,0 +1,30 @@
+import { useParams } from "@tanstack/react-router";
+import { Card, CardContent } from "@/components/ui/card";
+
+export function PlayerDetail() {
+  const { playerId } = useParams({ strict: false }) as { playerId: string };
+
+  return (
+    <div className="flex flex-col gap-6 p-6">
+      <header className="flex flex-col gap-1">
+        <h1 className="text-3xl font-bold tracking-tight">Player</h1>
+        <p className="text-sm text-muted-foreground">
+          Public record only — origin, contract history, career log,
+          transactions, and accolades.
+        </p>
+      </header>
+
+      <Card data-testid="player-detail-placeholder">
+        <CardContent className="py-8 text-center text-muted-foreground">
+          <p>Player detail view is coming soon.</p>
+          <p
+            className="text-xs"
+            data-testid={`player-detail-id-${playerId}`}
+          >
+            Player ID: {playerId}
+          </p>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/client/src/router.test.tsx
+++ b/client/src/router.test.tsx
@@ -184,6 +184,7 @@ describe("Router", () => {
     ["schedule", "Schedule"],
     ["media", "Media"],
     ["owner", "Owner"],
+    ["opponents", "Opponents"],
   ];
 
   for (const [path, heading] of stubRoutes) {

--- a/client/src/router.tsx
+++ b/client/src/router.tsx
@@ -18,6 +18,9 @@ import { Coaches } from "./features/league/coaches/index.tsx";
 import { CoachDetail } from "./features/league/coaches/detail.tsx";
 import { Scouts } from "./features/league/scouts/index.tsx";
 import { ScoutDetail } from "./features/league/scouts/detail.tsx";
+import { Opponents } from "./features/league/opponents/index.tsx";
+import { OpponentRoster } from "./features/league/opponents/detail.tsx";
+import { PlayerDetail } from "./features/league/players/detail.tsx";
 import { Draft } from "./features/league/draft.tsx";
 import { Trades } from "./features/league/trades.tsx";
 import { FreeAgency } from "./features/league/free-agency.tsx";
@@ -174,6 +177,24 @@ const ownerRoute = createRoute({
   component: Owner,
 });
 
+const opponentsRoute = createRoute({
+  getParentRoute: () => leagueLayoutRoute,
+  path: "opponents",
+  component: Opponents,
+});
+
+const opponentDetailRoute = createRoute({
+  getParentRoute: () => leagueLayoutRoute,
+  path: "opponents/$teamId",
+  component: OpponentRoster,
+});
+
+const playerDetailRoute = createRoute({
+  getParentRoute: () => leagueLayoutRoute,
+  path: "players/$playerId",
+  component: PlayerDetail,
+});
+
 const routeTree = rootRoute.addChildren([
   loginRoute,
   authenticatedRoute.addChildren([
@@ -196,6 +217,9 @@ const routeTree = rootRoute.addChildren([
       scheduleRoute,
       mediaRoute,
       ownerRoute,
+      opponentsRoute,
+      opponentDetailRoute,
+      playerDetailRoute,
     ]),
   ]),
 ]);


### PR DESCRIPTION
## Summary

- Ships the Opponent Roster surface from [ADR 0003](docs/product/decisions/0003-opponent-rosters.md) — a team picker grouped by conference/division and a per-team roster page with contracts, cap spend by position group, and public injury status.
- Each opponent row links to a new Player Detail route (placeholder for now; filled out in the next PR with draft origin + hometown).
- Statistics tab renders a "not recorded yet" placeholder because per-player season stats aren't persisted by the sim. No attributes, overall rating, scout grade, or scheme fit appear anywhere — the scouting wall stays intact.
- First of a planned series of PRs implementing ADR 0003: (2) player schema + detail header, (3) contract history, (4) transaction log, (5) season stats + accolades.