### PR TITLE
fix(db): prevent stack overflow in bulk inserts for wide tables

### DIFF
--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -29,16 +29,14 @@ entry when it's resolved or superseded.
   qualify for two non-specialist neutral buckets (e.g. CB + WR). Wire this into
   the generator with a rate knob, and surface both bucket lenses in the scout /
   depth-chart / draft UIs.
-- **2026-04-14 — Stack overflow in full-roster bulk insert during league
-  creation.** Ran the full `leagueService.create` flow end-to-end against real
-  Postgres (32 teams × 53 roster) and drizzle's `mergeQueries` stack-overflows
-  while building the bulk `playerAttributes` insert (~1696 rows × ~50 attribute
-  columns). Observed while writing the league-creation transactional rollback
-  integration test — the integration test sidesteps this by stubbing
-  `personnelService` with a single-row probe insert. Fix options: chunk the
-  attribute insert, narrow the attribute row shape, or build the SQL
-  iteratively. Split attribute rows into columns-per-table is overkill; chunked
-  inserts are the cheapest fix.
+- **2026-04-14 — Coach sim depth-chart publisher.** Decision 0001 requires the
+  coach sim to publish a stable depth-chart artifact the roster page reads.
+  Initial roster page stubs the source (empty depth chart until the sim writes
+  rows). Wire the real producer when coach-side sim work begins.
+- **2026-04-14 — Player detail view with per-game splits.** Roster Statistics
+  view is specified to link each row to a detail view with game-by-game splits
+  (decision 0001). Initial PR ships without that detail route; add the page when
+  per-game sim output lands.
 - **2026-04-14 — Multi-user leagues would need a `user_leagues` join table.**
   The `last_played_at` column added in PR #105 lives directly on `leagues`,
   matching today's single-user-per-league assumption (each league has one

--- a/server/db/chunked-insert.test.ts
+++ b/server/db/chunked-insert.test.ts
@@ -3,6 +3,7 @@ import {
   chunkedInsert,
   chunkedInsertReturning,
   DEFAULT_CHUNK_SIZE,
+  MAX_PARAMETERS_PER_BATCH,
 } from "./chunked-insert.ts";
 
 interface Call {
@@ -74,6 +75,31 @@ Deno.test("chunkedInsert", async (t) => {
 
     assertEquals(calls.length, 0);
   });
+
+  await t.step(
+    "reduces effective chunk size for wide rows to stay within parameter budget",
+    async () => {
+      const { exec, calls } = createMockExec();
+      const columnCount = 100;
+      const columns = Object.fromEntries(
+        Array.from({ length: columnCount }, (_, i) => [`col${i}`, i]),
+      );
+      const rowCount = 50;
+      const rows = Array.from({ length: rowCount }, () => ({ ...columns }));
+
+      // deno-lint-ignore no-explicit-any
+      await chunkedInsert(exec, {} as any, rows);
+
+      const maxRowsPerBatch = Math.floor(
+        MAX_PARAMETERS_PER_BATCH / columnCount,
+      );
+      const expectedBatches = Math.ceil(rowCount / maxRowsPerBatch);
+      assertEquals(calls.length, expectedBatches);
+      for (const call of calls) {
+        assertEquals(call.rows.length <= maxRowsPerBatch, true);
+      }
+    },
+  );
 });
 
 Deno.test("chunkedInsertReturning", async (t) => {
@@ -115,4 +141,37 @@ Deno.test("chunkedInsertReturning", async (t) => {
     assertEquals(result, []);
     assertEquals(calls.length, 0);
   });
+
+  await t.step(
+    "reduces effective chunk size for wide rows to stay within parameter budget",
+    async () => {
+      const columnCount = 100;
+      const columns = Object.fromEntries(
+        Array.from({ length: columnCount }, (_, i) => [`col${i}`, i]),
+      );
+      const rowCount = 50;
+      const rows = Array.from({ length: rowCount }, (_, i) => ({
+        id: i,
+        ...columns,
+      }));
+      const { exec, calls } = createMockExec((batch) =>
+        (batch as { id: number }[]).map((r) => ({ id: r.id }))
+      );
+
+      const result = await chunkedInsertReturning<{ id: number }>(
+        exec,
+        // deno-lint-ignore no-explicit-any
+        {} as any,
+        rows,
+        { id: "id" },
+      );
+
+      const maxRowsPerBatch = Math.floor(
+        MAX_PARAMETERS_PER_BATCH / (columnCount + 1),
+      );
+      const expectedBatches = Math.ceil(rowCount / maxRowsPerBatch);
+      assertEquals(calls.length, expectedBatches);
+      assertEquals(result.length, rowCount);
+    },
+  );
 });

