### PR TITLE
feat(create-league): rename first creation stage to "Building the foundation"

### DIFF
--- a/client/src/features/create-league/stages.ts
+++ b/client/src/features/create-league/stages.ts
@@ -1,5 +1,5 @@
 export const CREATION_STAGES = [
-  "Founding the league…",
+  "Building the foundation…",
   "Hiring coaches & front office…",
   "Scouting the talent pool…",
   "Drafting rosters…",


### PR DESCRIPTION
## Summary

- Renames the first loader stage in the league creation flow from "Founding the league…" to "Building the foundation…".
- Reads more naturally as the opening step before coaches, scouts, draft, and schedule stages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)