### PR TITLE
feat(simulation): add PlayEvent types and seeded RNG primitive

### DIFF
--- a/server/features/simulation/events.test.ts
+++ b/server/features/simulation/events.test.ts
@@ -1,0 +1,150 @@
+import { assertExists } from "@std/assert";
+import type {
+  BoxScore,
+  DefensiveCall,
+  DriveSummary,
+  GameResult,
+  InjuryEntry,
+  OffensiveCall,
+  PlayEvent,
+  PlayOutcome,
+  PlayParticipant,
+  PlayTag,
+} from "./events.ts";
+
+Deno.test("PlayEvent types", async (t) => {
+  await t.step("PlayEvent carries all required fields", () => {
+    const event: PlayEvent = {
+      gameId: "game-1",
+      driveIndex: 0,
+      playIndex: 0,
+      quarter: 1,
+      clock: "15:00",
+      situation: { down: 1, distance: 10, yardLine: 25 },
+      offenseTeamId: "team-a",
+      defenseTeamId: "team-b",
+      call: {
+        concept: "inside_zone",
+        personnel: "11",
+        formation: "shotgun",
+        motion: "none",
+      },
+      coverage: { front: "4-3", coverage: "cover_3", pressure: "base" },
+      participants: [{
+        role: "ballcarrier",
+        playerId: "p1",
+        tags: ["rush_attempt"],
+      }],
+      outcome: "rush",
+      yardage: 5,
+      tags: ["first_down"],
+    };
+    assertExists(event);
+  });
+
+  await t.step("PlayEvent quarter supports OT", () => {
+    const event: PlayEvent = {
+      gameId: "game-1",
+      driveIndex: 0,
+      playIndex: 0,
+      quarter: "OT",
+      clock: "10:00",
+      situation: { down: 1, distance: 10, yardLine: 50 },
+      offenseTeamId: "team-a",
+      defenseTeamId: "team-b",
+      call: {
+        concept: "hb_draw",
+        personnel: "12",
+        formation: "i_form",
+        motion: "none",
+      },
+      coverage: { front: "3-4", coverage: "cover_2", pressure: "blitz" },
+      participants: [],
+      outcome: "rush",
+      yardage: 3,
+      tags: [],
+    };
+    assertExists(event);
+  });
+
+  await t.step("GameResult carries all required fields", () => {
+    const result: GameResult = {
+      gameId: "game-1",
+      seed: 42,
+      finalScore: { home: 24, away: 17 },
+      events: [],
+      boxScore: {} as BoxScore,
+      driveLog: [] as DriveSummary[],
+      injuryReport: [] as InjuryEntry[],
+    };
+    assertExists(result);
+  });
+
+  await t.step(
+    "OffensiveCall has concept, personnel, formation, motion",
+    () => {
+      const call: OffensiveCall = {
+        concept: "pa_boot",
+        personnel: "11",
+        formation: "spread",
+        motion: "jet",
+      };
+      assertExists(call);
+    },
+  );
+
+  await t.step("DefensiveCall has front, coverage, pressure", () => {
+    const call: DefensiveCall = {
+      front: "nickel",
+      coverage: "cover_1",
+      pressure: "zone_blitz",
+    };
+    assertExists(call);
+  });
+
+  await t.step("PlayParticipant has role, playerId, tags", () => {
+    const participant: PlayParticipant = {
+      role: "passer",
+      playerId: "qb-1",
+      tags: ["completion", "pressure"],
+    };
+    assertExists(participant);
+  });
+
+  await t.step("PlayOutcome covers expected values", () => {
+    const outcomes: PlayOutcome[] = [
+      "rush",
+      "pass_complete",
+      "pass_incomplete",
+      "sack",
+      "interception",
+      "fumble",
+      "touchdown",
+      "field_goal",
+      "punt",
+      "penalty",
+      "kneel",
+      "spike",
+    ];
+    assertExists(outcomes);
+  });
+
+  await t.step("PlayTag covers expected values", () => {
+    const tags: PlayTag[] = [
+      "first_down",
+      "turnover",
+      "big_play",
+      "injury",
+      "penalty",
+      "touchdown",
+      "safety",
+      "two_point_conversion",
+      "sack",
+      "pressure",
+      "interception",
+      "fumble",
+      "fumble_recovery",
+    ];
+    assertExists(tags);
+  });
+});

