### PR TITLE
feat(contracts): add positional market value table module

### DIFF
--- a/packages/shared/market/positional-market-value.test.ts
+++ b/packages/shared/market/positional-market-value.test.ts
@@ -1,0 +1,140 @@
+import { assertEquals, assertGreater, assertLess } from "@std/assert";
+import {
+  POSITIONAL_MARKET_VALUES,
+  type PositionalMarketEntry,
+  positionalSalaryMultiplier,
+} from "./positional-market-value.ts";
+import {
+  NEUTRAL_BUCKETS,
+  type NeutralBucket,
+} from "../archetypes/neutral-bucket.ts";
+
+Deno.test("POSITIONAL_MARKET_VALUES covers every neutral bucket", () => {
+  for (const bucket of NEUTRAL_BUCKETS) {
+    assertEquals(
+      bucket in POSITIONAL_MARKET_VALUES,
+      true,
+      `Missing entry for ${bucket}`,
+    );
+  }
+});
+
+Deno.test("each entry has multiplier and curve parameters", () => {
+  for (const bucket of NEUTRAL_BUCKETS) {
+    const entry = POSITIONAL_MARKET_VALUES[bucket];
+    assertEquals(typeof entry.multiplier, "number");
+    assertEquals(typeof entry.curveExponent, "number");
+    assertGreater(entry.multiplier, 0);
+    assertGreater(entry.curveExponent, 0);
+  }
+});
+
+Deno.test("ordering: QB > EDGE > OT > WR > CB > IDL > S > TE > LB > IOL > RB > K/P/LS", () => {
+  const ordered: NeutralBucket[] = [
+    "QB",
+    "EDGE",
+    "OT",
+    "WR",
+    "CB",
+    "IDL",
+    "S",
+    "TE",
+    "LB",
+    "IOL",
+    "RB",
+  ];
+
+  for (let i = 0; i < ordered.length - 1; i++) {
+    assertGreater(
+      POSITIONAL_MARKET_VALUES[ordered[i]].multiplier,
+      POSITIONAL_MARKET_VALUES[ordered[i + 1]].multiplier,
+      `Expected ${ordered[i]} > ${ordered[i + 1]}`,
+    );
+  }
+
+  assertGreater(
+    POSITIONAL_MARKET_VALUES["RB"].multiplier,
+    POSITIONAL_MARKET_VALUES["K"].multiplier,
+    "Expected RB > K",
+  );
+  assertEquals(
+    POSITIONAL_MARKET_VALUES["K"].multiplier,
+    POSITIONAL_MARKET_VALUES["P"].multiplier,
+  );
+  assertGreater(
+    POSITIONAL_MARKET_VALUES["K"].multiplier,
+    POSITIONAL_MARKET_VALUES["LS"].multiplier,
+    "Expected K/P > LS",
+  );
+});
+
+Deno.test("headline invariant: at equal quality, QB salary ≈ 2.75× RB salary (±10%)", () => {
+  const quality = 85;
+  const qbMultiplier = positionalSalaryMultiplier("QB", quality);
+  const rbMultiplier = positionalSalaryMultiplier("RB", quality);
+  const ratio = qbMultiplier / rbMultiplier;
+
+  const target = 1.80 / 0.65;
+  const tolerance = 0.10;
+  assertGreater(ratio, target * (1 - tolerance));
+  assertLess(ratio, target * (1 + tolerance));
+});
+
+Deno.test("curve: at elite quality (95), QB curve is steeper than RB curve over last 10 overall", () => {
+  const qbAt95 = positionalSalaryMultiplier("QB", 95);
+  const qbAt85 = positionalSalaryMultiplier("QB", 85);
+  const qbDelta = qbAt95 - qbAt85;
+
+  const rbAt95 = positionalSalaryMultiplier("RB", 95);
+  const rbAt85 = positionalSalaryMultiplier("RB", 85);
+  const rbDelta = rbAt95 - rbAt85;
+
+  assertGreater(
+    qbDelta,
+    rbDelta,
+    "QB's curve should be steeper than RB's at elite quality",
+  );
+});
+
+Deno.test("curve: premium positions have higher exponents than depressed positions", () => {
+  assertGreater(
+    POSITIONAL_MARKET_VALUES["QB"].curveExponent,
+    POSITIONAL_MARKET_VALUES["RB"].curveExponent,
+  );
+  assertGreater(
+    POSITIONAL_MARKET_VALUES["EDGE"].curveExponent,
+    POSITIONAL_MARKET_VALUES["IOL"].curveExponent,
+  );
+});
+
+Deno.test("positionalSalaryMultiplier increases with quality", () => {
+  const positions: NeutralBucket[] = ["QB", "RB", "WR", "K"];
+  for (const pos of positions) {
+    const low = positionalSalaryMultiplier(pos, 60);
+    const mid = positionalSalaryMultiplier(pos, 75);
+    const high = positionalSalaryMultiplier(pos, 90);
+    assertGreater(mid, low, `${pos}: 75 should > 60`);
+    assertGreater(high, mid, `${pos}: 90 should > 75`);
+  }
+});
+
+Deno.test("module only depends on shared package types", () => {
+  // The module lives in packages/shared and only imports NeutralBucket from
+  // the same package. TypeScript compilation enforces it cannot import from
+  // server or any consumer — shared has no such dependency.
+  const entry: PositionalMarketEntry = POSITIONAL_MARKET_VALUES["QB"];
+  assertEquals(typeof entry.multiplier, "number");
+  assertEquals(typeof entry.curveExponent, "number");
+});
+
+Deno.test("default table is overridable for tests", () => {
+  const override: Record<NeutralBucket, PositionalMarketEntry> = {
+    ...POSITIONAL_MARKET_VALUES,
+    QB: { multiplier: 99, curveExponent: 1 },
+  };
+  assertEquals(override["QB"].multiplier, 99);
+  assertEquals(
+    override["RB"].multiplier,
+    POSITIONAL_MARKET_VALUES["RB"].multiplier,
+  );
+});

