### PR TITLE
docs(backlog): remove player detail view per-game splits item

### DIFF
--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -27,10 +27,6 @@ entry when it's resolved or superseded.
   coach sim to publish a stable depth-chart artifact the roster page reads.
   Initial roster page stubs the source (empty depth chart until the sim writes
   rows). Wire the real producer when coach-side sim work begins.
-- **2026-04-14 — Player detail view with per-game splits.** Roster Statistics
-  view is specified to link each row to a detail view with game-by-game splits
-  (decision 0001). Initial PR ships without that detail route; add the page when
-  per-game sim output lands.
 - **2026-04-14 — Stack overflow in full-roster bulk insert during league
   creation.** Ran the full `leagueService.create` flow end-to-end against real
   Postgres (32 teams × 53 roster) and drizzle's `mergeQueries` stack-overflows


### PR DESCRIPTION
## Summary

- Removes the "Player detail view with per-game splits" backlog bullet. The player detail page already exists with career log, contracts, transactions, and accolades. The per-game splits portion is blocked on per-game simulation output (player-level stats), which the game simulator does not yet produce. Per-game splits will be tracked as part of simulation output work when that begins.

🤖 Generated with [Claude Code](https://claude.com/claude-code)