### PR TITLE
feat(schemes): add computeSchemeFit with minimal archetype weights (ADR 0007, PR 4/6)

### DIFF
--- a/packages/shared/mod.ts
+++ b/packages/shared/mod.ts
@@ -40,6 +40,8 @@ export type {
   SchemeFingerprint,
   SchemeFingerprintOverrides,
 } from "./types/scheme-fingerprint.ts";
+export type { SchemeFitLabel } from "./types/scheme-fit.ts";
+export { SCHEME_FIT_LABELS } from "./types/scheme-fit.ts";
 export type {
   Scout,
   ScoutCareerStop,

--- a/packages/shared/types/scheme-fit.ts
+++ b/packages/shared/types/scheme-fit.ts
@@ -1,0 +1,14 @@
+/**
+ * Qualitative label returned by `computeSchemeFit`. Per ADR 0005 the
+ * Roster Fit indicator is only ever rendered as one of these buckets
+ * — no numeric fit score is exposed to the user.
+ */
+export type SchemeFitLabel = "ideal" | "fits" | "neutral" | "poor" | "miscast";
+
+export const SCHEME_FIT_LABELS: readonly SchemeFitLabel[] = [
+  "ideal",
+  "fits",
+  "neutral",
+  "poor",
+  "miscast",
+] as const;

--- a/server/features/schemes/archetype-weights.ts
+++ b/server/features/schemes/archetype-weights.ts
@@ -1,0 +1,217 @@
+import type {
+  DefensiveTendencies,
+  OffensiveTendencies,
+  PlayerAttributeKey,
+  PlayerPosition,
+} from "@zone-blitz/shared";
+
+/**
+ * Minimal v1 archetype-weight table per ADR 0007. Each entry says
+ * "when the fingerprint's `axis` sits toward `pole`, these player
+ * attributes become important at this position". The ADR flags the
+ * full table as multi-PR content work; this first cut covers the
+ * positions and axes with the clearest signal so the fit pipeline
+ * has something real to return. Positions not listed here fall
+ * through to `neutral`.
+ */
+
+type OffensiveAxisKey = keyof OffensiveTendencies;
+type DefensiveAxisKey = keyof DefensiveTendencies;
+
+type SpectrumAxisKey = OffensiveAxisKey | DefensiveAxisKey;
+
+export type SpectrumSide = "offense" | "defense";
+
+export type SpectrumPole = "low" | "high";
+
+export interface ArchetypeDemand {
+  side: SpectrumSide;
+  axis: SpectrumAxisKey;
+  pole: SpectrumPole;
+  attributes: readonly PlayerAttributeKey[];
+}
+
+export const POSITION_ARCHETYPE_WEIGHTS: Readonly<
+  Partial<Record<PlayerPosition, readonly ArchetypeDemand[]>>
+> = {
+  CB: [
+    {
+      side: "defense",
+      axis: "coverageManZone",
+      pole: "low",
+      attributes: ["manCoverage", "speed", "agility"],
+    },
+    {
+      side: "defense",
+      axis: "coverageManZone",
+      pole: "high",
+      attributes: ["zoneCoverage", "footballIq", "anticipation"],
+    },
+    {
+      side: "defense",
+      axis: "cornerPressOff",
+      pole: "low",
+      attributes: ["strength", "manCoverage", "jumping"],
+    },
+    {
+      side: "defense",
+      axis: "cornerPressOff",
+      pole: "high",
+      attributes: ["speed", "zoneCoverage"],
+    },
+  ],
+  S: [
+    {
+      side: "defense",
+      axis: "coverageShell",
+      pole: "low",
+      attributes: ["tackling", "runDefense", "strength"],
+    },
+    {
+      side: "defense",
+      axis: "coverageShell",
+      pole: "high",
+      attributes: ["zoneCoverage", "anticipation", "speed"],
+    },
+  ],
+  LB: [
+    {
+      side: "defense",
+      axis: "pressureRate",
+      pole: "high",
+      attributes: ["passRushing", "speed", "acceleration"],
+    },
+    {
+      side: "defense",
+      axis: "gapResponsibility",
+      pole: "low",
+      attributes: ["acceleration", "blockShedding"],
+    },
+    {
+      side: "defense",
+      axis: "gapResponsibility",
+      pole: "high",
+      attributes: ["strength", "runDefense"],
+    },
+  ],
+  DL: [
+    {
+      side: "defense",
+      axis: "frontOddEven",
+      pole: "high",
+      attributes: ["passRushing", "acceleration"],
+    },
+    {
+      side: "defense",
+      axis: "frontOddEven",
+      pole: "low",
+      attributes: ["strength", "blockShedding", "runDefense"],
+    },
+    {
+      side: "defense",
+      axis: "pressureRate",
+      pole: "high",
+      attributes: ["passRushing", "agility"],
+    },
+  ],
+  QB: [
+    {
+      side: "offense",
+      axis: "passingStyle",
+      pole: "low",
+      attributes: ["accuracyShort", "release", "anticipation"],
+    },
+    {
+      side: "offense",
+      axis: "passingStyle",
+      pole: "high",
+      attributes: ["accuracyOnTheRun", "elusiveness", "composure"],
+    },
+    {
+      side: "offense",
+      axis: "passingDepth",
+      pole: "high",
+      attributes: ["armStrength", "accuracyDeep"],
+    },
+    {
+      side: "offense",
+      axis: "passingDepth",
+      pole: "low",
+      attributes: ["accuracyShort", "accuracyMedium", "touch"],
+    },
+  ],
+  WR: [
+    {
+      side: "offense",
+      axis: "passingDepth",
+      pole: "high",
+      attributes: ["speed", "contestedCatching", "jumping"],
+    },
+    {
+      side: "offense",
+      axis: "passingDepth",
+      pole: "low",
+      attributes: ["routeRunning", "catching", "runAfterCatch"],
+    },
+    {
+      side: "offense",
+      axis: "preSnapMotionRate",
+      pole: "high",
+      attributes: ["routeRunning", "acceleration"],
+    },
+  ],
+  TE: [
+    {
+      side: "offense",
+      axis: "personnelWeight",
+      pole: "high",
+      attributes: ["runBlocking", "strength", "catching"],
+    },
+    {
+      side: "offense",
+      axis: "personnelWeight",
+      pole: "low",
+      attributes: ["routeRunning", "speed", "catching"],
+    },
+  ],
+  OL: [
+    {
+      side: "offense",
+      axis: "runGameBlocking",
+      pole: "low",
+      attributes: ["agility", "acceleration", "runBlocking"],
+    },
+    {
+      side: "offense",
+      axis: "runGameBlocking",
+      pole: "high",
+      attributes: ["strength", "runBlocking"],
+    },
+    {
+      side: "offense",
+      axis: "formationUnderCenterShotgun",
+      pole: "high",
+      attributes: ["passBlocking", "agility"],
+    },
+  ],
+  RB: [
+    {
+      side: "offense",
+      axis: "runGameBlocking",
+      pole: "low",
+      attributes: ["agility", "acceleration", "elusiveness"],
+    },
+    {
+      side: "offense",
+      axis: "runGameBlocking",
+      pole: "high",
+      attributes: ["strength", "ballCarrying"],
+    },
+    {
+      side: "offense",
+      axis: "runPassLean",
+      pole: "high",
+      attributes: ["catching", "runAfterCatch", "routeRunning"],
+    },
+  ],
+} as const;

--- a/server/features/schemes/fit.test.ts
+++ b/server/features/schemes/fit.test.ts
@@ -1,0 +1,235 @@
+import { assertEquals } from "@std/assert";
+import {
+  PLAYER_ATTRIBUTE_KEYS,
+  type PlayerAttributes,
+  type SchemeFingerprint,
+} from "@zone-blitz/shared";
+import { bucketScore, computeSchemeFit, type PlayerForFit } from "./fit.ts";
+
+function attributes(
+  overrides: Partial<PlayerAttributes> = {},
+): PlayerAttributes {
+  const base: Partial<PlayerAttributes> = {};
+  for (const key of PLAYER_ATTRIBUTE_KEYS) {
+    (base as Record<string, number>)[key] = 50;
+    (base as Record<string, number>)[`${key}Potential`] = 50;
+  }
+  return { ...base, ...overrides } as PlayerAttributes;
+}
+
+function fingerprint(
+  overrides: Partial<SchemeFingerprint> = {},
+): SchemeFingerprint {
+  return {
+    offense: null,
+    defense: null,
+    overrides: {},
+    ...overrides,
+  };
+}
+
+Deno.test("bucketScore maps the 5 bands documented in ADR 0005", () => {
+  assertEquals(bucketScore(95), "ideal");
+  assertEquals(bucketScore(85), "ideal");
+  assertEquals(bucketScore(70), "fits");
+  assertEquals(bucketScore(50), "neutral");
+  assertEquals(bucketScore(30), "poor");
+  assertEquals(bucketScore(5), "miscast");
+});
+
+Deno.test(
+  "computeSchemeFit returns neutral when the player's position has no demands defined",
+  () => {
+    const player: PlayerForFit = {
+      position: "K",
+      attributes: attributes(),
+    };
+    const fp = fingerprint({
+      defense: {
+        frontOddEven: 50,
+        gapResponsibility: 50,
+        subPackageLean: 50,
+        coverageManZone: 20,
+        coverageShell: 50,
+        cornerPressOff: 20,
+        pressureRate: 50,
+        disguiseRate: 50,
+      },
+    });
+    assertEquals(computeSchemeFit(player, fp), "neutral");
+  },
+);
+
+Deno.test(
+  "computeSchemeFit returns neutral when the fingerprint side is null",
+  () => {
+    const player: PlayerForFit = {
+      position: "CB",
+      attributes: attributes({ manCoverage: 90, speed: 90 }),
+    };
+    assertEquals(computeSchemeFit(player, fingerprint()), "neutral");
+  },
+);
+
+Deno.test(
+  "computeSchemeFit returns neutral when every axis is centered (no polarization)",
+  () => {
+    const player: PlayerForFit = {
+      position: "CB",
+      attributes: attributes({
+        manCoverage: 90,
+        zoneCoverage: 90,
+        speed: 90,
+      }),
+    };
+    const fp = fingerprint({
+      defense: {
+        frontOddEven: 50,
+        gapResponsibility: 50,
+        subPackageLean: 50,
+        coverageManZone: 50,
+        coverageShell: 50,
+        cornerPressOff: 50,
+        pressureRate: 50,
+        disguiseRate: 50,
+      },
+    });
+    assertEquals(computeSchemeFit(player, fp), "neutral");
+  },
+);
+
+Deno.test(
+  "computeSchemeFit rewards a man-coverage CB in a press-man defense",
+  () => {
+    const player: PlayerForFit = {
+      position: "CB",
+      attributes: attributes({
+        manCoverage: 95,
+        speed: 95,
+        agility: 90,
+        strength: 85,
+        jumping: 85,
+      }),
+    };
+    const fp = fingerprint({
+      defense: {
+        frontOddEven: 50,
+        gapResponsibility: 50,
+        subPackageLean: 50,
+        coverageManZone: 5, // strongly man
+        coverageShell: 50,
+        cornerPressOff: 5, // strongly press
+        pressureRate: 50,
+        disguiseRate: 50,
+      },
+    });
+    const label = computeSchemeFit(player, fp);
+    assertEquals(label === "ideal" || label === "fits", true);
+  },
+);
+
+Deno.test(
+  "computeSchemeFit flags a zone-only CB dropped into a heavy man scheme as poor/miscast",
+  () => {
+    const player: PlayerForFit = {
+      position: "CB",
+      attributes: attributes({
+        manCoverage: 20,
+        speed: 25,
+        agility: 25,
+        strength: 30,
+        zoneCoverage: 95,
+        footballIq: 95,
+        anticipation: 95,
+      }),
+    };
+    const fp = fingerprint({
+      defense: {
+        frontOddEven: 50,
+        gapResponsibility: 50,
+        subPackageLean: 50,
+        coverageManZone: 5,
+        coverageShell: 50,
+        cornerPressOff: 5,
+        pressureRate: 50,
+        disguiseRate: 50,
+      },
+    });
+    const label = computeSchemeFit(player, fp);
+    assertEquals(
+      label === "poor" || label === "miscast",
+      true,
+      `expected poor/miscast, got ${label}`,
+    );
+  },
+);
+
+Deno.test(
+  "computeSchemeFit swings from poor to ideal for the same player when the scheme flips",
+  () => {
+    const zoneCB: PlayerForFit = {
+      position: "CB",
+      attributes: attributes({
+        zoneCoverage: 95,
+        footballIq: 95,
+        anticipation: 95,
+        speed: 95,
+        manCoverage: 20,
+        agility: 40,
+        strength: 40,
+      }),
+    };
+    const manScheme = fingerprint({
+      defense: {
+        frontOddEven: 50,
+        gapResponsibility: 50,
+        subPackageLean: 50,
+        coverageManZone: 5,
+        coverageShell: 50,
+        cornerPressOff: 5,
+        pressureRate: 50,
+        disguiseRate: 50,
+      },
+    });
+    const zoneScheme = fingerprint({
+      defense: {
+        frontOddEven: 50,
+        gapResponsibility: 50,
+        subPackageLean: 50,
+        coverageManZone: 95,
+        coverageShell: 50,
+        cornerPressOff: 95,
+        pressureRate: 50,
+        disguiseRate: 50,
+      },
+    });
+    const inMan = computeSchemeFit(zoneCB, manScheme);
+    const inZone = computeSchemeFit(zoneCB, zoneScheme);
+    // Reassignment of the same player through a different scheme
+    // must move the label — the premise of the whole compute-on-read
+    // design.
+    assertEquals(inMan === inZone, false);
+  },
+);
+
+Deno.test("computeSchemeFit ignores the wrong-side tendency vector", () => {
+  // An offensive fingerprint should not impact a CB fit label.
+  const player: PlayerForFit = {
+    position: "CB",
+    attributes: attributes({ manCoverage: 99, speed: 99 }),
+  };
+  const fp = fingerprint({
+    offense: {
+      runPassLean: 5,
+      tempo: 5,
+      personnelWeight: 5,
+      formationUnderCenterShotgun: 5,
+      preSnapMotionRate: 5,
+      passingStyle: 5,
+      passingDepth: 5,
+      runGameBlocking: 5,
+      rpoIntegration: 5,
+    },
+  });
+  assertEquals(computeSchemeFit(player, fp), "neutral");
+});

--- a/server/features/schemes/fit.ts
+++ b/server/features/schemes/fit.ts
@@ -1,0 +1,96 @@
+import type {
+  PlayerAttributes,
+  PlayerPosition,
+  SchemeFingerprint,
+  SchemeFitLabel,
+} from "@zone-blitz/shared";
+import {
+  type ArchetypeDemand,
+  POSITION_ARCHETYPE_WEIGHTS,
+  type SpectrumPole,
+} from "./archetype-weights.ts";
+
+/**
+ * The minimum slice of a player required to compute fit. Accepts the
+ * full `PlayerAttributes` block but only reads the keys referenced by
+ * the position's archetype weights — unrelated attributes do not
+ * influence the result.
+ */
+export interface PlayerForFit {
+  position: PlayerPosition;
+  attributes: PlayerAttributes;
+}
+
+const LABEL_BUCKETS: { min: number; label: SchemeFitLabel }[] = [
+  { min: 85, label: "ideal" },
+  { min: 65, label: "fits" },
+  { min: 40, label: "neutral" },
+  { min: 20, label: "poor" },
+  { min: 0, label: "miscast" },
+];
+
+/**
+ * Map a 0–100 weighted-attribute score to the qualitative bucket the
+ * UI is allowed to show (per ADR 0005 — no numeric fit is leaked).
+ */
+export function bucketScore(score: number): SchemeFitLabel {
+  for (const bucket of LABEL_BUCKETS) {
+    if (score >= bucket.min) return bucket.label;
+  }
+  return "miscast";
+}
+
+function demandStrength(
+  axisValue: number | undefined,
+  pole: SpectrumPole,
+): number {
+  if (axisValue === undefined) return 0;
+  const lowStrength = Math.max(0, (50 - axisValue) / 50);
+  const highStrength = Math.max(0, (axisValue - 50) / 50);
+  return pole === "low" ? lowStrength : highStrength;
+}
+
+function axisValueFor(
+  demand: ArchetypeDemand,
+  fingerprint: SchemeFingerprint,
+): number | undefined {
+  const side = demand.side === "offense"
+    ? fingerprint.offense
+    : fingerprint.defense;
+  if (!side) return undefined;
+  return (side as unknown as Record<string, number>)[demand.axis];
+}
+
+/**
+ * Pure function: compute a qualitative fit label for a player against
+ * a team's scheme fingerprint. Returns `'neutral'` when the position
+ * has no archetype demands defined (v1 scope) or when the fingerprint
+ * has no polarized axes at this position. Never exposes a numeric
+ * score per ADR 0005.
+ */
+export function computeSchemeFit(
+  player: PlayerForFit,
+  fingerprint: SchemeFingerprint,
+): SchemeFitLabel {
+  const demands = POSITION_ARCHETYPE_WEIGHTS[player.position];
+  if (!demands || demands.length === 0) return "neutral";
+
+  let totalWeight = 0;
+  let totalContribution = 0;
+
+  for (const demand of demands) {
+    const axisValue = axisValueFor(demand, fingerprint);
+    const strength = demandStrength(axisValue, demand.pole);
+    if (strength === 0) continue;
+    for (const attr of demand.attributes) {
+      const value = player.attributes[attr] ?? 0;
+      totalContribution += strength * value;
+      totalWeight += strength * 100;
+    }
+  }
+
+  if (totalWeight === 0) return "neutral";
+
+  const score = (totalContribution / totalWeight) * 100;
+  return bucketScore(score);
+}

--- a/server/features/schemes/mod.ts
+++ b/server/features/schemes/mod.ts
@@ -1,2 +1,10 @@
 export { computeFingerprint } from "./fingerprint.ts";
 export type { StaffTendencies } from "./fingerprint.ts";
+export { bucketScore, computeSchemeFit } from "./fit.ts";
+export type { PlayerForFit } from "./fit.ts";
+export { POSITION_ARCHETYPE_WEIGHTS } from "./archetype-weights.ts";
+export type {
+  ArchetypeDemand,
+  SpectrumPole,
+  SpectrumSide,
+} from "./archetype-weights.ts";


### PR DESCRIPTION
## Summary

Fourth slice of ADR 0007 — the pure fit function the Roster Fit indicator will read.

- `computeSchemeFit(player, fingerprint)` returns the qualitative ADR 0005 label: `ideal` / `fits` / `neutral` / `poor` / `miscast`. No numeric fit score is ever exposed.
- Initial `POSITION_ARCHETYPE_WEIGHTS` covers CB, S, LB, DL, QB, WR, TE, OL, and RB against the axes where the signal is clearest. Positions without a weight table, or schemes with no polarized axes at the player's position, short-circuit to `neutral` rather than inventing signal.
- The ADR flags the full mapping as multi-PR content work; this PR lands the pipeline so subsequent iterations plug into a working surface without reshaping the API.

No UI or route wiring yet — follow-up PRs surface the label on the Roster page and the Fingerprint panel on the Coaches page.