### PR TITLE
feat(roster): surface qualitative scheme fit per player

### DIFF
--- a/client/src/features/league/opponents/detail.test.tsx
+++ b/client/src/features/league/opponents/detail.test.tsx
@@ -67,6 +67,7 @@ const roster = {
       capHit: 45_000_000,
       contractYearsRemaining: 3,
       injuryStatus: "healthy",
+      schemeFit: null,
     },
     {
       id: "p2",
@@ -78,6 +79,7 @@ const roster = {
       capHit: 8_000_000,
       contractYearsRemaining: 4,
       injuryStatus: "out",
+      schemeFit: null,
     },
     {
       id: "p3",
@@ -89,6 +91,7 @@ const roster = {
       capHit: 12_000_000,
       contractYearsRemaining: 2,
       injuryStatus: "questionable",
+      schemeFit: null,
     },
   ],
   positionGroups: [

--- a/client/src/features/league/roster.test.tsx
+++ b/client/src/features/league/roster.test.tsx
@@ -55,6 +55,7 @@ const baseRoster = {
       capHit: 45_000_000,
       contractYearsRemaining: 3,
       injuryStatus: "healthy",
+      schemeFit: "ideal",
     },
     {
       id: "p2",
@@ -66,6 +67,7 @@ const baseRoster = {
       capHit: 12_000_000,
       contractYearsRemaining: 2,
       injuryStatus: "questionable",
+      schemeFit: "miscast",
     },
     {
       id: "p3",
@@ -77,6 +79,7 @@ const baseRoster = {
       capHit: 8_000_000,
       contractYearsRemaining: 4,
       injuryStatus: "out",
+      schemeFit: "fits",
     },
     {
       id: "p4",
@@ -88,6 +91,7 @@ const baseRoster = {
       capHit: 3_000_000,
       contractYearsRemaining: 1,
       injuryStatus: "healthy",
+      schemeFit: null,
     },
   ],
   positionGroups: [
@@ -266,6 +270,20 @@ describe("Roster — active roster tab (default)", () => {
     expect(within(row).getByText("Offense")).toBeDefined();
     expect(within(row).getByText("28")).toBeDefined();
     expect(within(row).getByText(/healthy/i)).toBeDefined();
+  });
+
+  it("renders scheme fit as a qualitative badge (ADR 0005)", () => {
+    renderRoster();
+    expect(screen.getByTestId("roster-scheme-fit-p1").textContent).toMatch(
+      /ideal fit/i,
+    );
+    expect(screen.getByTestId("roster-scheme-fit-p2").textContent).toMatch(
+      /miscast/i,
+    );
+    expect(screen.getByTestId("roster-scheme-fit-p3").textContent).toMatch(
+      /^fits$/i,
+    );
+    expect(screen.getByTestId("roster-scheme-fit-p4").textContent).toBe("—");
   });
 
   it("does not render cap hit or contract columns (moved to Salary Cap page)", () => {

--- a/client/src/features/league/roster.tsx
+++ b/client/src/features/league/roster.tsx
@@ -28,6 +28,7 @@ import type {
   RosterPlayer,
 } from "@zone-blitz/shared/types/roster.ts";
 import type { PlayerInjuryStatus } from "@zone-blitz/shared/types/player.ts";
+import type { SchemeFitLabel } from "@zone-blitz/shared";
 import { useLeague } from "../../hooks/use-league.ts";
 import { useActiveRoster } from "../../hooks/use-active-roster.ts";
 import { useDepthChart } from "../../hooks/use-depth-chart.ts";
@@ -60,6 +61,23 @@ function injuryBadgeVariant(
 
 function formatInjury(status: PlayerInjuryStatus) {
   return status.replace(/_/g, " ");
+}
+
+const schemeFitLabels: Record<SchemeFitLabel, string> = {
+  ideal: "Ideal fit",
+  fits: "Fits",
+  neutral: "Neutral",
+  poor: "Poor fit",
+  miscast: "Miscast",
+};
+
+function schemeFitBadgeVariant(
+  label: SchemeFitLabel,
+): "secondary" | "destructive" | "outline" | "default" {
+  if (label === "ideal") return "default";
+  if (label === "fits") return "secondary";
+  if (label === "miscast" || label === "poor") return "destructive";
+  return "outline";
 }
 
 function ordinal(n: number): string {
@@ -121,6 +139,33 @@ const rosterColumns: ColumnDef<RosterPlayer>[] = [
         Age
       </SortableHeader>
     ),
+  },
+  {
+    accessorKey: "schemeFit",
+    header: ({ column }) => (
+      <SortableHeader column={column}>Scheme Fit</SortableHeader>
+    ),
+    cell: ({ row }) => {
+      const fit = row.original.schemeFit;
+      if (fit === null) {
+        return (
+          <span
+            className="text-muted-foreground"
+            data-testid={`roster-scheme-fit-${row.original.id}`}
+          >
+            —
+          </span>
+        );
+      }
+      return (
+        <Badge
+          variant={schemeFitBadgeVariant(fit)}
+          data-testid={`roster-scheme-fit-${row.original.id}`}
+        >
+          {schemeFitLabels[fit]}
+        </Badge>
+      );
+    },
   },
   {
     accessorKey: "injuryStatus",

--- a/client/src/features/league/salary-cap.test.tsx
+++ b/client/src/features/league/salary-cap.test.tsx
@@ -39,6 +39,7 @@ const baseRoster = {
       capHit: 45_000_000,
       contractYearsRemaining: 3,
       injuryStatus: "healthy",
+      schemeFit: null,
     },
     {
       id: "p2",
@@ -50,6 +51,7 @@ const baseRoster = {
       capHit: 12_000_000,
       contractYearsRemaining: 2,
       injuryStatus: "questionable",
+      schemeFit: null,
     },
     {
       id: "p3",
@@ -61,6 +63,7 @@ const baseRoster = {
       capHit: 8_000_000,
       contractYearsRemaining: 4,
       injuryStatus: "out",
+      schemeFit: null,
     },
     {
       id: "p4",
@@ -72,6 +75,7 @@ const baseRoster = {
       capHit: 3_000_000,
       contractYearsRemaining: 1,
       injuryStatus: "healthy",
+      schemeFit: null,
     },
   ],
   positionGroups: [

--- a/packages/shared/types/roster.ts
+++ b/packages/shared/types/roster.ts
@@ -1,6 +1,7 @@
 import type { NeutralBucket } from "../archetypes/neutral-bucket.ts";
 import type { CoachSummary } from "./coach.ts";
 import type { DepthChartSlotCode, PlayerInjuryStatus } from "./player.ts";
+import type { SchemeFitLabel } from "./scheme-fit.ts";
 
 export type NeutralBucketGroup = "offense" | "defense" | "special_teams";
 
@@ -32,6 +33,10 @@ export interface RosterPlayer {
   capHit: number;
   contractYearsRemaining: number;
   injuryStatus: PlayerInjuryStatus;
+  // Qualitative fit of this player against the team's current scheme
+  // fingerprint (ADR 0005). `null` when the team has no OC and no DC
+  // hired — nothing to fit against yet.
+  schemeFit: SchemeFitLabel | null;
 }
 
 export interface RosterPositionGroupSummary {

--- a/server/features/roster/roster.repository.test.ts
+++ b/server/features/roster/roster.repository.test.ts
@@ -18,6 +18,7 @@ import {
   stubAttributesFor,
 } from "../players/stub-players-generator.ts";
 import { coaches } from "../coaches/coach.schema.ts";
+import { coachTendencies } from "../coaches/coach-tendencies.schema.ts";
 import { leagues } from "../league/league.schema.ts";
 import { teams } from "../team/team.schema.ts";
 import { cities } from "../cities/city.schema.ts";
@@ -221,6 +222,10 @@ Deno.test({
       assertEquals(idl?.neutralBucketGroup, "defense");
       assertEquals(idl?.injuryStatus, "questionable");
 
+      // No coaches hired → no scheme to fit against → null per ADR 0005.
+      assertEquals(qb?.schemeFit, null);
+      assertEquals(idl?.schemeFit, null);
+
       const offense = roster.positionGroups.find((g) => g.group === "offense");
       assertEquals(offense?.headcount, 1);
       assertEquals(offense?.totalCap, 10_000_000);
@@ -230,6 +235,106 @@ Deno.test({
       const st = roster.positionGroups.find((g) => g.group === "special_teams");
       assertEquals(st?.headcount, 0);
     } finally {
+      await cleanup(db, {
+        players: playersCreated,
+        teams: teamsCreated,
+        cities: citiesCreated,
+        states: statesCreated,
+        leagues: leaguesCreated,
+      });
+      await client.end();
+    }
+  },
+});
+
+Deno.test({
+  name:
+    "rosterRepository.getActiveRoster: surfaces a qualitative schemeFit once a DC is hired with tendencies",
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    const { db, client } = createTestDb();
+    const repo = createRosterRepository({
+      db,
+      log: createTestLogger(),
+      now: () => new Date("2030-06-15T00:00:00Z"),
+    });
+    const playersCreated: string[] = [];
+    const teamsCreated: string[] = [];
+    const leaguesCreated: string[] = [];
+    const citiesCreated: string[] = [];
+    const statesCreated: string[] = [];
+    const coachesCreated: string[] = [];
+
+    try {
+      const { league, team, state, city } = await setupFixtures(db);
+      leaguesCreated.push(league.id);
+      teamsCreated.push(team.id);
+      citiesCreated.push(city.id);
+      statesCreated.push(state.id);
+
+      const cbId = crypto.randomUUID();
+      await db.insert(players).values({
+        id: cbId,
+        leagueId: league.id,
+        teamId: team.id,
+        firstName: "Corey",
+        lastName: "Corner",
+        injuryStatus: "healthy",
+        ...sizeFor("CB"),
+        birthDate: "2000-01-01",
+      });
+      playersCreated.push(cbId);
+      await db.insert(playerAttributes).values({
+        playerId: cbId,
+        ...stubAttributeColumns("CB"),
+      });
+
+      const dcId = crypto.randomUUID();
+      await db.insert(coaches).values({
+        id: dcId,
+        leagueId: league.id,
+        teamId: team.id,
+        firstName: "Deanna",
+        lastName: "Coordinator",
+        role: "DC",
+        age: 48,
+        hiredAt: new Date("2028-01-01T00:00:00Z"),
+        contractYears: 3,
+        contractSalary: 1,
+        contractBuyout: 1,
+      });
+      coachesCreated.push(dcId);
+
+      // Full press-man / man-coverage tilt so CB archetype weights have
+      // polarized axes to score against.
+      await db.insert(coachTendencies).values({
+        coachId: dcId,
+        frontOddEven: 50,
+        gapResponsibility: 50,
+        subPackageLean: 50,
+        coverageManZone: 10,
+        coverageShell: 50,
+        cornerPressOff: 10,
+        pressureRate: 50,
+        disguiseRate: 50,
+      });
+
+      const roster = await repo.getActiveRoster(league.id, team.id);
+      const cb = roster.players.find((p) => p.id === cbId);
+      assertEquals(cb?.neutralBucket, "CB");
+      // Hired DC + polarized axes → fit must be a qualitative label, not null.
+      if (cb?.schemeFit === null || cb?.schemeFit === undefined) {
+        throw new Error("expected non-null schemeFit once a DC is hired");
+      }
+      assertEquals(
+        ["ideal", "fits", "neutral", "poor", "miscast"].includes(cb.schemeFit),
+        true,
+      );
+    } finally {
+      if (coachesCreated.length) {
+        await db.delete(coaches).where(inArray(coaches.id, coachesCreated));
+      }
       await cleanup(db, {
         players: playersCreated,
         teams: teamsCreated,

--- a/server/features/roster/roster.repository.ts
+++ b/server/features/roster/roster.repository.ts
@@ -1,16 +1,22 @@
-import { and, desc, eq } from "drizzle-orm";
+import { and, desc, eq, inArray } from "drizzle-orm";
 import type pino from "pino";
 import {
+  type CoachTendencies,
+  DEFENSIVE_TENDENCY_KEYS,
+  type DefensiveTendencies,
   type DepthChartInactive,
   type DepthChartSlot,
   DomainError,
   neutralBucket,
   type NeutralBucketGroup,
   neutralBucketGroupOf,
+  OFFENSIVE_TENDENCY_KEYS,
+  type OffensiveTendencies,
   type PlayerAttributes,
   type RosterPlayer,
   type RosterPositionGroupSummary,
   type RosterStatistics,
+  type SchemeFitLabel,
 } from "@zone-blitz/shared";
 import type { Database } from "../../db/connection.ts";
 import { players } from "../players/player.schema.ts";
@@ -23,7 +29,35 @@ import { contracts } from "../contracts/contract.schema.ts";
 import { depthChartEntries } from "../players/depth-chart.schema.ts";
 import { leagues } from "../league/league.schema.ts";
 import { coaches } from "../coaches/coach.schema.ts";
+import { coachTendencies } from "../coaches/coach-tendencies.schema.ts";
+import { computeFingerprint, computeSchemeFit } from "../schemes/mod.ts";
 import type { RosterRepository } from "./roster.repository.interface.ts";
+
+type TendencyRow = typeof coachTendencies.$inferSelect;
+
+function pickOffense(row: TendencyRow): OffensiveTendencies | null {
+  if (OFFENSIVE_TENDENCY_KEYS.every((k) => row[k] === null)) return null;
+  const out = {} as OffensiveTendencies;
+  for (const k of OFFENSIVE_TENDENCY_KEYS) out[k] = (row[k] ?? 0) as number;
+  return out;
+}
+
+function pickDefense(row: TendencyRow): DefensiveTendencies | null {
+  if (DEFENSIVE_TENDENCY_KEYS.every((k) => row[k] === null)) return null;
+  const out = {} as DefensiveTendencies;
+  for (const k of DEFENSIVE_TENDENCY_KEYS) out[k] = (row[k] ?? 0) as number;
+  return out;
+}
+
+function toCoachTendencies(row: TendencyRow): CoachTendencies {
+  return {
+    coachId: row.coachId,
+    offense: pickOffense(row),
+    defense: pickDefense(row),
+    createdAt: row.createdAt,
+    updatedAt: row.updatedAt,
+  };
+}
 
 function ageFromBirthDate(birthDate: string, today: Date): number {
   const birth = new Date(birthDate);
@@ -103,6 +137,37 @@ export function createRosterRepository(deps: {
           and(eq(players.leagueId, leagueId), eq(players.teamId, teamId)),
         );
 
+      const coordinatorRows = await deps.db
+        .select({
+          role: coaches.role,
+          tendencyRow: coachTendencies,
+        })
+        .from(coaches)
+        .innerJoin(
+          coachTendencies,
+          eq(coachTendencies.coachId, coaches.id),
+        )
+        .where(
+          and(
+            eq(coaches.teamId, teamId),
+            inArray(coaches.role, ["OC", "DC"]),
+          ),
+        );
+
+      let ocTendencies: CoachTendencies | null = null;
+      let dcTendencies: CoachTendencies | null = null;
+      for (const row of coordinatorRows) {
+        if (!row.tendencyRow) continue;
+        const tendencies = toCoachTendencies(row.tendencyRow);
+        if (row.role === "OC") ocTendencies = tendencies;
+        if (row.role === "DC") dcTendencies = tendencies;
+      }
+      const fingerprint = computeFingerprint({
+        oc: ocTendencies,
+        dc: dcTendencies,
+      });
+      const hasStaff = ocTendencies !== null || dcTendencies !== null;
+
       const today = now();
       const rosterPlayers: RosterPlayer[] = rows.map((row) => {
         const attributes: PlayerAttributes = pickAttributes(
@@ -113,6 +178,12 @@ export function createRosterRepository(deps: {
           heightInches: row.heightInches,
           weightPounds: row.weightPounds,
         });
+        const schemeFit: SchemeFitLabel | null = hasStaff
+          ? computeSchemeFit(
+            { neutralBucket: bucket, attributes },
+            fingerprint,
+          )
+          : null;
         return {
           id: row.id,
           firstName: row.firstName,
@@ -126,6 +197,7 @@ export function createRosterRepository(deps: {
             ? Math.max(0, row.totalYears - row.currentYear + 1)
             : 0,
           injuryStatus: row.injuryStatus,
+          schemeFit,
         };
       });
 

--- a/server/features/roster/roster.router.test.ts
+++ b/server/features/roster/roster.router.test.ts
@@ -62,6 +62,7 @@ Deno.test("roster.router", async (t) => {
                   capHit: 10_000_000,
                   contractYearsRemaining: 3,
                   injuryStatus: "healthy",
+                  schemeFit: null,
                 },
               ],
               positionGroups: [


### PR DESCRIPTION
## Summary

- Wires #145's `computeSchemeFit` into the active-roster read path: `roster.repository` now pulls the team's OC + DC `coach_tendencies` rows, composes a `SchemeFingerprint` via `computeFingerprint`, and classifies each rostered player's `{ neutralBucket, attributes }` into a qualitative `SchemeFitLabel`. When no OC and no DC are hired, `schemeFit` is `null` so the UI renders a dash rather than asserting a misleading "neutral" — this closes the loop between ADR 0005 (Scheme Fit indicator) and ADR 0006 (positionless classification).
- `RosterPlayer` gains `schemeFit: SchemeFitLabel | null`; the Roster page renders it as a shadcn badge (ideal / fits / neutral / poor / miscast) with per-row test ids. No numeric score is exposed (ADR 0005). Salary cap and opponent roster fixtures get the same field so their existing columns keep rendering; adding the column on those surfaces is a small follow-up.
- Full suite green: 173 server + 30 packages + 256 client. New integration test exercises the non-null path with a hired DC + polarized coverage-man-zone / corner-press-off tendencies so the CB archetype weights have real axes to score against.