### PR TITLE
feat(ui): add Scheme Fit badge to salary-cap and opponent-roster tables

### DIFF
--- a/client/src/components/ui/scheme-fit-badge.tsx
+++ b/client/src/components/ui/scheme-fit-badge.tsx
@@ -1,0 +1,36 @@
+import type { SchemeFitLabel } from "@zone-blitz/shared";
+import { Badge } from "./badge.tsx";
+
+const schemeFitLabels: Record<SchemeFitLabel, string> = {
+  ideal: "Ideal fit",
+  fits: "Fits",
+  neutral: "Neutral",
+  poor: "Poor fit",
+  miscast: "Miscast",
+};
+
+function schemeFitBadgeVariant(
+  label: SchemeFitLabel,
+): "secondary" | "destructive" | "outline" | "default" {
+  if (label === "ideal") return "default";
+  if (label === "fits") return "secondary";
+  if (label === "miscast" || label === "poor") return "destructive";
+  return "outline";
+}
+
+export function SchemeFitBadge(
+  { fit, testId }: { fit: SchemeFitLabel | null; testId: string },
+) {
+  if (fit === null) {
+    return (
+      <span className="text-muted-foreground" data-testid={testId}>
+        —
+      </span>
+    );
+  }
+  return (
+    <Badge variant={schemeFitBadgeVariant(fit)} data-testid={testId}>
+      {schemeFitLabels[fit]}
+    </Badge>
+  );
+}

