### PR TITLE
feat(schemes): add computeFingerprint pure function (ADR 0007, PR 3/6)

### DIFF
--- a/packages/shared/mod.ts
+++ b/packages/shared/mod.ts
@@ -37,6 +37,10 @@ export {
   OFFENSIVE_TENDENCY_KEYS,
 } from "./types/coach-tendencies.ts";
 export type {
+  SchemeFingerprint,
+  SchemeFingerprintOverrides,
+} from "./types/scheme-fingerprint.ts";
+export type {
   Scout,
   ScoutCareerStop,
   ScoutConnection,

--- a/packages/shared/types/scheme-fingerprint.ts
+++ b/packages/shared/types/scheme-fingerprint.ts
@@ -1,0 +1,24 @@
+import type {
+  DefensiveTendencies,
+  OffensiveTendencies,
+} from "./coach-tendencies.ts";
+
+/**
+ * HC situational overrides (aggressiveness, 4th-down lean, etc.) per
+ * ADR 0007. Reserved for a follow-up slice — v1 ships an empty
+ * record so the Fingerprint shape stays stable when overrides are
+ * introduced.
+ */
+export type SchemeFingerprintOverrides = Record<string, number>;
+
+/**
+ * The computed team-level scheme fingerprint. Per ADR 0007 this is
+ * never persisted — it is derived on read from the currently-hired
+ * coordinators. Either side can be `null` when the relevant
+ * coordinator slot is vacant or not yet populated with tendencies.
+ */
+export interface SchemeFingerprint {
+  offense: OffensiveTendencies | null;
+  defense: DefensiveTendencies | null;
+  overrides: SchemeFingerprintOverrides;
+}

--- a/server/features/schemes/fingerprint.test.ts
+++ b/server/features/schemes/fingerprint.test.ts
@@ -1,0 +1,105 @@
+import { assertEquals } from "@std/assert";
+import type {
+  CoachTendencies,
+  DefensiveTendencies,
+  OffensiveTendencies,
+} from "@zone-blitz/shared";
+import { computeFingerprint } from "./fingerprint.ts";
+
+function offenseVector(): OffensiveTendencies {
+  return {
+    runPassLean: 40,
+    tempo: 50,
+    personnelWeight: 55,
+    formationUnderCenterShotgun: 30,
+    preSnapMotionRate: 80,
+    passingStyle: 30,
+    passingDepth: 45,
+    runGameBlocking: 20,
+    rpoIntegration: 30,
+  };
+}
+
+function defenseVector(): DefensiveTendencies {
+  return {
+    frontOddEven: 60,
+    gapResponsibility: 55,
+    subPackageLean: 50,
+    coverageManZone: 70,
+    coverageShell: 65,
+    cornerPressOff: 45,
+    pressureRate: 40,
+    disguiseRate: 60,
+  };
+}
+
+function tendencyRow(
+  overrides: Partial<CoachTendencies> = {},
+): CoachTendencies {
+  return {
+    coachId: "coach-1",
+    offense: null,
+    defense: null,
+    createdAt: new Date("2026-01-01"),
+    updatedAt: new Date("2026-01-01"),
+    ...overrides,
+  };
+}
+
+Deno.test("computeFingerprint hoists OC offense and DC defense vectors", () => {
+  const oc = tendencyRow({ coachId: "oc", offense: offenseVector() });
+  const dc = tendencyRow({ coachId: "dc", defense: defenseVector() });
+  const fp = computeFingerprint({ oc, dc });
+  assertEquals(fp.offense, offenseVector());
+  assertEquals(fp.defense, defenseVector());
+  assertEquals(fp.overrides, {});
+});
+
+Deno.test(
+  "computeFingerprint returns null sides when coordinators are vacant",
+  () => {
+    const fp = computeFingerprint({ oc: null, dc: null });
+    assertEquals(fp.offense, null);
+    assertEquals(fp.defense, null);
+    assertEquals(fp.overrides, {});
+  },
+);
+
+Deno.test(
+  "computeFingerprint tolerates coordinators without tendency data",
+  () => {
+    const oc = tendencyRow({ coachId: "oc", offense: null });
+    const dc = tendencyRow({ coachId: "dc", defense: null });
+    const fp = computeFingerprint({ oc, dc });
+    assertEquals(fp.offense, null);
+    assertEquals(fp.defense, null);
+  },
+);
+
+Deno.test(
+  "computeFingerprint ignores the opposite side of each coordinator's row",
+  () => {
+    // A DC row that accidentally carries an offense vector (shouldn't
+    // happen in practice given the generator, but the function must
+    // not read across sides — OC owns offense, DC owns defense).
+    const oc = tendencyRow({ coachId: "oc", offense: offenseVector() });
+    const dc = tendencyRow({
+      coachId: "dc",
+      offense: { ...offenseVector(), tempo: 99 },
+      defense: defenseVector(),
+    });
+    const fp = computeFingerprint({ oc, dc });
+    assertEquals(fp.offense?.tempo, 50);
+    assertEquals(fp.defense, defenseVector());
+  },
+);
+
+Deno.test(
+  "computeFingerprint treats missing coordinator keys the same as null",
+  () => {
+    const fp = computeFingerprint({});
+    assertEquals(fp.offense, null);
+    assertEquals(fp.defense, null);
+    assertEquals(fp.overrides, {});
+  },
+);

--- a/server/features/schemes/fingerprint.ts
+++ b/server/features/schemes/fingerprint.ts
@@ -1,0 +1,26 @@
+import type { CoachTendencies, SchemeFingerprint } from "@zone-blitz/shared";
+
+/**
+ * Staff slice required to compute a team's scheme fingerprint.
+ * Each slot is the coordinator's tendency row — `null` when vacant
+ * or not yet populated. Per ADR 0007, v1 reads only OC and DC; HC
+ * overrides and STC tendencies land in a follow-up.
+ */
+export interface StaffTendencies {
+  oc?: CoachTendencies | null;
+  dc?: CoachTendencies | null;
+}
+
+/**
+ * Pure function: compose the per-coordinator tendency vectors into a
+ * team-level fingerprint. The fingerprint is never persisted — this
+ * runs on read, so swapping a coordinator immediately shifts what the
+ * UI and sim see (per ADR 0007's compute-on-read stance).
+ */
+export function computeFingerprint(staff: StaffTendencies): SchemeFingerprint {
+  return {
+    offense: staff.oc?.offense ?? null,
+    defense: staff.dc?.defense ?? null,
+    overrides: {},
+  };
+}

--- a/server/features/schemes/mod.ts
+++ b/server/features/schemes/mod.ts
@@ -1,0 +1,2 @@
+export { computeFingerprint } from "./fingerprint.ts";
+export type { StaffTendencies } from "./fingerprint.ts";


### PR DESCRIPTION
## Summary

Third slice of ADR 0007 — server/features/schemes/ module, introduced with its first pure function.

- `computeFingerprint(staff)` composes a team-level `SchemeFingerprint` from the currently-hired coordinators' tendency rows. Never persisted, always computed on read.
- v1 hoists the OC's offensive vector and the DC's defensive vector; HC override composition and STC tendencies land in a follow-up.
- The `SchemeFingerprint` shape reserves an `overrides` map so the follow-up can extend without a breaking change for downstream consumers (Coaches Fingerprint panel, sim integration, scouting).