### PR TITLE
feat(depth-chart): publish initial depth charts during league creation

### DIFF
--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -29,10 +29,6 @@ entry when it's resolved or superseded.
   qualify for two non-specialist neutral buckets (e.g. CB + WR). Wire this into
   the generator with a rate knob, and surface both bucket lenses in the scout /
   depth-chart / draft UIs.
-- **2026-04-14 — Coach sim depth-chart publisher.** Decision 0001 requires the
-  coach sim to publish a stable depth-chart artifact the roster page reads.
-  Initial roster page stubs the source (empty depth chart until the sim writes
-  rows). Wire the real producer when coach-side sim work begins.
 - **2026-04-14 — Stack overflow in full-roster bulk insert during league
   creation.** Ran the full `leagueService.create` flow end-to-end against real
   Postgres (32 teams × 53 roster) and drizzle's `mergeQueries` stack-overflows

--- a/packages/shared/depth-chart/assign.test.ts
+++ b/packages/shared/depth-chart/assign.test.ts
@@ -1,0 +1,217 @@
+import { assertEquals } from "@std/assert";
+import {
+  assignDepthChart,
+  type DepthChartAssignment,
+  type PlayerForAssignment,
+} from "./assign.ts";
+import type { DepthChartSlotDefinition } from "./vocabulary.ts";
+
+function slot(
+  code: string,
+  group: "offense" | "defense" | "special_teams" = "offense",
+): DepthChartSlotDefinition {
+  return { code, label: code, group };
+}
+
+function player(
+  id: string,
+  neutralBucket: PlayerForAssignment["neutralBucket"],
+  score: number,
+): PlayerForAssignment {
+  return { id, neutralBucket, score };
+}
+
+function findByPlayer(
+  assignments: DepthChartAssignment[],
+  playerId: string,
+): DepthChartAssignment | undefined {
+  return assignments.find((a) => a.playerId === playerId);
+}
+
+function forSlot(
+  assignments: DepthChartAssignment[],
+  slotCode: string,
+): DepthChartAssignment[] {
+  return assignments
+    .filter((a) => a.slotCode === slotCode)
+    .sort((a, b) => a.slotOrdinal - b.slotOrdinal);
+}
+
+Deno.test("assignDepthChart: empty player list returns empty assignments", () => {
+  const result = assignDepthChart([], [slot("QB")]);
+  assertEquals(result, []);
+});
+
+Deno.test("assignDepthChart: assigns single player to matching slot", () => {
+  const result = assignDepthChart(
+    [player("qb1", "QB", 80)],
+    [slot("QB")],
+  );
+  assertEquals(result.length, 1);
+  assertEquals(result[0].playerId, "qb1");
+  assertEquals(result[0].slotCode, "QB");
+  assertEquals(result[0].slotOrdinal, 1);
+  assertEquals(result[0].isInactive, false);
+});
+
+Deno.test("assignDepthChart: ranks players by score within a slot", () => {
+  const result = assignDepthChart(
+    [player("qb1", "QB", 60), player("qb2", "QB", 90)],
+    [slot("QB")],
+  );
+  const qbSlot = forSlot(result, "QB");
+  assertEquals(qbSlot.length, 2);
+  assertEquals(qbSlot[0].playerId, "qb2");
+  assertEquals(qbSlot[0].slotOrdinal, 1);
+  assertEquals(qbSlot[1].playerId, "qb1");
+  assertEquals(qbSlot[1].slotOrdinal, 2);
+});
+
+Deno.test("assignDepthChart: distributes OT across LT and RT", () => {
+  const result = assignDepthChart(
+    [
+      player("ot1", "OT", 90),
+      player("ot2", "OT", 80),
+      player("ot3", "OT", 70),
+      player("ot4", "OT", 60),
+    ],
+    [slot("LT"), slot("RT")],
+  );
+  const lt = forSlot(result, "LT");
+  const rt = forSlot(result, "RT");
+  assertEquals(lt.length, 2);
+  assertEquals(rt.length, 2);
+  assertEquals(lt[0].playerId, "ot1");
+  assertEquals(rt[0].playerId, "ot2");
+  assertEquals(lt[1].playerId, "ot3");
+  assertEquals(rt[1].playerId, "ot4");
+});
+
+Deno.test("assignDepthChart: distributes IOL across LG, C, RG", () => {
+  const result = assignDepthChart(
+    [
+      player("iol1", "IOL", 90),
+      player("iol2", "IOL", 80),
+      player("iol3", "IOL", 70),
+    ],
+    [slot("LG"), slot("C"), slot("RG")],
+  );
+  assertEquals(forSlot(result, "LG").length, 1);
+  assertEquals(forSlot(result, "C").length, 1);
+  assertEquals(forSlot(result, "RG").length, 1);
+  assertEquals(forSlot(result, "LG")[0].playerId, "iol1");
+  assertEquals(forSlot(result, "C")[0].playerId, "iol2");
+  assertEquals(forSlot(result, "RG")[0].playerId, "iol3");
+});
+
+Deno.test("assignDepthChart: each player appears exactly once", () => {
+  const players = [
+    player("qb1", "QB", 90),
+    player("qb2", "QB", 80),
+    player("rb1", "RB", 85),
+    player("wr1", "WR", 75),
+  ];
+  const vocab = [slot("QB"), slot("RB"), slot("WR")];
+  const result = assignDepthChart(players, vocab);
+  assertEquals(result.length, 4);
+  const playerIds = result.map((a) => a.playerId).sort();
+  assertEquals(playerIds, ["qb1", "qb2", "rb1", "wr1"]);
+});
+
+Deno.test("assignDepthChart: no duplicate (slotCode, slotOrdinal) pairs", () => {
+  const players = [
+    player("qb1", "QB", 90),
+    player("qb2", "QB", 80),
+    player("qb3", "QB", 70),
+    player("rb1", "RB", 85),
+    player("rb2", "RB", 75),
+  ];
+  const vocab = [slot("QB"), slot("RB")];
+  const result = assignDepthChart(players, vocab);
+  const keys = result.map((a) => `${a.slotCode}:${a.slotOrdinal}`);
+  assertEquals(new Set(keys).size, keys.length);
+});
+
+Deno.test("assignDepthChart: players with no matching slot become inactive", () => {
+  const result = assignDepthChart(
+    [player("k1", "K", 80)],
+    [slot("QB")],
+  );
+  assertEquals(result.length, 1);
+  assertEquals(result[0].isInactive, true);
+});
+
+Deno.test("assignDepthChart: CB bucket fills both CB and NCB slots", () => {
+  const result = assignDepthChart(
+    [
+      player("cb1", "CB", 90),
+      player("cb2", "CB", 85),
+      player("cb3", "CB", 80),
+    ],
+    [slot("CB", "defense"), slot("NCB", "defense")],
+  );
+  const cb = forSlot(result, "CB");
+  const ncb = forSlot(result, "NCB");
+  assertEquals(cb[0].playerId, "cb1");
+  assertEquals(ncb[0].playerId, "cb2");
+});
+
+Deno.test("assignDepthChart: mixed roster assigns all positions", () => {
+  const players = [
+    player("qb1", "QB", 80),
+    player("rb1", "RB", 75),
+    player("wr1", "WR", 70),
+    player("te1", "TE", 65),
+    player("ot1", "OT", 85),
+    player("iol1", "IOL", 72),
+    player("edge1", "EDGE", 78),
+    player("idl1", "IDL", 68),
+    player("lb1", "LB", 73),
+    player("cb1", "CB", 82),
+    player("s1", "S", 76),
+    player("k1", "K", 50),
+    player("p1", "P", 50),
+    player("ls1", "LS", 50),
+  ];
+  const vocab = [
+    slot("QB"),
+    slot("RB"),
+    slot("WR"),
+    slot("TE"),
+    slot("LT"),
+    slot("LG"),
+    slot("C"),
+    slot("RG"),
+    slot("RT"),
+    slot("DE", "defense"),
+    slot("DT", "defense"),
+    slot("LB", "defense"),
+    slot("CB", "defense"),
+    slot("S", "defense"),
+    slot("K", "special_teams"),
+    slot("P", "special_teams"),
+    slot("LS", "special_teams"),
+  ];
+  const result = assignDepthChart(players, vocab);
+  assertEquals(result.length, 14);
+  for (const a of result) {
+    assertEquals(a.isInactive, false);
+  }
+  assertEquals(findByPlayer(result, "qb1")!.slotCode, "QB");
+  assertEquals(findByPlayer(result, "ot1")!.slotCode, "LT");
+  assertEquals(findByPlayer(result, "iol1")!.slotCode, "LG");
+  assertEquals(findByPlayer(result, "edge1")!.slotCode, "DE");
+  assertEquals(findByPlayer(result, "idl1")!.slotCode, "DT");
+});
+
+Deno.test("assignDepthChart: FB slot prefers RB-bucket players first", () => {
+  const result = assignDepthChart(
+    [
+      player("rb1", "RB", 90),
+      player("rb2", "RB", 60),
+    ],
+    [slot("RB"), slot("FB")],
+  );
+  assertEquals(findByPlayer(result, "rb1")!.slotCode, "RB");
+  assertEquals(findByPlayer(result, "rb2")!.slotCode, "FB");
+});