--- a/server/features/simulation/events.ts
+++ b/server/features/simulation/events.ts
@@ -1,0 +1,80 @@
+export type OffensiveCall = {
+  concept: string;
+  personnel: string;
+  formation: string;
+  motion: string;
+};
+
+export type DefensiveCall = {
+  front: string;
+  coverage: string;
+  pressure: string;
+};
+
+export type PlayParticipant = {
+  role: string;
+  playerId: string;
+  tags: string[];
+};
+
+export type PlayOutcome =
+  | "rush"
+  | "pass_complete"
+  | "pass_incomplete"
+  | "sack"
+  | "interception"
+  | "fumble"
+  | "touchdown"
+  | "field_goal"
+  | "punt"
+  | "penalty"
+  | "kneel"
+  | "spike";
+
+export type PlayTag =
+  | "first_down"
+  | "turnover"
+  | "big_play"
+  | "injury"
+  | "penalty"
+  | "touchdown"
+  | "safety"
+  | "two_point_conversion"
+  | "sack"
+  | "pressure"
+  | "interception"
+  | "fumble"
+  | "fumble_recovery";
+
+export type PlayEvent = {
+  gameId: string;
+  driveIndex: number;
+  playIndex: number;
+  quarter: 1 | 2 | 3 | 4 | "OT";
+  clock: string;
+  situation: { down: 1 | 2 | 3 | 4; distance: number; yardLine: number };
+  offenseTeamId: string;
+  defenseTeamId: string;
+  call: OffensiveCall;
+  coverage: DefensiveCall;
+  participants: PlayParticipant[];
+  outcome: PlayOutcome;
+  yardage: number;
+  tags: PlayTag[];
+};
+
+export type BoxScore = Record<string, unknown>;
+
+export type DriveSummary = Record<string, unknown>;
+
+export type InjuryEntry = Record<string, unknown>;
+
+export type GameResult = {
+  gameId: string;
+  seed: number;
+  finalScore: { home: number; away: number };
+  events: PlayEvent[];
+  boxScore: BoxScore;
+  driveLog: DriveSummary[];
+  injuryReport: InjuryEntry[];
+};

--- a/server/features/simulation/mod.ts
+++ b/server/features/simulation/mod.ts
@@ -1,0 +1,15 @@
+export type {
+  BoxScore,
+  DefensiveCall,
+  DriveSummary,
+  GameResult,
+  InjuryEntry,
+  OffensiveCall,
+  PlayEvent,
+  PlayOutcome,
+  PlayParticipant,
+  PlayTag,
+} from "./events.ts";
+
+export { createRng, deriveGameSeed, mulberry32 } from "./rng.ts";
+export type { SeededRng } from "./rng.ts";

--- a/server/features/simulation/rng.test.ts
+++ b/server/features/simulation/rng.test.ts
@@ -1,0 +1,138 @@
+import { assertEquals, assertNotEquals } from "@std/assert";
+import { createRng, deriveGameSeed, mulberry32 } from "./rng.ts";
+
+Deno.test("mulberry32", async (t) => {
+  await t.step("produces identical sequence for same seed", () => {
+    const rng1 = mulberry32(12345);
+    const rng2 = mulberry32(12345);
+    for (let i = 0; i < 100; i++) {
+      assertEquals(rng1(), rng2());
+    }
+  });
+
+  await t.step("produces different sequences for different seeds", () => {
+    const rng1 = mulberry32(12345);
+    const rng2 = mulberry32(54321);
+    let allSame = true;
+    for (let i = 0; i < 10; i++) {
+      if (rng1() !== rng2()) {
+        allSame = false;
+        break;
+      }
+    }
+    assertEquals(allSame, false);
+  });
+
+  await t.step("returns values in [0, 1) range", () => {
+    const rng = mulberry32(42);
+    for (let i = 0; i < 1000; i++) {
+      const val = rng();
+      assertEquals(val >= 0 && val < 1, true);
+    }
+  });
+
+  await t.step("is byte-identical on fixed seed across calls", () => {
+    const rng = mulberry32(99999);
+    const expected = [
+      rng(),
+      rng(),
+      rng(),
+      rng(),
+      rng(),
+    ];
+
+    const rng2 = mulberry32(99999);
+    for (let i = 0; i < expected.length; i++) {
+      assertEquals(rng2(), expected[i]);
+    }
+  });
+});
+
+Deno.test("createRng", async (t) => {
+  await t.step("next() returns raw values from underlying generator", () => {
+    const raw = mulberry32(42);
+    const rng = createRng(mulberry32(42));
+    for (let i = 0; i < 10; i++) {
+      assertEquals(rng.next(), raw());
+    }
+  });
+
+  await t.step("int() returns values in inclusive range", () => {
+    const rng = createRng(mulberry32(42));
+    for (let i = 0; i < 100; i++) {
+      const val = rng.int(1, 6);
+      assertEquals(val >= 1 && val <= 6, true);
+      assertEquals(Number.isInteger(val), true);
+    }
+  });
+
+  await t.step("pick() returns element from array", () => {
+    const rng = createRng(mulberry32(42));
+    const items = ["a", "b", "c", "d"] as const;
+    for (let i = 0; i < 50; i++) {
+      const val = rng.pick(items);
+      assertEquals(items.includes(val), true);
+    }
+  });
+
+  await t.step("gaussian() returns values clamped to range", () => {
+    const rng = createRng(mulberry32(42));
+    for (let i = 0; i < 100; i++) {
+      const val = rng.gaussian(50, 10, 20, 80);
+      assertEquals(val >= 20 && val <= 80, true);
+      assertEquals(Number.isInteger(val), true);
+    }
+  });
+
+  await t.step("is deterministic with same seed", () => {
+    const rng1 = createRng(mulberry32(777));
+    const rng2 = createRng(mulberry32(777));
+    for (let i = 0; i < 20; i++) {
+      assertEquals(rng1.int(0, 100), rng2.int(0, 100));
+    }
+  });
+});
+
+Deno.test("deriveGameSeed", async (t) => {
+  await t.step("returns deterministic seed for same inputs", () => {
+    const seed1 = deriveGameSeed(42, "game-1");
+    const seed2 = deriveGameSeed(42, "game-1");
+    assertEquals(seed1, seed2);
+  });
+
+  await t.step("returns different seeds for different game identifiers", () => {
+    const seed1 = deriveGameSeed(42, "game-1");
+    const seed2 = deriveGameSeed(42, "game-2");
+    assertNotEquals(seed1, seed2);
+  });
+
+  await t.step("returns different seeds for different league seeds", () => {
+    const seed1 = deriveGameSeed(42, "game-1");
+    const seed2 = deriveGameSeed(43, "game-1");
+    assertNotEquals(seed1, seed2);
+  });
+
+  await t.step("returns a 32-bit unsigned integer", () => {
+    const seed = deriveGameSeed(12345, "week-1-game-3");
+    assertEquals(seed >= 0, true);
+    assertEquals(seed <= 0xFFFFFFFF, true);
+    assertEquals(Number.isInteger(seed), true);
+  });
+
+  await t.step("a week of games is reproducible from a league seed", () => {
+    const leagueSeed = 2026;
+    const gameIds = [
+      "week1-game1",
+      "week1-game2",
+      "week1-game3",
+      "week1-game4",
+    ];
+
+    const seeds1 = gameIds.map((id) => deriveGameSeed(leagueSeed, id));
+    const seeds2 = gameIds.map((id) => deriveGameSeed(leagueSeed, id));
+    assertEquals(seeds1, seeds2);
+
+    const uniqueSeeds = new Set(seeds1);
+    assertEquals(uniqueSeeds.size, gameIds.length);
+  });
+});

