### PR TITLE
docs(pm): cap-situation + market ADRs with ticketing pipeline

### DIFF
--- a/.claude/skills/file-adr-tickets/SKILL.md
+++ b/.claude/skills/file-adr-tickets/SKILL.md
@@ -1,0 +1,156 @@
+---
+name: file-adr-tickets
+description: Turn an Accepted ADR into GitHub Issues that agents can claim. Use when a new ADR lands in docs/product/decisions/ or the user asks to "file tickets for ADR NNNN". Slices the ADR's Decision section into one issue per implementation deliverable, wires dependencies, and applies labels so agents can `gh issue list --label ready-for-agent` to pick work.
+---
+
+# File ADR Tickets
+
+You are acting as the Product Manager for this repo. An ADR captures a decision;
+this skill turns it into claimable work.
+
+## When to invoke
+
+- The user says "file tickets for ADR NNNN" or points at a decision doc.
+- An ADR just transitioned to `Status: Accepted` in
+  `docs/product/decisions/NNNN-*.md` and the implementation has not been filed
+  yet.
+- The user adds a `Implement ADR NNNN` line to `docs/backlog.md` — prefer filing
+  tickets over leaving the bullet.
+
+Do **not** invoke for ADRs still `Proposed` — the decision can still change.
+
+## Inputs
+
+- ADR path (required). If the user names an ADR number, resolve to the file
+  under `docs/product/decisions/`.
+
+## Procedure
+
+### 1. Read the ADR fully
+
+Before slicing anything, read:
+
+- The target ADR end-to-end.
+- Any ADR it links in the `Area:` or `Status:` frontmatter (supersedes / builds
+  on).
+- The relevant north-star doc (the ADR's `Area:` link).
+
+Do not skim. The ADR's Decision section is the source of acceptance criteria —
+wrong slicing upstream means wrong tickets downstream.
+
+### 2. Slice into tickets
+
+One ticket per **shippable deliverable**, not per paragraph. A good slice:
+
+- Can be merged as a PR on its own without breaking `main`.
+- Has a clear "done" condition that maps back to a specific line or sub-section
+  of the ADR's Decision.
+- Is small enough that a single agent session (or one focused PR) can complete
+  it.
+
+Heuristics:
+
+- A new module / table / constant → its own ticket.
+- Each consumer that has to adopt the new module → its own ticket, blocked by
+  the module ticket.
+- Test-only tightening, tuning, or telemetry → its own ticket if it's not
+  required for the first consumer to ship.
+- UI surface changes → separate from backend changes unless the change is
+  trivially coupled.
+
+Avoid:
+
+- Giant "implement ADR NNNN" mega-tickets. That's what the ADR is.
+- Tickets that just restate a sentence from Alternatives or Consequences — those
+  aren't deliverables.
+
+### 3. Draft each ticket
+
+Use the issue template at `.github/ISSUE_TEMPLATE/adr-ticket.md` as the body
+shape. Per ticket, fill in:
+
+- **Title** — imperative, under 70 chars. Pattern: `<type>(<scope>): <what>`
+  mirroring conventional-commit style when natural. Example:
+  `feat(contracts): add positional market multiplier table`.
+- **Context** — two or three sentences. What exists today; what this ticket
+  changes. Link the ADR by path.
+- **Acceptance criteria** — bulleted, checkable. Pull the specific invariants
+  the ADR pins (e.g. "QB:RB salary ratio ≈ 2.75× at equal overall, asserted in
+  tests"). If the ADR doesn't pin an invariant the ticket needs, flag it back to
+  the user rather than inventing one.
+- **Dependencies** — list of `#<issue>` refs that must land first. Use GitHub's
+  `Depends on #N` syntax so the blocked-by graph renders.
+- **ADR reference** — exact path, e.g.
+  `docs/product/decisions/0011-positional-market-value.md`.
+
+### 4. File in the right order
+
+Create tickets root-first so dependency refs can point at real issue numbers:
+
+1. File the ticket(s) with no dependencies.
+2. Capture returned issue numbers.
+3. File the next layer, substituting the real `#N` into `Depends on #N` lines
+   and `--label blocked` where applicable.
+4. Repeat until all tickets are filed.
+
+Use `gh issue create` with a HEREDOC body:
+
+```bash
+gh issue create \
+  --title "feat(contracts): add positional market multiplier table" \
+  --label "adr:0011" --label "ready-for-agent" \
+  --body "$(cat <<'EOF'
+## Context
+...
+## Acceptance criteria
+- [ ] ...
+## Dependencies
+(none)
+## ADR reference
+docs/product/decisions/0011-positional-market-value.md
+EOF
+)"
+```
+
+Tickets with unmet dependencies get `--label blocked` instead of
+`ready-for-agent`. When their blocker closes, the skill (or whoever closes the
+blocker) swaps the labels.
+
+### 5. Update the backlog
+
+- If a `Implement ADR NNNN` bullet exists in `docs/backlog.md`, replace it with
+  a one-liner pointing at the tracking issues:
+  `**2026-MM-DD — ADR NNNN tracked in issues #A, #B, #C.**`
+- Leave unrelated backlog entries alone.
+
+### 6. Report back
+
+Print to the user:
+
+- List of created issues (number + title).
+- The dependency graph as an inline ASCII tree or indented bullets.
+- Any ambiguity from the ADR that you had to decide or could not decide (surface
+  these; don't bury them).
+
+## Labels used by this skill
+
+- `adr:NNNN` — every ticket derived from an ADR gets this. One label per ADR;
+  create it on first use via
+  `gh label create "adr:NNNN" --color BFD4F2
+  --description "Derived from ADR NNNN" || true`.
+- `ready-for-agent` — no unmet dependencies; an agent can claim it.
+- `blocked` — has at least one open dependency. Swap to `ready-for-agent` when
+  blockers close.
+
+## Guardrails
+
+- **Never file tickets for a Proposed ADR.** Decisions in flux produce churned
+  tickets.
+- **Never mechanize the slicing.** A script parsing headings is wrong more often
+  than right — ADRs are prose. Read and judge.
+- **Don't invent acceptance criteria the ADR didn't commit to.** If a ticket
+  needs an invariant the ADR is silent on, ask the user to extend the ADR first,
+  then file.
+- **Don't file dozens of tickets silently.** If an ADR would produce more than
+  ~6 tickets, stop and check with the user that the slicing is right before
+  creating any.

--- a/.github/ISSUE_TEMPLATE/adr-ticket.md
+++ b/.github/ISSUE_TEMPLATE/adr-ticket.md
@@ -1,0 +1,27 @@
+---
+name: ADR ticket
+about: Work derived from an accepted ADR. Agents can claim these.
+title: "<type>(<scope>): <what>"
+labels: ["ready-for-agent"]
+---
+
+## Context
+
+<!-- Two or three sentences. What exists today; what this ticket changes. -->
+
+## Acceptance criteria
+
+<!-- Bulleted, checkable. Pull invariants the ADR pins. -->
+
+- [ ]
+- [ ]
+
+## Dependencies
+
+<!-- `Depends on #N` for each blocker. "(none)" if ready to start. -->
+
+(none)
+
+## ADR reference
+
+<!-- Exact path, e.g. docs/product/decisions/0011-positional-market-value.md -->

--- a/bin/issues-loop-parallel
+++ b/bin/issues-loop-parallel
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+# issues-loop-parallel — fan out GitHub issues labeled `ready-for-agent`
+# across N concurrent `claude -p` sessions. Each session claims one specific
+# issue (passed in), opens a worktree, ships a PR that closes the issue, and
+# watches it to merge.
+#
+# Usage:  bin/issues-loop-parallel [concurrency]   # default 3
+#
+# Trade-off vs bin/backlog-loop-parallel: source of truth is GitHub Issues
+# with the `ready-for-agent` label (filed by /file-adr-tickets from an
+# Accepted ADR). Dependencies between issues (`Depends on #N`) are NOT
+# respected — the `blocked` label is used to keep dependent issues out of
+# the pool, but if you flip a blocked issue to `ready-for-agent` while its
+# blocker is still open, a worker will try to ship it and fail.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+CONCURRENCY="${1:-3}"
+LABEL="${ISSUES_LOOP_LABEL:-ready-for-agent}"
+
+cd "$REPO_ROOT"
+
+# --- worker mode: invoked by xargs for each issue --------------------------
+if [[ "${ISSUES_LOOP_WORKER:-}" == "1" ]]; then
+  issue_number="$1"
+  echo "=== worker start: #$issue_number ==="
+
+  issue_json="$(gh issue view "$issue_number" --json number,title,body,labels,url)"
+  issue_title="$(printf '%s' "$issue_json" | jq -r '.title')"
+  issue_body="$(printf '%s' "$issue_json" | jq -r '.body')"
+  issue_url="$(printf '%s' "$issue_json" | jq -r '.url')"
+
+  prompt=$(cat <<PROMPT
+You are one parallel worker in an autonomous issue fan-out. Other workers
+are shipping other issues concurrently. The issue assigned to YOU is:
+
+#$issue_number — $issue_title
+$issue_url
+
+--- issue body ---
+$issue_body
+--- end body ---
+
+Execute end-to-end without asking for confirmation:
+
+1. EnterWorktree off main so you do not clash with sibling workers.
+2. Read the ADR referenced in the issue body (under "ADR reference"), plus
+   any ADRs it links, before designing the change.
+3. Check "Dependencies". If it lists \`Depends on #N\` and #N is still
+   open, stop: comment on the issue "Blocked by #N — re-label to
+   \`blocked\` until resolved" and exit. Do NOT attempt the work.
+4. Implement following CLAUDE.md: strict TDD, one logical change, deno lint
+   clean, relevant test suites green. The issue's Acceptance Criteria are
+   the checklist — every box must be checkable when you're done.
+5. Commit with Conventional Commits, push the branch, open a PR against
+   main with \`gh pr create\`. The PR body MUST include \`Closes #$issue_number\`
+   so the issue auto-closes on merge. Summary section only, no test plan.
+6. \`gh pr merge --auto --squash\`, then \`gh pr checks --watch\`. If checks
+   fail, fix on the same branch and push again.
+7. When the PR is merged, exit the worktree and end the session. The issue
+   closes automatically via the \`Closes\` ref.
+
+If investigation shows the issue is obsolete, superseded, or infeasible,
+close the issue with a comment explaining why. Do NOT open an empty PR.
+
+Do NOT stop until your PR is merged (or the issue is closed as obsolete).
+PROMPT
+)
+
+  if ! claude -p "$prompt" --dangerously-skip-permissions </dev/null; then
+    echo "!!! worker failed: #$issue_number" >&2
+    exit 1
+  fi
+  exit 0
+fi
+
+# --- dispatcher ------------------------------------------------------------
+git checkout main --quiet
+git pull --ff-only origin main --quiet
+
+numbers_file="$(mktemp)"
+trap 'rm -f "$numbers_file"' EXIT
+
+gh issue list \
+  --label "$LABEL" \
+  --state open \
+  --limit 200 \
+  --json number \
+  --jq '.[].number' > "$numbers_file"
+
+count=$(wc -l < "$numbers_file" | tr -d ' ')
+if [[ "$count" == "0" ]]; then
+  echo "No open issues with label '$LABEL'. Done."
+  exit 0
+fi
+
+echo "Dispatching $count issues across $CONCURRENCY workers…"
+
+ISSUES_LOOP_WORKER=1 \
+  xargs -n 1 -P "$CONCURRENCY" "$0" < "$numbers_file"
+
+echo "All workers finished."

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -9,6 +9,20 @@ entry when it's resolved or superseded.
 
 ## Open
 
+- **2026-04-14 — Implement positional market value table (ADR 0011).** Replace
+  ADR 0009's premium/mid/base tier buckets with a per-position market
+  multiplier + convex-at-top curve (QB 1.80 down to LS 0.20; RB depressed at
+  0.65). Single exported module consumed by the contract generator and the
+  future FA valuation code. Rookie-scale deals stay exempt. Tests pin the QB:RB
+  ~2.75× headline invariant and ordering, not exact numbers.
+- **2026-04-14 — Implement league-creation cap situations (ADR 0010).** Assign a
+  cap-situation archetype (Cap Hell / Tight / Balanced / Flush) per team at
+  league creation, bias contract generation so team totals land in the
+  archetype's band (replacing ADR 0009's uniform post-hoc scale), correlate
+  roster shape (age / star density) with archetype, and surface the badge +
+  committed/available numbers on the team-select screen. Allow Cap Hell to start
+  slightly over the cap; first-offseason compliance flow is a prerequisite
+  before advancing past that offseason.
 - **2026-04-14 — Scheme lens on scouting / FA / draft surfaces.** ADR 0006
   requires scout reports, free-agent shortlists, and draft boards to surface
   players as archetypes-in-role ("slot WR," "3-tech," "box safety") when

--- a/docs/product/decisions/0010-league-cap-situations.md
+++ b/docs/product/decisions/0010-league-cap-situations.md
@@ -1,0 +1,133 @@
+# 0010 — League-creation cap situations
+
+- **Date:** 2026-04-14
+- **Status:** Accepted
+- **Area:** salary cap, league creation — builds on
+  [`salary-cap.md`](../north-star/salary-cap.md) and
+  [`0009-archetype-aware-player-generator.md`](./0009-archetype-aware-player-generator.md).
+
+## Context
+
+ADR 0009 graduated the player generator to produce contracts from a position
+tier × quality band, then scaled each team's total down uniformly if it exceeded
+the cap. That keeps every team legal, but it also flattens every team to roughly
+the same cap posture on day one — which contradicts the salary-cap north-star.
+The real NFL has a few teams pressed against the ceiling (stars just extended,
+restructures stacked), a large middle, and a handful of flush rebuilders.
+Day-one uniformity robs the user of the most legible piece of team identity at
+the "pick your team" moment: the financial situation they're inheriting.
+
+We also want team selection to preview this, not hide it, so the user can
+deliberately pick "cap hell with a contender roster" or "flush rebuild" without
+having to cross-reference a cap screen.
+
+## Decision
+
+At league creation, each team is assigned a **cap situation archetype** drawn
+from a league-wide distribution. The archetype steers contract generation for
+that team so the resulting total cap committed lands in the band that defines
+the archetype. The team-select screen surfaces the archetype as a qualitative
+badge plus the committed / available split.
+
+### Archetypes and target distribution
+
+Four archetypes, expressed as a fraction of the hard cap committed before league
+play begins:
+
+- **Cap hell** — 95–103% committed (can be slightly over; user must trim to
+  comply by the first deadline). ~15% of teams.
+- **Tight** — 88–95% committed. ~25% of teams.
+- **Balanced** — 75–88% committed. ~35% of teams.
+- **Flush** — 55–75% committed. ~25% of teams.
+
+Rates are tunable constants, not hard-coded per team. The league-creation RNG
+(same seeded `random` already threaded through the generator in ADR 0009)
+assigns archetypes by sampling without replacement against these weights, so a
+32-team league reliably produces the full spread rather than, say, twelve Flush
+teams by chance.
+
+### Correlation with roster shape
+
+Archetypes are not orthogonal to the roster the player sees — that is what keeps
+them from feeling arbitrary:
+
+- **Cap hell** skews older and star-heavy (a couple of 85+ overalls on
+  premium-tier contracts), fewer rookie-scale contributors.
+- **Tight** leans veteran-balanced.
+- **Balanced** is the default spread ADR 0009 already produces.
+- **Flush** skews younger, more rookie-scale contracts, fewer premium-tier
+  veterans.
+
+Concretely this is expressed as a small bias layered on top of the per-player
+quality roll and age sampler from ADR 0009 — not a separate generator. The
+archetype's committed-cap band is the authoritative constraint; the roster bias
+is the mechanism that makes the band reachable without a uniform post-hoc scale.
+
+### Contract scaling under the archetype
+
+The ADR-0009 "scale every contract down uniformly if the team total exceeds the
+cap" step is replaced with "scale so the team total lands inside the archetype's
+band." Cap-hell teams are allowed to exceed 100% of the cap by a small margin
+(configurable, default ≤3%) — this is the inherited non-compliance state that
+the user will have to resolve in their first offseason, and it is a deliberate
+part of the Cap Hell feel.
+
+### Team-select surface
+
+The team-select screen gains, per team card:
+
+- A **cap situation badge** with the archetype label (`Cap Hell`, `Tight`,
+  `Balanced`, `Flush`) — styled so Cap Hell reads as danger and Flush as
+  opportunity.
+- The **committed / total** numbers and **available space** (can be negative for
+  Cap Hell).
+- No projections, no dead-cap breakdown — this is a picker, not the cap page.
+
+The badge label is the same vocabulary as the Flexibility score in the
+salary-cap north-star, so the picker and the in-season cap page speak the same
+language.
+
+### Determinism
+
+Archetype assignment consumes the same injected `random` factory the player
+generator already uses, so seeded tests remain deterministic. Distribution
+invariants (every archetype represented in a 32-team league within expected
+tolerance, Cap Hell teams land in band, Flush teams land in band) are asserted
+in tests.
+
+## Alternatives considered
+
+- **Generate independently, then label after the fact.** Would let the existing
+  generator run unchanged, and we'd just bucket teams by their resulting cap
+  percentage. Rejected: it produces a bell curve clustered around whatever the
+  uniform scale-down lands on, so Cap Hell and Flush are rare and mushy. The
+  point is to guarantee the spread, not observe it.
+- **Per-team commissioner-set archetypes.** Overkill for league creation;
+  belongs in a future custom-league / scenario-builder surface. The randomized
+  default is what every new league needs.
+- **More archetypes (e.g. "Rebuild with dead cap spike," "Contender on a
+  budget").** Tempting, but each archetype needs a legible badge and a testable
+  band. Four buckets is enough to carry the feel; we can split later if the
+  feedback is that Cap Hell is doing too much work.
+- **Show raw committed-cap percent only, no badge.** The number alone doesn't
+  carry the vibe — 94% committed reads the same as 89% committed to most users.
+  The qualitative label is the UX value.
+
+## Consequences
+
+- League creation produces a legibly varied cap landscape from the first screen.
+  Team-select becomes a meaningful choice instead of a cosmetic one.
+- ADR 0009's uniform post-hoc scaling is superseded by archetype-band scaling.
+  The contract generator now takes an archetype as input.
+- The Flexibility score vocabulary in the salary-cap north-star is now a live UI
+  surface — anywhere else that wants to show cap health (roster header, cap
+  page, standings) should reuse the same four labels.
+- Cap Hell teams can start slightly over the cap, which means the first
+  offseason flow must support a non-compliant starting state (cut / restructure
+  to comply by the deadline). This is consistent with the north-star's
+  "compliance deadline" mechanic but does mean that flow has to exist before the
+  league actually advances past the offseason.
+- NPC GM personalities (ADR-free, described in the salary-cap north-star) will
+  eventually want to correlate with archetypes — a Gambler team should be more
+  likely to spawn in Cap Hell, a Developer team in Flush. Out of scope here;
+  archetype assignment is personality-blind for now.

--- a/docs/product/decisions/0011-positional-market-value.md
+++ b/docs/product/decisions/0011-positional-market-value.md
@@ -1,0 +1,140 @@
+# 0011 — Positional market value
+
+- **Date:** 2026-04-14
+- **Status:** Accepted — refines the position-tier list in
+  [`0009-archetype-aware-player-generator.md`](./0009-archetype-aware-player-generator.md)
+  and feeds into
+  [`0010-league-cap-situations.md`](./0010-league-cap-situations.md).
+- **Area:** salary cap, free agency — builds on
+  [`salary-cap.md`](../north-star/salary-cap.md) and
+  [`free-agency-and-contracts.md`](../north-star/free-agency-and-contracts.md).
+
+## Context
+
+ADR 0009 bucketed positions into three tiers (premium / mid / base) for the stub
+contract generator. That was enough to avoid a literal even split, but it
+smooths out the thing that actually defines the NFL's financial shape: a
+quarterback gets a different _kind_ of contract than a guard, not just a bigger
+one on the same curve. An 85-overall QB is a generational-level payday; an
+85-overall RB is still on a second contract the market grumbles about.
+
+This matters in two places, which is why it gets its own decision rather than
+living inside ADR 0009:
+
+1. **League generation.** Cap-situation archetypes (ADR 0010) need to land in
+   their committed-cap bands using realistic inputs. If every position pays on
+   the same curve, a Cap Hell team is implausibly RB-heavy and a Flush team has
+   no star QB.
+2. **Free agency negotiations (future work).** Offers are evaluated against a
+   market value the player and their agent believe they deserve. That market
+   value is _positional_, not just a function of overall rating — a 90-overall
+   RB will not accept a 90-overall QB's offer because no other team will match
+   it either.
+
+## Decision
+
+Introduce a **positional market multiplier** as a first-class, tunable table,
+consumed by both the contract generator (ADR 0009) and the future free-agency
+valuation code. It replaces the three-tier bucket from ADR 0009.
+
+### Market multipliers
+
+Multipliers are applied to a quality-driven base salary. Higher multiplier =
+richer market. Initial table (tunable; tests assert the ordering, not the exact
+numbers):
+
+| Position | Multiplier | Rationale                                               |
+| -------- | ---------- | ------------------------------------------------------- |
+| QB       | 1.80       | Franchise-defining, scarce, drives everything           |
+| EDGE     | 1.45       | Pass-rush is the second-most-leveraged skill            |
+| OT       | 1.30       | Blindside protection; scarcity                          |
+| WR       | 1.25       | Top of market has crept up; #1s get paid                |
+| CB       | 1.20       | Premium coverage, though behind WR historically         |
+| IDL      | 1.10       | Interior disruption; healthy market for top tier        |
+| S        | 1.00       | Baseline — solid market, not a premium                  |
+| TE       | 0.95       | Top TEs approach WR money; middle of market is thin     |
+| LB       | 0.90       | Off-ball LB market has been suppressed                  |
+| IOL      | 0.85       | Guards/centers paid less than tackles                   |
+| RB       | 0.65       | Depressed market; short shelf life, high replaceability |
+| K        | 0.25       | Specialist, minimum-adjacent                            |
+| P        | 0.25       | Specialist, minimum-adjacent                            |
+| LS       | 0.20       | Specialist, minimum-adjacent                            |
+
+The QB-to-RB spread is the point: an 85-overall QB should come out of the
+generator at roughly **~2.75×** what an 85-overall RB does (1.80 / 0.65). That
+is approximately the live-NFL gap and is the headline invariant the tests pin.
+
+### Top-of-market skew
+
+A flat multiplier is not enough. Elite-tier quality at a premium position gets
+an _additional_ skew: the market pays the top QB far more than it pays the
+tenth-best QB, more than the analogous gap at IOL. Concretely, the per-player
+quality-to-salary curve is **convex at premium positions and flatter at
+depressed positions** — top QBs explode off the top of the curve, RBs plateau.
+This is a per-position curve shape, not a separate table, so it lives next to
+the multiplier.
+
+### Rookie contracts are exempt
+
+Rookie-scale deals come from the slotted rookie wage scale (salary-cap
+north-star), not this table. The market multiplier only applies to
+second-contract and later deals. This is why a Flush team leaning on a
+rookie-contract QB is cheap: the market is expensive, but the rookie scale
+overrides it for four or five years.
+
+### Free-agency valuation (forward-looking)
+
+When the FA loop lands, player/agent minimum-acceptable offers are computed from
+the same table. A player will reject an offer below their positional market
+value (modulo personality, loyalty, team situation — those get their own
+decision). This is why this table is not an internal helper of the contract
+generator: it is the canonical "what is a player worth" source.
+
+### Where the table lives
+
+One module, exported as a constant map (position → multiplier + curve
+parameters). Consumers:
+
+- `createStubPlayersGenerator` (ADR 0009) — replaces the tier buckets.
+- Cap-situation archetype sampler (ADR 0010) — influences which positions a Cap
+  Hell team is likely to have stars at (premium-market positions concentrate
+  cap; RB-heavy rosters literally cannot reach the Cap Hell band).
+- Future FA valuation — same import.
+
+Because it is the single source, tuning the market is one edit. That is the
+whole point.
+
+## Alternatives considered
+
+- **Keep the three-tier premium/mid/base buckets and tune them harder.** Tiers
+  collapse positions that have different markets (WR ≠ CB, LB ≠ TE, RB ≠ the
+  rest of "mid"). The RB depression specifically is invisible in a tiered model
+  — RB belongs in its own bucket or the model is wrong.
+- **Derive market from simulation (let prices emerge from supply/demand each
+  offseason).** Long-term, maybe. For now we need deterministic generation at
+  league creation; a seeded table gives us that and is a reasonable starting
+  point for the eventual dynamic market.
+- **Hard-code RB to a flat cap.** Too blunt — a generational RB should still get
+  paid, just less than a generational QB. The convex-curve-per-position approach
+  handles the Saquon / McCaffrey case without a special rule.
+- **Separate "cap value" and "FA value" tables.** They are the same thing. If
+  the generator and the FA loop disagree on what a QB is worth, the league
+  becomes incoherent the moment a contract expires.
+
+## Consequences
+
+- ADR 0009's `tier` field on the contract generator is superseded. The generator
+  now takes the market table as a dependency (default import, overridable for
+  tests).
+- Cap-situation archetypes (ADR 0010) become reachable in a realistic way — Cap
+  Hell teams naturally have premium-position stars driving the committed cap,
+  Flush teams can be light at premium positions or on rookie deals.
+- RB-heavy rosters are structurally cheaper. This is correct and is a thing the
+  user will feel when they pick an RB-heavy team and see "Flush" on the badge.
+- The table is a knob, not a law. When the live NFL market shifts (IOL is
+  catching up to OT, TE is approaching WR money), we edit one file and both
+  generation and FA re-price together.
+- Future work — positional scarcity inside a single league's FA class should
+  _further_ modulate these multipliers (a thin QB class pays even more; a loaded
+  RB class pays even less). Out of scope here; this ADR establishes the static
+  baseline.


### PR DESCRIPTION
## Summary

- **ADR 0010 — League-creation cap situations.** Four archetypes (Cap Hell / Tight / Balanced / Flush) assigned per team at league creation with a weighted distribution. Contract generation scales to the archetype's committed-cap band, superseding ADR 0009's uniform post-hoc scale. Team-select surfaces the badge.
- **ADR 0011 — Positional market value.** Single per-position multiplier table (QB 1.80 → RB 0.65, specialists ~0.20) with convex top-of-market skew. Consumed by the contract generator today and free-agency valuation later; supersedes ADR 0009's premium/mid/base tier field. Rookie scale is exempt.
- **`/file-adr-tickets` skill + issue template.** PM-mode procedure that slices an Accepted ADR into claimable GitHub Issues with acceptance criteria pinned to ADR invariants and `Depends on #N` refs for ordering.
- **`bin/issues-loop-parallel`.** Fans out issues labeled `ready-for-agent` across N concurrent `claude -p` workers, matching the existing `backlog-loop-parallel` pattern. Workers bail if their `Depends on` blocker is still open.
- **Backlog** carries one-liner placeholders for ADR 0010/0011 implementation until the skill converts them into issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)