### PR TITLE
refactor(league-nav): move Scouts link into Team nav group

### DIFF
--- a/client/src/features/league/layout.tsx
+++ b/client/src/features/league/layout.tsx
@@ -55,12 +55,12 @@ const navGroups: NavGroup[] = [
       { label: "Home", path: "", Icon: HomeIcon },
       { label: "Roster", path: "roster", Icon: UsersIcon },
       { label: "Coaches", path: "coaches", Icon: ClipboardListIcon },
+      { label: "Scouts", path: "scouts", Icon: SearchIcon },
     ],
   },
   {
     label: "Team Building",
     items: [
-      { label: "Scouts", path: "scouts", Icon: SearchIcon },
       { label: "Draft", path: "draft", Icon: ListOrderedIcon },
       { label: "Trades", path: "trades", Icon: ArrowLeftRightIcon },
       { label: "Free Agency", path: "free-agency", Icon: UserPlusIcon },


### PR DESCRIPTION
## Summary

- Move the Scouts sidebar link from the **Team Building** group to the **Team** group, where it sits alongside Roster and Coaches.
- Scouts represent team staff, which fits the Team grouping better than roster-acquisition workflows like Draft, Trades, Free Agency, and Salary Cap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)