### PR TITLE
chore(issues-loop): dispatch issues oldest-first

### DIFF
--- a/bin/issues-loop-parallel
+++ b/bin/issues-loop-parallel
@@ -101,8 +101,8 @@ gh issue list \
   --label "$LABEL" \
   --state open \
   --limit 200 \
-  --json number \
-  --jq '.[].number' > "$numbers_file"
+  --json number,createdAt \
+  --jq 'sort_by(.createdAt) | .[].number' > "$numbers_file"
 
 count=$(wc -l < "$numbers_file" | tr -d ' ')
 if [[ "$count" == "0" ]]; then


### PR DESCRIPTION
## Summary
- Sort `ready-for-agent` issues by `createdAt` ascending in `bin/issues-loop-parallel` so the dispatcher feeds workers FIFO instead of newest-first.