--- a/server/features/simulation/rng.ts
+++ b/server/features/simulation/rng.ts
@@ -1,0 +1,49 @@
+export function mulberry32(seed: number): () => number {
+  let state = seed >>> 0;
+  return () => {
+    state = (state + 0x6D2B79F5) >>> 0;
+    let t = state;
+    t = Math.imul(t ^ (t >>> 15), t | 1);
+    t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+export interface SeededRng {
+  next(): number;
+  int(min: number, max: number): number;
+  pick<T>(arr: readonly T[]): T;
+  gaussian(mean: number, stddev: number, min: number, max: number): number;
+}
+
+export function createRng(random: () => number): SeededRng {
+  return {
+    next: random,
+    int(min, max) {
+      return Math.floor(random() * (max - min + 1)) + min;
+    },
+    pick<T>(arr: readonly T[]): T {
+      return arr[Math.floor(random() * arr.length)];
+    },
+    gaussian(mean, stddev, min, max) {
+      const u1 = Math.max(random(), 1e-9);
+      const u2 = random();
+      const z = Math.sqrt(-2 * Math.log(u1)) * Math.cos(2 * Math.PI * u2);
+      const value = Math.round(mean + z * stddev);
+      return Math.max(min, Math.min(max, value));
+    },
+  };
+}
+
+export function deriveGameSeed(
+  leagueSeed: number,
+  gameIdentifier: string,
+): number {
+  let hash = leagueSeed >>> 0;
+  for (let i = 0; i < gameIdentifier.length; i++) {
+    hash = (hash ^ gameIdentifier.charCodeAt(i)) >>> 0;
+    hash = Math.imul(hash, 0x5BD1E995) >>> 0;
+    hash = (hash ^ (hash >>> 15)) >>> 0;
+  }
+  return hash >>> 0;
+}


### PR DESCRIPTION
## Summary

Closes #201

- Adds `PlayEvent`, `GameResult`, `OffensiveCall`, `DefensiveCall`, `PlayParticipant`, `PlayOutcome`, `PlayTag`, `BoxScore`, `DriveSummary`, and `InjuryEntry` types in `server/features/simulation/events.ts` per the ADR 0015 sketch.
- Implements a mulberry32 seeded RNG primitive with `createRng` wrapper (matching the ADR 0009 pattern used by the player generator) and a `deriveGameSeed` function for deterministic per-game seed derivation from a league seed + game identifier.
- Tests assert RNG byte-identity on fixed seeds and per-game seed determinism.

🤖 Generated with [Claude Code](https://claude.com/claude-code)