### PR TITLE
feat(players): render career statistics section on player detail page

### DIFF
--- a/client/src/features/league/players/career-stats-utils.test.ts
+++ b/client/src/features/league/players/career-stats-utils.test.ts
@@ -1,0 +1,182 @@
+import { describe, expect, it } from "vitest";
+import type { PlayerSeasonStatRow } from "@zone-blitz/shared/types/player.ts";
+import {
+  computeCareerTotals,
+  statColumnsForBucket,
+} from "./career-stats-utils.ts";
+
+function row(
+  overrides: Partial<PlayerSeasonStatRow> & {
+    stats: Record<string, number | string>;
+  },
+): PlayerSeasonStatRow {
+  return {
+    id: "r1",
+    seasonYear: 2024,
+    team: { id: "t1", name: "Bears", city: "Chicago", abbreviation: "CHI" },
+    playoffs: false,
+    gamesPlayed: 16,
+    gamesStarted: 16,
+    ...overrides,
+  };
+}
+
+describe("statColumnsForBucket", () => {
+  it("returns passing columns for QB", () => {
+    const cols = statColumnsForBucket("QB");
+    const keys = cols.map((c) => c.key);
+    expect(keys).toContain("passingYards");
+    expect(keys).toContain("passingTouchdowns");
+    expect(keys).toContain("interceptions");
+    expect(keys).toContain("completions");
+    expect(keys).toContain("attempts");
+    expect(keys).toContain("completionPercentage");
+    expect(keys).toContain("passerRating");
+  });
+
+  it("returns rushing columns for RB", () => {
+    const cols = statColumnsForBucket("RB");
+    const keys = cols.map((c) => c.key);
+    expect(keys).toContain("rushingYards");
+    expect(keys).toContain("rushingTouchdowns");
+    expect(keys).toContain("rushingAttempts");
+    expect(keys).toContain("yardsPerCarry");
+    expect(keys).toContain("fumbles");
+  });
+
+  it("returns receiving columns for WR and TE", () => {
+    const wrCols = statColumnsForBucket("WR");
+    const teCols = statColumnsForBucket("TE");
+    expect(wrCols).toEqual(teCols);
+    const keys = wrCols.map((c) => c.key);
+    expect(keys).toContain("receptions");
+    expect(keys).toContain("receivingYards");
+    expect(keys).toContain("receivingTouchdowns");
+    expect(keys).toContain("targets");
+    expect(keys).toContain("yardsPerReception");
+  });
+
+  it("returns defensive columns for front seven and secondary", () => {
+    for (const bucket of ["EDGE", "IDL", "LB", "CB", "S"] as const) {
+      const cols = statColumnsForBucket(bucket);
+      const keys = cols.map((c) => c.key);
+      expect(keys).toContain("tackles");
+      expect(keys).toContain("sacks");
+      expect(keys).toContain("interceptions");
+      expect(keys).toContain("passDefenses");
+      expect(keys).toContain("forcedFumbles");
+    }
+  });
+
+  it("returns kicking columns for K", () => {
+    const cols = statColumnsForBucket("K");
+    const keys = cols.map((c) => c.key);
+    expect(keys).toContain("fieldGoalsMade");
+    expect(keys).toContain("fieldGoalsAttempted");
+    expect(keys).toContain("fieldGoalPercentage");
+  });
+
+  it("returns punting columns for P", () => {
+    const cols = statColumnsForBucket("P");
+    const keys = cols.map((c) => c.key);
+    expect(keys).toContain("punts");
+    expect(keys).toContain("puntingYards");
+    expect(keys).toContain("puntingAverage");
+    expect(keys).toContain("puntsInside20");
+  });
+
+  it("returns empty columns for OL buckets and LS", () => {
+    for (const bucket of ["OT", "IOL", "LS"] as const) {
+      expect(statColumnsForBucket(bucket)).toEqual([]);
+    }
+  });
+});
+
+describe("computeCareerTotals", () => {
+  it("sums numeric stats across seasons", () => {
+    const rows = [
+      row({
+        id: "r1",
+        seasonYear: 2023,
+        gamesPlayed: 17,
+        gamesStarted: 17,
+        stats: { passingYards: 4200, passingTouchdowns: 32 },
+      }),
+      row({
+        id: "r2",
+        seasonYear: 2024,
+        gamesPlayed: 16,
+        gamesStarted: 16,
+        stats: { passingYards: 3800, passingTouchdowns: 28 },
+      }),
+    ];
+    const totals = computeCareerTotals(rows, [
+      "passingYards",
+      "passingTouchdowns",
+    ]);
+    expect(totals.gamesPlayed).toBe(33);
+    expect(totals.gamesStarted).toBe(33);
+    expect(totals.stats["passingYards"]).toBe(8000);
+    expect(totals.stats["passingTouchdowns"]).toBe(60);
+  });
+
+  it("aggregates across multiple teams (mid-season trade)", () => {
+    const rows = [
+      row({
+        id: "r1",
+        team: { id: "t1", name: "Bears", city: "Chicago", abbreviation: "CHI" },
+        gamesPlayed: 8,
+        gamesStarted: 8,
+        stats: { rushingYards: 500, rushingTouchdowns: 4 },
+      }),
+      row({
+        id: "r2",
+        team: {
+          id: "t2",
+          name: "Eagles",
+          city: "Philadelphia",
+          abbreviation: "PHI",
+        },
+        gamesPlayed: 9,
+        gamesStarted: 9,
+        stats: { rushingYards: 600, rushingTouchdowns: 6 },
+      }),
+    ];
+    const totals = computeCareerTotals(rows, [
+      "rushingYards",
+      "rushingTouchdowns",
+    ]);
+    expect(totals.gamesPlayed).toBe(17);
+    expect(totals.stats["rushingYards"]).toBe(1100);
+    expect(totals.stats["rushingTouchdowns"]).toBe(10);
+  });
+
+  it("returns zeros for empty rows", () => {
+    const totals = computeCareerTotals([], ["passingYards"]);
+    expect(totals.gamesPlayed).toBe(0);
+    expect(totals.gamesStarted).toBe(0);
+    expect(totals.stats["passingYards"]).toBe(0);
+  });
+
+  it("skips non-numeric stat values", () => {
+    const rows = [
+      row({ stats: { passingYards: 4200, note: "injured week 12" } }),
+    ];
+    const totals = computeCareerTotals(rows, ["passingYards", "note"]);
+    expect(totals.stats["passingYards"]).toBe(4200);
+    expect(totals.stats["note"]).toBe(0);
+  });
+
+  it("handles missing stat keys gracefully", () => {
+    const rows = [
+      row({ id: "r1", stats: { passingYards: 4200 } }),
+      row({ id: "r2", stats: { passingYards: 3800, interceptions: 12 } }),
+    ];
+    const totals = computeCareerTotals(rows, [
+      "passingYards",
+      "interceptions",
+    ]);
+    expect(totals.stats["passingYards"]).toBe(8000);
+    expect(totals.stats["interceptions"]).toBe(12);
+  });
+});

