### PR TITLE
feat(salary-cap): build dedicated salary cap page

### DIFF
--- a/client/src/features/league/roster.test.tsx
+++ b/client/src/features/league/roster.test.tsx
@@ -241,12 +241,9 @@ describe("Roster — active roster tab (default)", () => {
     expect(screen.getByText(/failed to load roster/i)).toBeDefined();
   });
 
-  it("renders the cap summary", () => {
+  it("does not render a cap summary (moved to Salary Cap page)", () => {
     renderRoster();
-    const summary = screen.getByTestId("roster-cap-summary");
-    expect(within(summary).getByText("$68,000,000")).toBeDefined();
-    expect(within(summary).getByText("$255,000,000")).toBeDefined();
-    expect(within(summary).getByText("$187,000,000")).toBeDefined();
+    expect(screen.queryByTestId("roster-cap-summary")).toBeNull();
   });
 
   it("renders every player in a single combined table", () => {
@@ -261,16 +258,20 @@ describe("Roster — active roster tab (default)", () => {
     ]);
   });
 
-  it("renders a player row with name, position, group, age, cap hit, contract years, and injury status", () => {
+  it("renders a player row with name, position, group, age, and injury status", () => {
     renderRoster();
     const row = screen.getByTestId("roster-row-p1");
     expect(within(row).getByText("Patrick Quarterback")).toBeDefined();
     expect(within(row).getByText("QB")).toBeDefined();
     expect(within(row).getByText("Offense")).toBeDefined();
     expect(within(row).getByText("28")).toBeDefined();
-    expect(within(row).getByText("$45,000,000")).toBeDefined();
-    expect(within(row).getByText("3 yrs")).toBeDefined();
     expect(within(row).getByText(/healthy/i)).toBeDefined();
+  });
+
+  it("does not render cap hit or contract columns (moved to Salary Cap page)", () => {
+    renderRoster();
+    expect(screen.queryByRole("button", { name: /cap hit/i })).toBeNull();
+    expect(screen.queryByRole("button", { name: /^contract/i })).toBeNull();
   });
 
   it("filters rows by the position group filter", () => {
@@ -289,21 +290,21 @@ describe("Roster — active roster tab (default)", () => {
     expect(rosterRowIds()).toEqual(["roster-row-p4"]);
   });
 
-  it("sorts rows when the Cap Hit header is clicked", () => {
+  it("sorts rows when the Age header is clicked", () => {
     renderRoster();
-    fireEvent.click(screen.getByRole("button", { name: /cap hit/i }));
+    fireEvent.click(screen.getByRole("button", { name: /age/i }));
     expect(rosterRowIds()).toEqual([
-      "roster-row-p4",
       "roster-row-p3",
       "roster-row-p2",
       "roster-row-p1",
+      "roster-row-p4",
     ]);
-    fireEvent.click(screen.getByRole("button", { name: /cap hit/i }));
+    fireEvent.click(screen.getByRole("button", { name: /age/i }));
     expect(rosterRowIds()).toEqual([
+      "roster-row-p4",
       "roster-row-p1",
       "roster-row-p2",
       "roster-row-p3",
-      "roster-row-p4",
     ]);
   });
 });

--- a/client/src/features/league/roster.tsx
+++ b/client/src/features/league/roster.tsx
@@ -45,20 +45,10 @@ const groupFilterOptions: (PlayerPositionGroup | "all")[] = [
   "special_teams",
 ];
 
-const currency = new Intl.NumberFormat("en-US", {
-  style: "currency",
-  currency: "USD",
-  maximumFractionDigits: 0,
-});
-
 const dateFormatter = new Intl.DateTimeFormat("en-US", {
   dateStyle: "medium",
   timeStyle: "short",
 });
-
-function formatCurrency(value: number) {
-  return currency.format(value);
-}
 
 function injuryBadgeVariant(
   status: PlayerInjuryStatus,
@@ -131,20 +121,6 @@ const rosterColumns: ColumnDef<RosterPlayer>[] = [
         Age
       </SortableHeader>
     ),
-  },
-  {
-    accessorKey: "capHit",
-    header: ({ column }) => (
-      <SortableHeader column={column}>Cap Hit</SortableHeader>
-    ),
-    cell: ({ row }) => formatCurrency(row.original.capHit),
-  },
-  {
-    accessorKey: "contractYearsRemaining",
-    header: ({ column }) => (
-      <SortableHeader column={column}>Contract</SortableHeader>
-    ),
-    cell: ({ row }) => `${row.original.contractYearsRemaining} yrs`,
   },
   {
     accessorKey: "injuryStatus",
@@ -227,31 +203,6 @@ function ActiveRosterView(
 function ActiveRosterContent({ roster }: { roster: ActiveRoster }) {
   return (
     <>
-      <Card data-testid="roster-cap-summary">
-        <CardHeader>
-          <CardTitle>Cap Summary</CardTitle>
-          <CardDescription>
-            Roster spend against the league salary cap.
-          </CardDescription>
-        </CardHeader>
-        <CardContent>
-          <dl className="grid grid-cols-1 gap-4 sm:grid-cols-3">
-            <CapStat
-              label="Total Cap"
-              value={formatCurrency(roster.totalCap)}
-            />
-            <CapStat
-              label="Salary Cap"
-              value={formatCurrency(roster.salaryCap)}
-            />
-            <CapStat
-              label="Cap Space"
-              value={formatCurrency(roster.capSpace)}
-            />
-          </dl>
-        </CardContent>
-      </Card>
-
       <DataTable
         columns={rosterColumns}
         data={roster.players}
@@ -462,14 +413,5 @@ function DepthChartMeta(
     >
       {[timestamp, author].filter(Boolean).join(" ")}
     </p>
-  );
-}
-
-function CapStat({ label, value }: { label: string; value: string }) {
-  return (
-    <div className="flex flex-col gap-1">
-      <dt className="text-sm text-muted-foreground">{label}</dt>
-      <dd className="text-2xl font-semibold">{value}</dd>
-    </div>
   );
 }

--- a/client/src/features/league/salary-cap.test.tsx
+++ b/client/src/features/league/salary-cap.test.tsx
@@ -1,16 +1,214 @@
-import { cleanup, render, screen } from "@testing-library/react";
-import { afterEach, describe, expect, it } from "vitest";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  within,
+} from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { SalaryCap } from "./salary-cap.tsx";
+
+const mockUseParams = vi.fn();
+const mockUseLeague = vi.fn();
+const mockUseActiveRoster = vi.fn();
+
+vi.mock("@tanstack/react-router", () => ({
+  useParams: (...args: unknown[]) => mockUseParams(...args),
+}));
+
+vi.mock("../../hooks/use-league.ts", () => ({
+  useLeague: (...args: unknown[]) => mockUseLeague(...args),
+}));
+
+vi.mock("../../hooks/use-active-roster.ts", () => ({
+  useActiveRoster: (...args: unknown[]) => mockUseActiveRoster(...args),
+}));
+
+const baseRoster = {
+  leagueId: "L1",
+  teamId: "T1",
+  players: [
+    {
+      id: "p1",
+      firstName: "Patrick",
+      lastName: "Quarterback",
+      position: "QB",
+      positionGroup: "offense",
+      age: 28,
+      capHit: 45_000_000,
+      contractYearsRemaining: 3,
+      injuryStatus: "healthy",
+    },
+    {
+      id: "p2",
+      firstName: "Derrick",
+      lastName: "Runback",
+      position: "RB",
+      positionGroup: "offense",
+      age: 26,
+      capHit: 12_000_000,
+      contractYearsRemaining: 2,
+      injuryStatus: "questionable",
+    },
+    {
+      id: "p3",
+      firstName: "Aaron",
+      lastName: "Rusher",
+      position: "EDGE",
+      positionGroup: "defense",
+      age: 24,
+      capHit: 8_000_000,
+      contractYearsRemaining: 4,
+      injuryStatus: "out",
+    },
+    {
+      id: "p4",
+      firstName: "Kyle",
+      lastName: "Kicker",
+      position: "K",
+      positionGroup: "special_teams",
+      age: 30,
+      capHit: 3_000_000,
+      contractYearsRemaining: 1,
+      injuryStatus: "healthy",
+    },
+  ],
+  positionGroups: [
+    { group: "offense", headcount: 2, totalCap: 57_000_000 },
+    { group: "defense", headcount: 1, totalCap: 8_000_000 },
+    { group: "special_teams", headcount: 1, totalCap: 3_000_000 },
+  ],
+  totalCap: 68_000_000,
+  salaryCap: 255_000_000,
+  capSpace: 187_000_000,
+};
+
+function renderSalaryCap() {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={client}>
+      <SalaryCap />
+    </QueryClientProvider>,
+  );
+}
+
+function capRowIds() {
+  return Array.from(document.querySelectorAll("tbody tr"))
+    .map((row) => row.getAttribute("data-testid"))
+    .filter((id): id is string =>
+      Boolean(id) && id!.startsWith("salary-cap-row-")
+    );
+}
 
 afterEach(() => {
   cleanup();
+  vi.clearAllMocks();
 });
 
-describe("SalaryCap", () => {
+beforeEach(() => {
+  mockUseParams.mockReturnValue({ leagueId: "L1" });
+  mockUseLeague.mockReturnValue({
+    data: { id: "L1", userTeamId: "T1", name: "Test League" },
+  });
+  mockUseActiveRoster.mockReturnValue({
+    data: baseRoster,
+    isLoading: false,
+    isError: false,
+  });
+});
+
+describe("SalaryCap — page", () => {
   it("renders the Salary Cap heading", () => {
-    render(<SalaryCap />);
+    renderSalaryCap();
     expect(
       screen.getByRole("heading", { name: "Salary Cap" }),
     ).toBeDefined();
+  });
+
+  it("shows a message when the league has no selected team", () => {
+    mockUseLeague.mockReturnValue({
+      data: { id: "L1", userTeamId: null, name: "Test League" },
+    });
+    renderSalaryCap();
+    expect(screen.getByText(/select a team/i)).toBeDefined();
+  });
+
+  it("shows a loading skeleton while data is fetching", () => {
+    mockUseActiveRoster.mockReturnValue({
+      data: undefined,
+      isLoading: true,
+      isError: false,
+    });
+    renderSalaryCap();
+    expect(screen.getByTestId("salary-cap-loading")).toBeDefined();
+  });
+
+  it("shows an error message when the data fails to load", () => {
+    mockUseActiveRoster.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      isError: true,
+    });
+    renderSalaryCap();
+    expect(screen.getByText(/failed to load salary cap/i)).toBeDefined();
+  });
+
+  it("renders the cap summary with total cap, salary cap, and cap space", () => {
+    renderSalaryCap();
+    const summary = screen.getByTestId("salary-cap-summary");
+    expect(within(summary).getByText("$68,000,000")).toBeDefined();
+    expect(within(summary).getByText("$255,000,000")).toBeDefined();
+    expect(within(summary).getByText("$187,000,000")).toBeDefined();
+  });
+
+  it("renders a position group breakdown with headcount and total cap", () => {
+    renderSalaryCap();
+    const groups = screen.getByTestId("salary-cap-position-groups");
+    const offense = within(groups).getByTestId(
+      "salary-cap-group-offense",
+    );
+    expect(within(offense).getByText("Offense")).toBeDefined();
+    expect(within(offense).getByText("$57,000,000")).toBeDefined();
+    expect(within(offense).getByText(/2 players/i)).toBeDefined();
+
+    const defense = within(groups).getByTestId(
+      "salary-cap-group-defense",
+    );
+    expect(within(defense).getByText("$8,000,000")).toBeDefined();
+
+    const st = within(groups).getByTestId(
+      "salary-cap-group-special_teams",
+    );
+    expect(within(st).getByText("Special Teams")).toBeDefined();
+  });
+
+  it("renders every player in the cap hit table, sorted by cap hit desc", () => {
+    renderSalaryCap();
+    expect(capRowIds()).toEqual([
+      "salary-cap-row-p1",
+      "salary-cap-row-p2",
+      "salary-cap-row-p3",
+      "salary-cap-row-p4",
+    ]);
+  });
+
+  it("renders a player row with name, position, cap hit, and contract years", () => {
+    renderSalaryCap();
+    const row = screen.getByTestId("salary-cap-row-p1");
+    expect(within(row).getByText("Patrick Quarterback")).toBeDefined();
+    expect(within(row).getByText("QB")).toBeDefined();
+    expect(within(row).getByText("$45,000,000")).toBeDefined();
+    expect(within(row).getByText("3 yrs")).toBeDefined();
+  });
+
+  it("filters rows by the global search input", () => {
+    renderSalaryCap();
+    fireEvent.change(screen.getByLabelText("Search players"), {
+      target: { value: "Kicker" },
+    });
+    expect(capRowIds()).toEqual(["salary-cap-row-p4"]);
   });
 });

--- a/client/src/features/league/salary-cap.tsx
+++ b/client/src/features/league/salary-cap.tsx
@@ -1,10 +1,227 @@
-import { StubPage } from "./stub-page.tsx";
+import { useMemo } from "react";
+import { useParams } from "@tanstack/react-router";
+import type { ColumnDef } from "@tanstack/react-table";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Skeleton } from "@/components/ui/skeleton";
+import { DataTable, SortableHeader } from "@/components/ui/data-table";
+import type {
+  ActiveRoster,
+  PlayerPositionGroup,
+  RosterPlayer,
+  RosterPositionGroupSummary,
+} from "@zone-blitz/shared/types/roster.ts";
+import { useLeague } from "../../hooks/use-league.ts";
+import { useActiveRoster } from "../../hooks/use-active-roster.ts";
+
+const groupLabels: Record<PlayerPositionGroup, string> = {
+  offense: "Offense",
+  defense: "Defense",
+  special_teams: "Special Teams",
+};
+
+const currency = new Intl.NumberFormat("en-US", {
+  style: "currency",
+  currency: "USD",
+  maximumFractionDigits: 0,
+});
+
+function formatCurrency(value: number) {
+  return currency.format(value);
+}
+
+const capColumns: ColumnDef<RosterPlayer>[] = [
+  {
+    id: "player",
+    accessorFn: (p) => `${p.firstName} ${p.lastName}`,
+    header: ({ column }) => (
+      <SortableHeader column={column}>Player</SortableHeader>
+    ),
+    cell: ({ row }) => (
+      <span className="font-medium">
+        {row.original.firstName} {row.original.lastName}
+      </span>
+    ),
+  },
+  {
+    accessorKey: "position",
+    header: ({ column }) => (
+      <SortableHeader column={column}>
+        Pos
+      </SortableHeader>
+    ),
+  },
+  {
+    accessorKey: "positionGroup",
+    header: ({ column }) => (
+      <SortableHeader column={column}>Group</SortableHeader>
+    ),
+    cell: ({ row }) => groupLabels[row.original.positionGroup],
+  },
+  {
+    accessorKey: "capHit",
+    header: ({ column }) => (
+      <SortableHeader column={column}>Cap Hit</SortableHeader>
+    ),
+    cell: ({ row }) => formatCurrency(row.original.capHit),
+  },
+  {
+    accessorKey: "contractYearsRemaining",
+    header: ({ column }) => (
+      <SortableHeader column={column}>Contract</SortableHeader>
+    ),
+    cell: ({ row }) => `${row.original.contractYearsRemaining} yrs`,
+  },
+];
 
 export function SalaryCap() {
+  const { leagueId } = useParams({ strict: false }) as { leagueId: string };
+  const { data: league } = useLeague(leagueId);
+  const teamId = league?.userTeamId ?? null;
+
   return (
-    <StubPage
-      title="Salary Cap"
-      description="Contract structure, dead money, and multi-year financial planning."
-    />
+    <div className="flex flex-col gap-6 p-6">
+      <div className="flex flex-col gap-2">
+        <h1 className="text-3xl font-bold tracking-tight">Salary Cap</h1>
+        <p className="max-w-2xl text-muted-foreground">
+          Contract structure, dead money, and multi-year financial planning.
+        </p>
+      </div>
+
+      {!teamId
+        ? (
+          <p className="text-muted-foreground">
+            Select a team for this league to view its salary cap.
+          </p>
+        )
+        : <SalaryCapView leagueId={leagueId} teamId={teamId} />}
+    </div>
+  );
+}
+
+function SalaryCapView(
+  { leagueId, teamId }: { leagueId: string; teamId: string },
+) {
+  const { data: roster, isLoading, isError } = useActiveRoster(
+    leagueId,
+    teamId,
+  );
+
+  if (isLoading) {
+    return (
+      <div data-testid="salary-cap-loading" className="flex flex-col gap-4">
+        <Skeleton className="h-24 w-full" />
+        <Skeleton className="h-64 w-full" />
+      </div>
+    );
+  }
+  if (isError || !roster) {
+    return (
+      <p className="text-destructive">
+        Failed to load salary cap. Try again in a moment.
+      </p>
+    );
+  }
+  return <SalaryCapContent roster={roster} />;
+}
+
+function SalaryCapContent({ roster }: { roster: ActiveRoster }) {
+  const sortedPlayers = useMemo(
+    () => [...roster.players].sort((a, b) => b.capHit - a.capHit),
+    [roster.players],
+  );
+
+  return (
+    <>
+      <Card data-testid="salary-cap-summary">
+        <CardHeader>
+          <CardTitle>Cap Summary</CardTitle>
+          <CardDescription>
+            Roster spend against the league salary cap.
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <dl className="grid grid-cols-1 gap-4 sm:grid-cols-3">
+            <CapStat
+              label="Total Cap"
+              value={formatCurrency(roster.totalCap)}
+            />
+            <CapStat
+              label="Salary Cap"
+              value={formatCurrency(roster.salaryCap)}
+            />
+            <CapStat
+              label="Cap Space"
+              value={formatCurrency(roster.capSpace)}
+            />
+          </dl>
+        </CardContent>
+      </Card>
+
+      <PositionGroupBreakdown groups={roster.positionGroups} />
+
+      <DataTable
+        columns={capColumns}
+        data={sortedPlayers}
+        getRowTestId={(player) => `salary-cap-row-${player.id}`}
+        toolbar={(table) => (
+          <div
+            className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between"
+            data-testid="salary-cap-toolbar"
+          >
+            <Input
+              aria-label="Search players"
+              placeholder="Search players…"
+              className="sm:max-w-xs"
+              value={(table.getState().globalFilter as string) ?? ""}
+              onChange={(event) => table.setGlobalFilter(event.target.value)}
+            />
+          </div>
+        )}
+      />
+    </>
+  );
+}
+
+function PositionGroupBreakdown(
+  { groups }: { groups: RosterPositionGroupSummary[] },
+) {
+  return (
+    <div
+      data-testid="salary-cap-position-groups"
+      className="grid grid-cols-1 gap-4 sm:grid-cols-3"
+    >
+      {groups.map((group) => (
+        <Card
+          key={group.group}
+          data-testid={`salary-cap-group-${group.group}`}
+        >
+          <CardHeader>
+            <CardTitle>{groupLabels[group.group]}</CardTitle>
+            <CardDescription>{group.headcount} players</CardDescription>
+          </CardHeader>
+          <CardContent>
+            <p className="text-2xl font-semibold">
+              {formatCurrency(group.totalCap)}
+            </p>
+          </CardContent>
+        </Card>
+      ))}
+    </div>
+  );
+}
+
+function CapStat({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="flex flex-col gap-1">
+      <dt className="text-sm text-muted-foreground">{label}</dt>
+      <dd className="text-2xl font-semibold">{value}</dd>
+    </div>
   );
 }


### PR DESCRIPTION
## Summary

- Moves the cap summary card off the Roster page onto a dedicated Salary Cap page (already linked under **Team Building** nav).
- Salary Cap page renders total/salary/space summary, position group breakdown, and a searchable player table sorted by cap hit.
- Drops the Cap Hit / Contract columns from the roster table — roster focuses on who's on the team, cap concerns live on the cap page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)