### PR TITLE
chore(issues-loop): stream claude output to stdout

### DIFF
--- a/bin/issues-loop-parallel
+++ b/bin/issues-loop-parallel
@@ -83,7 +83,7 @@ AND the dependent-unblock sweep has run.
 PROMPT
 )
 
-  if ! claude -p "$prompt" --dangerously-skip-permissions </dev/null; then
+  if ! claude -p "$prompt" --verbose --dangerously-skip-permissions </dev/null 2>&1 | sed -u "s/^/[#$issue_number] /"; then
     echo "!!! worker failed: #$issue_number" >&2
     exit 1
   fi


### PR DESCRIPTION
## Summary

- Add `--verbose` to `claude -p` in `bin/issues-loop-parallel` so workers stream tool calls and intermediate messages rather than only the final reply.
- Merge stderr into stdout and prefix each line with `[#<issue>]` via `sed -u` so parallel workers' output stays distinguishable when interleaved.
- `pipefail` is already set, so the pipeline's failure check still surfaces worker errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)