--- a/client/src/features/league/players/career-stats-utils.ts
+++ b/client/src/features/league/players/career-stats-utils.ts
@@ -1,0 +1,112 @@
+import type { NeutralBucket } from "@zone-blitz/shared";
+import type { PlayerSeasonStatRow } from "@zone-blitz/shared/types/player.ts";
+
+export interface StatColumnDefinition {
+  key: string;
+  label: string;
+}
+
+const PASSING_COLUMNS: StatColumnDefinition[] = [
+  { key: "completions", label: "CMP" },
+  { key: "attempts", label: "ATT" },
+  { key: "completionPercentage", label: "CMP%" },
+  { key: "passingYards", label: "YDS" },
+  { key: "passingTouchdowns", label: "TD" },
+  { key: "interceptions", label: "INT" },
+  { key: "passerRating", label: "RTG" },
+];
+
+const RUSHING_COLUMNS: StatColumnDefinition[] = [
+  { key: "rushingAttempts", label: "ATT" },
+  { key: "rushingYards", label: "YDS" },
+  { key: "yardsPerCarry", label: "YPC" },
+  { key: "rushingTouchdowns", label: "TD" },
+  { key: "fumbles", label: "FUM" },
+];
+
+const RECEIVING_COLUMNS: StatColumnDefinition[] = [
+  { key: "targets", label: "TGT" },
+  { key: "receptions", label: "REC" },
+  { key: "receivingYards", label: "YDS" },
+  { key: "yardsPerReception", label: "Y/R" },
+  { key: "receivingTouchdowns", label: "TD" },
+];
+
+const DEFENSIVE_COLUMNS: StatColumnDefinition[] = [
+  { key: "tackles", label: "TKL" },
+  { key: "sacks", label: "SCK" },
+  { key: "tacklesForLoss", label: "TFL" },
+  { key: "interceptions", label: "INT" },
+  { key: "passDefenses", label: "PD" },
+  { key: "forcedFumbles", label: "FF" },
+];
+
+const KICKING_COLUMNS: StatColumnDefinition[] = [
+  { key: "fieldGoalsMade", label: "FGM" },
+  { key: "fieldGoalsAttempted", label: "FGA" },
+  { key: "fieldGoalPercentage", label: "FG%" },
+  { key: "extraPointsMade", label: "XPM" },
+  { key: "extraPointsAttempted", label: "XPA" },
+];
+
+const PUNTING_COLUMNS: StatColumnDefinition[] = [
+  { key: "punts", label: "PUNTS" },
+  { key: "puntingYards", label: "YDS" },
+  { key: "puntingAverage", label: "AVG" },
+  { key: "puntsInside20", label: "IN20" },
+];
+
+const BUCKET_COLUMNS: Record<NeutralBucket, StatColumnDefinition[]> = {
+  QB: PASSING_COLUMNS,
+  RB: RUSHING_COLUMNS,
+  WR: RECEIVING_COLUMNS,
+  TE: RECEIVING_COLUMNS,
+  OT: [],
+  IOL: [],
+  EDGE: DEFENSIVE_COLUMNS,
+  IDL: DEFENSIVE_COLUMNS,
+  LB: DEFENSIVE_COLUMNS,
+  CB: DEFENSIVE_COLUMNS,
+  S: DEFENSIVE_COLUMNS,
+  K: KICKING_COLUMNS,
+  P: PUNTING_COLUMNS,
+  LS: [],
+};
+
+export function statColumnsForBucket(
+  bucket: NeutralBucket,
+): StatColumnDefinition[] {
+  return BUCKET_COLUMNS[bucket];
+}
+
+export interface CareerTotalsResult {
+  gamesPlayed: number;
+  gamesStarted: number;
+  stats: Record<string, number>;
+}
+
+export function computeCareerTotals(
+  rows: PlayerSeasonStatRow[],
+  statKeys: string[],
+): CareerTotalsResult {
+  let gamesPlayed = 0;
+  let gamesStarted = 0;
+  const stats: Record<string, number> = {};
+
+  for (const key of statKeys) {
+    stats[key] = 0;
+  }
+
+  for (const row of rows) {
+    gamesPlayed += row.gamesPlayed;
+    gamesStarted += row.gamesStarted;
+    for (const key of statKeys) {
+      const value = row.stats[key];
+      if (typeof value === "number") {
+        stats[key] += value;
+      }
+    }
+  }
+
+  return { gamesPlayed, gamesStarted, stats };
+}