--- a/packages/shared/depth-chart/assign.ts
+++ b/packages/shared/depth-chart/assign.ts
@@ -1,0 +1,94 @@
+import type { NeutralBucket } from "../archetypes/neutral-bucket.ts";
+import { eligibleBucketsForSlot } from "./slot-mapping.ts";
+import type { DepthChartSlotDefinition } from "./vocabulary.ts";
+
+export interface PlayerForAssignment {
+  id: string;
+  neutralBucket: NeutralBucket;
+  score: number;
+}
+
+export interface DepthChartAssignment {
+  playerId: string;
+  slotCode: string;
+  slotOrdinal: number;
+  isInactive: boolean;
+}
+
+export function assignDepthChart(
+  players: readonly PlayerForAssignment[],
+  vocabulary: readonly DepthChartSlotDefinition[],
+): DepthChartAssignment[] {
+  if (players.length === 0) return [];
+
+  const vocabCodes = vocabulary.map((v) => v.code);
+
+  const bucketToSlots = new Map<NeutralBucket, string[]>();
+  for (const code of vocabCodes) {
+    for (const bucket of eligibleBucketsForSlot(code)) {
+      if (!bucketToSlots.has(bucket)) bucketToSlots.set(bucket, []);
+      bucketToSlots.get(bucket)!.push(code);
+    }
+  }
+
+  const playersByBucket = new Map<NeutralBucket, PlayerForAssignment[]>();
+  for (const p of players) {
+    if (!playersByBucket.has(p.neutralBucket)) {
+      playersByBucket.set(p.neutralBucket, []);
+    }
+    playersByBucket.get(p.neutralBucket)!.push(p);
+  }
+  for (const group of playersByBucket.values()) {
+    group.sort((a, b) => b.score - a.score);
+  }
+
+  const slotCounts = new Map<string, number>();
+  for (const code of vocabCodes) {
+    slotCounts.set(code, 0);
+  }
+
+  const assignments: DepthChartAssignment[] = [];
+  const assigned = new Set<string>();
+
+  for (const [bucket, group] of playersByBucket) {
+    const slots = bucketToSlots.get(bucket);
+    if (!slots || slots.length === 0) continue;
+
+    for (const p of group) {
+      let targetSlot = slots[0];
+      let minCount = slotCounts.get(slots[0]) ?? 0;
+      for (let i = 1; i < slots.length; i++) {
+        const count = slotCounts.get(slots[i]) ?? 0;
+        if (count < minCount) {
+          minCount = count;
+          targetSlot = slots[i];
+        }
+      }
+
+      const ordinal = (slotCounts.get(targetSlot) ?? 0) + 1;
+      assignments.push({
+        playerId: p.id,
+        slotCode: targetSlot,
+        slotOrdinal: ordinal,
+        isInactive: false,
+      });
+      slotCounts.set(targetSlot, ordinal);
+      assigned.add(p.id);
+    }
+  }
+
+  for (const p of players) {
+    if (assigned.has(p.id)) continue;
+    const fallbackSlot = vocabCodes[0] ?? "RES";
+    const ordinal = (slotCounts.get(fallbackSlot) ?? 0) + 1;
+    assignments.push({
+      playerId: p.id,
+      slotCode: fallbackSlot,
+      slotOrdinal: ordinal,
+      isInactive: true,
+    });
+    slotCounts.set(fallbackSlot, ordinal);
+  }
+
+  return assignments;
+}

