### PR TITLE
fix(generators): deflake deterministic tests for scouts and coaches

### DIFF
--- a/server/features/coaches/coaches-generator.test.ts
+++ b/server/features/coaches/coaches-generator.test.ts
@@ -321,13 +321,16 @@ Deno.test("contract salaries fall within sane bounds per tier", () => {
 });
 
 Deno.test("seeded generator is deterministic", () => {
+  const fixedNow = () => new Date("2026-01-01T00:00:00Z");
   const a = createCoachesGenerator({
     random: seededRandom(42),
     nameGenerator: fixedNameGenerator(),
+    now: fixedNow,
   }).generate(INPUT);
   const b = createCoachesGenerator({
     random: seededRandom(42),
     nameGenerator: fixedNameGenerator(),
+    now: fixedNow,
   }).generate(INPUT);
   assertEquals(a.length, b.length);
   for (let i = 0; i < a.length; i++) {

--- a/server/features/scouts/scouts-generator.test.ts
+++ b/server/features/scouts/scouts-generator.test.ts
@@ -180,13 +180,16 @@ Deno.test("contract salaries fall within sane per-role bounds", () => {
 });
 
 Deno.test("seeded generator is deterministic", () => {
+  const fixedNow = () => new Date("2026-01-01T00:00:00Z");
   const a = createScoutsGenerator({
     random: seededRandom(42),
     nameGenerator: fixedNameGenerator(),
+    now: fixedNow,
   }).generate(INPUT);
   const b = createScoutsGenerator({
     random: seededRandom(42),
     nameGenerator: fixedNameGenerator(),
+    now: fixedNow,
   }).generate(INPUT);
   assertEquals(a.length, b.length);
   for (let i = 0; i < a.length; i++) {


### PR DESCRIPTION
## Summary

- Both `server/features/{scouts,coaches}/*-generator.test.ts` "seeded generator is deterministic" tests intermittently failed on unrelated PRs (#175, #178) with a 1ms diff on `hiredAt.getTime()`.
- Both generators already expose an injectable `now` option; the tests just weren't using it, so two sequential `new Date()` calls could land in different milliseconds.
- Inject a fixed clock (`() => new Date("2026-01-01T00:00:00Z")`) in both deterministic tests. Ran each 100 consecutive times locally — no failures.

Closes #181, #182