--- a/client/src/features/league/players/detail.test.tsx
+++ b/client/src/features/league/players/detail.test.tsx
@@ -453,6 +453,7 @@ describe("PlayerDetail — sections", () => {
     expect(screen.getByTestId("player-contract-history-empty")).toBeDefined();
     expect(screen.getByTestId("player-transactions-empty")).toBeDefined();
     expect(screen.getByTestId("player-career-log-empty")).toBeDefined();
+    expect(screen.getByText("Statistics")).toBeDefined();
     expect(screen.getByTestId("player-accolades-empty")).toBeDefined();
   });
 
@@ -578,6 +579,264 @@ describe("PlayerDetail — sections", () => {
       "Unprojected",
     );
     expect(screen.queryByTestId("player-pre-draft-notes")).toBeNull();
+  });
+});
+
+describe("PlayerDetail — career statistics", () => {
+  it("renders position-appropriate stat column headers for a QB", () => {
+    renderDetail();
+    const regular = screen.getByTestId("player-career-log-regular");
+    expect(regular.textContent).toContain("CMP");
+    expect(regular.textContent).toContain("ATT");
+    expect(regular.textContent).toContain("YDS");
+    expect(regular.textContent).toContain("TD");
+    expect(regular.textContent).toContain("INT");
+    expect(regular.textContent).toContain("RTG");
+    expect(regular.textContent).not.toContain("TKL");
+    expect(regular.textContent).not.toContain("REC");
+  });
+
+  it("renders rushing columns for an RB", () => {
+    mockUsePlayerDetail.mockReturnValue({
+      data: {
+        ...draftedPlayer,
+        neutralBucket: "RB",
+        seasonStats: [
+          {
+            id: "ss-rb1",
+            seasonYear: 2024,
+            team: {
+              id: "t2",
+              name: "Bengals",
+              city: "Cincinnati",
+              abbreviation: "CIN",
+            },
+            playoffs: false,
+            gamesPlayed: 17,
+            gamesStarted: 17,
+            stats: { rushingYards: 1200, rushingTouchdowns: 10 },
+          },
+        ],
+      },
+      isLoading: false,
+      error: null,
+    });
+    renderDetail();
+    const regular = screen.getByTestId("player-career-log-regular");
+    expect(regular.textContent).toContain("YDS");
+    expect(regular.textContent).toContain("YPC");
+    expect(regular.textContent).toContain("FUM");
+    expect(regular.textContent).not.toContain("CMP");
+    expect(regular.textContent).not.toContain("RTG");
+  });
+
+  it("renders receiving columns for a WR", () => {
+    mockUsePlayerDetail.mockReturnValue({
+      data: {
+        ...draftedPlayer,
+        neutralBucket: "WR",
+        seasonStats: [
+          {
+            id: "ss-wr1",
+            seasonYear: 2024,
+            team: {
+              id: "t2",
+              name: "Bengals",
+              city: "Cincinnati",
+              abbreviation: "CIN",
+            },
+            playoffs: false,
+            gamesPlayed: 17,
+            gamesStarted: 17,
+            stats: { receptions: 90, receivingYards: 1100 },
+          },
+        ],
+      },
+      isLoading: false,
+      error: null,
+    });
+    renderDetail();
+    const regular = screen.getByTestId("player-career-log-regular");
+    expect(regular.textContent).toContain("TGT");
+    expect(regular.textContent).toContain("REC");
+    expect(regular.textContent).toContain("Y/R");
+  });
+
+  it("renders defensive columns for a CB", () => {
+    mockUsePlayerDetail.mockReturnValue({
+      data: {
+        ...draftedPlayer,
+        neutralBucket: "CB",
+        seasonStats: [
+          {
+            id: "ss-cb1",
+            seasonYear: 2024,
+            team: {
+              id: "t2",
+              name: "Bengals",
+              city: "Cincinnati",
+              abbreviation: "CIN",
+            },
+            playoffs: false,
+            gamesPlayed: 17,
+            gamesStarted: 17,
+            stats: { tackles: 55, interceptions: 4 },
+          },
+        ],
+      },
+      isLoading: false,
+      error: null,
+    });
+    renderDetail();
+    const regular = screen.getByTestId("player-career-log-regular");
+    expect(regular.textContent).toContain("TKL");
+    expect(regular.textContent).toContain("SCK");
+    expect(regular.textContent).toContain("PD");
+    expect(regular.textContent).toContain("FF");
+  });
+
+  it("renders a Career Totals row aggregating all regular-season stats", () => {
+    mockUsePlayerDetail.mockReturnValue({
+      data: {
+        ...draftedPlayer,
+        seasonStats: [
+          {
+            id: "ss-a",
+            seasonYear: 2023,
+            team: {
+              id: "t2",
+              name: "Bengals",
+              city: "Cincinnati",
+              abbreviation: "CIN",
+            },
+            playoffs: false,
+            gamesPlayed: 17,
+            gamesStarted: 17,
+            stats: { passingYards: 4200, passingTouchdowns: 32 },
+          },
+          {
+            id: "ss-b",
+            seasonYear: 2024,
+            team: {
+              id: "t2",
+              name: "Bengals",
+              city: "Cincinnati",
+              abbreviation: "CIN",
+            },
+            playoffs: false,
+            gamesPlayed: 16,
+            gamesStarted: 16,
+            stats: { passingYards: 3800, passingTouchdowns: 28 },
+          },
+        ],
+      },
+      isLoading: false,
+      error: null,
+    });
+    renderDetail();
+    const totals = screen.getByTestId("player-career-log-regular-totals");
+    expect(totals.textContent).toContain("Career Totals");
+    expect(totals.textContent).toContain("33");
+    expect(totals.textContent).toContain("8,000");
+    expect(totals.textContent).toContain("60");
+  });
+
+  it("aggregates Career Totals across multiple teams (mid-season trade)", () => {
+    mockUsePlayerDetail.mockReturnValue({
+      data: {
+        ...draftedPlayer,
+        neutralBucket: "RB",
+        seasonStats: [
+          {
+            id: "ss-trade1",
+            seasonYear: 2024,
+            team: {
+              id: "t2",
+              name: "Bengals",
+              city: "Cincinnati",
+              abbreviation: "CIN",
+            },
+            playoffs: false,
+            gamesPlayed: 8,
+            gamesStarted: 8,
+            stats: { rushingYards: 500, rushingTouchdowns: 4 },
+          },
+          {
+            id: "ss-trade2",
+            seasonYear: 2024,
+            team: {
+              id: "t3",
+              name: "Eagles",
+              city: "Philadelphia",
+              abbreviation: "PHI",
+            },
+            playoffs: false,
+            gamesPlayed: 9,
+            gamesStarted: 9,
+            stats: { rushingYards: 600, rushingTouchdowns: 6 },
+          },
+        ],
+      },
+      isLoading: false,
+      error: null,
+    });
+    renderDetail();
+    const regular = screen.getByTestId("player-career-log-regular");
+    expect(regular.textContent).toContain("CIN");
+    expect(regular.textContent).toContain("PHI");
+    const totals = screen.getByTestId("player-career-log-regular-totals");
+    expect(totals.textContent).toContain("Career Totals");
+    expect(totals.textContent).toContain("17");
+    expect(totals.textContent).toContain("1,100");
+    expect(totals.textContent).toContain("10");
+  });
+
+  it("renders a splits link on current-season rows only", () => {
+    mockUsePlayerDetail.mockReturnValue({
+      data: {
+        ...draftedPlayer,
+        seasonStats: [
+          {
+            id: "ss-old",
+            seasonYear: 2023,
+            team: {
+              id: "t2",
+              name: "Bengals",
+              city: "Cincinnati",
+              abbreviation: "CIN",
+            },
+            playoffs: false,
+            gamesPlayed: 17,
+            gamesStarted: 17,
+            stats: { passingYards: 4000, passingTouchdowns: 30 },
+          },
+          {
+            id: "ss-cur",
+            seasonYear: 2024,
+            team: {
+              id: "t2",
+              name: "Bengals",
+              city: "Cincinnati",
+              abbreviation: "CIN",
+            },
+            playoffs: false,
+            gamesPlayed: 16,
+            gamesStarted: 16,
+            stats: { passingYards: 3800, passingTouchdowns: 28 },
+          },
+        ],
+      },
+      isLoading: false,
+      error: null,
+    });
+    renderDetail();
+    expect(screen.getByTestId("player-splits-link-ss-cur")).toBeDefined();
+    expect(screen.queryByTestId("player-splits-link-ss-old")).toBeNull();
+  });
+
+  it("renders the section title as Statistics", () => {
+    renderDetail();
+    expect(screen.getByText("Statistics")).toBeDefined();
   });
 });
 