--- a/packages/shared/depth-chart/slot-mapping.test.ts
+++ b/packages/shared/depth-chart/slot-mapping.test.ts
@@ -1,0 +1,46 @@
+import { assertEquals } from "@std/assert";
+import { eligibleBucketsForSlot } from "./slot-mapping.ts";
+
+Deno.test("eligibleBucketsForSlot: QB slot accepts QB bucket", () => {
+  assertEquals(eligibleBucketsForSlot("QB"), ["QB"]);
+});
+
+Deno.test("eligibleBucketsForSlot: FB slot accepts RB and TE buckets", () => {
+  assertEquals(eligibleBucketsForSlot("FB"), ["RB", "TE"]);
+});
+
+Deno.test("eligibleBucketsForSlot: OL slot accepts OT and IOL buckets", () => {
+  assertEquals(eligibleBucketsForSlot("OL"), ["OT", "IOL"]);
+});
+
+Deno.test("eligibleBucketsForSlot: LT slot accepts only OT bucket", () => {
+  assertEquals(eligibleBucketsForSlot("LT"), ["OT"]);
+});
+
+Deno.test("eligibleBucketsForSlot: IOL positions map correctly", () => {
+  assertEquals(eligibleBucketsForSlot("LG"), ["IOL"]);
+  assertEquals(eligibleBucketsForSlot("C"), ["IOL"]);
+  assertEquals(eligibleBucketsForSlot("RG"), ["IOL"]);
+});
+
+Deno.test("eligibleBucketsForSlot: OLB accepts EDGE and LB buckets", () => {
+  assertEquals(eligibleBucketsForSlot("OLB"), ["EDGE", "LB"]);
+});
+
+Deno.test("eligibleBucketsForSlot: DL slot accepts IDL and EDGE", () => {
+  assertEquals(eligibleBucketsForSlot("DL"), ["IDL", "EDGE"]);
+});
+
+Deno.test("eligibleBucketsForSlot: NCB accepts CB bucket", () => {
+  assertEquals(eligibleBucketsForSlot("NCB"), ["CB"]);
+});
+
+Deno.test("eligibleBucketsForSlot: special teams slots map 1:1", () => {
+  assertEquals(eligibleBucketsForSlot("K"), ["K"]);
+  assertEquals(eligibleBucketsForSlot("P"), ["P"]);
+  assertEquals(eligibleBucketsForSlot("LS"), ["LS"]);
+});
+
+Deno.test("eligibleBucketsForSlot: unknown slot returns empty", () => {
+  assertEquals(eligibleBucketsForSlot("UNKNOWN"), []);
+});

--- a/packages/shared/depth-chart/slot-mapping.ts
+++ b/packages/shared/depth-chart/slot-mapping.ts
@@ -1,0 +1,35 @@
+import type { NeutralBucket } from "../archetypes/neutral-bucket.ts";
+
+const SLOT_TO_BUCKETS: Readonly<Record<string, readonly NeutralBucket[]>> = {
+  QB: ["QB"],
+  RB: ["RB"],
+  FB: ["RB", "TE"],
+  WR: ["WR"],
+  TE: ["TE"],
+  LT: ["OT"],
+  LG: ["IOL"],
+  C: ["IOL"],
+  RG: ["IOL"],
+  RT: ["OT"],
+  OL: ["OT", "IOL"],
+  OLB: ["EDGE", "LB"],
+  ILB: ["LB"],
+  NT: ["IDL"],
+  DE: ["EDGE"],
+  DT: ["IDL"],
+  EDGE: ["EDGE"],
+  DL: ["IDL", "EDGE"],
+  LB: ["LB"],
+  CB: ["CB"],
+  NCB: ["CB"],
+  S: ["S"],
+  K: ["K"],
+  P: ["P"],
+  LS: ["LS"],
+};
+
+export function eligibleBucketsForSlot(
+  slotCode: string,
+): readonly NeutralBucket[] {
+  return SLOT_TO_BUCKETS[slotCode] ?? [];
+}

--- a/packages/shared/mod.ts
+++ b/packages/shared/mod.ts
@@ -131,6 +131,12 @@ export type {
   DepthChartSlotGroup,
 } from "./depth-chart/vocabulary.ts";
 export { depthChartVocabulary } from "./depth-chart/vocabulary.ts";
