### PR TITLE
feat(roster): add disabled release/trade/restructure action buttons

### DIFF
--- a/client/src/features/league/roster.test.tsx
+++ b/client/src/features/league/roster.test.tsx
@@ -325,6 +325,42 @@ describe("Roster — active roster tab (default)", () => {
       "roster-row-p3",
     ]);
   });
+
+  it("renders an Actions column header", () => {
+    renderRoster();
+    expect(screen.getByText("Actions")).toBeDefined();
+  });
+
+  it("renders disabled Release, Trade, and Restructure buttons for each player", () => {
+    renderRoster();
+    const row = screen.getByTestId("roster-row-p1");
+    const releaseBtn = within(row).getByRole("button", { name: /release/i });
+    const tradeBtn = within(row).getByRole("button", { name: /trade/i });
+    const restructureBtn = within(row).getByRole("button", {
+      name: /restructure/i,
+    });
+
+    expect(releaseBtn).toBeDefined();
+    expect(tradeBtn).toBeDefined();
+    expect(restructureBtn).toBeDefined();
+
+    expect(releaseBtn.hasAttribute("disabled")).toBe(true);
+    expect(tradeBtn.hasAttribute("disabled")).toBe(true);
+    expect(restructureBtn.hasAttribute("disabled")).toBe(true);
+  });
+
+  it("renders action buttons for every player row", () => {
+    renderRoster();
+    for (const id of ["p1", "p2", "p3", "p4"]) {
+      const row = screen.getByTestId(`roster-row-${id}`);
+      expect(within(row).getByRole("button", { name: /release/i }))
+        .toBeDefined();
+      expect(within(row).getByRole("button", { name: /trade/i }))
+        .toBeDefined();
+      expect(within(row).getByRole("button", { name: /restructure/i }))
+        .toBeDefined();
+    }
+  });
 });
 
 describe("Roster — depth chart tab", () => {

--- a/client/src/features/league/roster.tsx
+++ b/client/src/features/league/roster.tsx
@@ -178,6 +178,24 @@ const rosterColumns: ColumnDef<RosterPlayer>[] = [
       </Badge>
     ),
   },
+  {
+    id: "actions",
+    header: () => <span>Actions</span>,
+    cell: () => (
+      <div className="flex gap-1">
+        <Button variant="ghost" size="sm" disabled>
+          Release
+        </Button>
+        <Button variant="ghost" size="sm" disabled>
+          Trade
+        </Button>
+        <Button variant="ghost" size="sm" disabled>
+          Restructure
+        </Button>
+      </div>
+    ),
+    enableSorting: false,
+  },
 ];
 
 export function Roster() {

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -41,11 +41,6 @@ entry when it's resolved or superseded.
   design before a large player-creation pass ships. See
   `docs/product/decisions/0006-positionless-players.md` "Note for the future —
   player generation toward archetypes."
-- **2026-04-14 — Roster page release/trade/restructure flows.** The Active
-  Roster view (decision 0001) lists release, trade, and restructure as
-  per-player actions. Initial roster page PR ships these as disabled "coming
-  soon" buttons. Build out each flow as its own feature once product priorities
-  surface them.
 - **2026-04-14 — Coach sim depth-chart publisher.** Decision 0001 requires the
   coach sim to publish a stable depth-chart artifact the roster page reads.
   Initial roster page stubs the source (empty depth chart until the sim writes


### PR DESCRIPTION
## Summary

- Adds an Actions column to the Active Roster table with disabled Release, Trade, and Restructure buttons per player row, as specified in decision 0001.
- These are placeholder buttons that will be enabled when each flow (release, trade, restructure) is implemented as its own feature.
- Removes the corresponding backlog item.

🤖 Generated with [Claude Code](https://claude.com/claude-code)