### PR TITLE
feat(players): implement ADR 0006 unified player model

### DIFF
--- a/client/src/features/league/players/detail.test.tsx
+++ b/client/src/features/league/players/detail.test.tsx
@@ -143,6 +143,11 @@ const draftedPlayer = {
       detail: null,
     },
   ],
+  preDraftEvaluation: {
+    draftClassYear: 2020,
+    projectedRound: 1,
+    scoutingNotes: "Franchise-caliber arm talent with strong pocket poise.",
+  },
 };
 
 afterEach(() => {
@@ -360,5 +365,50 @@ describe("PlayerDetail — header + origin", () => {
     expect(main.textContent).not.toMatch(/\bOVR\b/);
     expect(main.textContent).not.toMatch(/scout grade/i);
     expect(main.textContent).not.toMatch(/potential/i);
+  });
+
+  it("renders the pre-draft evaluation when present", () => {
+    renderDetail();
+    const panel = screen.getByTestId("player-pre-draft");
+    expect(panel.textContent).toContain("Draft class");
+    expect(screen.getByTestId("player-pre-draft-class").textContent).toBe(
+      "2020",
+    );
+    expect(
+      screen.getByTestId("player-pre-draft-projection").textContent,
+    ).toContain("Round 1");
+    expect(screen.getByTestId("player-pre-draft-notes").textContent).toContain(
+      "Franchise-caliber",
+    );
+  });
+
+  it("omits the pre-draft evaluation when the profile is missing", () => {
+    mockUsePlayerDetail.mockReturnValue({
+      data: { ...draftedPlayer, preDraftEvaluation: null },
+      isLoading: false,
+      error: null,
+    });
+    renderDetail();
+    expect(screen.queryByTestId("player-pre-draft")).toBeNull();
+  });
+
+  it("shows Unprojected when the projected round is null", () => {
+    mockUsePlayerDetail.mockReturnValue({
+      data: {
+        ...draftedPlayer,
+        preDraftEvaluation: {
+          draftClassYear: 2020,
+          projectedRound: null,
+          scoutingNotes: null,
+        },
+      },
+      isLoading: false,
+      error: null,
+    });
+    renderDetail();
+    expect(screen.getByTestId("player-pre-draft").textContent).toContain(
+      "Unprojected",
+    );
+    expect(screen.queryByTestId("player-pre-draft-notes")).toBeNull();
   });
 });

--- a/client/src/features/league/players/detail.tsx
+++ b/client/src/features/league/players/detail.tsx
@@ -119,6 +119,7 @@ export function PlayerDetail() {
       <Origin detail={detail} leagueId={leagueId} />
       <ContractSection detail={detail} leagueId={leagueId} />
       <TransactionsSection detail={detail} leagueId={leagueId} />
+      <PreDraft detail={detail} />
       <PlaceholderSections />
     </div>
   );
@@ -270,6 +271,45 @@ function ContractSection(
         )}
 
       <ContractHistoryTable entries={contractHistory} leagueId={leagueId} />
+    </Section>
+  );
+}
+
+function PreDraft({ detail }: { detail: PlayerDetailData }) {
+  const evaluation = detail.preDraftEvaluation;
+  if (!evaluation) return null;
+  return (
+    <Section title="Pre-draft evaluation">
+      <Card data-testid="player-pre-draft">
+        <CardContent className="grid grid-cols-1 gap-4 pt-4 sm:grid-cols-2">
+          <Fact label="Draft class">
+            <span data-testid="player-pre-draft-class">
+              {evaluation.draftClassYear}
+            </span>
+          </Fact>
+          <Fact label="Projected round">
+            {evaluation.projectedRound !== null
+              ? (
+                <span data-testid="player-pre-draft-projection">
+                  Round {evaluation.projectedRound}
+                </span>
+              )
+              : <span className="text-muted-foreground">Unprojected</span>}
+          </Fact>
+          {evaluation.scoutingNotes && (
+            <div className="sm:col-span-2">
+              <Fact label="Scouting notes">
+                <span
+                  className="whitespace-pre-line"
+                  data-testid="player-pre-draft-notes"
+                >
+                  {evaluation.scoutingNotes}
+                </span>
+              </Fact>
+            </div>
+          )}
+        </CardContent>
+      </Card>
     </Section>
   );
 }