+export { eligibleBucketsForSlot } from "./depth-chart/slot-mapping.ts";
+export { assignDepthChart } from "./depth-chart/assign.ts";
+export type {
+  DepthChartAssignment,
+  PlayerForAssignment,
+} from "./depth-chart/assign.ts";
 
 // Interfaces — simulation
 export type {

--- a/server/features/depth-chart/depth-chart.publisher.interface.ts
+++ b/server/features/depth-chart/depth-chart.publisher.interface.ts
@@ -1,0 +1,17 @@
+import type { Executor } from "../../db/connection.ts";
+
+export interface PublishDepthChartsInput {
+  leagueId: string;
+  teamIds: string[];
+}
+
+export interface PublishDepthChartsResult {
+  entryCount: number;
+}
+
+export interface DepthChartPublisher {
+  publishForTeams(
+    input: PublishDepthChartsInput,
+    tx?: Executor,
+  ): Promise<PublishDepthChartsResult>;
+}

--- a/server/features/depth-chart/depth-chart.publisher.test.ts
+++ b/server/features/depth-chart/depth-chart.publisher.test.ts
@@ -1,0 +1,437 @@
+import { assertEquals } from "@std/assert";
+import { eq, inArray } from "drizzle-orm";
+import { drizzle } from "drizzle-orm/postgres-js";
+import postgres from "postgres";
+import pino from "pino";
+import { type NeutralBucket, PLAYER_ATTRIBUTE_KEYS } from "@zone-blitz/shared";
+import * as schema from "../../db/schema.ts";
+import { players } from "../players/player.schema.ts";
+import { playerAttributes } from "../players/attributes.schema.ts";
+import { depthChartEntries } from "../players/depth-chart.schema.ts";
+import {
+  BUCKET_PROFILES,
+  stubAttributesFor,
+} from "../players/stub-players-generator.ts";
+import { coaches } from "../coaches/coach.schema.ts";
+import { coachTendencies } from "../coaches/coach-tendencies.schema.ts";
+import { leagues } from "../league/league.schema.ts";
+import { teams } from "../team/team.schema.ts";
+import { cities } from "../cities/city.schema.ts";
+import { states } from "../states/state.schema.ts";
+import { createDepthChartPublisher } from "./depth-chart.publisher.ts";
+
+function createTestDb() {
+  const connectionString = Deno.env.get("DATABASE_URL");
+  if (!connectionString) {
+    throw new Error("DATABASE_URL is required for integration tests");
+  }
+  const client = postgres(connectionString);
+  const db = drizzle(client, { schema });
+  return { db, client };
+}
+
+function createTestLogger() {
+  return pino({ level: "silent" });
+}
+
+function sizeFor(bucket: NeutralBucket) {
+  return {
+    heightInches: BUCKET_PROFILES[bucket].heightInches,
+    weightPounds: BUCKET_PROFILES[bucket].weightPounds,
+  };
+}
+
+function stubAttributeColumns(bucket: NeutralBucket) {
+  const attrs = stubAttributesFor(bucket);
+  const row: Record<string, number> = {};
+  for (const key of PLAYER_ATTRIBUTE_KEYS) {
+    row[key] = attrs[key];
+    row[`${key}Potential`] = attrs[`${key}Potential` as keyof typeof attrs];
+  }
+  return row;
+}
+
+async function setupFixtures(db: ReturnType<typeof createTestDb>["db"]) {
+  const [league] = await db
+    .insert(leagues)
+    .values({ name: `League ${crypto.randomUUID()}`, salaryCap: 255_000_000 })
+    .returning();
+  const [state] = await db
+    .insert(states)
+    .values({
+      code: `test-${crypto.randomUUID()}`,
+      name: `TestState-${crypto.randomUUID()}`,
+      region: "West",
+    })
+    .returning();
+  const [city] = await db
+    .insert(cities)
+    .values({
+      name: `TestCity-${crypto.randomUUID()}`,
+      stateId: state.id,
+    })
+    .returning();
+  const [team] = await db
+    .insert(teams)
+    .values({
+      name: "Test Team",
+      abbreviation: `T${crypto.randomUUID().slice(0, 2).toUpperCase()}`,
+      cityId: city.id,
+      primaryColor: "#000000",
+      secondaryColor: "#FFFFFF",
+      accentColor: "#FF0000",
+      conference: "AFC",
+      division: "AFC East",
+    })
+    .returning();
+  return { league, team, state, city };
+}
+
+async function cleanup(
+  db: ReturnType<typeof createTestDb>["db"],
+  ids: {
+    coaches?: string[];
+    players?: string[];
+    teams?: string[];
+    cities?: string[];
+    states?: string[];
+    leagues?: string[];
+  },
+) {
+  if (ids.coaches?.length) {
+    await db.delete(coaches).where(inArray(coaches.id, ids.coaches));
+  }
+  if (ids.players?.length) {
+    await db.delete(players).where(inArray(players.id, ids.players));
+  }
+  if (ids.teams?.length) {
+    await db.delete(teams).where(inArray(teams.id, ids.teams));
+  }
+  if (ids.cities?.length) {
+    await db.delete(cities).where(inArray(cities.id, ids.cities));
+  }
+  if (ids.states?.length) {
+    await db.delete(states).where(inArray(states.id, ids.states));
+  }
+  if (ids.leagues?.length) {
+    await db.delete(leagues).where(inArray(leagues.id, ids.leagues));
+  }
+}
+
+Deno.test({
+  name:
+    "depthChartPublisher.publishForTeams: creates entries for all players on a team",
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    const { db, client } = createTestDb();
+    const publisher = createDepthChartPublisher({
+      db,
+      log: createTestLogger(),
+    });
+    const playersCreated: string[] = [];
+    const coachesCreated: string[] = [];
+    const teamsCreated: string[] = [];
+    const citiesCreated: string[] = [];
+    const statesCreated: string[] = [];
+    const leaguesCreated: string[] = [];
+    try {
+      const { league, team, state, city } = await setupFixtures(db);
+      leaguesCreated.push(league.id);
+      teamsCreated.push(team.id);
+      statesCreated.push(state.id);
+      citiesCreated.push(city.id);
+
+      const hcId = crypto.randomUUID();
+      const ocId = crypto.randomUUID();
+      const dcId = crypto.randomUUID();
+      await db.insert(coaches).values([
+        {
+          id: hcId,
+          leagueId: league.id,
+          teamId: team.id,
+          firstName: "Head",
+          lastName: "Coach",
+          role: "HC",
+          age: 50,
+          hiredAt: new Date("2028-01-01"),
+          contractYears: 3,
+          contractSalary: 1,
+          contractBuyout: 1,
+        },
+        {
+          id: ocId,
+          leagueId: league.id,
+          teamId: team.id,
+          firstName: "Off",
+          lastName: "Coordinator",
+          role: "OC",
+          age: 45,
+          hiredAt: new Date("2028-01-01"),
+          contractYears: 3,
+          contractSalary: 1,
+          contractBuyout: 1,
+          reportsToId: hcId,
+        },
+        {
+          id: dcId,
+          leagueId: league.id,
+          teamId: team.id,
+          firstName: "Def",
+          lastName: "Coordinator",
+          role: "DC",
+          age: 48,
+          hiredAt: new Date("2028-01-01"),
+          contractYears: 3,
+          contractSalary: 1,
+          contractBuyout: 1,
+          reportsToId: hcId,
+        },
+      ]);
+      coachesCreated.push(hcId, ocId, dcId);
+
+      await db.insert(coachTendencies).values([
+        {
+          coachId: ocId,
+          runPassLean: 50,
+          tempo: 50,
+          personnelWeight: 50,
+          formationUnderCenterShotgun: 50,
+          preSnapMotionRate: 50,
+          passingStyle: 50,
+          passingDepth: 50,
+          runGameBlocking: 50,
+          rpoIntegration: 50,
+        },
+        {
+          coachId: dcId,
+          frontOddEven: 50,
+          gapResponsibility: 50,
+          subPackageLean: 50,
+          coverageManZone: 50,
+          coverageShell: 50,
+          cornerPressOff: 50,
+          pressureRate: 50,
+          disguiseRate: 50,
+        },
+      ]);
+
+      const buckets: NeutralBucket[] = [
+        "QB",
+        "QB",
+        "RB",
+        "RB",
+        "WR",
+        "WR",
+        "WR",
+        "TE",
+        "TE",
+        "OT",
+        "OT",
+        "IOL",
+        "IOL",
+        "IOL",
+        "EDGE",
+        "EDGE",
+        "IDL",
+        "IDL",
+        "LB",
+        "LB",
+        "LB",
+        "CB",
+        "CB",
+        "CB",
+        "S",
+        "S",
+        "K",
+        "P",
+        "LS",
+      ];
+
+      for (const bucket of buckets) {
+        const id = crypto.randomUUID();
+        await db.insert(players).values({
+          id,
+          leagueId: league.id,
+          teamId: team.id,
+          firstName: bucket,
+          lastName: `Player-${id.slice(0, 4)}`,
+          injuryStatus: "healthy",
+          ...sizeFor(bucket),
+          birthDate: "2000-01-01",
+        });
+        await db.insert(playerAttributes).values({
+          playerId: id,
+          ...stubAttributeColumns(bucket),
+        });
+        playersCreated.push(id);
+      }
+
+      const result = await publisher.publishForTeams({
+        leagueId: league.id,
+        teamIds: [team.id],
+      });
+
+      assertEquals(result.entryCount, buckets.length);
+
+      const entries = await db
+        .select()
+        .from(depthChartEntries)
+        .where(eq(depthChartEntries.teamId, team.id));
+
+      assertEquals(entries.length, buckets.length);
+
+      const playerIds = new Set(entries.map((e) => e.playerId));
+      assertEquals(playerIds.size, buckets.length);
+
+      const keys = entries.map((e) => `${e.slotCode}:${e.slotOrdinal}`);
+      assertEquals(new Set(keys).size, keys.length);
+
+      const hcEntries = entries.filter(
+        (e) => e.publishedByCoachId === hcId,
+      );
+      assertEquals(hcEntries.length, buckets.length);
+    } finally {
+      await cleanup(db, {
+        coaches: coachesCreated,
+        players: playersCreated,
+        teams: teamsCreated,
+        cities: citiesCreated,
+        states: statesCreated,
+        leagues: leaguesCreated,
+      });
+      await client.end();
+    }
+  },
+});
+
+Deno.test({
+  name:
+    "depthChartPublisher.publishForTeams: replaces existing entries on re-publish",
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    const { db, client } = createTestDb();
+    const publisher = createDepthChartPublisher({
+      db,
+      log: createTestLogger(),
+    });
+    const playersCreated: string[] = [];
+    const coachesCreated: string[] = [];
+    const teamsCreated: string[] = [];
+    const citiesCreated: string[] = [];
+    const statesCreated: string[] = [];
+    const leaguesCreated: string[] = [];
+    try {
+      const { league, team, state, city } = await setupFixtures(db);
+      leaguesCreated.push(league.id);
+      teamsCreated.push(team.id);
+      statesCreated.push(state.id);
+      citiesCreated.push(city.id);
+
+      const hcId = crypto.randomUUID();
+      await db.insert(coaches).values({
+        id: hcId,
+        leagueId: league.id,
+        teamId: team.id,
+        firstName: "Head",
+        lastName: "Coach",
+        role: "HC",
+        age: 50,
+        hiredAt: new Date("2028-01-01"),
+        contractYears: 3,
+        contractSalary: 1,
+        contractBuyout: 1,
+      });
+      coachesCreated.push(hcId);
+
+      const qbId = crypto.randomUUID();
+      await db.insert(players).values({
+        id: qbId,
+        leagueId: league.id,
+        teamId: team.id,
+        firstName: "Test",
+        lastName: "QB",
+        injuryStatus: "healthy",
+        ...sizeFor("QB"),
+        birthDate: "2000-01-01",
+      });
+      await db.insert(playerAttributes).values({
+        playerId: qbId,
+        ...stubAttributeColumns("QB"),
+      });
+      playersCreated.push(qbId);
+
+      await publisher.publishForTeams({
+        leagueId: league.id,
+        teamIds: [team.id],
+      });
+
+      const firstRun = await db
+        .select()
+        .from(depthChartEntries)
+        .where(eq(depthChartEntries.teamId, team.id));
+      assertEquals(firstRun.length, 1);
+
+      await publisher.publishForTeams({
+        leagueId: league.id,
+        teamIds: [team.id],
+      });
+
+      const secondRun = await db
+        .select()
+        .from(depthChartEntries)
+        .where(eq(depthChartEntries.teamId, team.id));
+      assertEquals(secondRun.length, 1);
+    } finally {
+      await cleanup(db, {
+        coaches: coachesCreated,
+        players: playersCreated,
+        teams: teamsCreated,
+        cities: citiesCreated,
+        states: statesCreated,
+        leagues: leaguesCreated,
+      });
+      await client.end();
+    }
+  },
+});
+
+Deno.test({
+  name:
+    "depthChartPublisher.publishForTeams: returns zero entries for team with no players",
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    const { db, client } = createTestDb();
+    const publisher = createDepthChartPublisher({
+      db,
+      log: createTestLogger(),
+    });
+    const teamsCreated: string[] = [];
+    const citiesCreated: string[] = [];
+    const statesCreated: string[] = [];
+    const leaguesCreated: string[] = [];
+    try {
+      const { league, team, state, city } = await setupFixtures(db);
+      leaguesCreated.push(league.id);
+      teamsCreated.push(team.id);
+      statesCreated.push(state.id);
+      citiesCreated.push(city.id);
+
+      const result = await publisher.publishForTeams({
+        leagueId: league.id,
+        teamIds: [team.id],
+      });
+      assertEquals(result.entryCount, 0);
+    } finally {
+      await cleanup(db, {
+        teams: teamsCreated,
+        cities: citiesCreated,
+        states: statesCreated,
+        leagues: leaguesCreated,
+      });
+      await client.end();
+    }
+  },
+});

