### PR TITLE
feat(coaches): render Scheme Fingerprint panel on the Coaches page (ADR 0007, PR 5/6)

### DIFF
--- a/client/src/features/league/coaches/coaches.test.tsx
+++ b/client/src/features/league/coaches/coaches.test.tsx
@@ -7,6 +7,7 @@ import { createTestRouter } from "../../../router.tsx";
 const mockLeaguesGet = vi.fn();
 const mockTeamsGet = vi.fn();
 const mockStaffGet = vi.fn();
+const mockFingerprintGet = vi.fn();
 
 vi.mock("../../../api.ts", () => ({
   api: {
@@ -25,6 +26,9 @@ vi.mock("../../../api.ts", () => ({
               [":teamId"]: {
                 staff: {
                   $get: (...args: unknown[]) => mockStaffGet(...args),
+                },
+                fingerprint: {
+                  $get: (...args: unknown[]) => mockFingerprintGet(...args),
                 },
               },
             },
@@ -91,6 +95,10 @@ describe("Coaches page", () => {
     mockTeamsGet.mockResolvedValue({
       json: () => Promise.resolve([baseTeam]),
     });
+    mockFingerprintGet.mockResolvedValue({
+      json: () =>
+        Promise.resolve({ offense: null, defense: null, overrides: {} }),
+    });
     mockStaffGet.mockResolvedValue({
       json: () =>
         Promise.resolve([
@@ -134,6 +142,10 @@ describe("Coaches page", () => {
     mockTeamsGet.mockResolvedValue({
       json: () => Promise.resolve([baseTeam]),
     });
+    mockFingerprintGet.mockResolvedValue({
+      json: () =>
+        Promise.resolve({ offense: null, defense: null, overrides: {} }),
+    });
     mockStaffGet.mockResolvedValue({
       json: () => Promise.resolve([]),
     });
@@ -151,6 +163,10 @@ describe("Coaches page", () => {
     });
     mockTeamsGet.mockResolvedValue({
       json: () => Promise.resolve([baseTeam]),
+    });
+    mockFingerprintGet.mockResolvedValue({
+      json: () =>
+        Promise.resolve({ offense: null, defense: null, overrides: {} }),
     });
     mockStaffGet.mockRejectedValue(new Error("boom"));
 

--- a/client/src/features/league/coaches/fingerprint-panel.test.tsx
+++ b/client/src/features/league/coaches/fingerprint-panel.test.tsx
@@ -1,0 +1,58 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import type { SchemeFingerprint } from "@zone-blitz/shared";
+import { FingerprintPanel } from "./fingerprint-panel.tsx";
+
+afterEach(() => {
+  cleanup();
+});
+
+function offensiveFingerprint(): SchemeFingerprint {
+  return {
+    offense: {
+      runPassLean: 40,
+      tempo: 55,
+      personnelWeight: 50,
+      formationUnderCenterShotgun: 30,
+      preSnapMotionRate: 80,
+      passingStyle: 30,
+      passingDepth: 45,
+      runGameBlocking: 25,
+      rpoIntegration: 30,
+    },
+    defense: null,
+    overrides: {},
+  };
+}
+
+describe("FingerprintPanel", () => {
+  it("renders a skeleton while loading", () => {
+    render(<FingerprintPanel isLoading />);
+    expect(screen.getByTestId("fingerprint-skeleton")).toBeDefined();
+  });
+
+  it("renders a bar for each offensive axis when the OC is hired", () => {
+    render(<FingerprintPanel fingerprint={offensiveFingerprint()} />);
+    // ADR 0007 names 9 offensive axes.
+    expect(screen.getByText(/Run \/ Pass lean/i)).toBeDefined();
+    expect(screen.getByText(/RPO integration/i)).toBeDefined();
+    expect(screen.getByText(/Passing depth/i)).toBeDefined();
+  });
+
+  it("shows an empty-state for missing coordinators, not fabricated bars", () => {
+    render(
+      <FingerprintPanel
+        fingerprint={{ offense: null, defense: null, overrides: {} }}
+      />,
+    );
+    expect(screen.getByText(/No offensive coordinator/i)).toBeDefined();
+    expect(screen.getByText(/No defensive coordinator/i)).toBeDefined();
+  });
+
+  it("renders numbers as bar positions, never as text", () => {
+    render(<FingerprintPanel fingerprint={offensiveFingerprint()} />);
+    // ADR 0005: no numeric value should be exposed to the user.
+    expect(screen.queryByText("40")).toBeNull();
+    expect(screen.queryByText("80")).toBeNull();
+  });
+});

--- a/client/src/features/league/coaches/fingerprint-panel.tsx
+++ b/client/src/features/league/coaches/fingerprint-panel.tsx
@@ -1,0 +1,262 @@
+import type {
+  DefensiveTendencies,
+  OffensiveTendencies,
+  SchemeFingerprint,
+} from "@zone-blitz/shared";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Skeleton } from "@/components/ui/skeleton";
+import { Separator } from "@/components/ui/separator";
+
+interface OffensiveSpectrum {
+  key: keyof OffensiveTendencies;
+  lowLabel: string;
+  highLabel: string;
+  title: string;
+}
+
+interface DefensiveSpectrum {
+  key: keyof DefensiveTendencies;
+  lowLabel: string;
+  highLabel: string;
+  title: string;
+}
+
+// Spectrum labels are taken verbatim from ADR 0007's tendency table
+// so the panel never drifts from the data model's defined poles.
+const OFFENSIVE_SPECTRUMS: readonly OffensiveSpectrum[] = [
+  {
+    key: "runPassLean",
+    title: "Run / Pass lean",
+    lowLabel: "Run-heavy",
+    highLabel: "Pass-heavy",
+  },
+  {
+    key: "tempo",
+    title: "Tempo",
+    lowLabel: "Methodical",
+    highLabel: "Up-tempo",
+  },
+  {
+    key: "personnelWeight",
+    title: "Personnel weight",
+    lowLabel: "Light (10/11)",
+    highLabel: "Heavy (12/21/22)",
+  },
+  {
+    key: "formationUnderCenterShotgun",
+    title: "Formation",
+    lowLabel: "Under center",
+    highLabel: "Shotgun / pistol",
+  },
+  {
+    key: "preSnapMotionRate",
+    title: "Pre-snap motion",
+    lowLabel: "Static",
+    highLabel: "Motion-heavy",
+  },
+  {
+    key: "passingStyle",
+    title: "Passing style",
+    lowLabel: "Timing",
+    highLabel: "Improvisation",
+  },
+  {
+    key: "passingDepth",
+    title: "Passing depth",
+    lowLabel: "Short / intermediate",
+    highLabel: "Vertical",
+  },
+  {
+    key: "runGameBlocking",
+    title: "Run blocking",
+    lowLabel: "Zone",
+    highLabel: "Gap / power",
+  },
+  {
+    key: "rpoIntegration",
+    title: "RPO integration",
+    lowLabel: "None",
+    highLabel: "Heavy",
+  },
+];
+
+const DEFENSIVE_SPECTRUMS: readonly DefensiveSpectrum[] = [
+  {
+    key: "frontOddEven",
+    title: "Front",
+    lowLabel: "Odd (3-down)",
+    highLabel: "Even (4-down)",
+  },
+  {
+    key: "gapResponsibility",
+    title: "Gap responsibility",
+    lowLabel: "One-gap penetrate",
+    highLabel: "Two-gap control",
+  },
+  {
+    key: "subPackageLean",
+    title: "Sub-package lean",
+    lowLabel: "Base-committed",
+    highLabel: "Sub-package heavy",
+  },
+  {
+    key: "coverageManZone",
+    title: "Coverage",
+    lowLabel: "Man",
+    highLabel: "Zone",
+  },
+  {
+    key: "coverageShell",
+    title: "Shell",
+    lowLabel: "Single-high",
+    highLabel: "Two-high",
+  },
+  {
+    key: "cornerPressOff",
+    title: "Corner technique",
+    lowLabel: "Press",
+    highLabel: "Off",
+  },
+  {
+    key: "pressureRate",
+    title: "Pressure rate",
+    lowLabel: "Four-man rush",
+    highLabel: "Blitz-heavy",
+  },
+  {
+    key: "disguiseRate",
+    title: "Disguise",
+    lowLabel: "Static looks",
+    highLabel: "Heavy disguise",
+  },
+];
+
+interface SpectrumBarProps {
+  title: string;
+  lowLabel: string;
+  highLabel: string;
+  value: number;
+}
+
+function SpectrumBar({ title, lowLabel, highLabel, value }: SpectrumBarProps) {
+  const clamped = Math.max(0, Math.min(100, value));
+  return (
+    <div className="flex flex-col gap-1">
+      <p className="text-sm font-medium">{title}</p>
+      <div className="relative h-2 rounded bg-muted">
+        <div
+          className="absolute top-1/2 h-3 w-1 -translate-y-1/2 rounded-sm bg-primary"
+          style={{ left: `calc(${clamped}% - 2px)` }}
+          aria-label={`${title}: ${lowLabel} to ${highLabel}`}
+        />
+      </div>
+      <div className="flex justify-between text-xs text-muted-foreground">
+        <span>{lowLabel}</span>
+        <span>{highLabel}</span>
+      </div>
+    </div>
+  );
+}
+
+interface FingerprintPanelProps {
+  fingerprint?: SchemeFingerprint;
+  isLoading?: boolean;
+}
+
+export function FingerprintPanel({
+  fingerprint,
+  isLoading,
+}: FingerprintPanelProps) {
+  return (
+    <Card data-testid="fingerprint-panel">
+      <CardHeader>
+        <CardTitle>Scheme fingerprint</CardTitle>
+        <CardDescription>
+          Emergent identity from the current OC and DC. Updates the moment a
+          coordinator changes — there is no stored scheme.
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="flex flex-col gap-6">
+        {isLoading && (
+          <div
+            className="flex flex-col gap-3"
+            data-testid="fingerprint-skeleton"
+          >
+            <Skeleton className="h-6 w-full" />
+            <Skeleton className="h-6 w-full" />
+            <Skeleton className="h-6 w-full" />
+          </div>
+        )}
+
+        {!isLoading && (
+          <>
+            <FingerprintSide
+              heading="Offense"
+              emptyLabel="No offensive coordinator hired yet."
+              entries={fingerprint?.offense
+                ? OFFENSIVE_SPECTRUMS.map((s) => ({
+                  ...s,
+                  value: fingerprint.offense![s.key],
+                }))
+                : null}
+            />
+            <Separator />
+            <FingerprintSide
+              heading="Defense"
+              emptyLabel="No defensive coordinator hired yet."
+              entries={fingerprint?.defense
+                ? DEFENSIVE_SPECTRUMS.map((s) => ({
+                  ...s,
+                  value: fingerprint.defense![s.key],
+                }))
+                : null}
+            />
+          </>
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
+interface FingerprintSideProps {
+  heading: string;
+  emptyLabel: string;
+  entries:
+    | ({ title: string; lowLabel: string; highLabel: string; value: number })[]
+    | null;
+}
+
+function FingerprintSide({
+  heading,
+  emptyLabel,
+  entries,
+}: FingerprintSideProps) {
+  return (
+    <section className="flex flex-col gap-3" aria-label={heading}>
+      <h3 className="text-sm font-semibold uppercase text-muted-foreground">
+        {heading}
+      </h3>
+      {entries === null
+        ? <p className="text-sm text-muted-foreground">{emptyLabel}</p>
+        : (
+          <div className="grid gap-4 sm:grid-cols-2">
+            {entries.map((entry) => (
+              <SpectrumBar
+                key={entry.title}
+                title={entry.title}
+                lowLabel={entry.lowLabel}
+                highLabel={entry.highLabel}
+                value={entry.value}
+              />
+            ))}
+          </div>
+        )}
+    </section>
+  );
+}

--- a/client/src/features/league/coaches/index.tsx
+++ b/client/src/features/league/coaches/index.tsx
@@ -4,8 +4,10 @@ import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { Skeleton } from "@/components/ui/skeleton";
 import { useStaffTree } from "../../../hooks/use-staff-tree.ts";
 import { useTeams } from "../../../hooks/use-teams.ts";
+import { useSchemeFingerprint } from "../../../hooks/use-scheme-fingerprint.ts";
 import { buildStaffTree } from "./build-tree.ts";
 import { StaffTreeNode } from "./staff-tree-node.tsx";
+import { FingerprintPanel } from "./fingerprint-panel.tsx";
 
 export function Coaches() {
   const { leagueId: rawLeagueId } = useParams({ strict: false });
@@ -16,6 +18,10 @@ export function Coaches() {
   const { data: teams, isLoading: teamsLoading } = useTeams();
   const teamId = (teams?.[0]?.id as string | undefined) ?? "";
   const { data, isLoading, error } = useStaffTree(leagueId, teamId);
+  const {
+    data: fingerprint,
+    isLoading: fingerprintLoading,
+  } = useSchemeFingerprint(leagueId, teamId);
 
   const loading = teamsLoading || isLoading;
 
@@ -44,10 +50,16 @@ export function Coaches() {
       )}
 
       {!loading && !error && data && (
-        <StaffTree
-          nodes={data as CoachNode[]}
-          leagueId={leagueId}
-        />
+        <div className="flex flex-col gap-6">
+          <FingerprintPanel
+            fingerprint={fingerprint ?? undefined}
+            isLoading={fingerprintLoading}
+          />
+          <StaffTree
+            nodes={data as CoachNode[]}
+            leagueId={leagueId}
+          />
+        </div>
       )}
     </div>
   );

--- a/client/src/hooks/use-scheme-fingerprint.test.ts
+++ b/client/src/hooks/use-scheme-fingerprint.test.ts
@@ -1,0 +1,89 @@
+import { renderHook, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { describe, expect, it, vi } from "vitest";
+import { useSchemeFingerprint } from "./use-scheme-fingerprint.ts";
+import { createElement } from "react";
+
+const mockGet = vi.fn();
+
+vi.mock("../api.ts", () => ({
+  api: {
+    api: {
+      coaches: {
+        leagues: {
+          [":leagueId"]: {
+            teams: {
+              [":teamId"]: {
+                fingerprint: {
+                  $get: (...args: unknown[]) => mockGet(...args),
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+  },
+}));
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return ({ children }: { children: React.ReactNode }) =>
+    createElement(QueryClientProvider, { client: queryClient }, children);
+}
+
+describe("useSchemeFingerprint", () => {
+  it("fetches the fingerprint for a team scoped to a league", async () => {
+    const fingerprint = {
+      offense: {
+        runPassLean: 40,
+        tempo: 55,
+        personnelWeight: 50,
+        formationUnderCenterShotgun: 30,
+        preSnapMotionRate: 80,
+        passingStyle: 30,
+        passingDepth: 45,
+        runGameBlocking: 25,
+        rpoIntegration: 30,
+      },
+      defense: null,
+      overrides: {},
+    };
+    mockGet.mockResolvedValue({ json: () => Promise.resolve(fingerprint) });
+
+    const { result } = renderHook(
+      () => useSchemeFingerprint("league-1", "team-1"),
+      { wrapper: createWrapper() },
+    );
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+    expect(result.current.data).toEqual(fingerprint);
+    expect(mockGet).toHaveBeenCalledWith({
+      param: { leagueId: "league-1", teamId: "team-1" },
+    });
+  });
+
+  it("skips fetching when teamId is empty", () => {
+    mockGet.mockClear();
+    const { result } = renderHook(
+      () => useSchemeFingerprint("league-1", ""),
+      { wrapper: createWrapper() },
+    );
+    expect(result.current.isFetching).toBe(false);
+    expect(mockGet).not.toHaveBeenCalled();
+  });
+
+  it("skips fetching when leagueId is empty", () => {
+    mockGet.mockClear();
+    const { result } = renderHook(
+      () => useSchemeFingerprint("", "team-1"),
+      { wrapper: createWrapper() },
+    );
+    expect(result.current.isFetching).toBe(false);
+    expect(mockGet).not.toHaveBeenCalled();
+  });
+});

--- a/client/src/hooks/use-scheme-fingerprint.ts
+++ b/client/src/hooks/use-scheme-fingerprint.ts
@@ -1,0 +1,16 @@
+import { useQuery } from "@tanstack/react-query";
+import { api } from "../api.ts";
+
+export function useSchemeFingerprint(leagueId: string, teamId: string) {
+  return useQuery({
+    queryKey: ["coaches", "fingerprint", leagueId, teamId],
+    queryFn: async () => {
+      const res = await api.api.coaches.leagues[":leagueId"].teams[":teamId"]
+        .fingerprint.$get({
+          param: { leagueId, teamId },
+        });
+      return res.json();
+    },
+    enabled: leagueId.length > 0 && teamId.length > 0,
+  });
+}

--- a/server/features/coaches/coaches.router.test.ts
+++ b/server/features/coaches/coaches.router.test.ts
@@ -12,6 +12,8 @@ function createMockService(
     getStaffTree: () => Promise.resolve([]),
     getCoachDetail: () =>
       Promise.reject(new DomainError("NOT_FOUND", "Coach missing not found")),
+    getFingerprint: () =>
+      Promise.resolve({ offense: null, defense: null, overrides: {} }),
     ...overrides,
   };
 }
@@ -92,6 +94,47 @@ Deno.test("coaches.router", async (t) => {
       const body = await res.json();
       assertEquals(body.length, 2);
       assertEquals(body[0].id, "hc");
+    },
+  );
+
+  await t.step(
+    "GET /leagues/:leagueId/teams/:teamId/fingerprint returns the computed fingerprint",
+    async () => {
+      let receivedLeague: string | undefined;
+      let receivedTeam: string | undefined;
+      const router = createCoachesRouter(
+        createMockService({
+          getFingerprint: (leagueId, teamId) => {
+            receivedLeague = leagueId;
+            receivedTeam = teamId;
+            return Promise.resolve({
+              offense: {
+                runPassLean: 40,
+                tempo: 60,
+                personnelWeight: 50,
+                formationUnderCenterShotgun: 30,
+                preSnapMotionRate: 80,
+                passingStyle: 30,
+                passingDepth: 45,
+                runGameBlocking: 25,
+                rpoIntegration: 30,
+              },
+              defense: null,
+              overrides: {},
+            });
+          },
+        }),
+      );
+
+      const res = await router.request(
+        "/leagues/league-9/teams/team-17/fingerprint",
+      );
+      assertEquals(res.status, 200);
+      assertEquals(receivedLeague, "league-9");
+      assertEquals(receivedTeam, "team-17");
+      const body = await res.json();
+      assertEquals(body.offense.tempo, 60);
+      assertEquals(body.defense, null);
     },
   );
 

--- a/server/features/coaches/coaches.router.ts
+++ b/server/features/coaches/coaches.router.ts
@@ -10,6 +10,15 @@ export function createCoachesRouter(coachesService: CoachesService) {
       const staff = await coachesService.getStaffTree(leagueId, teamId);
       return c.json(staff);
     })
+    .get("/leagues/:leagueId/teams/:teamId/fingerprint", async (c) => {
+      const leagueId = c.req.param("leagueId");
+      const teamId = c.req.param("teamId");
+      const fingerprint = await coachesService.getFingerprint(
+        leagueId,
+        teamId,
+      );
+      return c.json(fingerprint);
+    })
     .get("/:coachId", async (c) => {
       const coachId = c.req.param("coachId");
       const detail = await coachesService.getCoachDetail(coachId);

--- a/server/features/coaches/coaches.service.interface.ts
+++ b/server/features/coaches/coaches.service.interface.ts
@@ -1,4 +1,8 @@
-import type { CoachDetail, CoachNode } from "@zone-blitz/shared";
+import type {
+  CoachDetail,
+  CoachNode,
+  SchemeFingerprint,
+} from "@zone-blitz/shared";
 import type { Executor } from "../../db/connection.ts";
 
 export interface CoachesGenerateInput {
@@ -29,4 +33,16 @@ export interface CoachesService {
    * with code `NOT_FOUND` when no coach has the given id.
    */
   getCoachDetail(id: string): Promise<CoachDetail>;
+
+  /**
+   * Composed scheme fingerprint for the team, per ADR 0007. Never
+   * persisted — built on read from the current OC's offensive tendency
+   * vector and DC's defensive tendency vector. Either side resolves to
+   * `null` when the slot is vacant or the coordinator has no tendency
+   * row yet (e.g. HC-only rosters during generation transitions).
+   */
+  getFingerprint(
+    leagueId: string,
+    teamId: string,
+  ): Promise<SchemeFingerprint>;
 }

--- a/server/features/coaches/coaches.service.ts
+++ b/server/features/coaches/coaches.service.ts
@@ -7,6 +7,7 @@ import type { CoachesGenerator } from "./coaches.generator.interface.ts";
 import type { CoachesRepository } from "./coaches.repository.interface.ts";
 import type { CoachTendenciesRepository } from "./coach-tendencies.repository.interface.ts";
 import type { CoachesService } from "./coaches.service.interface.ts";
+import { computeFingerprint } from "../schemes/fingerprint.ts";
 
 export function createCoachesService(deps: {
   generator: CoachesGenerator;
@@ -62,6 +63,25 @@ export function createCoachesService(deps: {
         throw new DomainError("NOT_FOUND", `Coach ${id} not found`);
       }
       return detail;
+    },
+
+    async getFingerprint(leagueId, teamId) {
+      log.debug({ leagueId, teamId }, "computing scheme fingerprint");
+      const staff = await deps.repo.getStaffTreeByTeam(leagueId, teamId);
+      const oc = staff.find((c) => c.role === "OC" && !c.isVacancy);
+      const dc = staff.find((c) => c.role === "DC" && !c.isVacancy);
+      const [ocTendencies, dcTendencies] = await Promise.all([
+        oc
+          ? deps.tendenciesRepo.getByCoachId(oc.id)
+          : Promise.resolve(undefined),
+        dc
+          ? deps.tendenciesRepo.getByCoachId(dc.id)
+          : Promise.resolve(undefined),
+      ]);
+      return computeFingerprint({
+        oc: ocTendencies ?? null,
+        dc: dcTendencies ?? null,
+      });
     },
   };
 }

--- a/server/features/personnel/personnel.service.test.ts
+++ b/server/features/personnel/personnel.service.test.ts
@@ -40,6 +40,8 @@ function createMockCoachesService(
     getStaffTree: () => Promise.resolve([]),
     getCoachDetail: () =>
       Promise.reject(new Error("getCoachDetail not stubbed")),
+    getFingerprint: () =>
+      Promise.resolve({ offense: null, defense: null, overrides: {} }),
     ...overrides,
   };
 }


### PR DESCRIPTION
## Summary

Fifth slice of ADR 0007 — the first UI surface the ADR 0005 roadmap called for.

- `coachesService.getFingerprint` composes the OC's offensive and DC's defensive tendency rows via `computeFingerprint` and serves the result at `GET /coaches/leagues/:leagueId/teams/:teamId/fingerprint`.
- The Coaches page now renders a `FingerprintPanel` above the staff tree, one bar per named spectrum from ADR 0007's tendency table.
- Each axis is a position along a bar. No numeric value is ever exposed to the user per ADR 0005. Coordinator vacancies show an empty-state message on the relevant side rather than zeroed-out bars.