### PR TITLE
feat(players): graduate stub generator to archetype-aware distributions

### DIFF
--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -9,15 +9,26 @@ entry when it's resolved or superseded.
 
 ## Open
 
-- **2026-04-14 — Archetype-aware player generation.** Decision 0006
-  (positionless players) depends on the player generator producing
-  archetype-shaped attribute profiles — "gun-slinger QB," "zone-blocking guard,"
-  etc. — rather than uniform rolls. Also needs a rare cross-archetype case
-  (Travis Hunter-style CB/WR) with a tunable rate. No player should be elite at
-  every attribute; budgets/tradeoffs should enforce shapes. Scope this generator
-  design before a large player-creation pass ships. See
-  `docs/product/decisions/0006-positionless-players.md` "Note for the future —
-  player generation toward archetypes."
+- **2026-04-14 — Scheme lens on scouting / FA / draft surfaces.** ADR 0006
+  requires scout reports, free-agent shortlists, and draft boards to surface
+  players as archetypes-in-role ("slot WR," "3-tech," "box safety") when
+  projected through the hired coach's fingerprint, and `null` / "not a fit" when
+  the player has no role in that scheme. Today those surfaces still read the
+  neutral bucket only. Needs a
+  `schemeLens(attributes, fingerprint) →
+  archetype | null` mapping — richer
+  than the qualitative Scheme Fit label shipped in #148 — plus consumer wiring
+  in the scouts, FA, and draft features.
+- **2026-04-14 — Extend Scheme Fit badge to salary-cap and opponent-roster
+  tables.** `RosterPlayer.schemeFit` is on the wire everywhere but only the
+  Roster page renders the badge. Salary cap and opponents detail already have
+  the field in their fixtures — just add the column.
+- **2026-04-14 — Cross-archetype player generation (Travis Hunter case).** ADR
+  0009 ships the archetype-aware player generator but defers the rare
+  cross-archetype roll: a small, tunable fraction of generated players should
+  qualify for two non-specialist neutral buckets (e.g. CB + WR). Wire this into
+  the generator with a rate knob, and surface both bucket lenses in the scout /
+  depth-chart / draft UIs.
 - **2026-04-14 — Coach sim depth-chart publisher.** Decision 0001 requires the
   coach sim to publish a stable depth-chart artifact the roster page reads.
   Initial roster page stubs the source (empty depth chart until the sim writes

--- a/docs/product/decisions/0009-archetype-aware-player-generator.md
+++ b/docs/product/decisions/0009-archetype-aware-player-generator.md
@@ -1,0 +1,104 @@
+# 0009 — Archetype-aware player generator
+
+- **Date:** 2026-04-14
+- **Status:** Accepted
+- **Area:** player generation, league creation — builds on
+  [`0006-positionless-players.md`](./0006-positionless-players.md) (see the
+  "Note for the future — player generation toward archetypes" section).
+
+## Context
+
+ADR 0006 flagged that the player generator must produce attribute profiles that
+lean toward recognizable archetypes, or the neutral and scheme lenses have
+nothing coherent to project onto. The backlog entry
+(`2026-04-14 — Archetype-aware player generation`) captures the same need.
+
+The v1 stub generator (`createStubPlayersGenerator`) shipped a seed-enough
+skeleton: every player has baseline 30 / potential 60, fixed height and weight
+per bucket, fixed `"State University"` college, fixed `2000-01-01` birthdate,
+and a flat `salaryCap / rosterSize` contract. That was sufficient to drive
+neutral-bucket classification, but it produces visually identical leagues,
+undifferentiated rosters, and no star-vs-scrub gradient. This ADR locks in the
+shape of the first real pass.
+
+## Decision
+
+The player generator graduates in place. The factory name
+(`createStubPlayersGenerator`) is kept for now — its consumers (service wiring,
+league-creation path) do not change; the internals produce realistic
+distributions instead of constants. Name generation is consumed through an
+injected `NameGenerator` dependency so it can later be swapped for the shared
+name generator being extracted in a parallel PR without another round of wiring
+changes here.
+
+### Distribution requirements
+
+1. **Attributes are rolled on an approximately-normal distribution per
+   archetype.** Signature attributes (per ADR 0006 bucket rules) are shifted up;
+   off-signature attributes are shifted down; a per-player overall "quality"
+   factor nudges the whole vector so stars, starters, and scrubs exist in
+   realistic proportions (rough target: a handful of 85+ overall per roster, a
+   long middle around 65–75, a tail in the 50s for depth).
+2. **Potential is current + a non-negative lift**, larger for younger players
+   and smaller as the player ages. Potential never drops below current and never
+   exceeds 99. This produces veterans near ceiling and rookies with room to grow
+   without letting every player rate identically.
+3. **Height and weight vary within bucket-appropriate ranges.** Ranges are
+   chosen so the output still classifies into the intended bucket under
+   `neutralBucket()` (ADR 0006 size gates); they do not fix a single value per
+   bucket.
+4. **Ages span a rookie-to-veteran curve.** Rostered players and free agents
+   sample ages across roughly 21–36; prospects sample 20–23 for a draft-eligible
+   class. Birthdates are derived from ages + a current-year anchor (defaults to
+   the current UTC year; injectable for tests).
+5. **Colleges and hometowns come from real pools.** Colleges are drawn from the
+   seeded `DEFAULT_COLLEGES` list (FBS/FCS programs). Hometowns are drawn from
+   the seeded `DEFAULT_CITIES` list in `"{city}, {state}"` format. Undrafted
+   players still get a hometown.
+6. **Contracts reflect position value and player quality, not an even split.**
+   Position tier (premium: QB / EDGE / OT / CB / WR; mid: TE / IOL / IDL / LB /
+   S / RB; base: K / P / LS) combines with a quality score derived from
+   attributes to produce an annual salary in a band per tier × quality. Years
+   vary (1–5) with veterans on shorter deals; guaranteed money and signing bonus
+   scale with quality; the team's total annual salary is scaled down uniformly
+   if it would exceed the cap.
+
+### Determinism
+
+The generator accepts an injectable `random: () => number` factory (default
+`Math.random`). Tests construct the generator with a seeded RNG so every
+assertion in the suite is deterministic. Distribution invariants the suite
+relies on (bucket composition, age range, attribute ranges, cap budget) are
+asserted in tests.
+
+### Cross-archetype players
+
+The Travis Hunter case is explicitly out of scope for this PR. A follow-up
+backlog entry covers it: a small, tunable fraction of generated players should
+roll attribute vectors that qualify for two non-specialist signatures. Adding it
+later does not require re-thinking this design.
+
+## Alternatives considered
+
+- **Full Perlin-noise / Gaussian-mixture generator** — too much complexity for a
+  v1 graduation. The normal-around-archetype pass gives most of the realism with
+  a legible implementation we can test deterministically.
+- **Ship archetype seeds but keep flat height/weight/age/college/contract** —
+  rejected. The visible realism (age curve, varied colleges, differing
+  contracts) is most of the player-feel win; attribute distribution alone is
+  invisible to casual users.
+- **Move generation into a shared package** — premature. The generator is
+  server-side; coaches, scouts, and front-office generators will stay in their
+  feature folders.
+
+## Consequences
+
+- League creation now produces visibly differentiated rosters. Screenshots in CI
+  / preview environments will no longer show 30 / 60 across the board.
+- `BUCKET_PROFILES` keeps its role as the single place that defines
+  per-archetype bias — tuning realism is one edit away.
+- Contract generator is coupled to attribute quality. If the attribute
+  distribution changes, the contract band may need re-tuning, and that is fine —
+  both are owned by this feature.
+- The archetype-aware-generation backlog item is resolved; the cross-archetype
+  follow-up becomes its own backlog entry.

--- a/server/features/players/stub-players-generator.test.ts
+++ b/server/features/players/stub-players-generator.test.ts
@@ -6,8 +6,11 @@ import {
   PLAYER_ATTRIBUTE_KEYS,
 } from "@zone-blitz/shared";
 import {
+  BUCKET_PROFILES,
   createStubPlayersGenerator,
+  type NameGenerator,
   ROSTER_BUCKET_COMPOSITION,
+  stubAttributesFor,
 } from "./stub-players-generator.ts";
 
 const TEAM_IDS = ["team-1", "team-2", "team-3"];
@@ -17,6 +20,36 @@ const INPUT = {
   teamIds: TEAM_IDS,
   rosterSize: 53,
 };
+
+// mulberry32 — small, deterministic RNG for reproducible distribution tests.
+function seededRandom(seed: number): () => number {
+  let state = seed >>> 0;
+  return () => {
+    state = (state + 0x6D2B79F5) >>> 0;
+    let t = state;
+    t = Math.imul(t ^ (t >>> 15), t | 1);
+    t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+function fixedNameGenerator(): NameGenerator {
+  let i = 0;
+  return {
+    next() {
+      i++;
+      return { firstName: `First${i}`, lastName: `Last${i}` };
+    },
+  };
+}
+
+function makeGenerator(seed = 12345) {
+  return createStubPlayersGenerator({
+    random: seededRandom(seed),
+    nameGenerator: fixedNameGenerator(),
+    currentYear: 2026,
+  });
+}
 
 function bucketOf(entry: {
   player: { heightInches: number; weightPounds: number };
@@ -30,14 +63,11 @@ function bucketOf(entry: {
 }
 
 Deno.test("generates correct number of rostered players per team", () => {
-  const generator = createStubPlayersGenerator();
-  const result = generator.generate(INPUT);
-
+  const result = makeGenerator().generate(INPUT);
   const rostered = result.players.filter(
     (p) => p.player.teamId !== null && p.player.status === "active",
   );
   assertEquals(rostered.length, TEAM_IDS.length * INPUT.rosterSize);
-
   for (const teamId of TEAM_IDS) {
     const teamPlayers = rostered.filter((p) => p.player.teamId === teamId);
     assertEquals(teamPlayers.length, INPUT.rosterSize);
@@ -45,9 +75,7 @@ Deno.test("generates correct number of rostered players per team", () => {
 });
 
 Deno.test("generates active free agents with null teamId", () => {
-  const generator = createStubPlayersGenerator();
-  const result = generator.generate(INPUT);
-
+  const result = makeGenerator().generate(INPUT);
   const freeAgents = result.players.filter(
     (p) => p.player.teamId === null && p.player.status === "active",
   );
@@ -55,18 +83,14 @@ Deno.test("generates active free agents with null teamId", () => {
 });
 
 Deno.test("all players have the correct leagueId", () => {
-  const generator = createStubPlayersGenerator();
-  const result = generator.generate(INPUT);
-
+  const result = makeGenerator().generate(INPUT);
   for (const entry of result.players) {
     assertEquals(entry.player.leagueId, INPUT.leagueId);
   }
 });
 
 Deno.test("prospects are emitted as players with status 'prospect' and no team", () => {
-  const generator = createStubPlayersGenerator();
-  const result = generator.generate(INPUT);
-
+  const result = makeGenerator().generate(INPUT);
   const prospects = result.players.filter(
     (p) => p.player.status === "prospect",
   );
@@ -76,10 +100,8 @@ Deno.test("prospects are emitted as players with status 'prospect' and no team",
   }
 });
 
-Deno.test("every generated player has a full attribute set", () => {
-  const generator = createStubPlayersGenerator();
-  const result = generator.generate(INPUT);
-
+Deno.test("every generated player has a full attribute set in range", () => {
+  const result = makeGenerator().generate(INPUT);
   const expectedKeyCount = PLAYER_ATTRIBUTE_KEYS.length * 2;
   for (const entry of result.players) {
     assertEquals(Object.keys(entry.attributes).length, expectedKeyCount);
@@ -91,52 +113,68 @@ Deno.test("every generated player has a full attribute set", () => {
       assertEquals(typeof potential, "number");
       assertEquals(current >= 0 && current <= 100, true);
       assertEquals(potential >= 0 && potential <= 100, true);
+      // Potential graduates from a fixed constant to current + non-negative
+      // lift, so this invariant matters.
+      assertEquals(potential >= current, true);
     }
   }
 });
 
 Deno.test("every player has identity fields populated", () => {
-  const generator = createStubPlayersGenerator();
-  const result = generator.generate(INPUT);
-
+  const result = makeGenerator().generate(INPUT);
   for (const entry of result.players) {
     assertEquals(typeof entry.player.heightInches, "number");
     assertEquals(typeof entry.player.weightPounds, "number");
     assertEquals(typeof entry.player.birthDate, "string");
+    assertEquals(typeof entry.player.college, "string");
   }
 });
 
 Deno.test("generates contracts for rostered players only", () => {
-  const generator = createStubPlayersGenerator();
+  const generator = makeGenerator();
   const players = [
     { id: "p1", teamId: "team-1" },
     { id: "p2", teamId: "team-1" },
     { id: "p3", teamId: null },
   ];
-
   const contracts = generator.generateContracts({
     salaryCap: 255_000_000,
     players,
   });
-
   assertEquals(contracts.length, 2);
   assertEquals(contracts.every((c) => c.teamId === "team-1"), true);
 });
 
-Deno.test("stub contracts distribute salary evenly under cap", () => {
-  const generator = createStubPlayersGenerator();
+Deno.test("stub contracts stay under the team salary cap", () => {
+  const generator = makeGenerator();
   const salaryCap = 255_000_000;
   const players = Array.from({ length: 53 }, (_, i) => ({
     id: `p${i}`,
     teamId: "team-1",
   }));
-
   const contracts = generator.generateContracts({ salaryCap, players });
-
   const totalAnnual = contracts.reduce((sum, c) => sum + c.annualSalary, 0);
   assertEquals(totalAnnual <= salaryCap, true);
-  assertEquals(contracts.every((c) => c.totalYears === 3), true);
-  assertEquals(contracts.every((c) => c.currentYear === 1), true);
+  for (const c of contracts) {
+    assertEquals(c.totalYears >= 1 && c.totalYears <= 5, true);
+    assertEquals(c.currentYear, 1);
+    assertEquals(c.totalSalary, c.annualSalary * c.totalYears);
+  }
+});
+
+Deno.test("contract annual salaries vary across a full roster", () => {
+  const generator = makeGenerator();
+  const players = Array.from({ length: 53 }, (_, i) => ({
+    id: `p${i}`,
+    teamId: "team-1",
+  }));
+  const contracts = generator.generateContracts({
+    salaryCap: 255_000_000,
+    players,
+  });
+  const unique = new Set(contracts.map((c) => c.annualSalary));
+  // Graduated generator replaces a single-value flat split with a distribution.
+  assertEquals(unique.size > 10, true);
 });
 
 Deno.test("roster composition sums to 53 players", () => {
@@ -150,8 +188,7 @@ Deno.test("roster composition sums to 53 players", () => {
 Deno.test(
   "every generated player classifies into a known neutral bucket",
   () => {
-    const generator = createStubPlayersGenerator();
-    const result = generator.generate(INPUT);
+    const result = makeGenerator().generate(INPUT);
     const validBuckets = new Set<NeutralBucket>(NEUTRAL_BUCKETS);
     for (const entry of result.players) {
       assertEquals(validBuckets.has(bucketOf(entry)), true);
@@ -162,8 +199,7 @@ Deno.test(
 Deno.test(
   "per-team rostered neutral buckets match the 53-man composition",
   () => {
-    const generator = createStubPlayersGenerator();
-    const result = generator.generate(INPUT);
+    const result = makeGenerator().generate(INPUT);
     for (const teamId of TEAM_IDS) {
       const teamPlayers = result.players.filter(
         (p) => p.player.teamId === teamId && p.player.status === "active",
@@ -181,31 +217,31 @@ Deno.test(
 );
 
 Deno.test("every generated player starts with healthy injury status", () => {
-  const generator = createStubPlayersGenerator();
-  const result = generator.generate(INPUT);
+  const result = makeGenerator().generate(INPUT);
   for (const entry of result.players) {
     assertEquals(entry.player.injuryStatus, "healthy");
   }
 });
 
-Deno.test("every generated player gets a hometown and either draft info or undrafted", () => {
-  const generator = createStubPlayersGenerator();
-  const result = generator.generate(INPUT);
-
-  for (const entry of result.players) {
-    assertEquals(typeof entry.player.hometown, "string");
-    const { draftYear, draftRound, draftPick, draftingTeamId } = entry.player;
-    const allNull = draftYear === null && draftRound === null &&
-      draftPick === null && draftingTeamId === null;
-    const allPresent = typeof draftYear === "number" &&
-      typeof draftRound === "number" && typeof draftPick === "number";
-    assertEquals(allNull || allPresent, true);
-  }
-});
+Deno.test(
+  "every generated player gets a hometown and either draft info or undrafted",
+  () => {
+    const result = makeGenerator().generate(INPUT);
+    for (const entry of result.players) {
+      assertEquals(typeof entry.player.hometown, "string");
+      assertEquals((entry.player.hometown ?? "").length > 0, true);
+      const { draftYear, draftRound, draftPick, draftingTeamId } = entry.player;
+      const allNull = draftYear === null && draftRound === null &&
+        draftPick === null && draftingTeamId === null;
+      const allPresent = typeof draftYear === "number" &&
+        typeof draftRound === "number" && typeof draftPick === "number";
+      assertEquals(allNull || allPresent, true);
+    }
+  },
+);
 
 Deno.test("at least one rostered active player is undrafted", () => {
-  const generator = createStubPlayersGenerator();
-  const result = generator.generate(INPUT);
+  const result = makeGenerator().generate(INPUT);
   const rostered = result.players.filter(
     (p) => p.player.teamId !== null && p.player.status === "active",
   );
@@ -214,8 +250,7 @@ Deno.test("at least one rostered active player is undrafted", () => {
 });
 
 Deno.test("drafted rostered players carry their drafting team", () => {
-  const generator = createStubPlayersGenerator();
-  const result = generator.generate(INPUT);
+  const result = makeGenerator().generate(INPUT);
   const rostered = result.players.filter(
     (p) => p.player.teamId !== null && p.player.status === "active",
   );
@@ -226,11 +261,145 @@ Deno.test("drafted rostered players carry their drafting team", () => {
 });
 
 Deno.test("all generated players have non-empty names", () => {
-  const generator = createStubPlayersGenerator();
-  const result = generator.generate(INPUT);
-
+  const result = makeGenerator().generate(INPUT);
   for (const entry of result.players) {
     assertEquals(entry.player.firstName.length > 0, true);
     assertEquals(entry.player.lastName.length > 0, true);
   }
 });
+
+// ---- Graduated-behaviour assertions (ADR 0009) ----
+
+Deno.test("attribute distribution produces a star-to-scrub gradient", () => {
+  const result = makeGenerator().generate(INPUT);
+  const rostered = result.players.filter(
+    (p) => p.player.teamId !== null && p.player.status === "active",
+  );
+  let minSignature = 100;
+  let maxSignature = 0;
+  for (const entry of rostered) {
+    const bucket = bucketOf(entry);
+    const profile = BUCKET_PROFILES[bucket];
+    const rec = entry.attributes as unknown as Record<string, number>;
+    let sum = 0;
+    for (const key of profile.signature) sum += rec[key];
+    const overall = sum / profile.signature.length;
+    if (overall < minSignature) minSignature = overall;
+    if (overall > maxSignature) maxSignature = overall;
+  }
+  // The v1 stub produced a single flat overall; the graduated generator must
+  // span at least 20 points of overall across a league.
+  assertEquals(maxSignature - minSignature > 20, true);
+  assertEquals(maxSignature > 75, true);
+  assertEquals(minSignature < 60, true);
+});
+
+Deno.test("heights and weights vary within a bucket", () => {
+  const result = makeGenerator().generate(INPUT);
+  const wrs = result.players.filter((p) =>
+    p.player.teamId !== null && bucketOf(p) === "WR"
+  );
+  const heights = new Set(wrs.map((p) => p.player.heightInches));
+  const weights = new Set(wrs.map((p) => p.player.weightPounds));
+  assertEquals(heights.size > 1, true);
+  assertEquals(weights.size > 1, true);
+});
+
+Deno.test("ages span a rookie-to-veteran curve", () => {
+  const result = makeGenerator().generate(INPUT);
+  const rostered = result.players.filter(
+    (p) => p.player.teamId !== null && p.player.status === "active",
+  );
+  const ages = rostered.map((p) => {
+    const [year] = p.player.birthDate.split("-");
+    return 2026 - Number(year);
+  });
+  const minAge = Math.min(...ages);
+  const maxAge = Math.max(...ages);
+  assertEquals(minAge >= 21, true);
+  assertEquals(maxAge <= 36, true);
+  // There should be both rookies (<=23) and veterans (>=30) in a 159-man pool.
+  assertEquals(ages.some((a) => a <= 23), true);
+  assertEquals(ages.some((a) => a >= 30), true);
+});
+
+Deno.test("prospects fall into a draft-eligible age band", () => {
+  const result = makeGenerator().generate(INPUT);
+  const prospects = result.players.filter(
+    (p) => p.player.status === "prospect",
+  );
+  for (const entry of prospects) {
+    const age = 2026 - Number(entry.player.birthDate.split("-")[0]);
+    assertEquals(age >= 20 && age <= 23, true);
+  }
+});
+
+Deno.test(
+  "colleges are drawn from the default college pool, not a constant",
+  () => {
+    const result = makeGenerator().generate(INPUT);
+    const colleges = new Set<string>();
+    for (const p of result.players) {
+      if (p.player.college) colleges.add(p.player.college);
+    }
+    // Many distinct colleges across 450+ players — the stub constant is gone.
+    assertEquals(colleges.size > 20, true);
+    assertEquals(colleges.has("State University"), false);
+  },
+);
+
+Deno.test("hometowns are varied and formatted as 'City, ST'", () => {
+  const result = makeGenerator().generate(INPUT);
+  const hometowns = new Set<string>();
+  for (const p of result.players) {
+    if (p.player.hometown) hometowns.add(p.player.hometown);
+  }
+  assertEquals(hometowns.size > 20, true);
+  for (const hometown of hometowns) {
+    assertEquals(/, [A-Z]{2}$/.test(hometown), true);
+  }
+});
+
+Deno.test("seeded generator is deterministic", () => {
+  const a = createStubPlayersGenerator({
+    random: seededRandom(42),
+    nameGenerator: fixedNameGenerator(),
+    currentYear: 2026,
+  }).generate(INPUT);
+  const b = createStubPlayersGenerator({
+    random: seededRandom(42),
+    nameGenerator: fixedNameGenerator(),
+    currentYear: 2026,
+  }).generate(INPUT);
+  assertEquals(a.players.length, b.players.length);
+  for (let i = 0; i < a.players.length; i++) {
+    assertEquals(a.players[i].player.birthDate, b.players[i].player.birthDate);
+    assertEquals(a.players[i].player.college, b.players[i].player.college);
+    assertEquals(a.players[i].player.hometown, b.players[i].player.hometown);
+    assertEquals(
+      a.players[i].player.heightInches,
+      b.players[i].player.heightInches,
+    );
+  }
+});
+
+Deno.test(
+  "stubAttributesFor produces attributes that classify into the requested bucket",
+  () => {
+    for (const bucket of NEUTRAL_BUCKETS) {
+      const attrs = stubAttributesFor(bucket);
+      const profile = BUCKET_PROFILES[bucket];
+      const classified = neutralBucket({
+        attributes: attrs,
+        heightInches: profile.heightInches,
+        weightPounds: profile.weightPounds,
+      });
+      assertEquals(classified, bucket);
+      for (const key of PLAYER_ATTRIBUTE_KEYS) {
+        const cur = (attrs as Record<string, number>)[key];
+        const pot = (attrs as Record<string, number>)[`${key}Potential`];
+        assertEquals(pot >= cur && pot <= 100, true);
+      }
+    }
+  },
+);

--- a/server/features/players/stub-players-generator.ts
+++ b/server/features/players/stub-players-generator.ts
@@ -1,6 +1,7 @@
 import {
   NEUTRAL_BUCKETS,
   type NeutralBucket,
+  neutralBucket,
   PLAYER_ATTRIBUTE_KEYS,
   type PlayerAttributeKey,
   type PlayerAttributes,
@@ -9,6 +10,8 @@ import {
   createNameGenerator,
   type NameGenerator,
 } from "../../shared/name-generator.ts";
+import { DEFAULT_COLLEGES } from "../colleges/default-colleges.ts";
+import { DEFAULT_CITIES } from "../cities/default-cities.ts";
 import type {
   ContractGeneratorInput,
   GeneratedContract,
@@ -17,164 +20,370 @@ import type {
   PlayersGeneratorInput,
 } from "./players.generator.interface.ts";
 
-const STUB_BASELINE = 30;
-const STUB_POTENTIAL = 60;
-const STUB_COLLEGE = "State University";
-const STUB_BIRTH_DATE = "2000-01-01";
-const STUB_HOMETOWNS = [
-  "Houston, TX",
-  "Miami, FL",
-  "Atlanta, GA",
-  "Chicago, IL",
-  "Los Angeles, CA",
-  "Philadelphia, PA",
-  "Dallas, TX",
-  "Detroit, MI",
-] as const;
+// ADR 0009 — this generator graduated from constants to archetype-aware,
+// distribution-driven rolls. Each bucket has a signature (boosted) and
+// de-emphasized attribute set; a per-player quality tier (star / starter /
+// depth) shifts the mean of the rolled distribution so rosters contain a
+// handful of blue-chip players, a long middle tier of starters, and plenty
+// of JAG depth. Height, weight, age, college, hometown, and contract are
+// all driven off the same RNG so a seeded test reproduces the exact league.
+// Names are supplied by the shared `NameGenerator` (server/shared).
 
-// Attribute profiles per neutral bucket. Each profile lifts the bucket's
-// signature attributes above baseline and picks a size within the bucket's
-// gate so neutralBucket() deterministically classifies the generated player
-// into the intended bucket. Preview of the archetype-aware generator flagged
-// by ADR 0006 — a richer distribution comes with the real generator.
+// Re-export the shared NameGenerator type for consumer tests that want to
+// mock a name source without reaching into server/shared directly.
+export type { NameGenerator };
+
 export interface BucketProfile {
+  /** Median height (inches); actual is drawn within ±heightSpread. */
   heightInches: number;
+  /** Median weight (pounds); actual is drawn within ±weightSpread. */
   weightPounds: number;
-  overrides: Partial<Record<PlayerAttributeKey, number>>;
+  heightSpread: number;
+  weightSpread: number;
+  /** Attributes biased upward (archetype signature + close complements). */
+  signature: readonly PlayerAttributeKey[];
+  /** Attributes biased downward (archetype doesn't rely on these). */
+  deEmphasized: readonly PlayerAttributeKey[];
 }
 
 export const BUCKET_PROFILES: Record<NeutralBucket, BucketProfile> = {
   QB: {
     heightInches: 75,
     weightPounds: 225,
-    overrides: {
-      armStrength: 55,
-      accuracyShort: 55,
-      accuracyMedium: 55,
-      accuracyDeep: 55,
-      release: 55,
-      decisionMaking: 55,
-    },
+    heightSpread: 2,
+    weightSpread: 15,
+    signature: [
+      "armStrength",
+      "accuracyShort",
+      "accuracyMedium",
+      "accuracyDeep",
+      "release",
+      "decisionMaking",
+      "touch",
+      "composure",
+    ],
+    deEmphasized: [
+      "passBlocking",
+      "runBlocking",
+      "blockShedding",
+      "tackling",
+      "manCoverage",
+      "zoneCoverage",
+      "kickingPower",
+      "puntingPower",
+      "snapAccuracy",
+    ],
   },
   RB: {
     heightInches: 71,
     weightPounds: 215,
-    overrides: {
-      ballCarrying: 55,
-      elusiveness: 55,
-      acceleration: 55,
-      speed: 55,
-    },
+    heightSpread: 2,
+    weightSpread: 15,
+    signature: [
+      "ballCarrying",
+      "elusiveness",
+      "acceleration",
+      "speed",
+      "agility",
+      "runAfterCatch",
+    ],
+    deEmphasized: [
+      "armStrength",
+      "accuracyDeep",
+      "passBlocking",
+      "manCoverage",
+      "zoneCoverage",
+      "kickingPower",
+      "puntingPower",
+      "snapAccuracy",
+    ],
   },
   WR: {
     heightInches: 73,
     weightPounds: 200,
-    overrides: {
-      routeRunning: 55,
-      catching: 55,
-      speed: 55,
-      acceleration: 55,
-    },
+    heightSpread: 3,
+    weightSpread: 15,
+    signature: [
+      "routeRunning",
+      "catching",
+      "speed",
+      "acceleration",
+      "agility",
+      "runAfterCatch",
+      "contestedCatching",
+    ],
+    deEmphasized: [
+      "armStrength",
+      "passBlocking",
+      "runBlocking",
+      "manCoverage",
+      "zoneCoverage",
+      "kickingPower",
+      "puntingPower",
+      "snapAccuracy",
+    ],
   },
   TE: {
     heightInches: 77,
-    weightPounds: 250,
-    overrides: {
-      catching: 55,
-      runBlocking: 55,
-      passBlocking: 55,
-    },
+    weightPounds: 252,
+    heightSpread: 2,
+    weightSpread: 12,
+    signature: [
+      "catching",
+      "runBlocking",
+      "passBlocking",
+      "contestedCatching",
+      "routeRunning",
+      "strength",
+    ],
+    deEmphasized: [
+      "armStrength",
+      "speed",
+      "manCoverage",
+      "zoneCoverage",
+      "kickingPower",
+      "puntingPower",
+      "snapAccuracy",
+    ],
   },
   OT: {
     heightInches: 78,
-    weightPounds: 310,
-    overrides: {
-      passBlocking: 55,
-      runBlocking: 55,
-      agility: 50,
-    },
+    weightPounds: 315,
+    heightSpread: 1,
+    weightSpread: 15,
+    signature: [
+      "passBlocking",
+      "runBlocking",
+      "agility",
+      "strength",
+      "footballIq",
+    ],
+    deEmphasized: [
+      "speed",
+      "catching",
+      "routeRunning",
+      "armStrength",
+      "manCoverage",
+      "zoneCoverage",
+      "kickingPower",
+      "puntingPower",
+      "snapAccuracy",
+    ],
   },
   IOL: {
     heightInches: 74,
-    weightPounds: 310,
-    overrides: {
-      runBlocking: 55,
-      passBlocking: 55,
-      strength: 55,
-    },
+    weightPounds: 312,
+    heightSpread: 1,
+    weightSpread: 12,
+    signature: [
+      "runBlocking",
+      "passBlocking",
+      "strength",
+      "footballIq",
+    ],
+    deEmphasized: [
+      "speed",
+      "catching",
+      "routeRunning",
+      "armStrength",
+      "manCoverage",
+      "zoneCoverage",
+      "kickingPower",
+      "puntingPower",
+      "snapAccuracy",
+    ],
   },
   EDGE: {
     heightInches: 76,
-    weightPounds: 260,
-    overrides: {
-      passRushing: 55,
-      acceleration: 55,
-      blockShedding: 55,
-      speed: 50,
-    },
+    weightPounds: 262,
+    heightSpread: 2,
+    weightSpread: 15,
+    signature: [
+      "passRushing",
+      "acceleration",
+      "blockShedding",
+      "speed",
+      "strength",
+      "tackling",
+    ],
+    deEmphasized: [
+      "armStrength",
+      "catching",
+      "routeRunning",
+      "passBlocking",
+      "runBlocking",
+      "manCoverage",
+      "kickingPower",
+      "puntingPower",
+      "snapAccuracy",
+    ],
   },
   IDL: {
     heightInches: 74,
     weightPounds: 305,
-    overrides: {
-      strength: 55,
-      blockShedding: 55,
-      runDefense: 55,
-      passRushing: 50,
-    },
+    heightSpread: 2,
+    weightSpread: 15,
+    signature: [
+      "strength",
+      "blockShedding",
+      "runDefense",
+      "passRushing",
+      "tackling",
+    ],
+    deEmphasized: [
+      "armStrength",
+      "speed",
+      "catching",
+      "routeRunning",
+      "passBlocking",
+      "runBlocking",
+      "manCoverage",
+      "zoneCoverage",
+      "kickingPower",
+      "puntingPower",
+      "snapAccuracy",
+    ],
   },
   LB: {
     heightInches: 73,
     weightPounds: 235,
-    overrides: {
-      tackling: 55,
-      runDefense: 55,
-      zoneCoverage: 50,
-      footballIq: 55,
-    },
+    heightSpread: 2,
+    weightSpread: 15,
+    signature: [
+      "tackling",
+      "runDefense",
+      "zoneCoverage",
+      "footballIq",
+      "speed",
+      "anticipation",
+      "blockShedding",
+    ],
+    deEmphasized: [
+      "armStrength",
+      "catching",
+      "routeRunning",
+      "passBlocking",
+      "runBlocking",
+      "kickingPower",
+      "puntingPower",
+      "snapAccuracy",
+    ],
   },
   CB: {
     heightInches: 72,
     weightPounds: 195,
-    overrides: {
-      manCoverage: 55,
-      zoneCoverage: 55,
-      speed: 55,
-      agility: 55,
-    },
+    heightSpread: 2,
+    weightSpread: 10,
+    signature: [
+      "manCoverage",
+      "zoneCoverage",
+      "speed",
+      "agility",
+      "anticipation",
+      "acceleration",
+    ],
+    deEmphasized: [
+      "armStrength",
+      "passBlocking",
+      "runBlocking",
+      "strength",
+      "blockShedding",
+      "kickingPower",
+      "puntingPower",
+      "snapAccuracy",
+    ],
   },
   S: {
     heightInches: 73,
     weightPounds: 210,
-    overrides: {
-      zoneCoverage: 55,
-      tackling: 55,
-      footballIq: 55,
-      anticipation: 55,
-    },
+    heightSpread: 2,
+    weightSpread: 12,
+    signature: [
+      "zoneCoverage",
+      "tackling",
+      "footballIq",
+      "anticipation",
+      "manCoverage",
+      "speed",
+    ],
+    deEmphasized: [
+      "armStrength",
+      "passBlocking",
+      "runBlocking",
+      "catching",
+      "routeRunning",
+      "kickingPower",
+      "puntingPower",
+      "snapAccuracy",
+    ],
   },
   K: {
     heightInches: 71,
     weightPounds: 195,
-    overrides: {
-      kickingPower: 70,
-      kickingAccuracy: 70,
-    },
+    heightSpread: 2,
+    weightSpread: 10,
+    signature: [
+      "kickingPower",
+      "kickingAccuracy",
+      "composure",
+      "clutch",
+    ],
+    deEmphasized: [
+      "armStrength",
+      "speed",
+      "strength",
+      "passBlocking",
+      "runBlocking",
+      "tackling",
+      "manCoverage",
+      "zoneCoverage",
+      "puntingPower",
+      "snapAccuracy",
+    ],
   },
   P: {
-    heightInches: 72,
+    heightInches: 73,
     weightPounds: 210,
-    overrides: {
-      puntingPower: 70,
-      puntingAccuracy: 70,
-    },
+    heightSpread: 2,
+    weightSpread: 10,
+    signature: [
+      "puntingPower",
+      "puntingAccuracy",
+      "composure",
+    ],
+    deEmphasized: [
+      "armStrength",
+      "speed",
+      "strength",
+      "passBlocking",
+      "runBlocking",
+      "tackling",
+      "manCoverage",
+      "zoneCoverage",
+      "kickingPower",
+      "snapAccuracy",
+    ],
   },
   LS: {
     heightInches: 73,
     weightPounds: 240,
-    overrides: {
-      snapAccuracy: 75,
-    },
+    heightSpread: 1,
+    weightSpread: 10,
+    signature: [
+      "snapAccuracy",
+      "tackling",
+      "composure",
+    ],
+    deEmphasized: [
+      "armStrength",
+      "speed",
+      "catching",
+      "routeRunning",
+      "manCoverage",
+      "zoneCoverage",
+      "kickingPower",
+      "puntingPower",
+    ],
   },
 };
 
@@ -205,169 +414,503 @@ const ROSTER_BUCKET_SLOTS: readonly NeutralBucket[] = ROSTER_BUCKET_COMPOSITION
 
 const FREE_AGENT_BUCKET_CYCLE: readonly NeutralBucket[] = [...NEUTRAL_BUCKETS];
 
-export function stubAttributesFor(bucket: NeutralBucket): PlayerAttributes {
+const FREE_AGENT_COUNT = 50;
+const DRAFT_PROSPECT_COUNT = 250;
+
+// Premium positions (QB / EDGE / OT / CB / WR) earn more per unit of quality;
+// pure specialists (K / P / LS) earn far less. Mid tier covers everyone else.
+const POSITION_TIER_MULTIPLIER: Record<NeutralBucket, number> = {
+  QB: 1.6,
+  EDGE: 1.35,
+  OT: 1.3,
+  CB: 1.25,
+  WR: 1.2,
+  IDL: 1.1,
+  TE: 1.0,
+  LB: 1.0,
+  S: 1.0,
+  IOL: 0.95,
+  RB: 0.95,
+  K: 0.45,
+  P: 0.4,
+  LS: 0.35,
+};
+
+const SALARY_FLOOR = 750_000;
+const SALARY_PER_QUALITY_POINT = 250_000;
+
+const VETERAN_AGE_MIN = 21;
+const VETERAN_AGE_MAX = 36;
+const PROSPECT_AGE_MIN = 20;
+const PROSPECT_AGE_MAX = 23;
+
+interface Rng {
+  next(): number;
+  int(min: number, max: number): number;
+  pick<T>(arr: readonly T[]): T;
+  gaussian(mean: number, stddev: number, min: number, max: number): number;
+}
+
+function createRng(random: () => number): Rng {
+  return {
+    next: random,
+    int(min, max) {
+      return Math.floor(random() * (max - min + 1)) + min;
+    },
+    pick<T>(arr: readonly T[]): T {
+      return arr[Math.floor(random() * arr.length)];
+    },
+    gaussian(mean, stddev, min, max) {
+      // Box-Muller, clamped. Two uniforms in, one normal out per call; the
+      // RNG stream advances deterministically per attribute roll.
+      const u1 = Math.max(random(), 1e-9);
+      const u2 = random();
+      const z = Math.sqrt(-2 * Math.log(u1)) * Math.cos(2 * Math.PI * u2);
+      const value = Math.round(mean + z * stddev);
+      return Math.max(min, Math.min(max, value));
+    },
+  };
+}
+
+function clamp(n: number, min: number, max: number): number {
+  return Math.max(min, Math.min(max, n));
+}
+
+/** Rough overall score in [30, 95] per tier. */
+function rollQuality(rng: Rng, tier: "star" | "starter" | "depth"): number {
+  const mean = tier === "star" ? 82 : tier === "starter" ? 70 : 58;
+  const stddev = tier === "star" ? 5 : tier === "starter" ? 6 : 7;
+  return rng.gaussian(mean, stddev, 30, 95);
+}
+
+function qualityTierForIndex(
+  indexInBucket: number,
+  bucketCount: number,
+): "star" | "starter" | "depth" {
+  if (bucketCount <= 1) return "starter";
+  if (indexInBucket === 0) return "star";
+  const starterCount = Math.max(1, Math.floor(bucketCount / 2));
+  if (indexInBucket <= starterCount) return "starter";
+  return "depth";
+}
+
+function rollAttributesFor(
+  rng: Rng,
+  bucket: NeutralBucket,
+  quality: number,
+): PlayerAttributes {
   const profile = BUCKET_PROFILES[bucket];
+  const signatureSet = new Set<PlayerAttributeKey>(profile.signature);
+  const deEmphasizedSet = new Set<PlayerAttributeKey>(profile.deEmphasized);
+
   const attrs: Record<string, number> = {};
   for (const key of PLAYER_ATTRIBUTE_KEYS) {
-    attrs[key] = profile.overrides[key] ?? STUB_BASELINE;
-    attrs[`${key}Potential`] = Math.max(
-      STUB_POTENTIAL,
-      profile.overrides[key] ?? STUB_BASELINE,
-    );
+    let mean: number;
+    if (signatureSet.has(key)) {
+      mean = quality + 10;
+    } else if (deEmphasizedSet.has(key)) {
+      mean = Math.max(25, Math.round(quality * 0.55));
+    } else {
+      mean = Math.round(quality * 0.85);
+    }
+    attrs[key] = rng.gaussian(mean, 5, 25, 99);
   }
   return attrs as PlayerAttributes;
 }
 
-const FREE_AGENT_COUNT = 50;
-const DRAFT_PROSPECT_COUNT = 250;
+/**
+ * Bucket signatures overlap (OT and IOL share run/pass block, LB and S share
+ * tackling + zone coverage, etc.), so a purely random roll can classify a
+ * player under the wrong bucket even when their size + profile match the
+ * intended archetype. This step bumps the intended bucket's signature
+ * attributes until the `neutralBucket()` classifier picks the intended
+ * bucket — a deterministic post-condition that keeps per-team roster
+ * composition stable while still allowing meaningful distribution variance.
+ */
+function lockInBucket(
+  attributes: PlayerAttributes,
+  bucket: NeutralBucket,
+  heightInches: number,
+  weightPounds: number,
+): void {
+  const rec = attributes as unknown as Record<string, number>;
+  const profile = BUCKET_PROFILES[bucket];
+  const MAX_ITERS = 20;
+  for (let iter = 0; iter < MAX_ITERS; iter++) {
+    const classified = neutralBucket({
+      attributes,
+      heightInches,
+      weightPounds,
+    });
+    if (classified === bucket) return;
+    for (const key of profile.signature) {
+      rec[key] = Math.min(99, rec[key] + 2);
+    }
+  }
+}
 
-function stubOrigin(index: number, draftingTeamId: string | null) {
-  const undrafted = index % 17 === 0;
+function rollPotentials(
+  rng: Rng,
+  attributes: PlayerAttributes,
+  age: number,
+): void {
+  const rec = attributes as unknown as Record<string, number>;
+  let liftMax: number;
+  if (age <= 22) liftMax = 18;
+  else if (age <= 25) liftMax = 12;
+  else if (age <= 28) liftMax = 7;
+  else if (age <= 31) liftMax = 4;
+  else liftMax = 2;
+  for (const key of PLAYER_ATTRIBUTE_KEYS) {
+    const current = rec[key];
+    const lift = rng.int(0, liftMax);
+    rec[`${key}Potential`] = clamp(current + lift, current, 99);
+  }
+}
+
+function rollHeightWeight(rng: Rng, bucket: NeutralBucket): {
+  heightInches: number;
+  weightPounds: number;
+} {
+  const profile = BUCKET_PROFILES[bucket];
+  const heightInches = profile.heightInches +
+    rng.int(-profile.heightSpread, profile.heightSpread);
+  const weightPounds = profile.weightPounds +
+    rng.int(-profile.weightSpread, profile.weightSpread);
+  return { heightInches, weightPounds };
+}
+
+function rollAge(
+  rng: Rng,
+  status: "rostered" | "free-agent" | "prospect",
+): number {
+  if (status === "prospect") {
+    return rng.int(PROSPECT_AGE_MIN, PROSPECT_AGE_MAX);
+  }
+  // Triangular-ish around the middle of the playing-age band.
+  const raw = (rng.next() + rng.next()) / 2;
+  const span = VETERAN_AGE_MAX - VETERAN_AGE_MIN;
+  return VETERAN_AGE_MIN + Math.round(raw * span);
+}
+
+function birthDateForAge(age: number, currentYear: number, rng: Rng): string {
+  const year = currentYear - age;
+  const month = rng.int(1, 12);
+  const day = rng.int(1, 28);
+  return `${year}-${String(month).padStart(2, "0")}-${
+    String(day).padStart(2, "0")
+  }`;
+}
+
+function pickCollege(rng: Rng): string {
+  return rng.pick(DEFAULT_COLLEGES).shortName;
+}
+
+function pickHometown(rng: Rng): string {
+  const city = rng.pick(DEFAULT_CITIES);
+  return `${city.name}, ${city.stateCode}`;
+}
+
+function rollOrigin(
+  rng: Rng,
+  age: number,
+  currentYear: number,
+  draftingTeamId: string | null,
+): {
+  hometown: string;
+  draftYear: number | null;
+  draftRound: number | null;
+  draftPick: number | null;
+  draftingTeamId: string | null;
+} {
+  const hometown = pickHometown(rng);
+  // ~12% undrafted among active players — roughly matches NFL roster shape.
+  const undrafted = rng.next() < 0.12;
   if (undrafted) {
     return {
-      hometown: STUB_HOMETOWNS[index % STUB_HOMETOWNS.length],
+      hometown,
       draftYear: null,
       draftRound: null,
       draftPick: null,
       draftingTeamId: null,
     };
   }
-  const round = (index % 7) + 1;
-  const pickInRound = (index % 32) + 1;
-  const overallPick = (round - 1) * 32 + pickInRound;
+  const yearsAgo = Math.max(0, age - 22);
+  const draftYear = currentYear - yearsAgo;
+  const round = rng.int(1, 7);
+  const pickInRound = rng.int(1, 32);
+  const draftPick = (round - 1) * 32 + pickInRound;
   return {
-    hometown: STUB_HOMETOWNS[index % STUB_HOMETOWNS.length],
-    draftYear: 2020 + (index % 6),
+    hometown,
+    draftYear,
     draftRound: round,
-    draftPick: overallPick,
+    draftPick,
     draftingTeamId,
   };
 }
 
-function playerShell(
-  bucket: NeutralBucket,
-  overrides: {
-    leagueId: string;
-    teamId: string | null;
-    status: "active" | "prospect";
-    firstName: string;
-    lastName: string;
-    origin: ReturnType<typeof stubOrigin>;
+function rollContract(
+  rng: Rng,
+  args: {
+    playerId: string;
+    teamId: string;
+    bucket: NeutralBucket;
+    quality: number;
+    age: number;
   },
-) {
-  const profile = BUCKET_PROFILES[bucket];
+): GeneratedContract {
+  const tier = POSITION_TIER_MULTIPLIER[args.bucket];
+  const excess = Math.max(0, args.quality - 50);
+  const base = SALARY_FLOOR + excess * SALARY_PER_QUALITY_POINT * tier;
+  const jitter = 0.9 + rng.next() * 0.2;
+  const annualSalary = Math.max(SALARY_FLOOR, Math.round(base * jitter));
+  let totalYears: number;
+  if (args.age >= 32) totalYears = rng.int(1, 2);
+  else if (args.quality >= 80) totalYears = rng.int(3, 5);
+  else if (args.quality >= 65) totalYears = rng.int(2, 4);
+  else totalYears = rng.int(1, 3);
+  const totalSalary = annualSalary * totalYears;
+  const guaranteedPct = args.quality >= 80
+    ? 0.5 + rng.next() * 0.2
+    : args.quality >= 65
+    ? 0.2 + rng.next() * 0.2
+    : 0.05 + rng.next() * 0.1;
+  const guaranteedMoney = Math.round(totalSalary * guaranteedPct);
+  const signingBonus = Math.round(guaranteedMoney * (0.3 + rng.next() * 0.3));
   return {
-    leagueId: overrides.leagueId,
-    teamId: overrides.teamId,
-    status: overrides.status,
-    firstName: overrides.firstName,
-    lastName: overrides.lastName,
-    injuryStatus: "healthy" as const,
-    heightInches: profile.heightInches,
-    weightPounds: profile.weightPounds,
-    college: STUB_COLLEGE,
-    birthDate: STUB_BIRTH_DATE,
-    ...overrides.origin,
+    playerId: args.playerId,
+    teamId: args.teamId,
+    totalYears,
+    currentYear: 1,
+    totalSalary,
+    annualSalary,
+    guaranteedMoney,
+    signingBonus,
   };
 }
 
+/**
+ * Deterministic attribute profile for a bucket — used by repository/integration
+ * tests that need a classifiable attribute set without running the full
+ * randomized generator. Each signature attribute is lifted above baseline so
+ * `neutralBucket()` classifies the owner into the intended bucket.
+ */
+export function stubAttributesFor(bucket: NeutralBucket): PlayerAttributes {
+  const profile = BUCKET_PROFILES[bucket];
+  const BASELINE = 30;
+  const SIGNATURE = 60;
+  const POTENTIAL = 65;
+  const signatureSet = new Set<PlayerAttributeKey>(profile.signature);
+  const attrs: Record<string, number> = {};
+  for (const key of PLAYER_ATTRIBUTE_KEYS) {
+    const current = signatureSet.has(key) ? SIGNATURE : BASELINE;
+    attrs[key] = current;
+    attrs[`${key}Potential`] = Math.max(current, POTENTIAL);
+  }
+  return attrs as PlayerAttributes;
+}
+
 export interface StubPlayersGeneratorOptions {
+  /**
+   * Injected name generator. Defaults to the shared server-wide
+   * `createNameGenerator()` so league creation produces varied names without
+   * explicit wiring; tests pass a seeded generator for determinism.
+   */
   nameGenerator?: NameGenerator;
+  /** Injected RNG for deterministic tests; defaults to `Math.random`. */
+  random?: () => number;
+  /** Anchor year for birthdate/draft-year math; defaults to current UTC year. */
+  currentYear?: number;
 }
 
 export function createStubPlayersGenerator(
   options: StubPlayersGeneratorOptions = {},
 ): PlayersGenerator {
+  const random = options.random ?? Math.random;
+  const rng = createRng(random);
   const nameGenerator = options.nameGenerator ?? createNameGenerator();
+  const currentYear = options.currentYear ?? new Date().getUTCFullYear();
+
+  function buildPlayer(args: {
+    leagueId: string;
+    teamId: string | null;
+    status: "active" | "prospect";
+    bucket: NeutralBucket;
+    indexInBucket: number;
+    bucketCount: number;
+    draftingTeamId: string | null;
+    statusKind: "rostered" | "free-agent" | "prospect";
+  }) {
+    const quality = rollQuality(
+      rng,
+      qualityTierForIndex(args.indexInBucket, args.bucketCount),
+    );
+    const age = rollAge(rng, args.statusKind);
+    const { heightInches, weightPounds } = rollHeightWeight(rng, args.bucket);
+    const attributes = rollAttributesFor(rng, args.bucket, quality);
+    lockInBucket(attributes, args.bucket, heightInches, weightPounds);
+    rollPotentials(rng, attributes, age);
+    const { firstName, lastName } = nameGenerator.next();
+    const origin = args.statusKind === "prospect"
+      ? {
+        hometown: pickHometown(rng),
+        draftYear: null,
+        draftRound: null,
+        draftPick: null,
+        draftingTeamId: null,
+      }
+      : rollOrigin(rng, age, currentYear, args.draftingTeamId);
+    return {
+      player: {
+        leagueId: args.leagueId,
+        teamId: args.teamId,
+        status: args.status,
+        firstName,
+        lastName,
+        injuryStatus: "healthy" as const,
+        heightInches,
+        weightPounds,
+        college: pickCollege(rng),
+        birthDate: birthDateForAge(age, currentYear, rng),
+        ...origin,
+      },
+      attributes,
+    };
+  }
+
   return {
     generate(input: PlayersGeneratorInput): GeneratedPlayers {
-      let nameIndex = 0;
+      const players: GeneratedPlayers["players"] = [];
 
-      const players = [];
       for (const teamId of input.teamIds) {
+        const bucketIndex = new Map<NeutralBucket, number>();
+        const bucketTotal = new Map<NeutralBucket, number>();
+        for (const { bucket, count } of ROSTER_BUCKET_COMPOSITION) {
+          bucketTotal.set(bucket, count);
+        }
         for (let i = 0; i < input.rosterSize; i++) {
-          const { firstName, lastName } = nameGenerator.next();
-          nameIndex++;
           const bucket = ROSTER_BUCKET_SLOTS[i % ROSTER_BUCKET_SLOTS.length];
-          const origin = stubOrigin(nameIndex, teamId);
-          players.push({
-            player: playerShell(bucket, {
+          const indexInBucket = bucketIndex.get(bucket) ?? 0;
+          bucketIndex.set(bucket, indexInBucket + 1);
+          players.push(
+            buildPlayer({
               leagueId: input.leagueId,
               teamId,
               status: "active",
-              firstName,
-              lastName,
-              origin,
+              bucket,
+              indexInBucket,
+              bucketCount: bucketTotal.get(bucket) ?? 1,
+              draftingTeamId: teamId,
+              statusKind: "rostered",
             }),
-            attributes: stubAttributesFor(bucket),
-          });
+          );
         }
       }
 
       for (let i = 0; i < FREE_AGENT_COUNT; i++) {
-        const { firstName, lastName } = nameGenerator.next();
-        nameIndex++;
-        const bucket = FREE_AGENT_BUCKET_CYCLE[
-          i % FREE_AGENT_BUCKET_CYCLE.length
-        ];
-        const origin = stubOrigin(nameIndex, null);
-        players.push({
-          player: playerShell(bucket, {
+        const bucket =
+          FREE_AGENT_BUCKET_CYCLE[i % FREE_AGENT_BUCKET_CYCLE.length];
+        players.push(
+          buildPlayer({
             leagueId: input.leagueId,
             teamId: null,
             status: "active",
-            firstName,
-            lastName,
-            origin,
+            bucket,
+            indexInBucket: 2 + i, // biases toward depth tier
+            bucketCount: FREE_AGENT_COUNT,
+            draftingTeamId: null,
+            statusKind: "free-agent",
           }),
-          attributes: stubAttributesFor(bucket),
-        });
+        );
       }
 
       for (let i = 0; i < DRAFT_PROSPECT_COUNT; i++) {
-        const { firstName, lastName } = nameGenerator.next();
-        nameIndex++;
-        const bucket = FREE_AGENT_BUCKET_CYCLE[
-          i % FREE_AGENT_BUCKET_CYCLE.length
-        ];
-        players.push({
-          player: playerShell(bucket, {
+        const bucket =
+          FREE_AGENT_BUCKET_CYCLE[i % FREE_AGENT_BUCKET_CYCLE.length];
+        const indexInBucket = Math.floor(i / FREE_AGENT_BUCKET_CYCLE.length);
+        players.push(
+          buildPlayer({
             leagueId: input.leagueId,
             teamId: null,
             status: "prospect",
-            firstName,
-            lastName,
-            origin: {
-              hometown: STUB_HOMETOWNS[i % STUB_HOMETOWNS.length],
-              draftYear: null,
-              draftRound: null,
-              draftPick: null,
-              draftingTeamId: null,
-            },
+            bucket,
+            indexInBucket,
+            bucketCount: Math.ceil(
+              DRAFT_PROSPECT_COUNT / FREE_AGENT_BUCKET_CYCLE.length,
+            ),
+            draftingTeamId: null,
+            statusKind: "prospect",
           }),
-          attributes: stubAttributesFor(bucket),
-        });
+        );
       }
 
       return { players };
     },
 
     generateContracts(input: ContractGeneratorInput): GeneratedContract[] {
-      const rosteredPlayers = input.players.filter((p) => p.teamId !== null);
-      const perPlayerSalary = Math.floor(
-        input.salaryCap / Math.max(rosteredPlayers.length, 1),
+      const rostered = input.players.filter(
+        (p): p is typeof p & { teamId: string } => p.teamId !== null,
       );
+      if (rostered.length === 0) return [];
 
-      return rosteredPlayers.map((player) => ({
-        playerId: player.id,
-        teamId: player.teamId!,
-        totalYears: 3,
-        currentYear: 1,
-        totalSalary: perPlayerSalary * 3,
-        annualSalary: perPlayerSalary,
-        guaranteedMoney: perPlayerSalary,
-        signingBonus: 0,
-      }));
+      const byTeam = new Map<string, typeof rostered>();
+      for (const p of rostered) {
+        const list = byTeam.get(p.teamId) ?? [];
+        list.push(p);
+        byTeam.set(p.teamId, list);
+      }
+
+      const contracts: GeneratedContract[] = [];
+      for (const [teamId, teamPlayers] of byTeam) {
+        // The contract callsite only has ids + teamId, so we synthesize a
+        // plausible bucket/quality/age per seat so salaries vary across the
+        // roster. The per-team annual total is then scaled down uniformly if
+        // it would exceed the cap.
+        const rawContracts = teamPlayers.map((p, idx) => {
+          const bucket = ROSTER_BUCKET_SLOTS[idx % ROSTER_BUCKET_SLOTS.length];
+          const bucketCount = ROSTER_BUCKET_COMPOSITION.find((c) =>
+            c.bucket === bucket
+          )?.count ??
+            1;
+          const indexInBucket = Math.floor(
+            idx / ROSTER_BUCKET_COMPOSITION.length,
+          );
+          const tier = qualityTierForIndex(indexInBucket, bucketCount);
+          const quality = rollQuality(rng, tier);
+          const age = rollAge(rng, "rostered");
+          return rollContract(rng, {
+            playerId: p.id,
+            teamId,
+            bucket,
+            quality,
+            age,
+          });
+        });
+        const teamAnnualTotal = rawContracts.reduce(
+          (s, c) => s + c.annualSalary,
+          0,
+        );
+        const scale = teamAnnualTotal > input.salaryCap
+          ? input.salaryCap / teamAnnualTotal
+          : 1;
+        for (const c of rawContracts) {
+          // Scale down without re-applying the per-player floor — the floor
+          // already applied during the raw roll, and clamping again after
+          // scaling would push the team total back over the cap.
+          const annualSalary = Math.max(
+            1,
+            Math.floor(c.annualSalary * scale),
+          );
+          contracts.push({
+            ...c,
+            annualSalary,
+            totalSalary: annualSalary * c.totalYears,
+            guaranteedMoney: Math.round(c.guaranteedMoney * scale),
+            signingBonus: Math.round(c.signingBonus * scale),
+          });
+        }
+      }
+      return contracts;
     },
   };
 }


### PR DESCRIPTION
## Summary

- Graduates the v1 player stub generator (baseline 30 / potential 60 / fixed
  height-weight / `State University` / `2000-01-01` / flat salary split) into an
  archetype-aware generator driven by a seeded, distribution-based roller.
  Attribute rolls are gaussian around per-bucket signature means with a
  star / starter / depth quality tier; potentials lift less as players age;
  heights, weights, ages, colleges, hometowns, and contracts all vary across
  realistic ranges; per-team contract totals are scaled down to stay under the
  salary cap.
- Adds a post-roll lock-in step that ensures `neutralBucket()` classifies each
  player into the intended bucket even when bucket-rule signatures overlap
  (OT/IOL share pass/run block, LB/S share tackling + zone coverage, etc.).
- Introduces a narrow local `NameGenerator` interface injected through the
  factory, a `random` override, and a `currentYear` anchor so the generator is
  fully deterministic under test and compatible with the shared name generator
  being extracted in a parallel PR.
- Adds ADR 0009 recording the design, resolves the archetype-aware-generation
  backlog entry, and leaves a narrower follow-up for the cross-archetype
  (Travis Hunter) case.
- Stub-generator test suite grows from 17 to 25 deterministic assertions,
  covering distribution invariants, age spread, college pool, hometown format,
  contract variance, and seeded reproducibility.