--- a/server/features/depth-chart/depth-chart.publisher.ts
+++ b/server/features/depth-chart/depth-chart.publisher.ts
@@ -1,0 +1,171 @@
+import { and, eq, inArray } from "drizzle-orm";
+import type pino from "pino";
+import {
+  assignDepthChart,
+  type CoachTendencies,
+  DEFENSIVE_TENDENCY_KEYS,
+  type DefensiveTendencies,
+  depthChartVocabulary,
+  neutralBucket,
+  OFFENSIVE_TENDENCY_KEYS,
+  type OffensiveTendencies,
+  type PlayerForAssignment,
+} from "@zone-blitz/shared";
+import type { Database } from "../../db/connection.ts";
+import { players } from "../players/player.schema.ts";
+import {
+  attributeSelectColumns,
+  pickAttributes,
+  playerAttributes,
+} from "../players/attributes.schema.ts";
+import { depthChartEntries } from "../players/depth-chart.schema.ts";
+import { coaches } from "../coaches/coach.schema.ts";
+import { coachTendencies } from "../coaches/coach-tendencies.schema.ts";
+import { computeFingerprint, computeSchemeScore } from "../schemes/mod.ts";
+import type { DepthChartPublisher } from "./depth-chart.publisher.interface.ts";
+
+type TendencyRow = typeof coachTendencies.$inferSelect;
+
+function pickOffense(row: TendencyRow): OffensiveTendencies | null {
+  if (OFFENSIVE_TENDENCY_KEYS.every((k) => row[k] === null)) return null;
+  const out = {} as OffensiveTendencies;
+  for (const k of OFFENSIVE_TENDENCY_KEYS) out[k] = (row[k] ?? 0) as number;
+  return out;
+}
+
+function pickDefense(row: TendencyRow): DefensiveTendencies | null {
+  if (DEFENSIVE_TENDENCY_KEYS.every((k) => row[k] === null)) return null;
+  const out = {} as DefensiveTendencies;
+  for (const k of DEFENSIVE_TENDENCY_KEYS) out[k] = (row[k] ?? 0) as number;
+  return out;
+}
+
+function toCoachTendencies(row: TendencyRow): CoachTendencies {
+  return {
+    coachId: row.coachId,
+    offense: pickOffense(row),
+    defense: pickDefense(row),
+    createdAt: row.createdAt,
+    updatedAt: row.updatedAt,
+  };
+}
+
+export function createDepthChartPublisher(deps: {
+  db: Database;
+  log: pino.Logger;
+}): DepthChartPublisher {
+  const log = deps.log.child({ module: "depth-chart.publisher" });
+
+  return {
+    async publishForTeams(input, tx) {
+      const executor = tx ?? deps.db;
+      let totalEntries = 0;
+
+      for (const teamId of input.teamIds) {
+        log.debug(
+          { leagueId: input.leagueId, teamId },
+          "publishing depth chart",
+        );
+
+        const coordinatorRows = await executor
+          .select({
+            role: coaches.role,
+            tendencyRow: coachTendencies,
+          })
+          .from(coaches)
+          .innerJoin(
+            coachTendencies,
+            eq(coachTendencies.coachId, coaches.id),
+          )
+          .where(
+            and(
+              eq(coaches.teamId, teamId),
+              inArray(coaches.role, ["OC", "DC"]),
+            ),
+          );
+
+        let ocTendencies: CoachTendencies | null = null;
+        let dcTendencies: CoachTendencies | null = null;
+        for (const row of coordinatorRows) {
+          if (!row.tendencyRow) continue;
+          const tendencies = toCoachTendencies(row.tendencyRow);
+          if (row.role === "OC") ocTendencies = tendencies;
+          if (row.role === "DC") dcTendencies = tendencies;
+        }
+        const fingerprint = computeFingerprint({
+          oc: ocTendencies,
+          dc: dcTendencies,
+        });
+        const vocabulary = depthChartVocabulary(fingerprint);
+
+        const [hc] = await executor
+          .select({ id: coaches.id })
+          .from(coaches)
+          .where(
+            and(eq(coaches.teamId, teamId), eq(coaches.role, "HC")),
+          )
+          .limit(1);
+
+        const playerRows = await executor
+          .select({
+            id: players.id,
+            heightInches: players.heightInches,
+            weightPounds: players.weightPounds,
+            ...attributeSelectColumns(),
+          })
+          .from(players)
+          .innerJoin(
+            playerAttributes,
+            eq(playerAttributes.playerId, players.id),
+          )
+          .where(
+            and(
+              eq(players.leagueId, input.leagueId),
+              eq(players.teamId, teamId),
+            ),
+          );
+
+        const playersForAssignment: PlayerForAssignment[] = playerRows.map(
+          (row) => {
+            const attributes = pickAttributes(
+              row as unknown as Record<string, unknown>,
+            );
+            const bucket = neutralBucket({
+              attributes,
+              heightInches: row.heightInches,
+              weightPounds: row.weightPounds,
+            });
+            const score = computeSchemeScore(
+              { neutralBucket: bucket, attributes },
+              fingerprint,
+            );
+            return { id: row.id, neutralBucket: bucket, score };
+          },
+        );
+
+        const assignments = assignDepthChart(playersForAssignment, vocabulary);
+
+        if (assignments.length > 0) {
+          await executor
+            .delete(depthChartEntries)
+            .where(eq(depthChartEntries.teamId, teamId));
+
+          await executor.insert(depthChartEntries).values(
+            assignments.map((a) => ({
+              teamId,
+              playerId: a.playerId,
+              slotCode: a.slotCode,
+              slotOrdinal: a.slotOrdinal,
+              isInactive: a.isInactive,
+              publishedByCoachId: hc?.id ?? null,
+            })),
+          );
+        }
+
+        totalEntries += assignments.length;
+      }
+
+      return { entryCount: totalEntries };
+    },
+  };
+}

