### PR TITLE
chore(players): link all player-name tables to the player detail page

### DIFF
--- a/client/src/features/league/roster.test.tsx
+++ b/client/src/features/league/roster.test.tsx
@@ -16,6 +16,23 @@ const mockUseDepthChart = vi.fn();
 
 vi.mock("@tanstack/react-router", () => ({
   useParams: (...args: unknown[]) => mockUseParams(...args),
+  Link: (
+    { to, params, children, ...rest }: {
+      to: string;
+      params: Record<string, string>;
+      children: React.ReactNode;
+    } & Record<string, unknown>,
+  ) => {
+    let href = to;
+    for (const [k, v] of Object.entries(params ?? {})) {
+      href = href.replace(`$${k}`, v);
+    }
+    return (
+      <a href={href} {...rest}>
+        {children}
+      </a>
+    );
+  },
 }));
 
 vi.mock("../../hooks/use-league.ts", () => ({
@@ -377,6 +394,15 @@ describe("Roster — active roster tab (default)", () => {
     expect(restructureBtn.hasAttribute("disabled")).toBe(true);
   });
 
+  it("links each player name to their detail page", () => {
+    renderRoster();
+    const link = screen.getByTestId(
+      "roster-player-link-p1",
+    ) as HTMLAnchorElement;
+    expect(link.getAttribute("href")).toBe("/leagues/L1/players/p1");
+    expect(link.textContent).toBe("Patrick Quarterback");
+  });
+
   it("renders action buttons for every player row", () => {
     renderRoster();
     for (const id of ["p1", "p2", "p3", "p4"]) {
@@ -437,12 +463,32 @@ describe("Roster — depth chart tab", () => {
     expect(within(rb).getByText("11th")).toBeDefined();
   });
 
+  it("links each depth chart slot player name to their detail page", () => {
+    renderRoster();
+    activateDepthChartTab();
+    const link = screen.getByTestId(
+      "depth-chart-player-link-p1",
+    ) as HTMLAnchorElement;
+    expect(link.getAttribute("href")).toBe("/leagues/L1/players/p1");
+    expect(link.textContent).toBe("Patrick Quarterback");
+  });
+
   it("renders inactives in their own list", () => {
     renderRoster();
     activateDepthChartTab();
     const inactives = screen.getByTestId("depth-chart-inactives");
     expect(within(inactives).getByText("Aaron Rusher")).toBeDefined();
     expect(within(inactives).getByText("EDGE")).toBeDefined();
+  });
+
+  it("links each inactive player name to their detail page", () => {
+    renderRoster();
+    activateDepthChartTab();
+    const link = screen.getByTestId(
+      "depth-chart-inactive-link-p3",
+    ) as HTMLAnchorElement;
+    expect(link.getAttribute("href")).toBe("/leagues/L1/players/p3");
+    expect(link.textContent).toBe("Aaron Rusher");
   });
 
   it("shows the last-updated timestamp and owning coach", () => {

--- a/client/src/features/league/roster.tsx
+++ b/client/src/features/league/roster.tsx
@@ -1,4 +1,4 @@
-import { useParams } from "@tanstack/react-router";
+import { Link, useParams } from "@tanstack/react-router";
 import type { ColumnDef, Row } from "@tanstack/react-table";
 import {
   Card,
@@ -85,87 +85,94 @@ function formatCoachRole(role: string) {
     .join(" ");
 }
 
-const rosterColumns: ColumnDef<RosterPlayer>[] = [
-  {
-    id: "player",
-    accessorFn: (p) => `${p.firstName} ${p.lastName}`,
-    header: ({ column }) => (
-      <SortableHeader column={column}>Player</SortableHeader>
-    ),
-    cell: ({ row }) => (
-      <span className="font-medium">
-        {row.original.firstName} {row.original.lastName}
-      </span>
-    ),
-  },
-  {
-    accessorKey: "depthChartSlot",
-    header: ({ column }) => (
-      <SortableHeader column={column}>
-        Pos
-      </SortableHeader>
-    ),
-    cell: ({ row }) => row.original.depthChartSlot ?? "—",
-  },
-  {
-    accessorKey: "neutralBucketGroup",
-    header: ({ column }) => (
-      <SortableHeader column={column}>Group</SortableHeader>
-    ),
-    cell: ({ row }) => groupLabels[row.original.neutralBucketGroup],
-    filterFn: (row: Row<RosterPlayer>, _id, value) =>
-      value === "all" || row.original.neutralBucketGroup === value,
-  },
-  {
-    accessorKey: "age",
-    header: ({ column }) => (
-      <SortableHeader column={column}>
-        Age
-      </SortableHeader>
-    ),
-  },
-  {
-    accessorKey: "schemeFit",
-    header: ({ column }) => (
-      <SortableHeader column={column}>Scheme Fit</SortableHeader>
-    ),
-    cell: ({ row }) => (
-      <SchemeFitBadge
-        fit={row.original.schemeFit}
-        testId={`roster-scheme-fit-${row.original.id}`}
-      />
-    ),
-  },
-  {
-    accessorKey: "injuryStatus",
-    header: ({ column }) => (
-      <SortableHeader column={column}>Status</SortableHeader>
-    ),
-    cell: ({ row }) => (
-      <Badge variant={injuryBadgeVariant(row.original.injuryStatus)}>
-        {formatInjury(row.original.injuryStatus)}
-      </Badge>
-    ),
-  },
-  {
-    id: "actions",
-    header: () => <span>Actions</span>,
-    cell: () => (
-      <div className="flex gap-1">
-        <Button variant="ghost" size="sm" disabled>
-          Release
-        </Button>
-        <Button variant="ghost" size="sm" disabled>
-          Trade
-        </Button>
-        <Button variant="ghost" size="sm" disabled>
-          Restructure
-        </Button>
-      </div>
-    ),
-    enableSorting: false,
-  },
-];
+function createRosterColumns(leagueId: string): ColumnDef<RosterPlayer>[] {
+  return [
+    {
+      id: "player",
+      accessorFn: (p) => `${p.firstName} ${p.lastName}`,
+      header: ({ column }) => (
+        <SortableHeader column={column}>Player</SortableHeader>
+      ),
+      cell: ({ row }) => (
+        <Link
+          to="/leagues/$leagueId/players/$playerId"
+          params={{ leagueId, playerId: row.original.id }}
+          className="font-medium underline-offset-2 hover:underline"
+          data-testid={`roster-player-link-${row.original.id}`}
+        >
+          {row.original.firstName} {row.original.lastName}
+        </Link>
+      ),
+    },
+    {
+      accessorKey: "depthChartSlot",
+      header: ({ column }) => (
+        <SortableHeader column={column}>
+          Pos
+        </SortableHeader>
+      ),
+      cell: ({ row }) => row.original.depthChartSlot ?? "—",
+    },
+    {
+      accessorKey: "neutralBucketGroup",
+      header: ({ column }) => (
+        <SortableHeader column={column}>Group</SortableHeader>
+      ),
+      cell: ({ row }) => groupLabels[row.original.neutralBucketGroup],
+      filterFn: (row: Row<RosterPlayer>, _id, value) =>
+        value === "all" || row.original.neutralBucketGroup === value,
+    },
+    {
+      accessorKey: "age",
+      header: ({ column }) => (
+        <SortableHeader column={column}>
+          Age
+        </SortableHeader>
+      ),
+    },
+    {
+      accessorKey: "schemeFit",
+      header: ({ column }) => (
+        <SortableHeader column={column}>Scheme Fit</SortableHeader>
+      ),
+      cell: ({ row }) => (
+        <SchemeFitBadge
+          fit={row.original.schemeFit}
+          testId={`roster-scheme-fit-${row.original.id}`}
+        />
+      ),
+    },
+    {
+      accessorKey: "injuryStatus",
+      header: ({ column }) => (
+        <SortableHeader column={column}>Status</SortableHeader>
+      ),
+      cell: ({ row }) => (
+        <Badge variant={injuryBadgeVariant(row.original.injuryStatus)}>
+          {formatInjury(row.original.injuryStatus)}
+        </Badge>
+      ),
+    },
+    {
+      id: "actions",
+      header: () => <span>Actions</span>,
+      cell: () => (
+        <div className="flex gap-1">
+          <Button variant="ghost" size="sm" disabled>
+            Release
+          </Button>
+          <Button variant="ghost" size="sm" disabled>
+            Trade
+          </Button>
+          <Button variant="ghost" size="sm" disabled>
+            Restructure
+          </Button>
+        </div>
+      ),
+      enableSorting: false,
+    },
+  ];
+}
 
 export function Roster() {
   const { leagueId } = useParams({ strict: false }) as { leagueId: string };
@@ -229,14 +236,16 @@ function ActiveRosterView(
       </p>
     );
   }
-  return <ActiveRosterContent roster={roster} />;
+  return <ActiveRosterContent roster={roster} leagueId={leagueId} />;
 }
 
-function ActiveRosterContent({ roster }: { roster: ActiveRoster }) {
+function ActiveRosterContent(
+  { roster, leagueId }: { roster: ActiveRoster; leagueId: string },
+) {
   return (
     <>
       <DataTable
-        columns={rosterColumns}
+        columns={createRosterColumns(leagueId)}
         data={roster.players}
         getRowTestId={(player) => `roster-row-${player.id}`}
         toolbar={(table) => {
@@ -310,10 +319,12 @@ function DepthChartView(
       </p>
     );
   }
-  return <DepthChartContent chart={chart} />;
+  return <DepthChartContent chart={chart} leagueId={leagueId} />;
 }
 
-function DepthChartContent({ chart }: { chart: DepthChart }) {
+function DepthChartContent(
+  { chart, leagueId }: { chart: DepthChart; leagueId: string },
+) {
   if (chart.slots.length === 0 && chart.inactives.length === 0) {
     return (
       <Card>
@@ -372,9 +383,14 @@ function DepthChartContent({ chart }: { chart: DepthChart }) {
                       <span className="w-8 text-sm font-semibold text-muted-foreground">
                         {ordinal(slot.slotOrdinal)}
                       </span>
-                      <span className="font-medium">
+                      <Link
+                        to="/leagues/$leagueId/players/$playerId"
+                        params={{ leagueId, playerId: slot.playerId }}
+                        className="font-medium underline-offset-2 hover:underline"
+                        data-testid={`depth-chart-player-link-${slot.playerId}`}
+                      >
                         {slot.firstName} {slot.lastName}
-                      </span>
+                      </Link>
                     </div>
                     <Badge variant={injuryBadgeVariant(slot.injuryStatus)}>
                       {formatInjury(slot.injuryStatus)}
@@ -408,7 +424,14 @@ function DepthChartContent({ chart }: { chart: DepthChart }) {
                 {chart.inactives.map((player) => (
                   <TableRow key={player.playerId}>
                     <TableCell className="font-medium">
-                      {player.firstName} {player.lastName}
+                      <Link
+                        to="/leagues/$leagueId/players/$playerId"
+                        params={{ leagueId, playerId: player.playerId }}
+                        className="underline-offset-2 hover:underline"
+                        data-testid={`depth-chart-inactive-link-${player.playerId}`}
+                      >
+                        {player.firstName} {player.lastName}
+                      </Link>
                     </TableCell>
                     <TableCell>{player.slotCode}</TableCell>
                     <TableCell>

--- a/client/src/features/league/salary-cap.test.tsx
+++ b/client/src/features/league/salary-cap.test.tsx
@@ -15,6 +15,23 @@ const mockUseActiveRoster = vi.fn();
 
 vi.mock("@tanstack/react-router", () => ({
   useParams: (...args: unknown[]) => mockUseParams(...args),
+  Link: (
+    { to, params, children, ...rest }: {
+      to: string;
+      params: Record<string, string>;
+      children: React.ReactNode;
+    } & Record<string, unknown>,
+  ) => {
+    let href = to;
+    for (const [k, v] of Object.entries(params ?? {})) {
+      href = href.replace(`$${k}`, v);
+    }
+    return (
+      <a href={href} {...rest}>
+        {children}
+      </a>
+    );
+  },
 }));
 
 vi.mock("../../hooks/use-league.ts", () => ({
@@ -230,6 +247,15 @@ describe("SalaryCap — page", () => {
     expect(
       within(row).getByTestId("salary-cap-scheme-fit-p3").textContent,
     ).toBe("—");
+  });
+
+  it("links each player name to their detail page", () => {
+    renderSalaryCap();
+    const link = screen.getByTestId(
+      "salary-cap-player-link-p1",
+    ) as HTMLAnchorElement;
+    expect(link.getAttribute("href")).toBe("/leagues/L1/players/p1");
+    expect(link.textContent).toBe("Patrick Quarterback");
   });
 
   it("filters rows by the global search input", () => {

--- a/client/src/features/league/salary-cap.tsx
+++ b/client/src/features/league/salary-cap.tsx
@@ -1,5 +1,5 @@
 import { useMemo } from "react";
-import { useParams } from "@tanstack/react-router";
+import { Link, useParams } from "@tanstack/react-router";
 import type { ColumnDef } from "@tanstack/react-table";
 import {
   Card,
@@ -37,61 +37,68 @@ function formatCurrency(value: number) {
   return currency.format(value);
 }
 
-const capColumns: ColumnDef<RosterPlayer>[] = [
-  {
-    id: "player",
-    accessorFn: (p) => `${p.firstName} ${p.lastName}`,
-    header: ({ column }) => (
-      <SortableHeader column={column}>Player</SortableHeader>
-    ),
-    cell: ({ row }) => (
-      <span className="font-medium">
-        {row.original.firstName} {row.original.lastName}
-      </span>
-    ),
-  },
-  {
-    accessorKey: "neutralBucket",
-    header: ({ column }) => (
-      <SortableHeader column={column}>
-        Pos
-      </SortableHeader>
-    ),
-  },
-  {
-    accessorKey: "neutralBucketGroup",
-    header: ({ column }) => (
-      <SortableHeader column={column}>Group</SortableHeader>
-    ),
-    cell: ({ row }) => groupLabels[row.original.neutralBucketGroup],
-  },
-  {
-    accessorKey: "schemeFit",
-    header: ({ column }) => (
-      <SortableHeader column={column}>Scheme Fit</SortableHeader>
-    ),
-    cell: ({ row }) => (
-      <SchemeFitBadge
-        fit={row.original.schemeFit}
-        testId={`salary-cap-scheme-fit-${row.original.id}`}
-      />
-    ),
-  },
-  {
-    accessorKey: "capHit",
-    header: ({ column }) => (
-      <SortableHeader column={column}>Cap Hit</SortableHeader>
-    ),
-    cell: ({ row }) => formatCurrency(row.original.capHit),
-  },
-  {
-    accessorKey: "contractYearsRemaining",
-    header: ({ column }) => (
-      <SortableHeader column={column}>Contract</SortableHeader>
-    ),
-    cell: ({ row }) => `${row.original.contractYearsRemaining} yrs`,
-  },
-];
+function createCapColumns(leagueId: string): ColumnDef<RosterPlayer>[] {
+  return [
+    {
+      id: "player",
+      accessorFn: (p) => `${p.firstName} ${p.lastName}`,
+      header: ({ column }) => (
+        <SortableHeader column={column}>Player</SortableHeader>
+      ),
+      cell: ({ row }) => (
+        <Link
+          to="/leagues/$leagueId/players/$playerId"
+          params={{ leagueId, playerId: row.original.id }}
+          className="font-medium underline-offset-2 hover:underline"
+          data-testid={`salary-cap-player-link-${row.original.id}`}
+        >
+          {row.original.firstName} {row.original.lastName}
+        </Link>
+      ),
+    },
+    {
+      accessorKey: "neutralBucket",
+      header: ({ column }) => (
+        <SortableHeader column={column}>
+          Pos
+        </SortableHeader>
+      ),
+    },
+    {
+      accessorKey: "neutralBucketGroup",
+      header: ({ column }) => (
+        <SortableHeader column={column}>Group</SortableHeader>
+      ),
+      cell: ({ row }) => groupLabels[row.original.neutralBucketGroup],
+    },
+    {
+      accessorKey: "schemeFit",
+      header: ({ column }) => (
+        <SortableHeader column={column}>Scheme Fit</SortableHeader>
+      ),
+      cell: ({ row }) => (
+        <SchemeFitBadge
+          fit={row.original.schemeFit}
+          testId={`salary-cap-scheme-fit-${row.original.id}`}
+        />
+      ),
+    },
+    {
+      accessorKey: "capHit",
+      header: ({ column }) => (
+        <SortableHeader column={column}>Cap Hit</SortableHeader>
+      ),
+      cell: ({ row }) => formatCurrency(row.original.capHit),
+    },
+    {
+      accessorKey: "contractYearsRemaining",
+      header: ({ column }) => (
+        <SortableHeader column={column}>Contract</SortableHeader>
+      ),
+      cell: ({ row }) => `${row.original.contractYearsRemaining} yrs`,
+    },
+  ];
+}
 
 export function SalaryCap() {
   const { leagueId } = useParams({ strict: false }) as { leagueId: string };
@@ -141,10 +148,12 @@ function SalaryCapView(
       </p>
     );
   }
-  return <SalaryCapContent roster={roster} />;
+  return <SalaryCapContent roster={roster} leagueId={leagueId} />;
 }
 
-function SalaryCapContent({ roster }: { roster: ActiveRoster }) {
+function SalaryCapContent(
+  { roster, leagueId }: { roster: ActiveRoster; leagueId: string },
+) {
   const sortedPlayers = useMemo(
     () => [...roster.players].sort((a, b) => b.capHit - a.capHit),
     [roster.players],
@@ -180,7 +189,7 @@ function SalaryCapContent({ roster }: { roster: ActiveRoster }) {
       <PositionGroupBreakdown groups={roster.positionGroups} />
 
       <DataTable
-        columns={capColumns}
+        columns={createCapColumns(leagueId)}
         data={sortedPlayers}
         getRowTestId={(player) => `salary-cap-row-${player.id}`}
         toolbar={(table) => (

--- a/client/src/features/league/scouts/detail.test.tsx
+++ b/client/src/features/league/scouts/detail.test.tsx
@@ -7,23 +7,23 @@ const mockDetailGet = vi.fn();
 
 vi.mock("@tanstack/react-router", () => ({
   useParams: () => ({ scoutId: "s1", leagueId: "1" }),
-  Link: ({
-    children,
-    params,
-  }: {
-    children: React.ReactNode;
-    to?: string;
-    params?: { leagueId: string; scoutId: string };
-    className?: string;
-  }) => (
-    <a
-      href={params
-        ? `/leagues/${params.leagueId}/scouts/${params.scoutId}`
-        : "#"}
-    >
-      {children}
-    </a>
-  ),
+  Link: (
+    { to, params, children, ...rest }: {
+      to: string;
+      params: Record<string, string>;
+      children: React.ReactNode;
+    } & Record<string, unknown>,
+  ) => {
+    let href = to;
+    for (const [k, v] of Object.entries(params ?? {})) {
+      href = href.replace(`$${k}`, v);
+    }
+    return (
+      <a href={href} {...rest}>
+        {children}
+      </a>
+    );
+  },
 }));
 
 vi.mock("../../../api.ts", () => ({
@@ -117,7 +117,7 @@ describe("ScoutDetail", () => {
           evaluations: [
             {
               id: "e1",
-              prospectId: null,
+              prospectId: "prospect-1",
               prospectName: "Rookie Back",
               draftYear: 2029,
               positionGroup: "RB",
@@ -179,7 +179,13 @@ describe("ScoutDetail", () => {
       expect(screen.getByText(/respected ACC evaluator/)).toBeDefined();
     });
     expect(screen.getByText(/Lions — Area Scout/)).toBeDefined();
-    expect(screen.getByText(/Rookie Back/)).toBeDefined();
+    const prospectLink = screen.getByTestId(
+      "scout-prospect-link-prospect-1",
+    ) as HTMLAnchorElement;
+    expect(prospectLink.getAttribute("href")).toBe(
+      "/leagues/1/players/prospect-1",
+    );
+    expect(prospectLink.textContent).toBe("Rookie Back");
     expect(screen.getByText(/late-round flyer/)).toBeDefined();
     expect(screen.getByText(/Peer Buddy/)).toBeDefined();
     expect(screen.getByText(/Lower confidence/)).toBeDefined();

--- a/client/src/features/league/scouts/detail.tsx
+++ b/client/src/features/league/scouts/detail.tsx
@@ -67,7 +67,7 @@ export function ScoutDetail() {
       <Header detail={detail} />
       <Resume detail={detail} />
       <Reputation detail={detail} />
-      <TrackRecord detail={detail} />
+      <TrackRecord detail={detail} leagueId={leagueId} />
       <ExternalRecord detail={detail} />
       <Connections detail={detail} leagueId={leagueId} />
     </div>
@@ -162,10 +162,12 @@ function Reputation({ detail }: { detail: ScoutDetailData }) {
   );
 }
 
-function TrackRecord({ detail }: { detail: ScoutDetailData }) {
+function TrackRecord(
+  { detail, leagueId }: { detail: ScoutDetailData; leagueId: string },
+) {
   return (
     <Section title="Track record with this team">
-      <EvaluationsTable evaluations={detail.evaluations} />
+      <EvaluationsTable evaluations={detail.evaluations} leagueId={leagueId} />
       <CrossCheckList detail={detail} />
     </Section>
   );
@@ -173,8 +175,10 @@ function TrackRecord({ detail }: { detail: ScoutDetailData }) {
 
 function EvaluationsTable({
   evaluations,
+  leagueId,
 }: {
   evaluations: ScoutEvaluation[];
+  leagueId: string;
 }) {
   if (evaluations.length === 0) {
     return (
@@ -202,7 +206,20 @@ function EvaluationsTable({
             <TableCell>{e.draftYear}</TableCell>
             <TableCell>{e.positionGroup}</TableCell>
             <TableCell>{e.roundTier}</TableCell>
-            <TableCell>{e.prospectName}</TableCell>
+            <TableCell>
+              {e.prospectId
+                ? (
+                  <Link
+                    to="/leagues/$leagueId/players/$playerId"
+                    params={{ leagueId, playerId: e.prospectId }}
+                    className="underline-offset-2 hover:underline"
+                    data-testid={`scout-prospect-link-${e.prospectId}`}
+                  >
+                    {e.prospectName}
+                  </Link>
+                )
+                : e.prospectName}
+            </TableCell>
             <TableCell>{e.grade}</TableCell>
             <TableCell>{e.evaluationLevel}</TableCell>
             <TableCell>


### PR DESCRIPTION
## Summary

- Converts plain-text player names into `<Link>` elements pointing to `/players/:playerId` on every surface that lists players: active roster, depth chart (slots + inactives), salary cap, and scout evaluation prospects.
- Opponent rosters already had links; free agency, draft, and trades are still stubs with no player tables to link.
- Uses the canonical `/leagues/:leagueId/players/:playerId` route with no per-surface query params, matching ADR 0013.

Closes #188

🤖 Generated with [Claude Code](https://claude.com/claude-code)