### PR TITLE
feat(roster): show scheme section labels on depth chart

### DIFF
--- a/client/src/features/league/roster.test.tsx
+++ b/client/src/features/league/roster.test.tsx
@@ -13,6 +13,7 @@ const mockUseParams = vi.fn();
 const mockUseLeague = vi.fn();
 const mockUseActiveRoster = vi.fn();
 const mockUseDepthChart = vi.fn();
+const mockUseSchemeFingerprint = vi.fn();
 
 vi.mock("@tanstack/react-router", () => ({
   useParams: (...args: unknown[]) => mockUseParams(...args),
@@ -28,6 +29,11 @@ vi.mock("../../hooks/use-active-roster.ts", () => ({
 
 vi.mock("../../hooks/use-depth-chart.ts", () => ({
   useDepthChart: (...args: unknown[]) => mockUseDepthChart(...args),
+}));
+
+vi.mock("../../hooks/use-scheme-fingerprint.ts", () => ({
+  useSchemeFingerprint: (...args: unknown[]) =>
+    mockUseSchemeFingerprint(...args),
 }));
 
 function renderRoster() {
@@ -119,6 +125,7 @@ const baseDepthChart = {
     { code: "QB", label: "Quarterback", group: "offense" },
     { code: "RB", label: "Running Back", group: "offense" },
     { code: "EDGE", label: "Edge Rusher", group: "defense" },
+    { code: "K", label: "Kicker", group: "special_teams" },
   ],
   slots: [
     {
@@ -169,6 +176,14 @@ const baseDepthChart = {
       slotOrdinal: 11,
       injuryStatus: "healthy",
     },
+    {
+      playerId: "p8",
+      firstName: "Kyle",
+      lastName: "Kicker",
+      slotCode: "K",
+      slotOrdinal: 1,
+      injuryStatus: "healthy",
+    },
   ],
   inactives: [
     {
@@ -205,6 +220,11 @@ beforeEach(() => {
   });
   mockUseDepthChart.mockReturnValue({
     data: baseDepthChart,
+    isLoading: false,
+    isError: false,
+  });
+  mockUseSchemeFingerprint.mockReturnValue({
+    data: undefined,
     isLoading: false,
     isError: false,
   });
@@ -451,6 +471,131 @@ describe("Roster — depth chart tab", () => {
     const meta = screen.getByTestId("depth-chart-meta");
     expect(within(meta).getByText(/andy coach/i)).toBeDefined();
     expect(within(meta).getByText(/2026/)).toBeDefined();
+  });
+
+  it("renders fallback group headers when no fingerprint is available", () => {
+    renderRoster();
+    activateDepthChartTab();
+    expect(screen.getByTestId("depth-chart-section-offense").textContent).toBe(
+      "Offense",
+    );
+    expect(screen.getByTestId("depth-chart-section-defense").textContent).toBe(
+      "Defense",
+    );
+    expect(
+      screen.getByTestId("depth-chart-section-special_teams").textContent,
+    ).toBe("Special Teams");
+  });
+
+  it("renders Base 3-4 defense header for a 3-4 DC", () => {
+    mockUseSchemeFingerprint.mockReturnValue({
+      data: {
+        offense: null,
+        defense: {
+          frontOddEven: 60,
+          gapResponsibility: 50,
+          subPackageLean: 40,
+          coverageManZone: 50,
+          coverageShell: 50,
+          cornerPressOff: 50,
+          pressureRate: 50,
+          disguiseRate: 50,
+        },
+        overrides: {},
+      },
+      isLoading: false,
+      isError: false,
+    });
+    renderRoster();
+    activateDepthChartTab();
+    expect(screen.getByTestId("depth-chart-section-defense").textContent).toBe(
+      "Base 3-4",
+    );
+  });
+
+  it("renders Base 4-3 defense header for a 4-3 DC", () => {
+    mockUseSchemeFingerprint.mockReturnValue({
+      data: {
+        offense: null,
+        defense: {
+          frontOddEven: 40,
+          gapResponsibility: 50,
+          subPackageLean: 40,
+          coverageManZone: 50,
+          coverageShell: 50,
+          cornerPressOff: 50,
+          pressureRate: 50,
+          disguiseRate: 50,
+        },
+        overrides: {},
+      },
+      isLoading: false,
+      isError: false,
+    });
+    renderRoster();
+    activateDepthChartTab();
+    expect(screen.getByTestId("depth-chart-section-defense").textContent).toBe(
+      "Base 4-3",
+    );
+  });
+
+  it("renders Base 3-4 · Nickel defense header for a 3-4 nickel DC", () => {
+    mockUseSchemeFingerprint.mockReturnValue({
+      data: {
+        offense: null,
+        defense: {
+          frontOddEven: 60,
+          gapResponsibility: 50,
+          subPackageLean: 60,
+          coverageManZone: 50,
+          coverageShell: 50,
+          cornerPressOff: 50,
+          pressureRate: 50,
+          disguiseRate: 50,
+        },
+        overrides: {},
+      },
+      isLoading: false,
+      isError: false,
+    });
+    renderRoster();
+    activateDepthChartTab();
+    expect(screen.getByTestId("depth-chart-section-defense").textContent).toBe(
+      "Base 3-4 · Nickel",
+    );
+  });
+
+  it("renders 21 Personnel offense header for a heavy-personnel OC", () => {
+    mockUseSchemeFingerprint.mockReturnValue({
+      data: {
+        offense: {
+          runPassLean: 50,
+          tempo: 50,
+          personnelWeight: 70,
+          formationUnderCenterShotgun: 50,
+          preSnapMotionRate: 50,
+          passingStyle: 50,
+          passingDepth: 50,
+          runGameBlocking: 50,
+          rpoIntegration: 50,
+        },
+        defense: null,
+        overrides: {},
+      },
+      isLoading: false,
+      isError: false,
+    });
+    renderRoster();
+    activateDepthChartTab();
+    expect(screen.getByTestId("depth-chart-section-offense").textContent).toBe(
+      "21 Personnel",
+    );
+    expect(screen.getByTestId("depth-chart-section-defense").textContent).toBe(
+      "Defense",
+    );
+    expect(
+      screen.getByTestId("depth-chart-section-special_teams").textContent,
+    ).toBe("Special Teams");
   });
 
   it("shows an empty state when the coach has not published a chart", () => {

--- a/client/src/features/league/roster.test.tsx
+++ b/client/src/features/league/roster.test.tsx
@@ -598,6 +598,22 @@ describe("Roster — depth chart tab", () => {
     ).toBe("Special Teams");
   });
 
+  it("renders empty depth chart meta when lastUpdatedAt and lastUpdatedBy are null", () => {
+    mockUseDepthChart.mockReturnValue({
+      data: {
+        ...baseDepthChart,
+        lastUpdatedAt: null,
+        lastUpdatedBy: null,
+      },
+      isLoading: false,
+      isError: false,
+    });
+    renderRoster();
+    activateDepthChartTab();
+    const meta = screen.getByTestId("depth-chart-meta");
+    expect(meta.textContent).toBe("");
+  });
+
   it("shows an empty state when the coach has not published a chart", () => {
     mockUseDepthChart.mockReturnValue({
       data: {

--- a/client/src/features/league/roster.tsx
+++ b/client/src/features/league/roster.tsx
@@ -29,9 +29,15 @@ import type {
   RosterPlayer,
 } from "@zone-blitz/shared/types/roster.ts";
 import type { PlayerInjuryStatus } from "@zone-blitz/shared/types/player.ts";
+import {
+  type DepthChartSectionLabels,
+  depthChartSectionLabels,
+  type DepthChartSlotGroup,
+} from "@zone-blitz/shared";
 import { useLeague } from "../../hooks/use-league.ts";
 import { useActiveRoster } from "../../hooks/use-active-roster.ts";
 import { useDepthChart } from "../../hooks/use-depth-chart.ts";
+import { useSchemeFingerprint } from "../../hooks/use-scheme-fingerprint.ts";
 
 const groupLabels: Record<NeutralBucketGroup, string> = {
   offense: "Offense",
@@ -290,10 +296,30 @@ function ActiveRosterContent({ roster }: { roster: ActiveRoster }) {
   );
 }
 
+const FALLBACK_SECTION_LABELS: DepthChartSectionLabels = {
+  offense: "Offense",
+  defense: "Defense",
+  specialTeams: "Special Teams",
+};
+
+const SECTION_LABEL_KEY: Record<
+  DepthChartSlotGroup,
+  keyof DepthChartSectionLabels
+> = {
+  offense: "offense",
+  defense: "defense",
+  special_teams: "specialTeams",
+};
+
 function DepthChartView(
   { leagueId, teamId }: { leagueId: string; teamId: string },
 ) {
   const { data: chart, isLoading, isError } = useDepthChart(leagueId, teamId);
+  const { data: fingerprint } = useSchemeFingerprint(leagueId, teamId);
+
+  const sectionLabels = fingerprint
+    ? depthChartSectionLabels(fingerprint)
+    : FALLBACK_SECTION_LABELS;
 
   if (isLoading) {
     return (
@@ -310,10 +336,15 @@ function DepthChartView(
       </p>
     );
   }
-  return <DepthChartContent chart={chart} />;
+  return <DepthChartContent chart={chart} sectionLabels={sectionLabels} />;
 }
 
-function DepthChartContent({ chart }: { chart: DepthChart }) {
+function DepthChartContent(
+  { chart, sectionLabels }: {
+    chart: DepthChart;
+    sectionLabels: DepthChartSectionLabels;
+  },
+) {
   if (chart.slots.length === 0 && chart.inactives.length === 0) {
     return (
       <Card>
@@ -335,7 +366,17 @@ function DepthChartContent({ chart }: { chart: DepthChart }) {
     bySlotCode.set(slot.slotCode, existing);
   }
 
-  const vocabCodes = chart.vocabulary;
+  const groupOrder: DepthChartSlotGroup[] = [
+    "offense",
+    "defense",
+    "special_teams",
+  ];
+  const vocabByGroup = new Map<DepthChartSlotGroup, typeof chart.vocabulary>();
+  for (const def of chart.vocabulary) {
+    const existing = vocabByGroup.get(def.group) ?? [];
+    existing.push(def);
+    vocabByGroup.set(def.group, existing);
+  }
 
   return (
     <>
@@ -344,48 +385,66 @@ function DepthChartContent({ chart }: { chart: DepthChart }) {
         lastUpdatedBy={chart.lastUpdatedBy}
       />
 
-      <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 xl:grid-cols-3">
-        {vocabCodes.map((def) => {
-          const slots = [...(bySlotCode.get(def.code) ?? [])].sort(
-            (a, b) => a.slotOrdinal - b.slotOrdinal,
-          );
-          if (slots.length === 0 && !bySlotCode.has(def.code)) return null;
-          return (
-            <Card
-              key={def.code}
-              data-testid={`depth-chart-position-${def.code}`}
+      {groupOrder.map((group) => {
+        const defs = vocabByGroup.get(group);
+        if (!defs || defs.length === 0) return null;
+        return (
+          <div key={group} className="flex flex-col gap-4">
+            <h3
+              data-testid={`depth-chart-section-${group}`}
+              className="text-lg font-semibold tracking-tight"
             >
-              <CardHeader>
-                <CardTitle>{def.code}</CardTitle>
-                {def.label !== def.code && (
-                  <CardDescription>{def.label}</CardDescription>
-                )}
-              </CardHeader>
-              <CardContent className="flex flex-col gap-2">
-                {slots.map((slot) => (
-                  <div
-                    key={slot.playerId}
-                    data-testid={`depth-chart-slot-${slot.playerId}`}
-                    className="flex items-center justify-between gap-3 rounded-md border px-3 py-2"
+              {sectionLabels[SECTION_LABEL_KEY[group]]}
+            </h3>
+            <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 xl:grid-cols-3">
+              {defs.map((def) => {
+                const slots = [...(bySlotCode.get(def.code) ?? [])].sort(
+                  (a, b) => a.slotOrdinal - b.slotOrdinal,
+                );
+                if (slots.length === 0 && !bySlotCode.has(def.code)) {
+                  return null;
+                }
+                return (
+                  <Card
+                    key={def.code}
+                    data-testid={`depth-chart-position-${def.code}`}
                   >
-                    <div className="flex items-baseline gap-3">
-                      <span className="w-8 text-sm font-semibold text-muted-foreground">
-                        {ordinal(slot.slotOrdinal)}
-                      </span>
-                      <span className="font-medium">
-                        {slot.firstName} {slot.lastName}
-                      </span>
-                    </div>
-                    <Badge variant={injuryBadgeVariant(slot.injuryStatus)}>
-                      {formatInjury(slot.injuryStatus)}
-                    </Badge>
-                  </div>
-                ))}
-              </CardContent>
-            </Card>
-          );
-        })}
-      </div>
+                    <CardHeader>
+                      <CardTitle>{def.code}</CardTitle>
+                      {def.label !== def.code && (
+                        <CardDescription>{def.label}</CardDescription>
+                      )}
+                    </CardHeader>
+                    <CardContent className="flex flex-col gap-2">
+                      {slots.map((slot) => (
+                        <div
+                          key={slot.playerId}
+                          data-testid={`depth-chart-slot-${slot.playerId}`}
+                          className="flex items-center justify-between gap-3 rounded-md border px-3 py-2"
+                        >
+                          <div className="flex items-baseline gap-3">
+                            <span className="w-8 text-sm font-semibold text-muted-foreground">
+                              {ordinal(slot.slotOrdinal)}
+                            </span>
+                            <span className="font-medium">
+                              {slot.firstName} {slot.lastName}
+                            </span>
+                          </div>
+                          <Badge
+                            variant={injuryBadgeVariant(slot.injuryStatus)}
+                          >
+                            {formatInjury(slot.injuryStatus)}
+                          </Badge>
+                        </div>
+                      ))}
+                    </CardContent>
+                  </Card>
+                );
+              })}
+            </div>
+          </div>
+        );
+      })}
 
       {chart.inactives.length > 0 && (
         <Card data-testid="depth-chart-inactives">


### PR DESCRIPTION
## Summary

- Depth chart group headers now render scheme-derived labels (e.g. "Base 3-4 · Nickel", "21 Personnel") using `depthChartSectionLabels()` from the shared vocabulary module, driven by the team's scheme fingerprint via `useSchemeFingerprint`.
- Falls back to plain "Offense" / "Defense" / "Special Teams" when no coordinator is hired (no fingerprint available).
- Position cards are grouped under their section headers (offense, defense, special teams) instead of a flat grid.
- Component tests assert correct header strings for 3-4 base DC, 4-3 base DC, 3-4 nickel DC, heavy-personnel OC, and the no-fingerprint fallback.

Closes #177