### PR TITLE
feat(roster): render coach-authored depth chart slot as Pos

### DIFF
--- a/client/src/features/league/opponents/detail.test.tsx
+++ b/client/src/features/league/opponents/detail.test.tsx
@@ -69,6 +69,7 @@ const roster = {
       injuryStatus: "healthy",
       schemeFit: "fits",
       schemeArchetype: null,
+      depthChartSlot: null,
     },
     {
       id: "p2",
@@ -82,6 +83,7 @@ const roster = {
       injuryStatus: "out",
       schemeFit: null,
       schemeArchetype: null,
+      depthChartSlot: null,
     },
     {
       id: "p3",
@@ -95,6 +97,7 @@ const roster = {
       injuryStatus: "questionable",
       schemeFit: "miscast",
       schemeArchetype: null,
+      depthChartSlot: null,
     },
   ],
   positionGroups: [

--- a/client/src/features/league/roster.test.tsx
+++ b/client/src/features/league/roster.test.tsx
@@ -57,6 +57,7 @@ const baseRoster = {
       injuryStatus: "healthy",
       schemeFit: "ideal",
       schemeArchetype: "pocket passer",
+      depthChartSlot: "QB1",
     },
     {
       id: "p2",
@@ -70,6 +71,7 @@ const baseRoster = {
       injuryStatus: "questionable",
       schemeFit: "miscast",
       schemeArchetype: "zone RB",
+      depthChartSlot: "RB2",
     },
     {
       id: "p3",
@@ -83,6 +85,7 @@ const baseRoster = {
       injuryStatus: "out",
       schemeFit: "fits",
       schemeArchetype: "speed DE",
+      depthChartSlot: "EDGE1",
     },
     {
       id: "p4",
@@ -96,6 +99,7 @@ const baseRoster = {
       injuryStatus: "healthy",
       schemeFit: null,
       schemeArchetype: null,
+      depthChartSlot: null,
     },
   ],
   positionGroups: [
@@ -275,10 +279,25 @@ describe("Roster — active roster tab (default)", () => {
     renderRoster();
     const row = screen.getByTestId("roster-row-p1");
     expect(within(row).getByText("Patrick Quarterback")).toBeDefined();
-    expect(within(row).getByText("QB")).toBeDefined();
+    expect(within(row).getByText("QB1")).toBeDefined();
     expect(within(row).getByText("Offense")).toBeDefined();
     expect(within(row).getByText("28")).toBeDefined();
     expect(within(row).getByText(/healthy/i)).toBeDefined();
+  });
+
+  it("renders the Pos column from the coach-authored depth chart slot (ADR 0006)", () => {
+    renderRoster();
+    expect(
+      within(screen.getByTestId("roster-row-p2")).getByText("RB2"),
+    ).toBeDefined();
+    expect(
+      within(screen.getByTestId("roster-row-p3")).getByText("EDGE1"),
+    ).toBeDefined();
+    // Unslotted player falls back to em-dash — no position to fabricate.
+    // Both the Pos cell and the scheme-fit badge render "—", so assert ≥ 2.
+    expect(
+      within(screen.getByTestId("roster-row-p4")).getAllByText("—").length,
+    ).toBeGreaterThanOrEqual(2);
   });
 
   it("renders scheme fit as a qualitative badge (ADR 0005)", () => {

--- a/client/src/features/league/roster.tsx
+++ b/client/src/features/league/roster.tsx
@@ -99,12 +99,13 @@ const rosterColumns: ColumnDef<RosterPlayer>[] = [
     ),
   },
   {
-    accessorKey: "neutralBucket",
+    accessorKey: "depthChartSlot",
     header: ({ column }) => (
       <SortableHeader column={column}>
         Pos
       </SortableHeader>
     ),
+    cell: ({ row }) => row.original.depthChartSlot ?? "—",
   },
   {
     accessorKey: "neutralBucketGroup",

--- a/client/src/features/league/salary-cap.test.tsx
+++ b/client/src/features/league/salary-cap.test.tsx
@@ -41,6 +41,7 @@ const baseRoster = {
       injuryStatus: "healthy",
       schemeFit: "ideal",
       schemeArchetype: null,
+      depthChartSlot: null,
     },
     {
       id: "p2",
@@ -54,6 +55,7 @@ const baseRoster = {
       injuryStatus: "questionable",
       schemeFit: "poor",
       schemeArchetype: null,
+      depthChartSlot: null,
     },
     {
       id: "p3",
@@ -67,6 +69,7 @@ const baseRoster = {
       injuryStatus: "out",
       schemeFit: null,
       schemeArchetype: null,
+      depthChartSlot: null,
     },
     {
       id: "p4",
@@ -80,6 +83,7 @@ const baseRoster = {
       injuryStatus: "healthy",
       schemeFit: "fits",
       schemeArchetype: null,
+      depthChartSlot: null,
     },
   ],
   positionGroups: [

--- a/packages/shared/types/roster.ts
+++ b/packages/shared/types/roster.ts
@@ -37,6 +37,7 @@ export interface RosterPlayer {
   injuryStatus: PlayerInjuryStatus;
   schemeFit: SchemeFitLabel | null;
   schemeArchetype: SchemeArchetype | null;
+  depthChartSlot: string | null;
 }
 
 export interface RosterPositionGroupSummary {

--- a/server/features/roster/roster.repository.test.ts
+++ b/server/features/roster/roster.repository.test.ts
@@ -368,6 +368,111 @@ Deno.test({
 
 Deno.test({
   name:
+    "rosterRepository.getActiveRoster: attaches depthChartSlot from the authored depth chart",
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    const { db, client } = createTestDb();
+    const repo = createRosterRepository({
+      db,
+      log: createTestLogger(),
+      now: () => new Date("2030-06-15T00:00:00Z"),
+    });
+    const playersCreated: string[] = [];
+    const teamsCreated: string[] = [];
+    const leaguesCreated: string[] = [];
+    const citiesCreated: string[] = [];
+    const statesCreated: string[] = [];
+    const coachesCreated: string[] = [];
+
+    try {
+      const { league, team, state, city } = await setupFixtures(db);
+      leaguesCreated.push(league.id);
+      teamsCreated.push(team.id);
+      citiesCreated.push(city.id);
+      statesCreated.push(state.id);
+
+      const slottedId = crypto.randomUUID();
+      const unslottedId = crypto.randomUUID();
+      await db.insert(players).values([
+        {
+          id: slottedId,
+          leagueId: league.id,
+          teamId: team.id,
+          firstName: "Sam",
+          lastName: "Slotted",
+          injuryStatus: "healthy",
+          ...sizeFor("QB"),
+          birthDate: "2000-01-01",
+        },
+        {
+          id: unslottedId,
+          leagueId: league.id,
+          teamId: team.id,
+          firstName: "Una",
+          lastName: "Unslotted",
+          injuryStatus: "healthy",
+          ...sizeFor("RB"),
+          birthDate: "2001-01-01",
+        },
+      ]);
+      playersCreated.push(slottedId, unslottedId);
+
+      await db.insert(playerAttributes).values([
+        { playerId: slottedId, ...stubAttributeColumns("QB") },
+        { playerId: unslottedId, ...stubAttributeColumns("RB") },
+      ]);
+
+      const coachId = crypto.randomUUID();
+      await db.insert(coaches).values({
+        id: coachId,
+        leagueId: league.id,
+        teamId: team.id,
+        firstName: "Hank",
+        lastName: "Coach",
+        role: "HC",
+        age: 50,
+        hiredAt: new Date("2028-01-01T00:00:00Z"),
+        contractYears: 3,
+        contractSalary: 1,
+        contractBuyout: 1,
+      });
+      coachesCreated.push(coachId);
+
+      await db.insert(depthChartEntries).values({
+        teamId: team.id,
+        playerId: slottedId,
+        slotCode: "QB1",
+        slotOrdinal: 1,
+        isInactive: false,
+        publishedByCoachId: coachId,
+      });
+
+      const roster = await repo.getActiveRoster(league.id, team.id);
+
+      const slotted = roster.players.find((p) => p.id === slottedId);
+      assertEquals(slotted?.depthChartSlot, "QB1");
+
+      const unslotted = roster.players.find((p) => p.id === unslottedId);
+      assertEquals(unslotted?.depthChartSlot, null);
+    } finally {
+      if (coachesCreated.length) {
+        await db.delete(coaches).where(inArray(coaches.id, coachesCreated));
+      }
+      await cleanup(db, {
+        players: playersCreated,
+        teams: teamsCreated,
+        cities: citiesCreated,
+        states: statesCreated,
+        leagues: leaguesCreated,
+      });
+      await client.end();
+    }
+  },
+});
+
+Deno.test({
+  name:
     "rosterRepository.getDepthChart: returns slots, inactives, and latest publisher",
   sanitizeResources: false,
   sanitizeOps: false,

--- a/server/features/roster/roster.repository.ts
+++ b/server/features/roster/roster.repository.ts
@@ -130,6 +130,7 @@ export function createRosterRepository(deps: {
           annualSalary: contracts.annualSalary,
           totalYears: contracts.totalYears,
           currentYear: contracts.currentYear,
+          depthChartSlot: depthChartEntries.slotCode,
           ...attributeSelectColumns(),
         })
         .from(players)
@@ -138,6 +139,13 @@ export function createRosterRepository(deps: {
           eq(playerAttributes.playerId, players.id),
         )
         .leftJoin(contracts, eq(contracts.playerId, players.id))
+        .leftJoin(
+          depthChartEntries,
+          and(
+            eq(depthChartEntries.playerId, players.id),
+            eq(depthChartEntries.teamId, teamId),
+          ),
+        )
         .where(
           and(eq(players.leagueId, leagueId), eq(players.teamId, teamId)),
         );
@@ -207,6 +215,7 @@ export function createRosterRepository(deps: {
           injuryStatus: row.injuryStatus,
           schemeFit,
           schemeArchetype,
+          depthChartSlot: row.depthChartSlot ?? null,
         };
       });
 

--- a/server/features/roster/roster.router.test.ts
+++ b/server/features/roster/roster.router.test.ts
@@ -65,6 +65,7 @@ Deno.test("roster.router", async (t) => {
                   injuryStatus: "healthy",
                   schemeFit: null,
                   schemeArchetype: null,
+                  depthChartSlot: null,
                 },
               ],
               positionGroups: [


### PR DESCRIPTION
## Summary

- Per [ADR 0006](../docs/product/decisions/0006-positionless-players.md), players are positionless; the user's own roster should use the scheme lens — specifically, the slot the coach authored on the depth chart — rather than the league-wide neutral bucket.
- Server now left-joins `depth_chart_entries` into the active-roster query and exposes `depthChartSlot: string | null` on `RosterPlayer`.
- Client Pos column renders `depthChartSlot` with an em-dash fallback for any player the coach hasn't slotted yet (e.g. fresh signing before the depth chart regenerates — see #191).