### PR TITLE
ci(deploy): self-heal disk pressure before aborting

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -59,10 +59,20 @@ jobs:
             set -euo pipefail
             cd /opt/zone-blitz
 
-            # Fail fast on disk pressure before docker pull
+            # If the disk is under pressure, try to self-heal by dropping
+            # all unused images before failing the deploy. The post-deploy
+            # `until=24h` prune only runs on success, so a streak of failed
+            # deploys (or fast-churning images) leaves the FS full with no
+            # way to recover without manual SSH. This gives us one chance
+            # to reclaim space; if still above threshold, abort.
             used=$(df --output=pcent / | tail -1 | tr -dc '0-9')
             if [ "$used" -ge 85 ]; then
-              echo "Aborting deploy: root FS is ${used}% full (threshold 85%)."
+              echo "Root FS at ${used}% — running aggressive prune to self-heal."
+              docker image prune -a -f || true
+              used=$(df --output=pcent / | tail -1 | tr -dc '0-9')
+            fi
+            if [ "$used" -ge 85 ]; then
+              echo "Aborting deploy: root FS is ${used}% full after prune (threshold 85%)."
               df -h /
               exit 1
             fi


### PR DESCRIPTION
## Summary

- Disk-pressure guard currently aborts *before* the post-deploy `docker image prune --filter until=24h` runs, so a full disk can never clean itself — the cleanup is gated behind a successful deploy.
- Hit this on the Droplet today: 41G/49G used, 67 dangling images, deploys blocked. Had to SSH in and manually run `docker image prune -a -f`.
- This PR runs an aggressive prune inline when the FS is over threshold, then re-checks. Still aborts if the disk is genuinely full (not recoverable images).
- Preserves the 24h rollback window on healthy deploys; only drops it when we'd otherwise fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)