### PR TITLE
feat(depth-chart): add depthChartSectionLabels helper

### DIFF
--- a/packages/shared/depth-chart/vocabulary.test.ts
+++ b/packages/shared/depth-chart/vocabulary.test.ts
@@ -3,6 +3,7 @@ import type { SchemeFingerprint } from "../types/scheme-fingerprint.ts";
 import type { OffensiveTendencies } from "../types/coach-tendencies.ts";
 import type { DefensiveTendencies } from "../types/coach-tendencies.ts";
 import {
+  depthChartSectionLabels,
   type DepthChartSlotDefinition,
   depthChartVocabulary,
 } from "./vocabulary.ts";
@@ -263,4 +264,140 @@ Deno.test("depthChartVocabulary: full ground-and-pound team snapshot", () => {
     "P",
     "LS",
   ]);
+});
+
+// depthChartSectionLabels tests
+
+Deno.test("depthChartSectionLabels: null offense returns plain 'Offense'", () => {
+  const labels = depthChartSectionLabels(fp({ offense: null }));
+  assertEquals(labels.offense, "Offense");
+});
+
+Deno.test("depthChartSectionLabels: null defense returns plain 'Defense'", () => {
+  const labels = depthChartSectionLabels(fp({ defense: null }));
+  assertEquals(labels.defense, "Defense");
+});
+
+Deno.test("depthChartSectionLabels: special teams is always 'Special Teams'", () => {
+  const labels = depthChartSectionLabels(fp());
+  assertEquals(labels.specialTeams, "Special Teams");
+});
+
+Deno.test("depthChartSectionLabels: defense odd front (frontOddEven >= 56) is 'Base 3-4'", () => {
+  const labels = depthChartSectionLabels(fp({ defense: { frontOddEven: 70 } }));
+  assertEquals(labels.defense, "Base 3-4");
+});
+
+Deno.test("depthChartSectionLabels: defense odd front at boundary 56 is 'Base 3-4'", () => {
+  const labels = depthChartSectionLabels(fp({ defense: { frontOddEven: 56 } }));
+  assertEquals(labels.defense, "Base 3-4");
+});
+
+Deno.test("depthChartSectionLabels: defense even front (frontOddEven <= 45) is 'Base 4-3'", () => {
+  const labels = depthChartSectionLabels(fp({ defense: { frontOddEven: 30 } }));
+  assertEquals(labels.defense, "Base 4-3");
+});
+
+Deno.test("depthChartSectionLabels: defense even front at boundary 45 is 'Base 4-3'", () => {
+  const labels = depthChartSectionLabels(fp({ defense: { frontOddEven: 45 } }));
+  assertEquals(labels.defense, "Base 4-3");
+});
+
+Deno.test("depthChartSectionLabels: defense hybrid front (frontOddEven 46-55) is 'Hybrid Front'", () => {
+  const labels = depthChartSectionLabels(fp({ defense: { frontOddEven: 50 } }));
+  assertEquals(labels.defense, "Hybrid Front");
+});
+
+Deno.test("depthChartSectionLabels: defense hybrid front at boundary 46 is 'Hybrid Front'", () => {
+  const labels = depthChartSectionLabels(fp({ defense: { frontOddEven: 46 } }));
+  assertEquals(labels.defense, "Hybrid Front");
+});
+
+Deno.test("depthChartSectionLabels: defense hybrid front at boundary 55 is 'Hybrid Front'", () => {
+  const labels = depthChartSectionLabels(fp({ defense: { frontOddEven: 55 } }));
+  assertEquals(labels.defense, "Hybrid Front");
+});
+
+Deno.test("depthChartSectionLabels: nickel suffix on odd front", () => {
+  const labels = depthChartSectionLabels(
+    fp({ defense: { frontOddEven: 70, subPackageLean: 60 } }),
+  );
+  assertEquals(labels.defense, "Base 3-4 · Nickel");
+});
+
+Deno.test("depthChartSectionLabels: nickel suffix on even front", () => {
+  const labels = depthChartSectionLabels(
+    fp({ defense: { frontOddEven: 30, subPackageLean: 56 } }),
+  );
+  assertEquals(labels.defense, "Base 4-3 · Nickel");
+});
+
+Deno.test("depthChartSectionLabels: nickel suffix on hybrid front", () => {
+  const labels = depthChartSectionLabels(
+    fp({ defense: { frontOddEven: 50, subPackageLean: 70 } }),
+  );
+  assertEquals(labels.defense, "Hybrid Front · Nickel");
+});
+
+Deno.test("depthChartSectionLabels: nickel suffix at boundary 56", () => {
+  const labels = depthChartSectionLabels(
+    fp({ defense: { frontOddEven: 50, subPackageLean: 56 } }),
+  );
+  assertEquals(labels.defense, "Hybrid Front · Nickel");
+});
+
+Deno.test("depthChartSectionLabels: no nickel suffix at 55", () => {
+  const labels = depthChartSectionLabels(
+    fp({ defense: { frontOddEven: 50, subPackageLean: 55 } }),
+  );
+  assertEquals(labels.defense, "Hybrid Front");
+});
+
+Deno.test("depthChartSectionLabels: heavy offense (personnelWeight >= 66) is '21 Personnel'", () => {
+  const labels = depthChartSectionLabels(
+    fp({ offense: { personnelWeight: 80 } }),
+  );
+  assertEquals(labels.offense, "21 Personnel");
+});
+
+Deno.test("depthChartSectionLabels: heavy offense at boundary 66 is '21 Personnel'", () => {
+  const labels = depthChartSectionLabels(
+    fp({ offense: { personnelWeight: 66 } }),
+  );
+  assertEquals(labels.offense, "21 Personnel");
+});
+
+Deno.test("depthChartSectionLabels: light offense (personnelWeight <= 45) is '10 Personnel'", () => {
+  const labels = depthChartSectionLabels(
+    fp({ offense: { personnelWeight: 20 } }),
+  );
+  assertEquals(labels.offense, "10 Personnel");
+});
+
+Deno.test("depthChartSectionLabels: light offense at boundary 45 is '10 Personnel'", () => {
+  const labels = depthChartSectionLabels(
+    fp({ offense: { personnelWeight: 45 } }),
+  );
+  assertEquals(labels.offense, "10 Personnel");
+});
+
+Deno.test("depthChartSectionLabels: balanced offense (personnelWeight 46-65) is '11 Personnel'", () => {
+  const labels = depthChartSectionLabels(
+    fp({ offense: { personnelWeight: 50 } }),
+  );
+  assertEquals(labels.offense, "11 Personnel");
+});
+
+Deno.test("depthChartSectionLabels: balanced offense at boundary 46 is '11 Personnel'", () => {
+  const labels = depthChartSectionLabels(
+    fp({ offense: { personnelWeight: 46 } }),
+  );
+  assertEquals(labels.offense, "11 Personnel");
+});
+
+Deno.test("depthChartSectionLabels: balanced offense at boundary 65 is '11 Personnel'", () => {
+  const labels = depthChartSectionLabels(
+    fp({ offense: { personnelWeight: 65 } }),
+  );
+  assertEquals(labels.offense, "11 Personnel");
 });