--- a/client/src/features/league/players/detail.tsx
+++ b/client/src/features/league/players/detail.tsx
@@ -89,13 +89,6 @@ function formatStatValue(value: number | string): string {
   return value;
 }
 
-function toStatLabel(key: string): string {
-  return key
-    .replace(/([A-Z])/g, " $1")
-    .replace(/^./, (c) => c.toUpperCase())
-    .trim();
-}
-
 function injuryBadgeVariant(
   status: PlayerInjuryStatus,
 ): "secondary" | "destructive" | "outline" {

--- a/client/src/features/league/players/detail.tsx
+++ b/client/src/features/league/players/detail.tsx
@@ -11,6 +11,10 @@ import type {
   PlayerTransactionEntry,
   PlayerTransactionType,
 } from "@zone-blitz/shared/types/player.ts";
+import {
+  computeCareerTotals,
+  statColumnsForBucket,
+} from "./career-stats-utils.ts";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { Badge } from "@/components/ui/badge";
 import {
@@ -641,7 +645,7 @@ function CareerLogSection(
 
   if (regular.length === 0 && playoff.length === 0) {
     return (
-      <Section title="Career log">
+      <Section title="Statistics">
         <p
           className="text-sm text-muted-foreground"
           data-testid="player-career-log-empty"
@@ -652,27 +656,33 @@ function CareerLogSection(
     );
   }
 
-  const statKeys = new Set<string>();
-  for (const row of detail.seasonStats) {
-    for (const key of Object.keys(row.stats)) statKeys.add(key);
-  }
-  const statColumns = [...statKeys];
+  const positionColumns = statColumnsForBucket(detail.neutralBucket);
+  const statKeys = positionColumns.map((c) => c.key);
+  const currentSeasonYear = Math.max(
+    ...detail.seasonStats.map((r) => r.seasonYear),
+  );
 
   return (
-    <Section title="Career log">
+    <Section title="Statistics">
       <CareerLogTable
         caption="Regular season"
         rows={regular}
-        statColumns={statColumns}
+        positionColumns={positionColumns}
+        statKeys={statKeys}
         leagueId={leagueId}
+        playerId={detail.id}
+        currentSeasonYear={currentSeasonYear}
         testId="player-career-log-regular"
       />
       {playoff.length > 0 && (
         <CareerLogTable
           caption="Playoffs"
           rows={playoff}
-          statColumns={statColumns}
+          positionColumns={positionColumns}
+          statKeys={statKeys}
           leagueId={leagueId}
+          playerId={detail.id}
+          currentSeasonYear={currentSeasonYear}
           testId="player-career-log-playoffs"
         />
       )}
@@ -681,14 +691,28 @@ function CareerLogSection(
 }
 
 function CareerLogTable(
-  { caption, rows, statColumns, leagueId, testId }: {
+  {
+    caption,
+    rows,
+    positionColumns,
+    statKeys,
+    leagueId,
+    playerId,
+    currentSeasonYear,
+    testId,
+  }: {
     caption: string;
     rows: PlayerSeasonStatRow[];
-    statColumns: string[];
+    positionColumns: { key: string; label: string }[];
+    statKeys: string[];
     leagueId: string;
+    playerId: string;
+    currentSeasonYear: number;
     testId: string;
   },
 ) {
+  const totals = computeCareerTotals(rows, statKeys);
+
   return (
     <Card data-testid={testId}>
       <CardHeader>
@@ -704,8 +728,8 @@ function CareerLogTable(
               <TableHead>Team</TableHead>
               <TableHead>GP</TableHead>
               <TableHead>GS</TableHead>
-              {statColumns.map((key) => (
-                <TableHead key={key}>{toStatLabel(key)}</TableHead>
+              {positionColumns.map((col) => (
+                <TableHead key={col.key}>{col.label}</TableHead>
               ))}
             </TableRow>
           </TableHeader>
@@ -715,7 +739,21 @@ function CareerLogTable(
                 key={row.id}
                 data-testid={`player-career-row-${row.id}`}
               >
-                <TableCell>{row.seasonYear}</TableCell>
+                <TableCell>
+                  {row.seasonYear === currentSeasonYear
+                    ? (
+                      <Link
+                        to="/leagues/$leagueId/players/$playerId"
+                        params={{ leagueId, playerId }}
+                        hash="splits"
+                        className="underline-offset-2 hover:underline"
+                        data-testid={`player-splits-link-${row.id}`}
+                      >
+                        {row.seasonYear}
+                      </Link>
+                    )
+                    : row.seasonYear}
+                </TableCell>
                 <TableCell>
                   <Link
                     to="/leagues/$leagueId/opponents/$teamId"
@@ -727,13 +765,28 @@ function CareerLogTable(
                 </TableCell>
                 <TableCell>{row.gamesPlayed}</TableCell>
                 <TableCell>{row.gamesStarted}</TableCell>
-                {statColumns.map((key) => (
-                  <TableCell key={key}>
-                    {key in row.stats ? formatStatValue(row.stats[key]) : "—"}
+                {positionColumns.map((col) => (
+                  <TableCell key={col.key}>
+                    {col.key in row.stats
+                      ? formatStatValue(row.stats[col.key])
+                      : "—"}
                   </TableCell>
                 ))}
               </TableRow>
             ))}
+            <TableRow
+              className="font-semibold"
+              data-testid={`${testId}-totals`}
+            >
+              <TableCell colSpan={2}>Career Totals</TableCell>
+              <TableCell>{totals.gamesPlayed}</TableCell>
+              <TableCell>{totals.gamesStarted}</TableCell>
+              {positionColumns.map((col) => (
+                <TableCell key={col.key}>
+                  {formatStatValue(totals.stats[col.key])}
+                </TableCell>
+              ))}
+            </TableRow>
           </TableBody>
         </Table>
       </CardContent>

--- a/packages/shared/mod.ts
+++ b/packages/shared/mod.ts
@@ -178,5 +178,11 @@ export {
   playerAttributesSchema,
 } from "./schemas/player-attributes.ts";
 
+// Statistics
+export type { StatColumnDefinition } from "./statistics/position-stat-columns.ts";
+export { statColumnsForBucket } from "./statistics/position-stat-columns.ts";
+export type { CareerTotalsResult } from "./statistics/career-totals.ts";
+export { computeCareerTotals } from "./statistics/career-totals.ts";
+
 // Errors
 export { DomainError } from "./errors/domain-error.ts";

--- a/packages/shared/statistics/career-totals.test.ts
+++ b/packages/shared/statistics/career-totals.test.ts
@@ -1,0 +1,116 @@
+import { assertEquals } from "@std/assert";
+import type { PlayerSeasonStatRow } from "../types/player.ts";
+import { computeCareerTotals } from "./career-totals.ts";
+
+function row(
+  overrides: Partial<PlayerSeasonStatRow> & {
+    stats: Record<string, number | string>;
+  },
+): PlayerSeasonStatRow {
+  return {
+    id: "r1",
+    seasonYear: 2024,
+    team: { id: "t1", name: "Bears", city: "Chicago", abbreviation: "CHI" },
+    playoffs: false,
+    gamesPlayed: 16,
+    gamesStarted: 16,
+    ...overrides,
+  };
+}
+
+Deno.test("computeCareerTotals — sums numeric stats across seasons", () => {
+  const rows = [
+    row({
+      id: "r1",
+      seasonYear: 2023,
+      gamesPlayed: 17,
+      gamesStarted: 17,
+      stats: { passingYards: 4200, passingTouchdowns: 32 },
+    }),
+    row({
+      id: "r2",
+      seasonYear: 2024,
+      gamesPlayed: 16,
+      gamesStarted: 16,
+      stats: { passingYards: 3800, passingTouchdowns: 28 },
+    }),
+  ];
+
+  const totals = computeCareerTotals(rows, [
+    "passingYards",
+    "passingTouchdowns",
+  ]);
+  assertEquals(totals.gamesPlayed, 33);
+  assertEquals(totals.gamesStarted, 33);
+  assertEquals(totals.stats["passingYards"], 8000);
+  assertEquals(totals.stats["passingTouchdowns"], 60);
+});
+
+Deno.test("computeCareerTotals — aggregates across different teams (mid-season trade)", () => {
+  const rows = [
+    row({
+      id: "r1",
+      seasonYear: 2024,
+      team: { id: "t1", name: "Bears", city: "Chicago", abbreviation: "CHI" },
+      gamesPlayed: 8,
+      gamesStarted: 8,
+      stats: { rushingYards: 500, rushingTouchdowns: 4 },
+    }),
+    row({
+      id: "r2",
+      seasonYear: 2024,
+      team: {
+        id: "t2",
+        name: "Eagles",
+        city: "Philadelphia",
+        abbreviation: "PHI",
+      },
+      gamesPlayed: 9,
+      gamesStarted: 9,
+      stats: { rushingYards: 600, rushingTouchdowns: 6 },
+    }),
+  ];
+
+  const totals = computeCareerTotals(rows, [
+    "rushingYards",
+    "rushingTouchdowns",
+  ]);
+  assertEquals(totals.gamesPlayed, 17);
+  assertEquals(totals.gamesStarted, 17);
+  assertEquals(totals.stats["rushingYards"], 1100);
+  assertEquals(totals.stats["rushingTouchdowns"], 10);
+});
+
+Deno.test("computeCareerTotals — returns zeros when rows are empty", () => {
+  const totals = computeCareerTotals([], ["passingYards"]);
+  assertEquals(totals.gamesPlayed, 0);
+  assertEquals(totals.gamesStarted, 0);
+  assertEquals(totals.stats["passingYards"], 0);
+});
+
+Deno.test("computeCareerTotals — skips non-numeric stat values", () => {
+  const rows = [
+    row({
+      id: "r1",
+      stats: { passingYards: 4200, note: "injured week 12" },
+    }),
+  ];
+
+  const totals = computeCareerTotals(rows, ["passingYards", "note"]);
+  assertEquals(totals.stats["passingYards"], 4200);
+  assertEquals(totals.stats["note"], 0);
+});
+
+Deno.test("computeCareerTotals — handles missing stat keys gracefully", () => {
+  const rows = [
+    row({ id: "r1", stats: { passingYards: 4200 } }),
+    row({ id: "r2", stats: { passingYards: 3800, interceptions: 12 } }),
+  ];
+
+  const totals = computeCareerTotals(rows, [
+    "passingYards",
+    "interceptions",
+  ]);
+  assertEquals(totals.stats["passingYards"], 8000);
+  assertEquals(totals.stats["interceptions"], 12);
+});

--- a/packages/shared/statistics/career-totals.ts
+++ b/packages/shared/statistics/career-totals.ts
@@ -1,0 +1,33 @@
+import type { PlayerSeasonStatRow } from "../types/player.ts";
+
+export interface CareerTotalsResult {
+  gamesPlayed: number;
+  gamesStarted: number;
+  stats: Record<string, number>;
+}
+
+export function computeCareerTotals(
+  rows: PlayerSeasonStatRow[],
+  statKeys: string[],
+): CareerTotalsResult {
+  let gamesPlayed = 0;
+  let gamesStarted = 0;
+  const stats: Record<string, number> = {};
+
+  for (const key of statKeys) {
+    stats[key] = 0;
+  }
+
+  for (const row of rows) {
+    gamesPlayed += row.gamesPlayed;
+    gamesStarted += row.gamesStarted;
+    for (const key of statKeys) {
+      const value = row.stats[key];
+      if (typeof value === "number") {
+        stats[key] += value;
+      }
+    }
+  }
+
+  return { gamesPlayed, gamesStarted, stats };
+}

--- a/packages/shared/statistics/position-stat-columns.test.ts
+++ b/packages/shared/statistics/position-stat-columns.test.ts
@@ -1,0 +1,122 @@
+import { assertEquals } from "@std/assert";
+import type { NeutralBucket } from "../archetypes/neutral-bucket.ts";
+import { statColumnsForBucket } from "./position-stat-columns.ts";
+
+Deno.test("statColumnsForBucket — QB returns passing columns", () => {
+  const cols = statColumnsForBucket("QB");
+  const keys = cols.map((c) => c.key);
+  assertEquals(keys.includes("passingYards"), true);
+  assertEquals(keys.includes("passingTouchdowns"), true);
+  assertEquals(keys.includes("interceptions"), true);
+  assertEquals(keys.includes("completions"), true);
+  assertEquals(keys.includes("attempts"), true);
+  assertEquals(keys.includes("completionPercentage"), true);
+  assertEquals(keys.includes("passerRating"), true);
+});
+
+Deno.test("statColumnsForBucket — RB returns rushing columns", () => {
+  const cols = statColumnsForBucket("RB");
+  const keys = cols.map((c) => c.key);
+  assertEquals(keys.includes("rushingYards"), true);
+  assertEquals(keys.includes("rushingTouchdowns"), true);
+  assertEquals(keys.includes("rushingAttempts"), true);
+  assertEquals(keys.includes("yardsPerCarry"), true);
+  assertEquals(keys.includes("fumbles"), true);
+});
+
+Deno.test("statColumnsForBucket — WR returns receiving columns", () => {
+  const cols = statColumnsForBucket("WR");
+  const keys = cols.map((c) => c.key);
+  assertEquals(keys.includes("receptions"), true);
+  assertEquals(keys.includes("receivingYards"), true);
+  assertEquals(keys.includes("receivingTouchdowns"), true);
+  assertEquals(keys.includes("targets"), true);
+  assertEquals(keys.includes("yardsPerReception"), true);
+});
+
+Deno.test("statColumnsForBucket — TE returns receiving columns (same as WR)", () => {
+  const wCols = statColumnsForBucket("WR");
+  const tCols = statColumnsForBucket("TE");
+  assertEquals(wCols, tCols);
+});
+
+const frontSeven: NeutralBucket[] = ["EDGE", "IDL", "LB"];
+for (const bucket of frontSeven) {
+  Deno.test(`statColumnsForBucket — ${bucket} returns defensive columns`, () => {
+    const cols = statColumnsForBucket(bucket);
+    const keys = cols.map((c) => c.key);
+    assertEquals(keys.includes("tackles"), true);
+    assertEquals(keys.includes("sacks"), true);
+    assertEquals(keys.includes("tacklesForLoss"), true);
+    assertEquals(keys.includes("interceptions"), true);
+    assertEquals(keys.includes("passDefenses"), true);
+    assertEquals(keys.includes("forcedFumbles"), true);
+  });
+}
+
+const secondary: NeutralBucket[] = ["CB", "S"];
+for (const bucket of secondary) {
+  Deno.test(`statColumnsForBucket — ${bucket} returns defensive columns`, () => {
+    const cols = statColumnsForBucket(bucket);
+    const keys = cols.map((c) => c.key);
+    assertEquals(keys.includes("tackles"), true);
+    assertEquals(keys.includes("sacks"), true);
+    assertEquals(keys.includes("interceptions"), true);
+    assertEquals(keys.includes("passDefenses"), true);
+  });
+}
+
+Deno.test("statColumnsForBucket — K returns kicking columns", () => {
+  const cols = statColumnsForBucket("K");
+  const keys = cols.map((c) => c.key);
+  assertEquals(keys.includes("fieldGoalsMade"), true);
+  assertEquals(keys.includes("fieldGoalsAttempted"), true);
+  assertEquals(keys.includes("fieldGoalPercentage"), true);
+  assertEquals(keys.includes("extraPointsMade"), true);
+  assertEquals(keys.includes("extraPointsAttempted"), true);
+});
+
+Deno.test("statColumnsForBucket — P returns punting columns", () => {
+  const cols = statColumnsForBucket("P");
+  const keys = cols.map((c) => c.key);
+  assertEquals(keys.includes("punts"), true);
+  assertEquals(keys.includes("puntingYards"), true);
+  assertEquals(keys.includes("puntingAverage"), true);
+  assertEquals(keys.includes("puntsInside20"), true);
+});
+
+Deno.test("statColumnsForBucket — OL buckets return empty stat columns", () => {
+  for (const bucket of ["OT", "IOL", "LS"] as NeutralBucket[]) {
+    const cols = statColumnsForBucket(bucket);
+    assertEquals(cols.length, 0);
+  }
+});
+
+Deno.test("every column definition has a non-empty label", () => {
+  const allBuckets: NeutralBucket[] = [
+    "QB",
+    "RB",
+    "WR",
+    "TE",
+    "OT",
+    "IOL",
+    "EDGE",
+    "IDL",
+    "LB",
+    "CB",
+    "S",
+    "K",
+    "P",
+    "LS",
+  ];
+  for (const bucket of allBuckets) {
+    for (const col of statColumnsForBucket(bucket)) {
+      assertEquals(typeof col.label, "string");
+      assertEquals(
+        col.label.length > 0,
+        true,
+        `${col.key} should have a label`,
+      );
+    }
+  }
+});

--- a/packages/shared/statistics/position-stat-columns.ts
+++ b/packages/shared/statistics/position-stat-columns.ts
@@ -1,0 +1,79 @@
+import type { NeutralBucket } from "../archetypes/neutral-bucket.ts";
+
+export interface StatColumnDefinition {
+  key: string;
+  label: string;
+}
+
+const PASSING_COLUMNS: StatColumnDefinition[] = [
+  { key: "completions", label: "CMP" },
+  { key: "attempts", label: "ATT" },
+  { key: "completionPercentage", label: "CMP%" },
+  { key: "passingYards", label: "YDS" },
+  { key: "passingTouchdowns", label: "TD" },
+  { key: "interceptions", label: "INT" },
+  { key: "passerRating", label: "RTG" },
+];
+
+const RUSHING_COLUMNS: StatColumnDefinition[] = [
+  { key: "rushingAttempts", label: "ATT" },
+  { key: "rushingYards", label: "YDS" },
+  { key: "yardsPerCarry", label: "YPC" },
+  { key: "rushingTouchdowns", label: "TD" },
+  { key: "fumbles", label: "FUM" },
+];
+
+const RECEIVING_COLUMNS: StatColumnDefinition[] = [
+  { key: "targets", label: "TGT" },
+  { key: "receptions", label: "REC" },
+  { key: "receivingYards", label: "YDS" },
+  { key: "yardsPerReception", label: "Y/R" },
+  { key: "receivingTouchdowns", label: "TD" },
+];
+
+const DEFENSIVE_COLUMNS: StatColumnDefinition[] = [
+  { key: "tackles", label: "TKL" },
+  { key: "sacks", label: "SCK" },
+  { key: "tacklesForLoss", label: "TFL" },
+  { key: "interceptions", label: "INT" },
+  { key: "passDefenses", label: "PD" },
+  { key: "forcedFumbles", label: "FF" },
+];
+
+const KICKING_COLUMNS: StatColumnDefinition[] = [
+  { key: "fieldGoalsMade", label: "FGM" },
+  { key: "fieldGoalsAttempted", label: "FGA" },
+  { key: "fieldGoalPercentage", label: "FG%" },
+  { key: "extraPointsMade", label: "XPM" },
+  { key: "extraPointsAttempted", label: "XPA" },
+];
+
+const PUNTING_COLUMNS: StatColumnDefinition[] = [
+  { key: "punts", label: "PUNTS" },
+  { key: "puntingYards", label: "YDS" },
+  { key: "puntingAverage", label: "AVG" },
+  { key: "puntsInside20", label: "IN20" },
+];
+
+const BUCKET_COLUMNS: Record<NeutralBucket, StatColumnDefinition[]> = {
+  QB: PASSING_COLUMNS,
+  RB: RUSHING_COLUMNS,
+  WR: RECEIVING_COLUMNS,
+  TE: RECEIVING_COLUMNS,
+  OT: [],
+  IOL: [],
+  EDGE: DEFENSIVE_COLUMNS,
+  IDL: DEFENSIVE_COLUMNS,
+  LB: DEFENSIVE_COLUMNS,
+  CB: DEFENSIVE_COLUMNS,
+  S: DEFENSIVE_COLUMNS,
+  K: KICKING_COLUMNS,
+  P: PUNTING_COLUMNS,
+  LS: [],
+};
+
+export function statColumnsForBucket(
+  bucket: NeutralBucket,
+): StatColumnDefinition[] {
+  return BUCKET_COLUMNS[bucket];
+}


### PR DESCRIPTION
## Summary

- Adds position-group-aware stat columns to the player detail page's statistics section: passing for QB, rushing for RB, receiving for WR/TE, defensive for front seven/secondary, kicking/punting for specialists (per ADR 0001 & 0013).
- Adds a Career Totals row that aggregates games played, games started, and all position-appropriate stats across seasons and teams (mid-season trade legible).
- Current-season rows link to a splits view; prior-season rows show plain text year.
- Renames the section from "Career log" to "Statistics" to match ADR 0013 language.
- Includes shared package utilities (`statColumnsForBucket`, `computeCareerTotals`) with Deno tests, plus client-side utilities with Vitest tests covering position-group column selection, career totals aggregation, mid-season-trade rendering, and current-season splits link target.

Closes #185

🤖 Generated with [Claude Code](https://claude.com/claude-code)