--- a/server/features/depth-chart/mod.ts
+++ b/server/features/depth-chart/mod.ts
@@ -1,0 +1,6 @@
+export { createDepthChartPublisher } from "./depth-chart.publisher.ts";
+export type { DepthChartPublisher } from "./depth-chart.publisher.interface.ts";
+export type {
+  PublishDepthChartsInput,
+  PublishDepthChartsResult,
+} from "./depth-chart.publisher.interface.ts";

--- a/server/features/mod.ts
+++ b/server/features/mod.ts
@@ -20,6 +20,7 @@ import {
 } from "./team/mod.ts";
 import { createSeasonRepository, createSeasonService } from "./season/mod.ts";
 import { createPersonnelService } from "./personnel/mod.ts";
+import { createDepthChartPublisher } from "./depth-chart/mod.ts";
 import {
   createPlayersRepository,
   createPlayersRouter,
@@ -122,11 +123,13 @@ export function createFeatureRouters(
     db,
     log,
   });
+  const depthChartPublisher = createDepthChartPublisher({ db, log });
   const personnelService = createPersonnelService({
     playersService,
     coachesService,
     scoutsService,
     frontOfficeService,
+    depthChartPublisher,
     log,
   });
   const scheduleService = createScheduleService({

--- a/server/features/personnel/personnel.service.test.ts
+++ b/server/features/personnel/personnel.service.test.ts
@@ -4,6 +4,7 @@ import type { PlayersService } from "../players/players.service.interface.ts";
 import type { CoachesService } from "../coaches/coaches.service.interface.ts";
 import type { ScoutsService } from "../scouts/scouts.service.interface.ts";
 import type { FrontOfficeService } from "../front-office/front-office.service.interface.ts";
+import type { DepthChartPublisher } from "../depth-chart/depth-chart.publisher.interface.ts";
 
 function createTestLogger() {
   return {
@@ -67,6 +68,15 @@ function createMockFrontOfficeService(
   };
 }
 
+function createMockDepthChartPublisher(
+  overrides: Partial<DepthChartPublisher> = {},
+): DepthChartPublisher {
+  return {
+    publishForTeams: () => Promise.resolve({ entryCount: 0 }),
+    ...overrides,
+  };
+}
+
 Deno.test("personnel.service", async (t) => {
   await t.step(
     "generate delegates to all four services and aggregates counts",
@@ -126,6 +136,7 @@ Deno.test("personnel.service", async (t) => {
         coachesService,
         scoutsService,
         frontOfficeService,
+        depthChartPublisher: createMockDepthChartPublisher(),
         log: createTestLogger(),
       });
 
@@ -195,6 +206,12 @@ Deno.test("personnel.service", async (t) => {
             return Promise.resolve({ frontOfficeCount: 0 });
           },
         }),
+        depthChartPublisher: createMockDepthChartPublisher({
+          publishForTeams: (_input, tx) => {
+            received.depthChart = tx;
+            return Promise.resolve({ entryCount: 0 });
+          },
+        }),
         log: createTestLogger(),
       });
 
@@ -210,6 +227,7 @@ Deno.test("personnel.service", async (t) => {
       );
 
       assertEquals(received.players, marker);
+      assertEquals(received.depthChart, marker);
       assertEquals(received.coaches, marker);
       assertEquals(received.scouts, marker);
       assertEquals(received.frontOffice, marker);
@@ -224,6 +242,7 @@ Deno.test("personnel.service", async (t) => {
         coachesService: createMockCoachesService(),
         scoutsService: createMockScoutsService(),
         frontOfficeService: createMockFrontOfficeService(),
+        depthChartPublisher: createMockDepthChartPublisher(),
         log: createTestLogger(),
       });
 

--- a/server/features/personnel/personnel.service.ts
+++ b/server/features/personnel/personnel.service.ts
@@ -4,12 +4,14 @@ import type { PlayersService } from "../players/players.service.interface.ts";
 import type { CoachesService } from "../coaches/coaches.service.interface.ts";
 import type { ScoutsService } from "../scouts/scouts.service.interface.ts";
 import type { FrontOfficeService } from "../front-office/front-office.service.interface.ts";
+import type { DepthChartPublisher } from "../depth-chart/depth-chart.publisher.interface.ts";
 
 export function createPersonnelService(deps: {
   playersService: PlayersService;
   coachesService: CoachesService;
   scoutsService: ScoutsService;
   frontOfficeService: FrontOfficeService;
+  depthChartPublisher: DepthChartPublisher;
   log: pino.Logger;
 }): PersonnelService {
   const log = deps.log.child({ module: "personnel.service" });
@@ -33,6 +35,16 @@ export function createPersonnelService(deps: {
         leagueId: input.leagueId,
         teamIds: input.teamIds,
       }, tx);
+
+      const depthChartResult = await deps.depthChartPublisher.publishForTeams({
+        leagueId: input.leagueId,
+        teamIds: input.teamIds,
+      }, tx);
+
+      log.info(
+        { depthChartEntries: depthChartResult.entryCount },
+        "published initial depth charts",
+      );
 
       const scoutsResult = await deps.scoutsService.generate({
         leagueId: input.leagueId,

--- a/server/features/schemes/fit.ts
+++ b/server/features/schemes/fit.ts
@@ -61,19 +61,12 @@ function axisValueFor(
   return (side as unknown as Record<string, number>)[demand.axis];
 }
 
-/**
- * Pure function: compute a qualitative fit label for a player against
- * a team's scheme fingerprint. Returns `'neutral'` when the position
- * has no archetype demands defined (v1 scope) or when the fingerprint
- * has no polarized axes at this position. Never exposes a numeric
- * score per ADR 0005.
- */
-export function computeSchemeFit(
+export function computeSchemeScore(
   player: PlayerForFit,
   fingerprint: SchemeFingerprint,
-): SchemeFitLabel {
+): number {
   const demands = POSITION_ARCHETYPE_WEIGHTS[player.neutralBucket];
-  if (!demands || demands.length === 0) return "neutral";
+  if (!demands || demands.length === 0) return 50;
 
   let totalWeight = 0;
   let totalContribution = 0;
@@ -89,8 +82,13 @@ export function computeSchemeFit(
     }
   }
 
-  if (totalWeight === 0) return "neutral";
+  if (totalWeight === 0) return 50;
+  return (totalContribution / totalWeight) * 100;
+}
 
-  const score = (totalContribution / totalWeight) * 100;
-  return bucketScore(score);
+export function computeSchemeFit(
+  player: PlayerForFit,
+  fingerprint: SchemeFingerprint,
+): SchemeFitLabel {
+  return bucketScore(computeSchemeScore(player, fingerprint));
 }

--- a/server/features/schemes/mod.ts
+++ b/server/features/schemes/mod.ts
@@ -1,6 +1,6 @@
 export { computeFingerprint } from "./fingerprint.ts";
 export type { StaffTendencies } from "./fingerprint.ts";
-export { bucketScore, computeSchemeFit } from "./fit.ts";
+export { bucketScore, computeSchemeFit, computeSchemeScore } from "./fit.ts";
 export type { PlayerForFit } from "./fit.ts";
 export { schemeLens } from "./lens.ts";
 export type { PlayerForLens } from "./lens.ts";


### PR DESCRIPTION
## Summary

- Adds a depth chart publisher that auto-assigns players to scheme-driven
  slots at league creation time, wired into the personnel generation flow
  after coaches are created. The roster page's Depth Chart view now shows
  real player assignments instead of an empty placeholder.
- Introduces shared-package modules for slot mapping (slot code → eligible
  neutral buckets) and a pure assignment algorithm that ranks players by
  scheme fit score and load-balances multi-slot positions (OT → LT/RT,
  IOL → LG/C/RG).
- Extracts `computeSchemeScore` from the existing fit pipeline so the
  publisher can rank players numerically.
- Removes the resolved "Coach sim depth-chart publisher" backlog item.

🤖 Generated with [Claude Code](https://claude.com/claude-code)