--- a/server/db/chunked-insert.ts
+++ b/server/db/chunked-insert.ts
@@ -1,6 +1,21 @@
 import type { Executor } from "./connection.ts";
 
 export const DEFAULT_CHUNK_SIZE = 100;
+export const MAX_PARAMETERS_PER_BATCH = 5_000;
+
+function effectiveChunkSize(
+  rows: readonly Record<string, unknown>[],
+  chunkSize: number,
+): number {
+  if (rows.length === 0) return chunkSize;
+  const columnCount = Object.keys(rows[0]).length;
+  if (columnCount === 0) return chunkSize;
+  const maxByParams = Math.max(
+    1,
+    Math.floor(MAX_PARAMETERS_PER_BATCH / columnCount),
+  );
+  return Math.min(chunkSize, maxByParams);
+}
 
 export async function chunkedInsert(
   exec: Executor,
@@ -9,9 +24,10 @@ export async function chunkedInsert(
   rows: readonly Record<string, unknown>[],
   chunkSize: number = DEFAULT_CHUNK_SIZE,
 ): Promise<void> {
-  for (let i = 0; i < rows.length; i += chunkSize) {
+  const size = effectiveChunkSize(rows, chunkSize);
+  for (let i = 0; i < rows.length; i += size) {
     // deno-lint-ignore no-explicit-any
-    await (exec.insert as any)(table).values(rows.slice(i, i + chunkSize));
+    await (exec.insert as any)(table).values(rows.slice(i, i + size));
   }
 }
 
@@ -23,11 +39,12 @@ export async function chunkedInsertReturning<R>(
   returning: Record<string, unknown>,
   chunkSize: number = DEFAULT_CHUNK_SIZE,
 ): Promise<R[]> {
+  const size = effectiveChunkSize(rows, chunkSize);
   const results: R[] = [];
-  for (let i = 0; i < rows.length; i += chunkSize) {
+  for (let i = 0; i < rows.length; i += size) {
     // deno-lint-ignore no-explicit-any
     const batch = await (exec.insert as any)(table)
-      .values(rows.slice(i, i + chunkSize))
+      .values(rows.slice(i, i + size))
       .returning(returning);
     results.push(...(batch as R[]));
   }

--- a/server/features/depth-chart/depth-chart.publisher.test.ts
+++ b/server/features/depth-chart/depth-chart.publisher.test.ts
@@ -11,7 +11,7 @@ import { depthChartEntries } from "../players/depth-chart.schema.ts";
 import {
   BUCKET_PROFILES,
   stubAttributesFor,
-} from "../players/stub-players-generator.ts";
+} from "../players/players-generator.ts";
 import { coaches } from "../coaches/coach.schema.ts";
 import { coachTendencies } from "../coaches/coach-tendencies.schema.ts";
 import { leagues } from "../league/league.schema.ts";


### PR DESCRIPTION
## Summary

- Drizzle's `mergeQueries` recurses once per bound parameter when building VALUES clauses. For wide tables like `playerAttributes` (99 columns), the default chunk size of 100 rows produces ~9,900 recursive calls per batch, overflowing the V8 call stack during full league creation (32 teams × 53 roster = 1,696 attribute rows).
- Introduces a `MAX_PARAMETERS_PER_BATCH` budget (5,000) in `chunkedInsert` and `chunkedInsertReturning`. The effective chunk size is automatically reduced to `floor(budget / columnCount)` when the caller's requested size would exceed the parameter budget.
- Removes the resolved stack overflow backlog entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)