### PR TITLE
docs(backlog): track ADR 0011 via issues

### DIFF
--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -9,12 +9,8 @@ entry when it's resolved or superseded.
 
 ## Open
 
-- **2026-04-14 — Implement positional market value table (ADR 0011).** Replace
-  ADR 0009's premium/mid/base tier buckets with a per-position market
-  multiplier + convex-at-top curve (QB 1.80 down to LS 0.20; RB depressed at
-  0.65). Single exported module consumed by the contract generator and the
-  future FA valuation code. Rookie-scale deals stay exempt. Tests pin the QB:RB
-  ~2.75× headline invariant and ordering, not exact numbers.
+- **2026-04-14 — ADR 0011 (positional market value) tracked in issues #168,
+  #169.**
 - **2026-04-14 — Implement league-creation cap situations (ADR 0010).** Assign a
   cap-situation archetype (Cap Hell / Tight / Balanced / Flush) per team at
   league creation, bias contract generation so team totals land in the


### PR DESCRIPTION
## Summary

Replace the ADR 0011 placeholder in the backlog with tracking links to issues #168 (market value table module) and #169 (generator consumer, blocked on #168). First pilot of the `/file-adr-tickets` PM pipeline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)