--- a/packages/shared/depth-chart/vocabulary.ts
+++ b/packages/shared/depth-chart/vocabulary.ts
@@ -31,6 +31,7 @@ const DEFAULT_DEFENSE: DepthChartSlotDefinition[] = [
 ];
 
 const HEAVY_PERSONNEL_THRESHOLD = 66;
+const LIGHT_PERSONNEL_CEILING = 45;
 const ODD_FRONT_THRESHOLD = 56;
 const EVEN_FRONT_CEILING = 45;
 const SUB_PACKAGE_THRESHOLD = 56;
@@ -100,6 +101,51 @@ function defenseSlots(
   slots.push({ code: "S", label: "Safety", group: "defense" });
 
   return slots;
+}
+
+export interface DepthChartSectionLabels {
+  offense: string;
+  defense: string;
+  specialTeams: string;
+}
+
+export function depthChartSectionLabels(
+  fingerprint: SchemeFingerprint,
+): DepthChartSectionLabels {
+  return {
+    offense: offenseLabel(fingerprint),
+    defense: defenseLabel(fingerprint),
+    specialTeams: "Special Teams",
+  };
+}
+
+function offenseLabel(fingerprint: SchemeFingerprint): string {
+  if (!fingerprint.offense) return "Offense";
+
+  const weight = fingerprint.offense.personnelWeight;
+  if (weight >= HEAVY_PERSONNEL_THRESHOLD) return "21 Personnel";
+  if (weight <= LIGHT_PERSONNEL_CEILING) return "10 Personnel";
+  return "11 Personnel";
+}
+
+function defenseLabel(fingerprint: SchemeFingerprint): string {
+  if (!fingerprint.defense) return "Defense";
+
+  const front = fingerprint.defense.frontOddEven;
+  let label: string;
+  if (front >= ODD_FRONT_THRESHOLD) {
+    label = "Base 3-4";
+  } else if (front <= EVEN_FRONT_CEILING) {
+    label = "Base 4-3";
+  } else {
+    label = "Hybrid Front";
+  }
+
+  if (fingerprint.defense.subPackageLean >= SUB_PACKAGE_THRESHOLD) {
+    label += " · Nickel";
+  }
+
+  return label;
 }
 
 export function depthChartVocabulary(

--- a/packages/shared/mod.ts
+++ b/packages/shared/mod.ts
@@ -132,10 +132,14 @@ export type {
 export { NEUTRAL_BUCKETS, neutralBucket } from "./archetypes/neutral-bucket.ts";
 export type { Game } from "./types/game.ts";
 export type {
+  DepthChartSectionLabels,
   DepthChartSlotDefinition,
   DepthChartSlotGroup,
 } from "./depth-chart/vocabulary.ts";
-export { depthChartVocabulary } from "./depth-chart/vocabulary.ts";
+export {
+  depthChartSectionLabels,
+  depthChartVocabulary,
+} from "./depth-chart/vocabulary.ts";
 export { eligibleBucketsForSlot } from "./depth-chart/slot-mapping.ts";
 export { assignDepthChart } from "./depth-chart/assign.ts";
 export type {


### PR DESCRIPTION
## Summary

- Adds `depthChartSectionLabels(fingerprint)` to `packages/shared/depth-chart/vocabulary.ts`, returning `{ offense, defense, specialTeams }` display labels derived from the `SchemeFingerprint` using existing threshold constants.
- Defense labels resolve to "Base 3-4", "Base 4-3", or "Hybrid Front" with an optional " · Nickel" suffix; offense labels resolve to "21 Personnel", "10 Personnel", or "11 Personnel"; null fingerprint sides fall back to plain "Offense"/"Defense".
- Adds `LIGHT_PERSONNEL_CEILING` constant (45) alongside existing thresholds, and re-exports the new function and `DepthChartSectionLabels` type from `packages/shared/mod.ts`.
- 22 new unit tests covering every branch, boundary value, nickel suffix combinations, and null-fingerprint fallbacks.

Closes #176

🤖 Generated with [Claude Code](https://claude.com/claude-code)