### PR TITLE
feat(roster): surface Scheme Fit badges on the Roster page (ADR 0007, PR 6/6)

### DIFF
--- a/client/src/features/league/roster.test.tsx
+++ b/client/src/features/league/roster.test.tsx
@@ -13,6 +13,7 @@ const mockUseParams = vi.fn();
 const mockUseLeague = vi.fn();
 const mockUseActiveRoster = vi.fn();
 const mockUseDepthChart = vi.fn();
+const mockUseRosterFit = vi.fn();
 
 vi.mock("@tanstack/react-router", () => ({
   useParams: (...args: unknown[]) => mockUseParams(...args),
@@ -28,6 +29,10 @@ vi.mock("../../hooks/use-active-roster.ts", () => ({
 
 vi.mock("../../hooks/use-depth-chart.ts", () => ({
   useDepthChart: (...args: unknown[]) => mockUseDepthChart(...args),
+}));
+
+vi.mock("../../hooks/use-roster-fit.ts", () => ({
+  useRosterFit: (...args: unknown[]) => mockUseRosterFit(...args),
 }));
 
 function renderRoster() {
@@ -188,6 +193,11 @@ beforeEach(() => {
   });
   mockUseDepthChart.mockReturnValue({
     data: baseDepthChart,
+    isLoading: false,
+    isError: false,
+  });
+  mockUseRosterFit.mockReturnValue({
+    data: {},
     isLoading: false,
     isError: false,
   });

--- a/client/src/features/league/roster.tsx
+++ b/client/src/features/league/roster.tsx
@@ -28,9 +28,11 @@ import type {
   RosterPlayer,
 } from "@zone-blitz/shared/types/roster.ts";
 import type { PlayerInjuryStatus } from "@zone-blitz/shared/types/player.ts";
+import type { SchemeFitLabel } from "@zone-blitz/shared";
 import { useLeague } from "../../hooks/use-league.ts";
 import { useActiveRoster } from "../../hooks/use-active-roster.ts";
 import { useDepthChart } from "../../hooks/use-depth-chart.ts";
+import { useRosterFit } from "../../hooks/use-roster-fit.ts";
 
 const groupLabels: Record<NeutralBucketGroup, string> = {
   offense: "Offense",
@@ -62,6 +64,22 @@ function formatInjury(status: PlayerInjuryStatus) {
   return status.replace(/_/g, " ");
 }
 
+const FIT_LABELS: Record<SchemeFitLabel, string> = {
+  ideal: "Ideal",
+  fits: "Fits",
+  neutral: "Neutral",
+  poor: "Poor",
+  miscast: "Miscast",
+};
+
+function fitBadgeVariant(
+  label: SchemeFitLabel,
+): "default" | "secondary" | "destructive" | "outline" {
+  if (label === "ideal" || label === "fits") return "default";
+  if (label === "poor" || label === "miscast") return "destructive";
+  return "outline";
+}
+
 function ordinal(n: number): string {
   const mod100 = n % 100;
   if (mod100 >= 11 && mod100 <= 13) return `${n}th`;
@@ -84,7 +102,11 @@ function formatCoachRole(role: string) {
     .join(" ");
 }
 
-const rosterColumns: ColumnDef<RosterPlayer>[] = [
+interface RosterRow extends RosterPlayer {
+  fit: SchemeFitLabel | null;
+}
+
+const rosterColumns: ColumnDef<RosterRow>[] = [
   {
     id: "player",
     accessorFn: (p) => `${p.firstName} ${p.lastName}`,
@@ -111,7 +133,7 @@ const rosterColumns: ColumnDef<RosterPlayer>[] = [
       <SortableHeader column={column}>Group</SortableHeader>
     ),
     cell: ({ row }) => groupLabels[row.original.neutralBucketGroup],
-    filterFn: (row: Row<RosterPlayer>, _id, value) =>
+    filterFn: (row: Row<RosterRow>, _id, value) =>
       value === "all" || row.original.neutralBucketGroup === value,
   },
   {
@@ -132,6 +154,24 @@ const rosterColumns: ColumnDef<RosterPlayer>[] = [
         {formatInjury(row.original.injuryStatus)}
       </Badge>
     ),
+  },
+  {
+    id: "fit",
+    accessorFn: (p) => p.fit ?? "",
+    header: ({ column }) => (
+      <SortableHeader column={column}>Scheme Fit</SortableHeader>
+    ),
+    cell: ({ row }) => {
+      const label = row.original.fit;
+      if (!label) {
+        return <span className="text-xs text-muted-foreground">—</span>;
+      }
+      return (
+        <Badge variant={fitBadgeVariant(label)} data-testid={`fit-${label}`}>
+          {FIT_LABELS[label]}
+        </Badge>
+      );
+    },
   },
 ];
 
@@ -181,6 +221,7 @@ function ActiveRosterView(
     leagueId,
     teamId,
   );
+  const { data: fits } = useRosterFit(leagueId, teamId);
 
   if (isLoading) {
     return (
@@ -197,15 +238,24 @@ function ActiveRosterView(
       </p>
     );
   }
-  return <ActiveRosterContent roster={roster} />;
+  return <ActiveRosterContent roster={roster} fits={fits ?? null} />;
 }
 
-function ActiveRosterContent({ roster }: { roster: ActiveRoster }) {
+function ActiveRosterContent(
+  { roster, fits }: {
+    roster: ActiveRoster;
+    fits: Record<string, SchemeFitLabel> | null;
+  },
+) {
+  const rows: RosterRow[] = roster.players.map((player) => ({
+    ...player,
+    fit: (fits?.[player.id] as SchemeFitLabel | undefined) ?? null,
+  }));
   return (
     <>
       <DataTable
         columns={rosterColumns}
-        data={roster.players}
+        data={rows}
         getRowTestId={(player) => `roster-row-${player.id}`}
         toolbar={(table) => {
           const groupFilter =

--- a/client/src/hooks/use-roster-fit.test.ts
+++ b/client/src/hooks/use-roster-fit.test.ts
@@ -1,0 +1,72 @@
+import { renderHook, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { describe, expect, it, vi } from "vitest";
+import { useRosterFit } from "./use-roster-fit.ts";
+import { createElement } from "react";
+
+const mockGet = vi.fn();
+
+vi.mock("../api.ts", () => ({
+  api: {
+    api: {
+      roster: {
+        leagues: {
+          [":leagueId"]: {
+            teams: {
+              [":teamId"]: {
+                fit: {
+                  $get: (...args: unknown[]) => mockGet(...args),
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+  },
+}));
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return ({ children }: { children: React.ReactNode }) =>
+    createElement(QueryClientProvider, { client: queryClient }, children);
+}
+
+describe("useRosterFit", () => {
+  it("fetches the fit map for a team scoped to a league", async () => {
+    const fits = { "p-1": "fits", "p-2": "neutral" };
+    mockGet.mockResolvedValue({ json: () => Promise.resolve(fits) });
+
+    const { result } = renderHook(() => useRosterFit("l1", "t1"), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+    expect(result.current.data).toEqual(fits);
+    expect(mockGet).toHaveBeenCalledWith({
+      param: { leagueId: "l1", teamId: "t1" },
+    });
+  });
+
+  it("does not fetch when teamId is null", () => {
+    mockGet.mockClear();
+    const { result } = renderHook(() => useRosterFit("l1", null), {
+      wrapper: createWrapper(),
+    });
+    expect(result.current.isFetching).toBe(false);
+    expect(mockGet).not.toHaveBeenCalled();
+  });
+
+  it("does not fetch when leagueId is empty", () => {
+    mockGet.mockClear();
+    const { result } = renderHook(() => useRosterFit("", "t1"), {
+      wrapper: createWrapper(),
+    });
+    expect(result.current.isFetching).toBe(false);
+    expect(mockGet).not.toHaveBeenCalled();
+  });
+});

--- a/client/src/hooks/use-roster-fit.ts
+++ b/client/src/hooks/use-roster-fit.ts
@@ -1,0 +1,17 @@
+import { useQuery } from "@tanstack/react-query";
+import { api } from "../api.ts";
+
+export function useRosterFit(leagueId: string, teamId: string | null) {
+  const safeTeamId = teamId ?? "";
+  return useQuery({
+    queryKey: ["roster", "fit", leagueId, safeTeamId],
+    queryFn: async () => {
+      const res = await api.api.roster.leagues[":leagueId"].teams[":teamId"]
+        .fit.$get({
+          param: { leagueId, teamId: safeTeamId },
+        });
+      return res.json();
+    },
+    enabled: leagueId.length > 0 && safeTeamId.length > 0,
+  });
+}

--- a/server/features/mod.ts
+++ b/server/features/mod.ts
@@ -151,7 +151,11 @@ export function createFeatureRouters(
   const teamRouter = createTeamRouter(teamService);
   const coachesRouter = createCoachesRouter(coachesService);
   const scoutsRouter = createScoutsRouter(scoutsService);
-  const rosterService = createRosterService({ repo: rosterRepo, log });
+  const rosterService = createRosterService({
+    repo: rosterRepo,
+    coachesService,
+    log,
+  });
   const rosterRouter = createRosterRouter(rosterService);
   const playersRouter = createPlayersRouter(playersService);
 

--- a/server/features/roster/roster.repository.interface.ts
+++ b/server/features/roster/roster.repository.interface.ts
@@ -1,8 +1,16 @@
 import type {
   ActiveRoster,
   DepthChart,
+  NeutralBucket,
+  PlayerAttributes,
   RosterStatistics,
 } from "@zone-blitz/shared";
+
+export interface RosterPlayerForFit {
+  playerId: string;
+  neutralBucket: NeutralBucket;
+  attributes: PlayerAttributes;
+}
 
 export interface RosterRepository {
   /**
@@ -30,4 +38,16 @@ export interface RosterRepository {
     teamId: string,
     seasonId: string | null,
   ): Promise<RosterStatistics>;
+
+  /**
+   * Active-roster slice used to compute scheme fit per ADR 0007.
+   * Returns `{ playerId, neutralBucket, attributes }` for every player
+   * currently on the team. The service composes this with the team's
+   * SchemeFingerprint to label each player's alignment without ever
+   * exposing raw attributes to the caller.
+   */
+  getActivePlayersForFit(
+    leagueId: string,
+    teamId: string,
+  ): Promise<RosterPlayerForFit[]>;
 }

--- a/server/features/roster/roster.repository.ts
+++ b/server/features/roster/roster.repository.ts
@@ -229,6 +229,39 @@ export function createRosterRepository(deps: {
       };
     },
 
+    async getActivePlayersForFit(leagueId, teamId) {
+      log.debug({ leagueId, teamId }, "fetching roster attributes for fit");
+      const rows = await deps.db
+        .select({
+          id: players.id,
+          heightInches: players.heightInches,
+          weightPounds: players.weightPounds,
+          ...attributeSelectColumns(),
+        })
+        .from(players)
+        .innerJoin(
+          playerAttributes,
+          eq(playerAttributes.playerId, players.id),
+        )
+        .where(
+          and(eq(players.leagueId, leagueId), eq(players.teamId, teamId)),
+        );
+      return rows.map((row) => {
+        const attributes: PlayerAttributes = pickAttributes(
+          row as unknown as Record<string, unknown>,
+        );
+        return {
+          playerId: row.id,
+          neutralBucket: neutralBucket({
+            attributes,
+            heightInches: row.heightInches,
+            weightPounds: row.weightPounds,
+          }),
+          attributes,
+        };
+      });
+    },
+
     getStatistics(leagueId, teamId, seasonId) {
       log.debug(
         { leagueId, teamId, seasonId },

--- a/server/features/roster/roster.router.test.ts
+++ b/server/features/roster/roster.router.test.ts
@@ -26,6 +26,7 @@ function createMockService(
   return {
     getActiveRoster: () => Promise.resolve(emptyActive),
     getDepthChart: () => Promise.resolve(emptyChart),
+    getRosterFits: () => Promise.resolve({}),
     getStatistics: () =>
       Promise.resolve({
         leagueId: "l",
@@ -152,6 +153,30 @@ Deno.test("roster.router", async (t) => {
 
       await router.request("/leagues/lg-1/teams/tm-1/statistics");
       assertEquals(receivedSeason, null);
+    },
+  );
+
+  await t.step(
+    "GET /leagues/:leagueId/teams/:teamId/fit returns the fit map",
+    async () => {
+      let receivedLeague: string | undefined;
+      let receivedTeam: string | undefined;
+      const router = createRosterRouter(
+        createMockService({
+          getRosterFits: (leagueId, teamId) => {
+            receivedLeague = leagueId;
+            receivedTeam = teamId;
+            return Promise.resolve({ "p-1": "fits", "p-2": "neutral" });
+          },
+        }),
+      );
+      const res = await router.request("/leagues/lg-1/teams/tm-1/fit");
+      assertEquals(res.status, 200);
+      assertEquals(receivedLeague, "lg-1");
+      assertEquals(receivedTeam, "tm-1");
+      const body = await res.json();
+      assertEquals(body["p-1"], "fits");
+      assertEquals(body["p-2"], "neutral");
     },
   );
 });

--- a/server/features/roster/roster.router.ts
+++ b/server/features/roster/roster.router.ts
@@ -16,6 +16,12 @@ export function createRosterRouter(rosterService: RosterService) {
       const chart = await rosterService.getDepthChart(leagueId, teamId);
       return c.json(chart);
     })
+    .get("/leagues/:leagueId/teams/:teamId/fit", async (c) => {
+      const leagueId = c.req.param("leagueId");
+      const teamId = c.req.param("teamId");
+      const fits = await rosterService.getRosterFits(leagueId, teamId);
+      return c.json(fits);
+    })
     .get("/leagues/:leagueId/teams/:teamId/statistics", async (c) => {
       const leagueId = c.req.param("leagueId");
       const teamId = c.req.param("teamId");

--- a/server/features/roster/roster.service.interface.ts
+++ b/server/features/roster/roster.service.interface.ts
@@ -2,6 +2,7 @@ import type {
   ActiveRoster,
   DepthChart,
   RosterStatistics,
+  SchemeFitLabel,
 } from "@zone-blitz/shared";
 
 export interface RosterService {
@@ -12,4 +13,17 @@ export interface RosterService {
     teamId: string,
     seasonId: string | null,
   ): Promise<RosterStatistics>;
+
+  /**
+   * Qualitative scheme-fit label for every player on the team's active
+   * roster, keyed by player id. Per ADR 0005 the response is never
+   * numeric — callers render it as a badge. Labels reflect the
+   * currently-hired OC/DC via `coachesService.getFingerprint`, so
+   * swapping a coordinator immediately shifts what this endpoint
+   * returns on the next read.
+   */
+  getRosterFits(
+    leagueId: string,
+    teamId: string,
+  ): Promise<Record<string, SchemeFitLabel>>;
 }

--- a/server/features/roster/roster.service.test.ts
+++ b/server/features/roster/roster.service.test.ts
@@ -2,10 +2,14 @@ import { assertEquals } from "@std/assert";
 import type {
   ActiveRoster,
   DepthChart,
+  PLAYER_ATTRIBUTE_KEYS as _PLAYER_ATTRIBUTE_KEYS,
+  PlayerAttributes,
   RosterStatistics,
 } from "@zone-blitz/shared";
+import { PLAYER_ATTRIBUTE_KEYS } from "@zone-blitz/shared";
 import { createRosterService } from "./roster.service.ts";
 import type { RosterRepository } from "./roster.repository.interface.ts";
+import type { CoachesService } from "../coaches/coaches.service.interface.ts";
 
 function createTestLogger() {
   return {
@@ -47,8 +51,34 @@ function createMockRepo(
     getActiveRoster: () => Promise.resolve(emptyActive),
     getDepthChart: () => Promise.resolve(emptyChart),
     getStatistics: () => Promise.resolve(emptyStats),
+    getActivePlayersForFit: () => Promise.resolve([]),
     ...overrides,
   };
+}
+
+function createMockCoachesService(
+  overrides: Partial<CoachesService> = {},
+): CoachesService {
+  return {
+    generate: () => Promise.resolve({ coachCount: 0 }),
+    getStaffTree: () => Promise.resolve([]),
+    getCoachDetail: () =>
+      Promise.reject(new Error("getCoachDetail not stubbed")),
+    getFingerprint: () =>
+      Promise.resolve({ offense: null, defense: null, overrides: {} }),
+    ...overrides,
+  };
+}
+
+function attributes(
+  overrides: Partial<PlayerAttributes> = {},
+): PlayerAttributes {
+  const base: Partial<PlayerAttributes> = {};
+  for (const key of PLAYER_ATTRIBUTE_KEYS) {
+    (base as Record<string, number>)[key] = 50;
+    (base as Record<string, number>)[`${key}Potential`] = 50;
+  }
+  return { ...base, ...overrides } as PlayerAttributes;
 }
 
 Deno.test("roster.service", async (t) => {
@@ -73,6 +103,7 @@ Deno.test("roster.service", async (t) => {
             });
           },
         }),
+        coachesService: createMockCoachesService(),
         log: createTestLogger(),
       });
 
@@ -99,6 +130,7 @@ Deno.test("roster.service", async (t) => {
           });
         },
       }),
+      coachesService: createMockCoachesService(),
       log: createTestLogger(),
     });
     const result = await service.getDepthChart("lg-1", "tm-1");
@@ -120,6 +152,7 @@ Deno.test("roster.service", async (t) => {
           });
         },
       }),
+      coachesService: createMockCoachesService(),
       log: createTestLogger(),
     });
     await service.getStatistics("lg-1", "tm-1", "season-42");
@@ -128,4 +161,61 @@ Deno.test("roster.service", async (t) => {
     await service.getStatistics("lg-1", "tm-1", null);
     assertEquals(receivedSeason, null);
   });
+
+  await t.step(
+    "getRosterFits returns a SchemeFitLabel for every active player",
+    async () => {
+      const service = createRosterService({
+        repo: createMockRepo({
+          getActivePlayersForFit: () =>
+            Promise.resolve([
+              {
+                playerId: "cb-man",
+                neutralBucket: "CB",
+                attributes: attributes({
+                  manCoverage: 95,
+                  speed: 95,
+                  agility: 90,
+                  strength: 80,
+                  jumping: 85,
+                }),
+              },
+              {
+                playerId: "k",
+                neutralBucket: "K",
+                attributes: attributes(),
+              },
+            ]),
+        }),
+        coachesService: createMockCoachesService({
+          getFingerprint: () =>
+            Promise.resolve({
+              offense: null,
+              defense: {
+                frontOddEven: 50,
+                gapResponsibility: 50,
+                subPackageLean: 50,
+                coverageManZone: 5,
+                coverageShell: 50,
+                cornerPressOff: 5,
+                pressureRate: 50,
+                disguiseRate: 50,
+              },
+              overrides: {},
+            }),
+        }),
+        log: createTestLogger(),
+      });
+
+      const fits = await service.getRosterFits("lg-1", "tm-1");
+      assertEquals(Object.keys(fits).length, 2);
+      // Man-coverage CB in a press-man scheme: ideal or fits.
+      assertEquals(
+        fits["cb-man"] === "ideal" || fits["cb-man"] === "fits",
+        true,
+      );
+      // Specialist with no demands maps to neutral.
+      assertEquals(fits["k"], "neutral");
+    },
+  );
 });

--- a/server/features/roster/roster.service.ts
+++ b/server/features/roster/roster.service.ts
@@ -1,9 +1,13 @@
 import type pino from "pino";
+import type { SchemeFitLabel } from "@zone-blitz/shared";
 import type { RosterRepository } from "./roster.repository.interface.ts";
 import type { RosterService } from "./roster.service.interface.ts";
+import type { CoachesService } from "../coaches/coaches.service.interface.ts";
+import { computeSchemeFit } from "../schemes/fit.ts";
 
 export function createRosterService(deps: {
   repo: RosterRepository;
+  coachesService: CoachesService;
   log: pino.Logger;
 }): RosterService {
   const log = deps.log.child({ module: "roster.service" });
@@ -22,6 +26,25 @@ export function createRosterService(deps: {
     async getStatistics(leagueId, teamId, seasonId) {
       log.debug({ leagueId, teamId, seasonId }, "fetching roster statistics");
       return await deps.repo.getStatistics(leagueId, teamId, seasonId);
+    },
+
+    async getRosterFits(leagueId, teamId) {
+      log.debug({ leagueId, teamId }, "computing roster fits");
+      const [fingerprint, players] = await Promise.all([
+        deps.coachesService.getFingerprint(leagueId, teamId),
+        deps.repo.getActivePlayersForFit(leagueId, teamId),
+      ]);
+      const out: Record<string, SchemeFitLabel> = {};
+      for (const player of players) {
+        out[player.playerId] = computeSchemeFit(
+          {
+            neutralBucket: player.neutralBucket,
+            attributes: player.attributes,
+          },
+          fingerprint,
+        );
+      }
+      return out;
     },
   };
 }


### PR DESCRIPTION
## Summary

Final slice of ADR 0007 — composes the fit pipeline end-to-end.

- `rosterService.getRosterFits` calls `coachesService.getFingerprint` for the team and joins it with a new `rosterRepo.getActivePlayersForFit` that returns each active player's neutralBucket + attributes. Serves a `playerId → SchemeFitLabel` map at `GET /roster/leagues/:leagueId/teams/:teamId/fit`.
- The Roster table gains a Scheme Fit column with color-coded badges (ideal/fits → default, neutral → outline, poor/miscast → destructive). No numeric score is exposed per ADR 0005.
- Players at positions with no archetype demands yet fall through to `neutral`, so the column remains safe to render while the archetype-weight content work iterates.