### PR TITLE
docs(backlog): remove user_leagues join table note

### DIFF
--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -37,13 +37,16 @@ entry when it's resolved or superseded.
   view is specified to link each row to a detail view with game-by-game splits
   (decision 0001). Initial PR ships without that detail route; add the page when
   per-game sim output lands.
-- **2026-04-14 — Multi-user leagues would need a `user_leagues` join table.**
-  The `last_played_at` column added in PR #105 lives directly on `leagues`,
-  matching today's single-user-per-league assumption (each league has one
-  `user_team_id`). If leagues ever become shared between multiple users, we'd
-  need to move `last_played_at` (and anything else that's actually per-user)
-  onto a `user_leagues` junction table keyed by `(user_id, league_id)` and join
-  it into the list query.
+- **2026-04-14 — Stack overflow in full-roster bulk insert during league
+  creation.** Ran the full `leagueService.create` flow end-to-end against real
+  Postgres (32 teams × 53 roster) and drizzle's `mergeQueries` stack-overflows
+  while building the bulk `playerAttributes` insert (~1696 rows × ~50 attribute
+  columns). Observed while writing the league-creation transactional rollback
+  integration test — the integration test sidesteps this by stubbing
+  `personnelService` with a single-row probe insert. Fix options: chunk the
+  attribute insert, narrow the attribute row shape, or build the SQL
+  iteratively. Split attribute rows into columns-per-table is overkill; chunked
+  inserts are the cheapest fix.
 - **2026-04-13 — Finer-grained league phase sub-states.** The `season.phase`
   enum only tracks `preseason | regular_season | playoffs | offseason`. Product
   docs (`docs/product/league-management.md`) describe sub-steps during the


### PR DESCRIPTION
## Summary

- Removes the multi-user leagues / `user_leagues` join table backlog bullet — it was a forward-looking architectural note ("if leagues ever become shared…"), not an actionable task.
- The system is single-user-per-league today with no planned multi-user feature; implementing a junction table now would be premature with no consumers or migration path needed.
- The concern is better revisited as part of actual multi-user league design work when that feature is scoped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)