--- a/client/src/features/league/opponents/detail.test.tsx
+++ b/client/src/features/league/opponents/detail.test.tsx
@@ -67,7 +67,7 @@ const roster = {
       capHit: 45_000_000,
       contractYearsRemaining: 3,
       injuryStatus: "healthy",
-      schemeFit: null,
+      schemeFit: "fits",
     },
     {
       id: "p2",
@@ -91,7 +91,7 @@ const roster = {
       capHit: 12_000_000,
       contractYearsRemaining: 2,
       injuryStatus: "questionable",
-      schemeFit: null,
+      schemeFit: "miscast",
     },
   ],
   positionGroups: [
@@ -194,6 +194,22 @@ describe("OpponentRoster — page", () => {
     renderDetail();
     fireEvent.click(screen.getByRole("tab", { name: /statistics/i }));
     expect(screen.getByTestId("opponent-statistics-placeholder")).toBeDefined();
+  });
+
+  it("renders a scheme fit badge when the player has a fit value", () => {
+    renderDetail();
+    const row = screen.getByTestId("opponent-row-p1");
+    expect(
+      within(row).getByTestId("opponent-scheme-fit-p1").textContent,
+    ).toBe("Fits");
+  });
+
+  it("renders a dash for scheme fit when the value is null", () => {
+    renderDetail();
+    const row = screen.getByTestId("opponent-row-p2");
+    expect(
+      within(row).getByTestId("opponent-scheme-fit-p2").textContent,
+    ).toBe("—");
   });
 
   it("shows an error state when the roster fails to load", () => {

--- a/client/src/features/league/opponents/detail.tsx
+++ b/client/src/features/league/opponents/detail.tsx
@@ -13,6 +13,7 @@ import { Input } from "@/components/ui/input";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { DataTable, SortableHeader } from "@/components/ui/data-table";
+import { SchemeFitBadge } from "@/components/ui/scheme-fit-badge";
 import type {
   ActiveRoster,
   NeutralBucketGroup,
@@ -97,6 +98,18 @@ function createRosterColumns(leagueId: string): ColumnDef<RosterPlayer>[] {
       accessorKey: "age",
       header: ({ column }) => (
         <SortableHeader column={column}>Age</SortableHeader>
+      ),
+    },
+    {
+      accessorKey: "schemeFit",
+      header: ({ column }) => (
+        <SortableHeader column={column}>Scheme Fit</SortableHeader>
+      ),
+      cell: ({ row }) => (
+        <SchemeFitBadge
+          fit={row.original.schemeFit}
+          testId={`opponent-scheme-fit-${row.original.id}`}
+        />
       ),
     },
     {

--- a/client/src/features/league/roster.tsx
+++ b/client/src/features/league/roster.tsx
@@ -8,6 +8,7 @@ import {
   CardTitle,
 } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
+import { SchemeFitBadge } from "@/components/ui/scheme-fit-badge";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Skeleton } from "@/components/ui/skeleton";
@@ -28,7 +29,6 @@ import type {
   RosterPlayer,
 } from "@zone-blitz/shared/types/roster.ts";
 import type { PlayerInjuryStatus } from "@zone-blitz/shared/types/player.ts";
-import type { SchemeFitLabel } from "@zone-blitz/shared";
 import { useLeague } from "../../hooks/use-league.ts";
 import { useActiveRoster } from "../../hooks/use-active-roster.ts";
 import { useDepthChart } from "../../hooks/use-depth-chart.ts";
@@ -61,23 +61,6 @@ function injuryBadgeVariant(
 
 function formatInjury(status: PlayerInjuryStatus) {
   return status.replace(/_/g, " ");
-}
-
-const schemeFitLabels: Record<SchemeFitLabel, string> = {
-  ideal: "Ideal fit",
-  fits: "Fits",
-  neutral: "Neutral",
-  poor: "Poor fit",
-  miscast: "Miscast",
-};
-
-function schemeFitBadgeVariant(
-  label: SchemeFitLabel,
-): "secondary" | "destructive" | "outline" | "default" {
-  if (label === "ideal") return "default";
-  if (label === "fits") return "secondary";
-  if (label === "miscast" || label === "poor") return "destructive";
-  return "outline";
 }
 
 function ordinal(n: number): string {
@@ -145,27 +128,12 @@ const rosterColumns: ColumnDef<RosterPlayer>[] = [
     header: ({ column }) => (
       <SortableHeader column={column}>Scheme Fit</SortableHeader>
     ),
-    cell: ({ row }) => {
-      const fit = row.original.schemeFit;
-      if (fit === null) {
-        return (
-          <span
-            className="text-muted-foreground"
-            data-testid={`roster-scheme-fit-${row.original.id}`}
-          >
-            —
-          </span>
-        );
-      }
-      return (
-        <Badge
-          variant={schemeFitBadgeVariant(fit)}
-          data-testid={`roster-scheme-fit-${row.original.id}`}
-        >
-          {schemeFitLabels[fit]}
-        </Badge>
-      );
-    },
+    cell: ({ row }) => (
+      <SchemeFitBadge
+        fit={row.original.schemeFit}
+        testId={`roster-scheme-fit-${row.original.id}`}
+      />
+    ),
   },
   {
     accessorKey: "injuryStatus",

--- a/client/src/features/league/salary-cap.test.tsx
+++ b/client/src/features/league/salary-cap.test.tsx
@@ -39,7 +39,7 @@ const baseRoster = {
       capHit: 45_000_000,
       contractYearsRemaining: 3,
       injuryStatus: "healthy",
-      schemeFit: null,
+      schemeFit: "ideal",
     },
     {
       id: "p2",
@@ -51,7 +51,7 @@ const baseRoster = {
       capHit: 12_000_000,
       contractYearsRemaining: 2,
       injuryStatus: "questionable",
-      schemeFit: null,
+      schemeFit: "poor",
     },
     {
       id: "p3",
@@ -75,7 +75,7 @@ const baseRoster = {
       capHit: 3_000_000,
       contractYearsRemaining: 1,
       injuryStatus: "healthy",
-      schemeFit: null,
+      schemeFit: "fits",
     },
   ],
   positionGroups: [
@@ -206,6 +206,22 @@ describe("SalaryCap — page", () => {
     expect(within(row).getByText("QB")).toBeDefined();
     expect(within(row).getByText("$45,000,000")).toBeDefined();
     expect(within(row).getByText("3 yrs")).toBeDefined();
+  });
+
+  it("renders a scheme fit badge when the player has a fit value", () => {
+    renderSalaryCap();
+    const row = screen.getByTestId("salary-cap-row-p1");
+    expect(
+      within(row).getByTestId("salary-cap-scheme-fit-p1").textContent,
+    ).toBe("Ideal fit");
+  });
+
+  it("renders a dash for scheme fit when the value is null", () => {
+    renderSalaryCap();
+    const row = screen.getByTestId("salary-cap-row-p3");
+    expect(
+      within(row).getByTestId("salary-cap-scheme-fit-p3").textContent,
+    ).toBe("—");
   });
 
   it("filters rows by the global search input", () => {

--- a/client/src/features/league/salary-cap.tsx
+++ b/client/src/features/league/salary-cap.tsx
@@ -11,6 +11,7 @@ import {
 import { Input } from "@/components/ui/input";
 import { Skeleton } from "@/components/ui/skeleton";
 import { DataTable, SortableHeader } from "@/components/ui/data-table";
+import { SchemeFitBadge } from "@/components/ui/scheme-fit-badge";
 import type {
   ActiveRoster,
   NeutralBucketGroup,
@@ -63,6 +64,18 @@ const capColumns: ColumnDef<RosterPlayer>[] = [
       <SortableHeader column={column}>Group</SortableHeader>
     ),
     cell: ({ row }) => groupLabels[row.original.neutralBucketGroup],
+  },
+  {
+    accessorKey: "schemeFit",
+    header: ({ column }) => (
+      <SortableHeader column={column}>Scheme Fit</SortableHeader>
+    ),
+    cell: ({ row }) => (
+      <SchemeFitBadge
+        fit={row.original.schemeFit}
+        testId={`salary-cap-scheme-fit-${row.original.id}`}
+      />
+    ),
   },
   {
     accessorKey: "capHit",

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -28,10 +28,6 @@ entry when it's resolved or superseded.
   archetype | null` mapping — richer
   than the qualitative Scheme Fit label shipped in #148 — plus consumer wiring
   in the scouts, FA, and draft features.
-- **2026-04-14 — Extend Scheme Fit badge to salary-cap and opponent-roster
-  tables.** `RosterPlayer.schemeFit` is on the wire everywhere but only the
-  Roster page renders the badge. Salary cap and opponents detail already have
-  the field in their fixtures — just add the column.
 - **2026-04-14 — Archetype-aware player generation.** Decision 0006
   (positionless players) depends on the player generator producing
   archetype-shaped attribute profiles — "gun-slinger QB," "zone-blocking guard,"


### PR DESCRIPTION
## Summary

- Extracts the inline Scheme Fit badge rendering from the roster page into a shared `SchemeFitBadge` component (`client/src/components/ui/scheme-fit-badge.tsx`)
- Adds a Scheme Fit column to the salary cap table, showing qualitative fit badges (Ideal fit, Fits, Neutral, Poor fit, Miscast) or a dash when null
- Adds a Scheme Fit column to the opponent roster detail table with the same badge rendering
- Updates test fixtures with non-null `schemeFit` values and adds test coverage for the new columns in both pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)