### PR TITLE
refactor(players): drop stub prefix from players generator

### DIFF
--- a/server/features/mod.ts
+++ b/server/features/mod.ts
@@ -21,10 +21,10 @@ import {
 import { createSeasonRepository, createSeasonService } from "./season/mod.ts";
 import { createPersonnelService } from "./personnel/mod.ts";
 import {
+  createPlayersGenerator,
   createPlayersRepository,
   createPlayersRouter,
   createPlayersService,
-  createStubPlayersGenerator,
 } from "./players/mod.ts";
 import {
   createCoachesRepository,
@@ -99,7 +99,7 @@ export function createFeatureRouters(
   const teamService = createTeamService({ teamRepo, log });
   const seasonService = createSeasonService({ seasonRepo, log });
   const playersService = createPlayersService({
-    generator: createStubPlayersGenerator(),
+    generator: createPlayersGenerator(),
     repo: playersRepo,
     db,
     log,

--- a/server/features/players/mod.ts
+++ b/server/features/players/mod.ts
@@ -1,4 +1,4 @@
-export { createStubPlayersGenerator } from "./stub-players-generator.ts";
+export { createPlayersGenerator } from "./players-generator.ts";
 export { createPlayersService } from "./players.service.ts";
 export { createPlayersRepository } from "./players.repository.ts";
 export { createPlayersRouter } from "./players.router.ts";

--- a/server/features/players/players-generator.test.ts
+++ b/server/features/players/players-generator.test.ts
@@ -7,11 +7,11 @@ import {
 } from "@zone-blitz/shared";
 import {
   BUCKET_PROFILES,
-  createStubPlayersGenerator,
+  createPlayersGenerator,
   type NameGenerator,
   ROSTER_BUCKET_COMPOSITION,
   stubAttributesFor,
-} from "./stub-players-generator.ts";
+} from "./players-generator.ts";
 
 const TEAM_IDS = ["team-1", "team-2", "team-3"];
 const INPUT = {
@@ -44,7 +44,7 @@ function fixedNameGenerator(): NameGenerator {
 }
 
 function makeGenerator(seed = 12345) {
-  return createStubPlayersGenerator({
+  return createPlayersGenerator({
     random: seededRandom(seed),
     nameGenerator: fixedNameGenerator(),
     currentYear: 2026,
@@ -361,12 +361,12 @@ Deno.test("hometowns are varied and formatted as 'City, ST'", () => {
 });
 
 Deno.test("seeded generator is deterministic", () => {
-  const a = createStubPlayersGenerator({
+  const a = createPlayersGenerator({
     random: seededRandom(42),
     nameGenerator: fixedNameGenerator(),
     currentYear: 2026,
   }).generate(INPUT);
-  const b = createStubPlayersGenerator({
+  const b = createPlayersGenerator({
     random: seededRandom(42),
     nameGenerator: fixedNameGenerator(),
     currentYear: 2026,

--- a/server/features/players/players-generator.ts
+++ b/server/features/players/players-generator.ts
@@ -710,7 +710,7 @@ export function stubAttributesFor(bucket: NeutralBucket): PlayerAttributes {
   return attrs as PlayerAttributes;
 }
 
-export interface StubPlayersGeneratorOptions {
+export interface PlayersGeneratorOptions {
   /**
    * Injected name generator. Defaults to the shared server-wide
    * `createNameGenerator()` so league creation produces varied names without
@@ -723,8 +723,8 @@ export interface StubPlayersGeneratorOptions {
   currentYear?: number;
 }
 
-export function createStubPlayersGenerator(
-  options: StubPlayersGeneratorOptions = {},
+export function createPlayersGenerator(
+  options: PlayersGeneratorOptions = {},
 ): PlayersGenerator {
   const random = options.random ?? Math.random;
   const rng = createRng(random);

--- a/server/features/players/players.repository.test.ts
+++ b/server/features/players/players.repository.test.ts
@@ -19,10 +19,7 @@ import { states } from "../states/state.schema.ts";
 import { seasons } from "../season/season.schema.ts";
 import { type NeutralBucket, PLAYER_ATTRIBUTE_KEYS } from "@zone-blitz/shared";
 import { createPlayersRepository } from "./players.repository.ts";
-import {
-  BUCKET_PROFILES,
-  stubAttributesFor,
-} from "./stub-players-generator.ts";
+import { BUCKET_PROFILES, stubAttributesFor } from "./players-generator.ts";
 
 function attributesForBucket(
   bucket: NeutralBucket = "QB",

--- a/server/features/roster/roster.repository.test.ts
+++ b/server/features/roster/roster.repository.test.ts
@@ -16,7 +16,7 @@ import { depthChartEntries } from "../players/depth-chart.schema.ts";
 import {
   BUCKET_PROFILES,
   stubAttributesFor,
-} from "../players/stub-players-generator.ts";
+} from "../players/players-generator.ts";
 import { coaches } from "../coaches/coach.schema.ts";
 import { coachTendencies } from "../coaches/coach-tendencies.schema.ts";
 import { leagues } from "../league/league.schema.ts";


### PR DESCRIPTION
## Summary

- Rename `stub-players-generator.ts` -> `players-generator.ts` (and `.test.ts`) via `git mv` so blame history is preserved.
- Rename the public surface: `createStubPlayersGenerator` -> `createPlayersGenerator`, `StubPlayersGeneratorOptions` -> `PlayersGeneratorOptions`.
- Update all call sites: `server/features/mod.ts`, `server/features/players/mod.ts`, `players.repository.test.ts`, `roster.repository.test.ts`.
- `stubAttributesFor` is intentionally preserved — it's a deterministic test fixture (a stub in the test-double sense), not a placeholder implementation.

This is pure naming cleanup following PR #157, which graduated the player generator into a real archetype-aware distribution-driven implementation. The `stub` prefix no longer matches the code and is misleading to anyone browsing the feature folder. Aligning the name now makes the three remaining graduations (coaches / scouts / front-office) less noisy.