--- a/packages/shared/market/positional-market-value.ts
+++ b/packages/shared/market/positional-market-value.ts
@@ -1,0 +1,40 @@
+import type { NeutralBucket } from "../archetypes/neutral-bucket.ts";
+
+export interface PositionalMarketEntry {
+  multiplier: number;
+  curveExponent: number;
+}
+
+export const POSITIONAL_MARKET_VALUES: Record<
+  NeutralBucket,
+  PositionalMarketEntry
+> = {
+  QB: { multiplier: 1.80, curveExponent: 1.40 },
+  EDGE: { multiplier: 1.45, curveExponent: 1.30 },
+  OT: { multiplier: 1.30, curveExponent: 1.25 },
+  WR: { multiplier: 1.25, curveExponent: 1.20 },
+  CB: { multiplier: 1.20, curveExponent: 1.15 },
+  IDL: { multiplier: 1.10, curveExponent: 1.10 },
+  S: { multiplier: 1.00, curveExponent: 1.05 },
+  TE: { multiplier: 0.95, curveExponent: 1.03 },
+  LB: { multiplier: 0.90, curveExponent: 1.02 },
+  IOL: { multiplier: 0.85, curveExponent: 1.01 },
+  RB: { multiplier: 0.65, curveExponent: 1.00 },
+  K: { multiplier: 0.25, curveExponent: 1.00 },
+  P: { multiplier: 0.25, curveExponent: 1.00 },
+  LS: { multiplier: 0.20, curveExponent: 1.00 },
+};
+
+/**
+ * Combines the positional base multiplier with a per-position convex curve
+ * applied to a normalized quality score (0–99 → 0–1). Premium positions have
+ * steeper curves so elite talent is disproportionately expensive.
+ */
+export function positionalSalaryMultiplier(
+  position: NeutralBucket,
+  quality: number,
+): number {
+  const { multiplier, curveExponent } = POSITIONAL_MARKET_VALUES[position];
+  const normalized = Math.max(0, Math.min(quality, 99)) / 99;
+  return multiplier * Math.pow(normalized, curveExponent);
+}

--- a/packages/shared/mod.ts
+++ b/packages/shared/mod.ts
@@ -138,6 +138,13 @@ export type {
   PlayerForAssignment,
 } from "./depth-chart/assign.ts";
 
+// Market
+export type { PositionalMarketEntry } from "./market/positional-market-value.ts";
+export {
+  POSITIONAL_MARKET_VALUES,
+  positionalSalaryMultiplier,
+} from "./market/positional-market-value.ts";
+
 // Interfaces — simulation
 export type {
   GameEvent,


### PR DESCRIPTION
## Summary

Closes #168

- Adds a positional market value module (`packages/shared/market/positional-market-value.ts`) implementing ADR 0011's market multiplier table. Every position (QB through LS) gets a `multiplier` and `curveExponent` that together produce a convex-at-premium, flat-at-depressed salary curve.
- Exports `POSITIONAL_MARKET_VALUES` (the constant map), `positionalSalaryMultiplier` (the helper function), and `PositionalMarketEntry` (the type) from `@zone-blitz/shared`.
- Tests pin the ordering invariant (QB > EDGE > ... > LS), the headline ratio (QB ≈ 2.75× RB at equal quality within ±10%), curve steepness (QB's elite delta > RB's), and monotonicity. 100% coverage on the new module.

🤖 Generated with [Claude Code](https://claude.com/claude-code)