--- a/packages/shared/mod.ts
+++ b/packages/shared/mod.ts
@@ -68,6 +68,7 @@ export type {
   PlayerStatus,
   PlayerTransactionEntry,
   PlayerTransactionType,
+  PreDraftEvaluation,
 } from "./types/player.ts";
 export {
   CONTRACT_TERMINATION_REASONS,

--- a/packages/shared/mod.ts
+++ b/packages/shared/mod.ts
@@ -59,7 +59,6 @@ export type {
   ContractHistoryEntry,
   ContractTerminationReason,
   CurrentContractSummary,
-  DraftProspect,
   Player,
   PlayerDetail,
   PlayerInjuryStatus,

--- a/packages/shared/mod.ts
+++ b/packages/shared/mod.ts
@@ -59,6 +59,7 @@ export type {
   ContractHistoryEntry,
   ContractTerminationReason,
   CurrentContractSummary,
+  DraftEligiblePlayer,
   Player,
   PlayerDetail,
   PlayerInjuryStatus,

--- a/packages/shared/types/player.ts
+++ b/packages/shared/types/player.ts
@@ -107,6 +107,12 @@ export interface PlayerTransactionEntry {
   detail: string | null;
 }
 
+export interface PreDraftEvaluation {
+  draftClassYear: number;
+  projectedRound: number | null;
+  scoutingNotes: string | null;
+}
+
 export interface PlayerDetail {
   id: string;
   firstName: string;
@@ -127,6 +133,12 @@ export interface PlayerDetail {
   currentContract: CurrentContractSummary | null;
   contractHistory: ContractHistoryEntry[];
   transactions: PlayerTransactionEntry[];
+  /**
+   * Frozen pre-draft snapshot from `player_draft_profile`. Null only
+   * when the player was never drafted through the scouting pipeline
+   * (e.g. legacy rows generated before ADR 0006 landed).
+   */
+  preDraftEvaluation: PreDraftEvaluation | null;
 }
 
 export interface DraftEligiblePlayer {

--- a/packages/shared/types/player.ts
+++ b/packages/shared/types/player.ts
@@ -129,6 +129,20 @@ export interface PlayerDetail {
   transactions: PlayerTransactionEntry[];
 }
 
+export interface DraftEligiblePlayer {
+  id: string;
+  firstName: string;
+  lastName: string;
+  position: PlayerPosition;
+  college: string | null;
+  hometown: string | null;
+  heightInches: number;
+  weightPounds: number;
+  birthDate: string;
+  draftClassYear: number;
+  projectedRound: number | null;
+}
+
 export interface Contract {
   id: string;
   playerId: string;

--- a/packages/shared/types/player.ts
+++ b/packages/shared/types/player.ts
@@ -182,16 +182,3 @@ export interface CurrentContractSummary {
   signingBonus: number;
 }
 
-export interface DraftProspect {
-  id: string;
-  seasonId: string;
-  firstName: string;
-  lastName: string;
-  position: PlayerPosition;
-  heightInches: number;
-  weightPounds: number;
-  college: string | null;
-  birthDate: string;
-  createdAt: Date;
-  updatedAt: Date;
-}

--- a/server/db/schema.ts
+++ b/server/db/schema.ts
@@ -48,17 +48,13 @@ export {
   scoutRoundTierEnum,
 } from "../features/scouts/scout-history.schema.ts";
 export {
-  draftProspects,
   playerInjuryStatusEnum,
   playerPositionEnum,
   players,
   playerStatusEnum,
 } from "../features/players/player.schema.ts";
 export { depthChartEntries } from "../features/players/depth-chart.schema.ts";
-export {
-  draftProspectAttributes,
-  playerAttributes,
-} from "../features/players/attributes.schema.ts";
+export { playerAttributes } from "../features/players/attributes.schema.ts";
 export { playerDraftProfile } from "../features/players/player-draft-profile.schema.ts";
 export { playerSeasonRatings } from "../features/players/player-season-ratings.schema.ts";
 export { contracts } from "../features/players/contract.schema.ts";

--- a/server/features/personnel/personnel.service.test.ts
+++ b/server/features/personnel/personnel.service.test.ts
@@ -26,6 +26,8 @@ function createMockPlayersService(
         contractCount: 0,
       }),
     getDetail: () => Promise.reject(new Error("not implemented in mock")),
+    findDraftEligiblePlayers: () => Promise.resolve([]),
+    draftPlayer: () => Promise.reject(new Error("draftPlayer not stubbed")),
     ...overrides,
   };
 }

--- a/server/features/players/attributes.schema.test.ts
+++ b/server/features/players/attributes.schema.test.ts
@@ -2,10 +2,7 @@ import { assertEquals } from "@std/assert";
 import { getTableConfig } from "drizzle-orm/pg-core";
 import { getTableName } from "drizzle-orm";
 import { PLAYER_ATTRIBUTE_KEYS } from "@zone-blitz/shared";
-import {
-  draftProspectAttributes,
-  playerAttributes,
-} from "./attributes.schema.ts";
+import { playerAttributes } from "./attributes.schema.ts";
 
 Deno.test("player_attributes table has a column per attribute plus potential", () => {
   const config = getTableConfig(playerAttributes);
@@ -19,28 +16,11 @@ Deno.test("player_attributes table has a column per attribute plus potential", (
   }
 });
 
-Deno.test("draft_prospect_attributes table mirrors player_attributes columns", () => {
-  const config = getTableConfig(draftProspectAttributes);
-  const names = new Set(config.columns.map((c) => c.name));
-
-  assertEquals(names.has("draft_prospect_id"), true);
-  for (const key of PLAYER_ATTRIBUTE_KEYS) {
-    const snake = key.replace(/[A-Z]/g, (c) => `_${c.toLowerCase()}`);
-    assertEquals(names.has(snake), true);
-    assertEquals(names.has(`${snake}_potential`), true);
-  }
-});
-
-Deno.test("attribute tables declare cascading foreign keys to their parents", () => {
+Deno.test("player_attributes cascades from players", () => {
   const playerConfig = getTableConfig(playerAttributes);
   const playerFks = playerConfig.foreignKeys.map((fk) => fk.reference());
   assertEquals(playerFks.length, 1);
   assertEquals(getTableName(playerFks[0].foreignTable), "players");
-
-  const prospectConfig = getTableConfig(draftProspectAttributes);
-  const prospectFks = prospectConfig.foreignKeys.map((fk) => fk.reference());
-  assertEquals(prospectFks.length, 1);
-  assertEquals(getTableName(prospectFks[0].foreignTable), "draft_prospects");
 });
 
 Deno.test("player_attributes has range checks for every rating column", () => {

--- a/server/features/players/attributes.schema.ts
+++ b/server/features/players/attributes.schema.ts
@@ -1,7 +1,7 @@
 import { check, pgTable, smallint, timestamp, uuid } from "drizzle-orm/pg-core";
 import { sql } from "drizzle-orm";
 import { PLAYER_ATTRIBUTE_KEYS } from "@zone-blitz/shared";
-import { draftProspects, players } from "./player.schema.ts";
+import { players } from "./player.schema.ts";
 
 export function camelToSnake(key: string): string {
   return key.replace(/[A-Z]/g, (c) => `_${c.toLowerCase()}`);
@@ -44,17 +44,4 @@ export const playerAttributes = pgTable(
     updatedAt: timestamp("updated_at").defaultNow().notNull(),
   },
   () => attributeRangeChecks("player_attributes"),
-);
-
-export const draftProspectAttributes = pgTable(
-  "draft_prospect_attributes",
-  {
-    draftProspectId: uuid("draft_prospect_id")
-      .primaryKey()
-      .references(() => draftProspects.id, { onDelete: "cascade" }),
-    ...attributeColumns(),
-    createdAt: timestamp("created_at").defaultNow().notNull(),
-    updatedAt: timestamp("updated_at").defaultNow().notNull(),
-  },
-  () => attributeRangeChecks("draft_prospect_attributes"),
 );

--- a/server/features/players/player.schema.ts
+++ b/server/features/players/player.schema.ts
@@ -16,7 +16,6 @@ import {
 } from "@zone-blitz/shared";
 import { leagues } from "../league/league.schema.ts";
 import { teams } from "../team/team.schema.ts";
-import { seasons } from "../season/season.schema.ts";
 
 export const playerPositionEnum = pgEnum("player_position", PLAYER_POSITIONS);
 export const playerInjuryStatusEnum = pgEnum(
@@ -56,19 +55,3 @@ export const players = pgTable("players", {
     .on(table.status)
     .where(sql`${table.status} = 'prospect'`),
 ]);
-
-export const draftProspects = pgTable("draft_prospects", {
-  id: uuid("id").defaultRandom().primaryKey(),
-  seasonId: uuid("season_id")
-    .notNull()
-    .references(() => seasons.id, { onDelete: "cascade" }),
-  firstName: text("first_name").notNull(),
-  lastName: text("last_name").notNull(),
-  position: playerPositionEnum("position").notNull(),
-  heightInches: integer("height_inches").notNull(),
-  weightPounds: integer("weight_pounds").notNull(),
-  college: text("college"),
-  birthDate: date("birth_date").notNull(),
-  createdAt: timestamp("created_at").defaultNow().notNull(),
-  updatedAt: timestamp("updated_at").defaultNow().notNull(),
-});

--- a/server/features/players/players.generator.interface.ts
+++ b/server/features/players/players.generator.interface.ts
@@ -1,9 +1,4 @@
-import type {
-  Contract,
-  DraftProspect,
-  Player,
-  PlayerAttributes,
-} from "@zone-blitz/shared";
+import type { Contract, Player, PlayerAttributes } from "@zone-blitz/shared";
 
 export interface PlayersGeneratorInput {
   leagueId: string;
@@ -17,14 +12,8 @@ export interface GeneratedPlayer {
   attributes: PlayerAttributes;
 }
 
-export interface GeneratedDraftProspect {
-  prospect: Omit<DraftProspect, "id" | "createdAt" | "updatedAt">;
-  attributes: PlayerAttributes;
-}
-
 export interface GeneratedPlayers {
   players: GeneratedPlayer[];
-  draftProspects: GeneratedDraftProspect[];
 }
 
 export interface ContractGeneratorInput {

--- a/server/features/players/players.repository.interface.ts
+++ b/server/features/players/players.repository.interface.ts
@@ -1,4 +1,5 @@
-import type { PlayerDetail } from "@zone-blitz/shared";
+import type { DraftEligiblePlayer, PlayerDetail } from "@zone-blitz/shared";
+import type { Executor } from "../../db/connection.ts";
 
 export interface PlayersRepository {
   /**
@@ -10,4 +11,26 @@ export interface PlayersRepository {
    * Returns undefined when the id does not resolve.
    */
   getDetailById(playerId: string): Promise<PlayerDetail | undefined>;
+
+  /**
+   * Every player in the league currently in the draft pool —
+   * `status = 'prospect'` — joined with their immutable pre-draft
+   * profile. Ordered by projected round (nulls last) then last name.
+   */
+  findDraftEligiblePlayers(leagueId: string): Promise<DraftEligiblePlayer[]>;
+
+  /**
+   * Flip a single player from `status = 'prospect'` to `status = 'active'`
+   * and set their team. Guarded against double-draft by the `status` filter
+   * in the WHERE clause — the caller gets `"not_found"` back when nothing
+   * matches (player missing, already active, or already retired), which it
+   * can translate into a domain error. Returns `"ok"` when the row flipped.
+   *
+   * Intended to run inside a service-owned transaction so the draft-pick
+   * record and the status flip commit atomically.
+   */
+  transitionProspectToActive(
+    input: { playerId: string; teamId: string },
+    tx?: Executor,
+  ): Promise<"ok" | "not_found">;
 }

--- a/server/features/players/players.repository.test.ts
+++ b/server/features/players/players.repository.test.ts
@@ -8,11 +8,24 @@ import { players } from "./player.schema.ts";
 import { contracts } from "./contract.schema.ts";
 import { contractHistory } from "./contract-history.schema.ts";
 import { playerTransactions } from "./player-transaction.schema.ts";
+import { playerAttributes } from "./attributes.schema.ts";
+import { playerDraftProfile } from "./player-draft-profile.schema.ts";
 import { leagues } from "../league/league.schema.ts";
 import { teams } from "../team/team.schema.ts";
 import { cities } from "../cities/city.schema.ts";
 import { states } from "../states/state.schema.ts";
+import { seasons } from "../season/season.schema.ts";
+import { PLAYER_ATTRIBUTE_KEYS } from "@zone-blitz/shared";
 import { createPlayersRepository } from "./players.repository.ts";
+
+function zeroAttributes(): Record<string, number> {
+  const attrs: Record<string, number> = {};
+  for (const key of PLAYER_ATTRIBUTE_KEYS) {
+    attrs[key] = 50;
+    attrs[`${key}Potential`] = 60;
+  }
+  return attrs;
+}
 
 function createTestDb() {
   const connectionString = Deno.env.get("DATABASE_URL");
@@ -427,6 +440,235 @@ Deno.test({
     try {
       const detail = await repo.getDetailById(crypto.randomUUID());
       assertEquals(detail, undefined);
+    } finally {
+      await client.end();
+    }
+  },
+});
+
+Deno.test({
+  name:
+    "playersRepository.findDraftEligiblePlayers: returns only prospects in the given league, sorted by projected round",
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    const { db, client } = createTestDb();
+    const repo = createPlayersRepository({ db, log: createTestLogger() });
+    const playersCreated: string[] = [];
+    const teamsCreated: string[] = [];
+    const leaguesCreated: string[] = [];
+    const citiesCreated: string[] = [];
+    const statesCreated: string[] = [];
+    const seasonsCreated: string[] = [];
+
+    try {
+      const { league, team, city, state } = await setupFixtures(db);
+      leaguesCreated.push(league.id);
+      teamsCreated.push(team.id);
+      citiesCreated.push(city.id);
+      statesCreated.push(state.id);
+
+      const [season] = await db
+        .insert(seasons)
+        .values({ leagueId: league.id, year: 2028 })
+        .returning();
+      seasonsCreated.push(season.id);
+
+      const prospectEarly = crypto.randomUUID();
+      const prospectLate = crypto.randomUUID();
+      const prospectNoProjection = crypto.randomUUID();
+      const activePlayer = crypto.randomUUID();
+      await db.insert(players).values([
+        {
+          id: prospectLate,
+          leagueId: league.id,
+          status: "prospect",
+          firstName: "Zeb",
+          lastName: "Young",
+          position: "WR",
+          heightInches: 72,
+          weightPounds: 200,
+          birthDate: "2004-02-01",
+        },
+        {
+          id: prospectEarly,
+          leagueId: league.id,
+          status: "prospect",
+          firstName: "Abe",
+          lastName: "Adams",
+          position: "QB",
+          heightInches: 74,
+          weightPounds: 220,
+          birthDate: "2004-03-01",
+          college: "State",
+          hometown: "Austin, TX",
+        },
+        {
+          id: prospectNoProjection,
+          leagueId: league.id,
+          status: "prospect",
+          firstName: "Cal",
+          lastName: "Baker",
+          position: "RB",
+          heightInches: 70,
+          weightPounds: 205,
+          birthDate: "2004-04-01",
+        },
+        {
+          id: activePlayer,
+          leagueId: league.id,
+          teamId: team.id,
+          status: "active",
+          firstName: "Sam",
+          lastName: "Stone",
+          position: "QB",
+          heightInches: 74,
+          weightPounds: 225,
+          birthDate: "2000-01-01",
+        },
+      ]);
+      playersCreated.push(
+        prospectEarly,
+        prospectLate,
+        prospectNoProjection,
+        activePlayer,
+      );
+
+      await db.insert(playerAttributes).values([
+        { playerId: prospectEarly, ...zeroAttributes() },
+        { playerId: prospectLate, ...zeroAttributes() },
+        { playerId: prospectNoProjection, ...zeroAttributes() },
+        { playerId: activePlayer, ...zeroAttributes() },
+      ]);
+      await db.insert(playerDraftProfile).values([
+        {
+          playerId: prospectEarly,
+          seasonId: season.id,
+          draftClassYear: 2028,
+          projectedRound: 1,
+          ...zeroAttributes(),
+        },
+        {
+          playerId: prospectLate,
+          seasonId: season.id,
+          draftClassYear: 2028,
+          projectedRound: 5,
+          ...zeroAttributes(),
+        },
+        {
+          playerId: prospectNoProjection,
+          seasonId: season.id,
+          draftClassYear: 2028,
+          projectedRound: null,
+          ...zeroAttributes(),
+        },
+      ]);
+
+      const result = await repo.findDraftEligiblePlayers(league.id);
+      assertEquals(result.length, 3);
+      assertEquals(result[0].id, prospectEarly);
+      assertEquals(result[1].id, prospectLate);
+      assertEquals(result[2].id, prospectNoProjection);
+      assertEquals(result[0].projectedRound, 1);
+      assertEquals(result[0].draftClassYear, 2028);
+      assertEquals(result[0].hometown, "Austin, TX");
+    } finally {
+      await cleanup(db, {
+        players: playersCreated,
+        teams: teamsCreated,
+        cities: citiesCreated,
+        states: statesCreated,
+        leagues: leaguesCreated,
+      });
+      for (const id of seasonsCreated) {
+        await db.delete(seasons).where(eq(seasons.id, id));
+      }
+      await client.end();
+    }
+  },
+});
+
+Deno.test({
+  name:
+    "playersRepository.transitionProspectToActive: flips a prospect to active and returns ok",
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    const { db, client } = createTestDb();
+    const repo = createPlayersRepository({ db, log: createTestLogger() });
+    const playersCreated: string[] = [];
+    const teamsCreated: string[] = [];
+    const leaguesCreated: string[] = [];
+    const citiesCreated: string[] = [];
+    const statesCreated: string[] = [];
+
+    try {
+      const { league, team, city, state } = await setupFixtures(db);
+      leaguesCreated.push(league.id);
+      teamsCreated.push(team.id);
+      citiesCreated.push(city.id);
+      statesCreated.push(state.id);
+
+      const prospectId = crypto.randomUUID();
+      await db.insert(players).values({
+        id: prospectId,
+        leagueId: league.id,
+        status: "prospect",
+        firstName: "Abe",
+        lastName: "Adams",
+        position: "QB",
+        heightInches: 74,
+        weightPounds: 220,
+        birthDate: "2004-03-01",
+      });
+      playersCreated.push(prospectId);
+
+      const result = await repo.transitionProspectToActive({
+        playerId: prospectId,
+        teamId: team.id,
+      });
+      assertEquals(result, "ok");
+
+      const [row] = await db.select().from(players).where(
+        eq(players.id, prospectId),
+      );
+      assertEquals(row.status, "active");
+      assertEquals(row.teamId, team.id);
+      assertEquals(row.draftingTeamId, team.id);
+
+      // Re-running must not transition an already-active player.
+      const second = await repo.transitionProspectToActive({
+        playerId: prospectId,
+        teamId: team.id,
+      });
+      assertEquals(second, "not_found");
+    } finally {
+      await cleanup(db, {
+        players: playersCreated,
+        teams: teamsCreated,
+        cities: citiesCreated,
+        states: statesCreated,
+        leagues: leaguesCreated,
+      });
+      await client.end();
+    }
+  },
+});
+
+Deno.test({
+  name:
+    "playersRepository.transitionProspectToActive: returns not_found when the id is unknown",
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    const { db, client } = createTestDb();
+    const repo = createPlayersRepository({ db, log: createTestLogger() });
+    try {
+      const result = await repo.transitionProspectToActive({
+        playerId: crypto.randomUUID(),
+        teamId: crypto.randomUUID(),
+      });
+      assertEquals(result, "not_found");
     } finally {
       await client.end();
     }

--- a/server/features/players/players.repository.test.ts
+++ b/server/features/players/players.repository.test.ts
@@ -163,6 +163,7 @@ Deno.test({
       assertEquals(detail?.origin.draftingTeam?.name, "Bengals");
       assertEquals(detail?.origin.college, "State University");
       assertEquals(detail?.origin.hometown, "Dallas, TX");
+      assertEquals(detail?.preDraftEvaluation, null);
     } finally {
       await cleanup(db, {
         players: playersCreated,
@@ -670,6 +671,87 @@ Deno.test({
       });
       assertEquals(result, "not_found");
     } finally {
+      await client.end();
+    }
+  },
+});
+
+Deno.test({
+  name:
+    "playersRepository.getDetailById: surfaces preDraftEvaluation when a draft profile exists",
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    const { db, client } = createTestDb();
+    const repo = createPlayersRepository({
+      db,
+      log: createTestLogger(),
+      now: () => new Date("2026-06-15T00:00:00Z"),
+    });
+    const playersCreated: string[] = [];
+    const leaguesCreated: string[] = [];
+    const citiesCreated: string[] = [];
+    const statesCreated: string[] = [];
+    const teamsCreated: string[] = [];
+    const seasonsCreated: string[] = [];
+
+    try {
+      const { league, team, city, state } = await setupFixtures(db);
+      leaguesCreated.push(league.id);
+      citiesCreated.push(city.id);
+      statesCreated.push(state.id);
+      teamsCreated.push(team.id);
+
+      const [season] = await db
+        .insert(seasons)
+        .values({ leagueId: league.id, year: 2028 })
+        .returning();
+      seasonsCreated.push(season.id);
+
+      const playerId = crypto.randomUUID();
+      await db.insert(players).values({
+        id: playerId,
+        leagueId: league.id,
+        status: "active",
+        firstName: "Abe",
+        lastName: "Adams",
+        position: "QB",
+        heightInches: 74,
+        weightPounds: 220,
+        birthDate: "2004-03-01",
+      });
+      playersCreated.push(playerId);
+      await db.insert(playerAttributes).values({
+        playerId,
+        ...zeroAttributes(),
+      });
+      await db.insert(playerDraftProfile).values({
+        playerId,
+        seasonId: season.id,
+        draftClassYear: 2028,
+        projectedRound: 2,
+        scoutingNotes: "Riser during the combine.",
+        ...zeroAttributes(),
+      });
+
+      const detail = await repo.getDetailById(playerId);
+      assertEquals(detail?.preDraftEvaluation?.draftClassYear, 2028);
+      assertEquals(detail?.preDraftEvaluation?.projectedRound, 2);
+      assertEquals(
+        detail?.preDraftEvaluation?.scoutingNotes,
+        "Riser during the combine.",
+      );
+    } finally {
+      await cleanup(db, {
+        players: playersCreated,
+        teams: teamsCreated,
+        cities: citiesCreated,
+        states: statesCreated,
+        leagues: leaguesCreated,
+      });
+      for (const id of seasonsCreated) {
+        await db.delete(seasons).where(eq(seasons.id, id));
+      }
       await client.end();
     }
   },

--- a/server/features/players/players.repository.ts
+++ b/server/features/players/players.repository.ts
@@ -1,16 +1,18 @@
-import { asc, eq } from "drizzle-orm";
+import { and, asc, eq, sql } from "drizzle-orm";
 import type pino from "pino";
 import type {
   ContractHistoryEntry,
   CurrentContractSummary,
+  DraftEligiblePlayer,
   PlayerDetail,
   PlayerTransactionEntry,
 } from "@zone-blitz/shared";
-import type { Database } from "../../db/connection.ts";
+import type { Database, Executor } from "../../db/connection.ts";
 import { players } from "./player.schema.ts";
 import { contracts } from "./contract.schema.ts";
 import { contractHistory } from "./contract-history.schema.ts";
 import { playerTransactions } from "./player-transaction.schema.ts";
+import { playerDraftProfile } from "./player-draft-profile.schema.ts";
 import { teams } from "../team/team.schema.ts";
 import { cities } from "../cities/city.schema.ts";
 import { alias } from "drizzle-orm/pg-core";
@@ -249,6 +251,80 @@ export function createPlayersRepository(deps: {
         transactions: await loadTransactions(playerId),
       };
       return detail;
+    },
+
+    async findDraftEligiblePlayers(leagueId) {
+      log.debug({ leagueId }, "loading draft-eligible players");
+
+      const rows = await deps.db
+        .select({
+          id: players.id,
+          firstName: players.firstName,
+          lastName: players.lastName,
+          position: players.position,
+          college: players.college,
+          hometown: players.hometown,
+          heightInches: players.heightInches,
+          weightPounds: players.weightPounds,
+          birthDate: players.birthDate,
+          draftClassYear: playerDraftProfile.draftClassYear,
+          projectedRound: playerDraftProfile.projectedRound,
+        })
+        .from(players)
+        .innerJoin(
+          playerDraftProfile,
+          eq(playerDraftProfile.playerId, players.id),
+        )
+        .where(
+          and(
+            eq(players.leagueId, leagueId),
+            eq(players.status, "prospect"),
+          ),
+        )
+        .orderBy(
+          sql`${playerDraftProfile.projectedRound} ASC NULLS LAST`,
+          asc(players.lastName),
+        );
+
+      return rows.map((row): DraftEligiblePlayer => ({
+        id: row.id,
+        firstName: row.firstName,
+        lastName: row.lastName,
+        position: row.position,
+        college: row.college,
+        hometown: row.hometown,
+        heightInches: row.heightInches,
+        weightPounds: row.weightPounds,
+        birthDate: row.birthDate,
+        draftClassYear: row.draftClassYear,
+        projectedRound: row.projectedRound,
+      }));
+    },
+
+    async transitionProspectToActive(input, tx) {
+      log.info(
+        { playerId: input.playerId, teamId: input.teamId },
+        "transitioning prospect to active",
+      );
+      const exec: Executor = tx ?? deps.db;
+
+      const updated = await exec
+        .update(players)
+        .set({
+          status: "active",
+          teamId: input.teamId,
+          draftingTeamId: input.teamId,
+          updatedAt: new Date(),
+        })
+        .where(
+          and(
+            eq(players.id, input.playerId),
+            eq(players.status, "prospect"),
+          ),
+        )
+        .returning({ id: players.id });
+
+      return updated.length === 1 ? "ok" : "not_found";
     },
   };
 }

--- a/server/features/players/players.repository.ts
+++ b/server/features/players/players.repository.ts
@@ -129,12 +129,19 @@ export function createPlayersRepository(deps: {
           draftingTeamName: draftingTeams.name,
           draftingTeamCity: draftingCities.name,
           draftingTeamAbbreviation: draftingTeams.abbreviation,
+          preDraftClassYear: playerDraftProfile.draftClassYear,
+          preDraftProjectedRound: playerDraftProfile.projectedRound,
+          preDraftScoutingNotes: playerDraftProfile.scoutingNotes,
         })
         .from(players)
         .leftJoin(currentTeams, eq(currentTeams.id, players.teamId))
         .leftJoin(currentCities, eq(currentCities.id, currentTeams.cityId))
         .leftJoin(draftingTeams, eq(draftingTeams.id, players.draftingTeamId))
         .leftJoin(draftingCities, eq(draftingCities.id, draftingTeams.cityId))
+        .leftJoin(
+          playerDraftProfile,
+          eq(playerDraftProfile.playerId, players.id),
+        )
         .where(eq(players.id, playerId))
         .limit(1);
 
@@ -249,6 +256,13 @@ export function createPlayersRepository(deps: {
         currentContract,
         contractHistory: contractHistoryEntries,
         transactions: await loadTransactions(playerId),
+        preDraftEvaluation: row.preDraftClassYear !== null
+          ? {
+            draftClassYear: row.preDraftClassYear,
+            projectedRound: row.preDraftProjectedRound,
+            scoutingNotes: row.preDraftScoutingNotes,
+          }
+          : null,
       };
       return detail;
     },

--- a/server/features/players/players.router.test.ts
+++ b/server/features/players/players.router.test.ts
@@ -15,6 +15,8 @@ function createMockService(
       }),
     getDetail: () =>
       Promise.reject(new DomainError("NOT_FOUND", "player not found")),
+    findDraftEligiblePlayers: () => Promise.resolve([]),
+    draftPlayer: () => Promise.reject(new Error("draftPlayer not stubbed")),
     ...overrides,
   };
 }

--- a/server/features/players/players.router.test.ts
+++ b/server/features/players/players.router.test.ts
@@ -56,6 +56,7 @@ Deno.test("players.router", async (t) => {
       currentContract: null,
       contractHistory: [],
       transactions: [],
+      preDraftEvaluation: null,
     };
 
     const router = createPlayersRouter(

--- a/server/features/players/players.service.interface.ts
+++ b/server/features/players/players.service.interface.ts
@@ -1,4 +1,4 @@
-import type { PlayerDetail } from "@zone-blitz/shared";
+import type { DraftEligiblePlayer, PlayerDetail } from "@zone-blitz/shared";
 import type { Executor } from "../../db/connection.ts";
 
 export interface PlayersGenerateInput {
@@ -15,6 +15,11 @@ export interface PlayersGenerateResult {
   contractCount: number;
 }
 
+export interface DraftPlayerInput {
+  playerId: string;
+  teamId: string;
+}
+
 export interface PlayersService {
   generate(
     input: PlayersGenerateInput,
@@ -22,4 +27,14 @@ export interface PlayersService {
   ): Promise<PlayersGenerateResult>;
 
   getDetail(playerId: string): Promise<PlayerDetail>;
+
+  findDraftEligiblePlayers(leagueId: string): Promise<DraftEligiblePlayer[]>;
+
+  /**
+   * Atomic `prospect → active` transition for a single player. The only
+   * code path allowed to flip `players.status` out of `prospect`.
+   * Throws NOT_FOUND when the player does not exist or is no longer a
+   * prospect (already drafted, retired, etc.).
+   */
+  draftPlayer(input: DraftPlayerInput): Promise<void>;
 }

--- a/server/features/players/players.service.test.ts
+++ b/server/features/players/players.service.test.ts
@@ -4,6 +4,7 @@ import {
   PLAYER_ATTRIBUTE_KEYS,
   type PlayerAttributes,
   type PlayerDetail,
+  type PlayerStatus,
 } from "@zone-blitz/shared";
 import { createPlayersService } from "./players.service.ts";
 import type {
@@ -32,10 +33,7 @@ function createTestLogger() {
 }
 
 function createEmptyPlayers(): GeneratedPlayers {
-  return {
-    players: [],
-    draftProspects: [],
-  };
+  return { players: [] };
 }
 
 function createMockGenerator(
@@ -62,7 +60,10 @@ interface InsertCall {
   values: unknown[];
 }
 
-function createMockDb(rosteredPlayerIds: string[] = []): {
+function createMockDb(
+  rosteredPlayerIds: string[] = [],
+  seasonYear: number | null = 2026,
+): {
   db: import("../../db/connection.ts").Database;
   calls: InsertCall[];
 } {
@@ -76,17 +77,41 @@ function createMockDb(rosteredPlayerIds: string[] = []): {
             returning(_columns?: unknown) {
               if (Array.isArray(values)) {
                 return Promise.resolve(
-                  values.map((v, i) => ({
-                    id: rosteredPlayerIds[i] ??
-                      `generated-${calls.length}-${i}`,
-                    teamId: (v as { teamId?: string | null }).teamId ?? null,
-                  })),
+                  values.map((v, i) => {
+                    const row = v as {
+                      teamId?: string | null;
+                      status?: PlayerStatus;
+                    };
+                    return {
+                      id: rosteredPlayerIds[i] ??
+                        `generated-${calls.length}-${i}`,
+                      teamId: row.teamId ?? null,
+                      status: row.status ?? "active",
+                    };
+                  }),
                 );
               }
               return Promise.resolve([]);
             },
           };
           return Object.assign(Promise.resolve(), chain);
+        },
+      };
+    },
+    select(_columns: unknown) {
+      return {
+        from(_table: unknown) {
+          return {
+            where(_expr: unknown) {
+              return {
+                limit(_n: number) {
+                  return Promise.resolve(
+                    seasonYear === null ? [] : [{ year: seasonYear }],
+                  );
+                },
+              };
+            },
+          };
         },
       };
     },
@@ -168,7 +193,7 @@ Deno.test("players.service — getDetail", async (t) => {
 
 Deno.test("players.service", async (t) => {
   await t.step(
-    "generate inserts players, attributes, draft prospects, and contracts",
+    "generate inserts active players and contracts",
     async () => {
       const { db, calls } = createMockDb(["p1", "p2"]);
       const generator = createMockGenerator({
@@ -217,24 +242,9 @@ Deno.test("players.service", async (t) => {
               attributes: stubAttrs(),
             },
           ],
-          draftProspects: [
-            {
-              prospect: {
-                seasonId: "s1",
-                firstName: "K",
-                lastName: "L",
-                position: "QB",
-                heightInches: 72,
-                weightPounds: 220,
-                college: null,
-                birthDate: "2003-01-01",
-              },
-              attributes: stubAttrs(),
-            },
-          ],
         }),
-        generateContracts: (input) => {
-          return input.players.map((p) => ({
+        generateContracts: (input) =>
+          input.players.map((p) => ({
             playerId: p.id,
             teamId: p.teamId!,
             totalYears: 3,
@@ -243,8 +253,7 @@ Deno.test("players.service", async (t) => {
             annualSalary: 100_000,
             guaranteedMoney: 100_000,
             signingBonus: 0,
-          }));
-        },
+          })),
       });
 
       const service = createPlayersService({
@@ -263,22 +272,137 @@ Deno.test("players.service", async (t) => {
       });
 
       assertEquals(result.playerCount, 2);
-      assertEquals(result.draftProspectCount, 1);
+      assertEquals(result.draftProspectCount, 0);
       assertEquals(result.contractCount, 2);
 
-      // 7 insert calls: players, player_attributes, player_transactions,
-      // draft_prospects, draft_prospect_attributes, contracts, contract_history
-      assertEquals(calls.length, 7);
+      // players + player_attributes + player_transactions + contracts + contract_history = 5 writes
+      assertEquals(calls.length, 5);
 
-      const attributeCall = calls[1];
-      const attributeRows = attributeCall.values as Array<
-        Record<string, unknown>
-      >;
+      const attributeRows = calls[1].values as Array<Record<string, unknown>>;
       assertEquals(attributeRows.length, 2);
       assertEquals(attributeRows[0].playerId, "p1");
-      assertEquals(attributeRows[1].playerId, "p2");
       assertEquals(attributeRows[0].speed, 40);
       assertEquals(attributeRows[0].speedPotential, 60);
+    },
+  );
+
+  await t.step(
+    "generate writes a player_draft_profile row for every prospect-status player",
+    async () => {
+      const { db, calls } = createMockDb(["prospect-1"], 2027);
+      const generator = createMockGenerator({
+        generate: () => ({
+          players: [
+            {
+              player: {
+                leagueId: "l1",
+                teamId: null,
+                status: "prospect",
+                firstName: "K",
+                lastName: "L",
+                position: "QB",
+                injuryStatus: "healthy",
+                heightInches: 72,
+                weightPounds: 220,
+                college: null,
+                hometown: null,
+                birthDate: "2003-01-01",
+                draftYear: null,
+                draftRound: null,
+                draftPick: null,
+                draftingTeamId: null,
+              },
+              attributes: stubAttrs(),
+            },
+          ],
+        }),
+      });
+
+      const service = createPlayersService({
+        generator,
+        repo: createMockRepo(),
+        db,
+        log: createTestLogger(),
+      });
+
+      const result = await service.generate({
+        leagueId: "l1",
+        seasonId: "s1",
+        teamIds: [],
+        rosterSize: 0,
+        salaryCap: 0,
+      });
+
+      assertEquals(result.playerCount, 1);
+      assertEquals(result.draftProspectCount, 1);
+      assertEquals(result.contractCount, 0);
+
+      // players + player_attributes + player_draft_profile = 3 writes
+      assertEquals(calls.length, 3);
+
+      const profileRows = calls[2].values as Array<Record<string, unknown>>;
+      assertEquals(profileRows.length, 1);
+      assertEquals(profileRows[0].playerId, "prospect-1");
+      assertEquals(profileRows[0].seasonId, "s1");
+      assertEquals(profileRows[0].draftClassYear, 2027);
+      assertEquals(profileRows[0].projectedRound, null);
+      assertEquals(profileRows[0].scoutingNotes, null);
+      assertEquals(profileRows[0].speed, 40);
+    },
+  );
+
+  await t.step(
+    "generate throws when the season backing a prospect cannot be found",
+    async () => {
+      const { db } = createMockDb(["prospect-1"], null);
+      const generator = createMockGenerator({
+        generate: () => ({
+          players: [
+            {
+              player: {
+                leagueId: "l1",
+                teamId: null,
+                status: "prospect",
+                firstName: "K",
+                lastName: "L",
+                position: "QB",
+                injuryStatus: "healthy",
+                heightInches: 72,
+                weightPounds: 220,
+                college: null,
+                hometown: null,
+                birthDate: "2003-01-01",
+                draftYear: null,
+                draftRound: null,
+                draftPick: null,
+                draftingTeamId: null,
+              },
+              attributes: stubAttrs(),
+            },
+          ],
+        }),
+      });
+
+      const service = createPlayersService({
+        generator,
+        repo: createMockRepo(),
+        db,
+        log: createTestLogger(),
+      });
+
+      let caught: Error | undefined;
+      try {
+        await service.generate({
+          leagueId: "l1",
+          seasonId: "missing",
+          teamIds: [],
+          rosterSize: 0,
+          salaryCap: 0,
+        });
+      } catch (err) {
+        caught = err as Error;
+      }
+      assertEquals(caught?.message.includes("missing"), true);
     },
   );
 
@@ -340,9 +464,7 @@ Deno.test("players.service", async (t) => {
               attributes: stubAttrs(),
             },
           ],
-          draftProspects: [],
         }),
-        generateContracts: () => [],
       });
 
       const service = createPlayersService({
@@ -364,15 +486,15 @@ Deno.test("players.service", async (t) => {
       );
 
       assertEquals(dbCalls.length, 0);
-      // players + player_attributes + player_transactions writes routed through tx
+      // players + player_attributes + player_transactions routed through tx
       assertEquals(txCalls.length, 3);
     },
   );
 
   await t.step(
-    "generate passes inserted players to contract generator",
+    "generate only hands rostered active players to the contract generator",
     async () => {
-      const { db } = createMockDb(["player-1"]);
+      const { db } = createMockDb(["player-1", "prospect-1"]);
       let contractsGeneratorReceivedPlayers:
         | { id: string; teamId: string | null }[]
         | undefined;
@@ -401,8 +523,28 @@ Deno.test("players.service", async (t) => {
               },
               attributes: stubAttrs(),
             },
+            {
+              player: {
+                leagueId: "l1",
+                teamId: null,
+                status: "prospect",
+                firstName: "K",
+                lastName: "L",
+                position: "QB",
+                injuryStatus: "healthy",
+                heightInches: 72,
+                weightPounds: 220,
+                college: null,
+                hometown: null,
+                birthDate: "2003-01-01",
+                draftYear: null,
+                draftRound: null,
+                draftPick: null,
+                draftingTeamId: null,
+              },
+              attributes: stubAttrs(),
+            },
           ],
-          draftProspects: [],
         }),
         generateContracts: (input) => {
           contractsGeneratorReceivedPlayers = input.players;

--- a/server/features/players/players.service.test.ts
+++ b/server/features/players/players.service.test.ts
@@ -18,6 +18,8 @@ function createMockRepo(
 ): PlayersRepository {
   return {
     getDetailById: () => Promise.resolve(undefined),
+    findDraftEligiblePlayers: () => Promise.resolve([]),
+    transitionProspectToActive: () => Promise.resolve("not_found"),
     ...overrides,
   };
 }
@@ -114,6 +116,11 @@ function createMockDb(
           };
         },
       };
+    },
+    transaction<T>(
+      callback: (tx: import("../../db/connection.ts").Database) => Promise<T>,
+    ) {
+      return callback(db);
     },
   } as unknown as import("../../db/connection.ts").Database;
   return { db, calls };
@@ -570,6 +577,93 @@ Deno.test("players.service", async (t) => {
       assertEquals(contractsGeneratorReceivedPlayers?.length, 1);
       assertEquals(contractsGeneratorReceivedPlayers?.[0].id, "player-1");
       assertEquals(contractsGeneratorReceivedPlayers?.[0].teamId, "t1");
+    },
+  );
+});
+
+Deno.test("players.service — findDraftEligiblePlayers", async (t) => {
+  await t.step(
+    "delegates to the repo and passes through the result",
+    async () => {
+      const { db } = createMockDb();
+      let seenLeagueId: string | undefined;
+      const service = createPlayersService({
+        generator: createMockGenerator(),
+        repo: createMockRepo({
+          findDraftEligiblePlayers: (leagueId) => {
+            seenLeagueId = leagueId;
+            return Promise.resolve([
+              {
+                id: "p1",
+                firstName: "Abe",
+                lastName: "Adams",
+                position: "QB",
+                college: "State",
+                hometown: "Austin, TX",
+                heightInches: 74,
+                weightPounds: 220,
+                birthDate: "2004-03-01",
+                draftClassYear: 2028,
+                projectedRound: 1,
+              },
+            ]);
+          },
+        }),
+        db,
+        log: createTestLogger(),
+      });
+
+      const result = await service.findDraftEligiblePlayers("league-1");
+      assertEquals(seenLeagueId, "league-1");
+      assertEquals(result.length, 1);
+      assertEquals(result[0].id, "p1");
+    },
+  );
+});
+
+Deno.test("players.service — draftPlayer", async (t) => {
+  await t.step(
+    "runs the transition inside a transaction and resolves on ok",
+    async () => {
+      const { db } = createMockDb();
+      let transitionInput:
+        | { playerId: string; teamId: string }
+        | undefined;
+      const service = createPlayersService({
+        generator: createMockGenerator(),
+        repo: createMockRepo({
+          transitionProspectToActive: (input) => {
+            transitionInput = input;
+            return Promise.resolve("ok");
+          },
+        }),
+        db,
+        log: createTestLogger(),
+      });
+
+      await service.draftPlayer({ playerId: "p1", teamId: "t1" });
+      assertEquals(transitionInput?.playerId, "p1");
+      assertEquals(transitionInput?.teamId, "t1");
+    },
+  );
+
+  await t.step(
+    "throws NOT_FOUND when the repo cannot transition the player",
+    async () => {
+      const { db } = createMockDb();
+      const service = createPlayersService({
+        generator: createMockGenerator(),
+        repo: createMockRepo({
+          transitionProspectToActive: () => Promise.resolve("not_found"),
+        }),
+        db,
+        log: createTestLogger(),
+      });
+      await assertRejects(
+        () => service.draftPlayer({ playerId: "missing", teamId: "t1" }),
+        DomainError,
+        "not draft-eligible",
+      );
     },
   );
 });

--- a/server/features/players/players.service.test.ts
+++ b/server/features/players/players.service.test.ts
@@ -162,6 +162,7 @@ Deno.test("players.service — getDetail", async (t) => {
         currentContract: null,
         contractHistory: [],
         transactions: [],
+        preDraftEvaluation: null,
       };
       const { db } = createMockDb();
       const service = createPlayersService({

--- a/server/features/players/players.service.ts
+++ b/server/features/players/players.service.ts
@@ -41,6 +41,26 @@ export function createPlayersService(deps: {
       return detail;
     },
 
+    findDraftEligiblePlayers(leagueId) {
+      return deps.repo.findDraftEligiblePlayers(leagueId);
+    },
+
+    async draftPlayer(input) {
+      log.info(
+        { playerId: input.playerId, teamId: input.teamId },
+        "drafting player",
+      );
+      const result = await deps.db.transaction((tx) =>
+        deps.repo.transitionProspectToActive(input, tx)
+      );
+      if (result === "not_found") {
+        throw new DomainError(
+          "NOT_FOUND",
+          `Player ${input.playerId} is not draft-eligible`,
+        );
+      }
+    },
+
     async generate(input, tx) {
       const exec = tx ?? deps.db;
       log.info(

--- a/server/features/players/players.service.ts
+++ b/server/features/players/players.service.ts
@@ -1,21 +1,27 @@
+import { eq } from "drizzle-orm";
 import type pino from "pino";
-import { DomainError } from "@zone-blitz/shared";
+import { DomainError, type PlayerStatus } from "@zone-blitz/shared";
 import type { Database } from "../../db/connection.ts";
 import {
   chunkedInsert,
   chunkedInsertReturning,
 } from "../../db/chunked-insert.ts";
-import { draftProspects, players } from "./player.schema.ts";
-import {
-  draftProspectAttributes,
-  playerAttributes,
-} from "./attributes.schema.ts";
+import { players } from "./player.schema.ts";
+import { playerAttributes } from "./attributes.schema.ts";
+import { playerDraftProfile } from "./player-draft-profile.schema.ts";
 import { contracts } from "./contract.schema.ts";
 import { contractHistory } from "./contract-history.schema.ts";
 import { playerTransactions } from "./player-transaction.schema.ts";
+import { seasons } from "../season/season.schema.ts";
 import type { PlayersGenerator } from "./players.generator.interface.ts";
 import type { PlayersRepository } from "./players.repository.interface.ts";
 import type { PlayersService } from "./players.service.interface.ts";
+
+type InsertedPlayerRow = {
+  id: string;
+  teamId: string | null;
+  status: PlayerStatus;
+};
 
 export function createPlayersService(deps: {
   generator: PlayersGenerator;
@@ -49,16 +55,14 @@ export function createPlayersService(deps: {
         rosterSize: input.rosterSize,
       });
 
-      let insertedPlayers: { id: string; teamId: string | null }[] = [];
+      let insertedPlayers: InsertedPlayerRow[] = [];
 
       if (generated.players.length > 0) {
-        insertedPlayers = await chunkedInsertReturning<
-          { id: string; teamId: string | null }
-        >(
+        insertedPlayers = await chunkedInsertReturning<InsertedPlayerRow>(
           exec,
           players,
           generated.players.map((entry) => entry.player),
-          { id: players.id, teamId: players.teamId },
+          { id: players.id, teamId: players.teamId, status: players.status },
         );
 
         const attributeRows = insertedPlayers.map((row, index) => ({
@@ -67,9 +71,13 @@ export function createPlayersService(deps: {
         }));
         await chunkedInsert(exec, playerAttributes, attributeRows);
 
+        const activePlayers = insertedPlayers
+          .map((row, index) => ({ row, source: generated.players[index] }))
+          .filter(({ row }) => row.status === "active");
+
         const currentLeagueYear = new Date().getUTCFullYear();
-        const transactionRows = insertedPlayers.flatMap((row, index) => {
-          const source = generated.players[index].player;
+        const transactionRows = activePlayers.flatMap(({ row, source }) => {
+          const src = source.player;
           const events: {
             playerId: string;
             teamId: string | null;
@@ -79,24 +87,24 @@ export function createPlayersService(deps: {
             detail: string | null;
           }[] = [];
           if (
-            source.draftYear !== null &&
-            source.draftingTeamId !== null &&
-            source.draftRound !== null &&
-            source.draftPick !== null
+            src.draftYear !== null &&
+            src.draftingTeamId !== null &&
+            src.draftRound !== null &&
+            src.draftPick !== null
           ) {
             events.push({
               playerId: row.id,
-              teamId: source.draftingTeamId,
+              teamId: src.draftingTeamId,
               counterpartyTeamId: null,
               type: "drafted",
-              seasonYear: source.draftYear,
+              seasonYear: src.draftYear,
               detail:
-                `Round ${source.draftRound}, pick ${source.draftPick} overall`,
+                `Round ${src.draftRound}, pick ${src.draftPick} overall`,
             });
           }
           if (row.teamId !== null) {
-            const isOwnDraftTeam = source.draftingTeamId === row.teamId &&
-              source.draftYear !== null;
+            const isOwnDraftTeam = src.draftingTeamId === row.teamId &&
+              src.draftYear !== null;
             if (!isOwnDraftTeam) {
               events.push({
                 playerId: row.id,
@@ -104,9 +112,7 @@ export function createPlayersService(deps: {
                 counterpartyTeamId: null,
                 type: "signed",
                 seasonYear: currentLeagueYear,
-                detail: source.draftYear === null
-                  ? "Undrafted free agent"
-                  : null,
+                detail: src.draftYear === null ? "Undrafted free agent" : null,
               });
             }
           }
@@ -115,39 +121,54 @@ export function createPlayersService(deps: {
         if (transactionRows.length > 0) {
           await chunkedInsert(exec, playerTransactions, transactionRows);
         }
+
+        const prospectEntries = insertedPlayers
+          .map((row, index) => ({ row, entry: generated.players[index] }))
+          .filter(({ row }) => row.status === "prospect");
+
+        if (prospectEntries.length > 0) {
+          const [season] = await exec
+            .select({ year: seasons.year })
+            .from(seasons)
+            .where(eq(seasons.id, input.seasonId))
+            .limit(1);
+
+          if (!season) {
+            throw new Error(
+              `season ${input.seasonId} not found while generating prospects`,
+            );
+          }
+
+          const draftProfileRows = prospectEntries.map(({ row, entry }) => ({
+            playerId: row.id,
+            seasonId: input.seasonId,
+            draftClassYear: season.year,
+            projectedRound: null,
+            scoutingNotes: null,
+            ...entry.attributes,
+          }));
+          await chunkedInsert(exec, playerDraftProfile, draftProfileRows);
+        }
       }
 
-      if (generated.draftProspects.length > 0) {
-        const insertedProspects = await chunkedInsertReturning<{ id: string }>(
-          exec,
-          draftProspects,
-          generated.draftProspects.map((entry) => entry.prospect),
-          { id: draftProspects.id },
-        );
-
-        const prospectAttributeRows = insertedProspects.map((row, index) => ({
-          draftProspectId: row.id,
-          ...generated.draftProspects[index].attributes,
-        }));
-        await chunkedInsert(
-          exec,
-          draftProspectAttributes,
-          prospectAttributeRows,
-        );
-      }
+      const prospectCount =
+        insertedPlayers.filter((p) => p.status === "prospect").length;
 
       log.info(
         {
           leagueId: input.leagueId,
           players: insertedPlayers.length,
-          draftProspects: generated.draftProspects.length,
+          prospects: prospectCount,
         },
         "persisted players",
       );
 
+      const rosteredPlayers = insertedPlayers.filter(
+        (p) => p.status === "active" && p.teamId !== null,
+      );
       const generatedContracts = deps.generator.generateContracts({
         salaryCap: input.salaryCap,
-        players: insertedPlayers,
+        players: rosteredPlayers,
       });
 
       if (generatedContracts.length > 0) {
@@ -177,7 +198,7 @@ export function createPlayersService(deps: {
 
       return {
         playerCount: insertedPlayers.length,
-        draftProspectCount: generated.draftProspects.length,
+        draftProspectCount: prospectCount,
         contractCount: generatedContracts.length,
       };
     },

--- a/server/features/players/stub-players-generator.test.ts
+++ b/server/features/players/stub-players-generator.test.ts
@@ -21,7 +21,9 @@ Deno.test("generates correct number of rostered players per team", () => {
   const generator = createStubPlayersGenerator();
   const result = generator.generate(INPUT);
 
-  const rostered = result.players.filter((p) => p.player.teamId !== null);
+  const rostered = result.players.filter(
+    (p) => p.player.teamId !== null && p.player.status === "active",
+  );
   assertEquals(rostered.length, TEAM_IDS.length * INPUT.rosterSize);
 
   for (const teamId of TEAM_IDS) {
@@ -30,11 +32,13 @@ Deno.test("generates correct number of rostered players per team", () => {
   }
 });
 
-Deno.test("generates free agents with null teamId", () => {
+Deno.test("generates active free agents with null teamId", () => {
   const generator = createStubPlayersGenerator();
   const result = generator.generate(INPUT);
 
-  const freeAgents = result.players.filter((p) => p.player.teamId === null);
+  const freeAgents = result.players.filter(
+    (p) => p.player.teamId === null && p.player.status === "active",
+  );
   assertEquals(freeAgents.length, 50);
 });
 
@@ -47,22 +51,25 @@ Deno.test("all players have the correct leagueId", () => {
   }
 });
 
-Deno.test("generates draft prospects linked to seasonId", () => {
+Deno.test("prospects are emitted as players with status 'prospect' and no team", () => {
   const generator = createStubPlayersGenerator();
   const result = generator.generate(INPUT);
 
-  assertEquals(result.draftProspects.length, 250);
-  for (const entry of result.draftProspects) {
-    assertEquals(entry.prospect.seasonId, INPUT.seasonId);
+  const prospects = result.players.filter(
+    (p) => p.player.status === "prospect",
+  );
+  assertEquals(prospects.length, 250);
+  for (const entry of prospects) {
+    assertEquals(entry.player.teamId, null);
   }
 });
 
-Deno.test("every player and prospect has a full attribute set", () => {
+Deno.test("every generated player has a full attribute set", () => {
   const generator = createStubPlayersGenerator();
   const result = generator.generate(INPUT);
 
   const expectedKeyCount = PLAYER_ATTRIBUTE_KEYS.length * 2;
-  for (const entry of [...result.players, ...result.draftProspects]) {
+  for (const entry of result.players) {
     assertEquals(Object.keys(entry.attributes).length, expectedKeyCount);
     for (const key of PLAYER_ATTRIBUTE_KEYS) {
       const current = (entry.attributes as Record<string, number>)[key];
@@ -76,7 +83,7 @@ Deno.test("every player and prospect has a full attribute set", () => {
   }
 });
 
-Deno.test("every player and prospect has identity fields populated", () => {
+Deno.test("every player has identity fields populated", () => {
   const generator = createStubPlayersGenerator();
   const result = generator.generate(INPUT);
 
@@ -84,11 +91,6 @@ Deno.test("every player and prospect has identity fields populated", () => {
     assertEquals(typeof entry.player.heightInches, "number");
     assertEquals(typeof entry.player.weightPounds, "number");
     assertEquals(typeof entry.player.birthDate, "string");
-  }
-  for (const entry of result.draftProspects) {
-    assertEquals(typeof entry.prospect.heightInches, "number");
-    assertEquals(typeof entry.prospect.weightPounds, "number");
-    assertEquals(typeof entry.prospect.birthDate, "string");
   }
 });
 
@@ -134,7 +136,7 @@ Deno.test("roster composition sums to 53 players", () => {
 });
 
 Deno.test(
-  "every rostered player receives a position from the known set",
+  "every generated player receives a position from the known set",
   () => {
     const generator = createStubPlayersGenerator();
     const result = generator.generate(INPUT);
@@ -152,7 +154,7 @@ Deno.test(
     const result = generator.generate(INPUT);
     for (const teamId of TEAM_IDS) {
       const teamPlayers = result.players.filter(
-        (p) => p.player.teamId === teamId,
+        (p) => p.player.teamId === teamId && p.player.status === "active",
       );
       const byPosition = new Map<PlayerPosition, number>();
       for (const entry of teamPlayers) {
@@ -168,20 +170,11 @@ Deno.test(
   },
 );
 
-Deno.test("every rostered player starts with healthy injury status", () => {
+Deno.test("every generated player starts with healthy injury status", () => {
   const generator = createStubPlayersGenerator();
   const result = generator.generate(INPUT);
   for (const entry of result.players) {
     assertEquals(entry.player.injuryStatus, "healthy");
-  }
-});
-
-Deno.test("every draft prospect receives a valid position", () => {
-  const generator = createStubPlayersGenerator();
-  const result = generator.generate(INPUT);
-  const validPositions = new Set<PlayerPosition>(PLAYER_POSITIONS);
-  for (const entry of result.draftProspects) {
-    assertEquals(validPositions.has(entry.prospect.position), true);
   }
 });
 
@@ -200,10 +193,12 @@ Deno.test("every generated player gets a hometown and either draft info or undra
   }
 });
 
-Deno.test("at least one rostered player is undrafted", () => {
+Deno.test("at least one rostered active player is undrafted", () => {
   const generator = createStubPlayersGenerator();
   const result = generator.generate(INPUT);
-  const rostered = result.players.filter((p) => p.player.teamId !== null);
+  const rostered = result.players.filter(
+    (p) => p.player.teamId !== null && p.player.status === "active",
+  );
   const undrafted = rostered.filter((p) => p.player.draftYear === null);
   assertEquals(undrafted.length > 0, true);
 });
@@ -211,23 +206,21 @@ Deno.test("at least one rostered player is undrafted", () => {
 Deno.test("drafted rostered players carry their drafting team", () => {
   const generator = createStubPlayersGenerator();
   const result = generator.generate(INPUT);
-  const rostered = result.players.filter((p) => p.player.teamId !== null);
+  const rostered = result.players.filter(
+    (p) => p.player.teamId !== null && p.player.status === "active",
+  );
   const drafted = rostered.filter((p) => p.player.draftYear !== null);
   for (const entry of drafted) {
     assertEquals(typeof entry.player.draftingTeamId, "string");
   }
 });
 
-Deno.test("all generated players and prospects have non-empty names", () => {
+Deno.test("all generated players have non-empty names", () => {
   const generator = createStubPlayersGenerator();
   const result = generator.generate(INPUT);
 
   for (const entry of result.players) {
     assertEquals(entry.player.firstName.length > 0, true);
     assertEquals(entry.player.lastName.length > 0, true);
-  }
-  for (const entry of result.draftProspects) {
-    assertEquals(entry.prospect.firstName.length > 0, true);
-    assertEquals(entry.prospect.lastName.length > 0, true);
   }
 });

--- a/server/features/players/stub-players-generator.ts
+++ b/server/features/players/stub-players-generator.ts
@@ -279,28 +279,35 @@ export function createStubPlayersGenerator(): PlayersGenerator {
         });
       }
 
-      const draftProspects = [];
       for (let i = 0; i < DRAFT_PROSPECT_COUNT; i++) {
         const { firstName, lastName } = randomName(nameIndex++);
         const position = FREE_AGENT_POSITION_CYCLE[
           i % FREE_AGENT_POSITION_CYCLE.length
         ];
-        draftProspects.push({
-          prospect: {
-            seasonId: input.seasonId,
+        players.push({
+          player: {
+            leagueId: input.leagueId,
+            teamId: null,
+            status: "prospect" as const,
             firstName,
             lastName,
             position,
+            injuryStatus: "healthy" as const,
             heightInches: STUB_HEIGHT_INCHES,
             weightPounds: STUB_WEIGHT_POUNDS,
             college: STUB_COLLEGE,
+            hometown: STUB_HOMETOWNS[i % STUB_HOMETOWNS.length],
             birthDate: STUB_BIRTH_DATE,
+            draftYear: null,
+            draftRound: null,
+            draftPick: null,
+            draftingTeamId: null,
           },
           attributes: stubAttributes(),
         });
       }
 
-      return { players, draftProspects };
+      return { players };
     },
 
     generateContracts(input: ContractGeneratorInput): GeneratedContract[] {

--- a/server/features/scouts/scout-history.schema.ts
+++ b/server/features/scouts/scout-history.schema.ts
@@ -8,7 +8,7 @@ import {
   uuid,
 } from "drizzle-orm/pg-core";
 import { scouts } from "./scout.schema.ts";
-import { draftProspects } from "../players/player.schema.ts";
+import { players } from "../players/player.schema.ts";
 
 export const scoutEvaluationLevelEnum = pgEnum("scout_evaluation_level", [
   "quick",
@@ -76,7 +76,7 @@ export const scoutEvaluations = pgTable("scout_evaluations", {
   scoutId: uuid("scout_id")
     .notNull()
     .references(() => scouts.id, { onDelete: "cascade" }),
-  prospectId: uuid("prospect_id").references(() => draftProspects.id, {
+  prospectId: uuid("prospect_id").references(() => players.id, {
     onDelete: "set null",
   }),
   prospectName: text("prospect_name").notNull(),


### PR DESCRIPTION
## Summary

Complete implementation of [ADR 0006 — Unify draft prospects and players into a single \`players\` entity](../blob/main/docs/product/decisions/0006-unified-player-model.md). Supersedes #123 and #125 (closed) by bundling the full cutover into a single PR — once PR 1 (#118) landed, the remaining pieces were too entangled to keep as a stacked sequence after main's contract/transaction work merged in parallel.

The three squashed commits land together:

1. **refactor(players): unify draft prospects into players with status** — migration 0022 folds every \`draft_prospects\` row into \`players\` with \`status = 'prospect'\` (preserving the original uuid so \`scout_evaluations.prospect_id\` stays valid), copies attributes, seeds \`player_draft_profile\` with draft class year pulled from the season, drops the legacy tables, and repoints the scout-evaluation FK at \`players.id\`. \`PlayersGenerator\` emits one array; prospects are entries with \`status: 'prospect'\`. The service writes a draft profile for every prospect-status player and only hands rostered actives to the contract generator.
2. **feat(players): add draft pool read and atomic \`draftPlayer\` transition** — \`PlayersRepository.findDraftEligiblePlayers(leagueId)\` for the draft pool (sorted by projected round, nulls last) and \`transitionProspectToActive\`, the only code path that flips \`status\` out of \`prospect\` (the \`WHERE status = 'prospect'\` guard turns double-draft into \`"not_found"\`). Service exposes \`draftPlayer({ playerId, teamId })\` running the transition inside a transaction. New \`DraftEligiblePlayer\` shared type.
3. **feat(players): render pre-draft evaluation on player detail page** — \`PlayerDetail.preDraftEvaluation\` sourced via LEFT JOIN on \`player_draft_profile\`. Detail page renders a "Pre-draft evaluation" card with draft class year, projected round (or "Unprojected"), and scouting notes. Hidden attributes and scout grades still stay behind the scouting wall from ADR 0003.

Draft-pool list endpoint + page is a deliberate follow-up — the repo is ready, the UI just isn't scoped here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)