### PR TITLE
refactor(rng): extract shared seeded RNG util with DI-friendly interface

### DIFF
--- a/packages/shared/mod.ts
+++ b/packages/shared/mod.ts
@@ -194,5 +194,14 @@ export { statColumnsForBucket } from "./statistics/position-stat-columns.ts";
 export type { CareerTotalsResult } from "./statistics/career-totals.ts";
 export { computeCareerTotals } from "./statistics/career-totals.ts";
 
+// RNG
+export {
+  createRng,
+  createSeededRng,
+  deriveGameSeed,
+  mulberry32,
+} from "./rng/mod.ts";
+export type { SeededRng } from "./rng/mod.ts";
+
 // Errors
 export { DomainError } from "./errors/domain-error.ts";

--- a/packages/shared/rng/mod.ts
+++ b/packages/shared/rng/mod.ts
@@ -1,0 +1,7 @@
+export {
+  createRng,
+  createSeededRng,
+  deriveGameSeed,
+  mulberry32,
+} from "./rng.ts";
+export type { SeededRng } from "./rng.ts";

--- a/packages/shared/rng/rng.test.ts
+++ b/packages/shared/rng/rng.test.ts
@@ -1,0 +1,162 @@
+import { assertEquals, assertNotEquals } from "@std/assert";
+import {
+  createRng,
+  createSeededRng,
+  deriveGameSeed,
+  mulberry32,
+} from "./rng.ts";
+import type { SeededRng } from "./rng.ts";
+
+Deno.test("mulberry32", async (t) => {
+  await t.step("produces identical sequence for same seed", () => {
+    const rng1 = mulberry32(12345);
+    const rng2 = mulberry32(12345);
+    for (let i = 0; i < 100; i++) {
+      assertEquals(rng1(), rng2());
+    }
+  });
+
+  await t.step("produces different sequences for different seeds", () => {
+    const rng1 = mulberry32(12345);
+    const rng2 = mulberry32(54321);
+    let allSame = true;
+    for (let i = 0; i < 10; i++) {
+      if (rng1() !== rng2()) {
+        allSame = false;
+        break;
+      }
+    }
+    assertEquals(allSame, false);
+  });
+
+  await t.step("returns values in [0, 1) range", () => {
+    const rng = mulberry32(42);
+    for (let i = 0; i < 1000; i++) {
+      const val = rng();
+      assertEquals(val >= 0 && val < 1, true);
+    }
+  });
+
+  await t.step("is byte-identical on fixed seed across calls", () => {
+    const rng = mulberry32(99999);
+    const expected = [
+      rng(),
+      rng(),
+      rng(),
+      rng(),
+      rng(),
+    ];
+
+    const rng2 = mulberry32(99999);
+    for (let i = 0; i < expected.length; i++) {
+      assertEquals(rng2(), expected[i]);
+    }
+  });
+});
+
+Deno.test("createRng", async (t) => {
+  await t.step("next() returns raw values from underlying generator", () => {
+    const raw = mulberry32(42);
+    const rng = createRng(mulberry32(42));
+    for (let i = 0; i < 10; i++) {
+      assertEquals(rng.next(), raw());
+    }
+  });
+
+  await t.step("int() returns values in inclusive range", () => {
+    const rng = createRng(mulberry32(42));
+    for (let i = 0; i < 100; i++) {
+      const val = rng.int(1, 6);
+      assertEquals(val >= 1 && val <= 6, true);
+      assertEquals(Number.isInteger(val), true);
+    }
+  });
+
+  await t.step("pick() returns element from array", () => {
+    const rng = createRng(mulberry32(42));
+    const items = ["a", "b", "c", "d"] as const;
+    for (let i = 0; i < 50; i++) {
+      const val = rng.pick(items);
+      assertEquals(items.includes(val), true);
+    }
+  });
+
+  await t.step("gaussian() returns values clamped to range", () => {
+    const rng = createRng(mulberry32(42));
+    for (let i = 0; i < 100; i++) {
+      const val = rng.gaussian(50, 10, 20, 80);
+      assertEquals(val >= 20 && val <= 80, true);
+      assertEquals(Number.isInteger(val), true);
+    }
+  });
+
+  await t.step("is deterministic with same seed", () => {
+    const rng1 = createRng(mulberry32(777));
+    const rng2 = createRng(mulberry32(777));
+    for (let i = 0; i < 20; i++) {
+      assertEquals(rng1.int(0, 100), rng2.int(0, 100));
+    }
+  });
+});
+
+Deno.test("createSeededRng", async (t) => {
+  await t.step("combines mulberry32 and createRng", () => {
+    const convenience = createSeededRng(42);
+    const manual = createRng(mulberry32(42));
+    for (let i = 0; i < 20; i++) {
+      assertEquals(convenience.next(), manual.next());
+    }
+  });
+
+  await t.step("returns a valid SeededRng interface", () => {
+    const rng: SeededRng = createSeededRng(12345);
+    assertEquals(typeof rng.next, "function");
+    assertEquals(typeof rng.int, "function");
+    assertEquals(typeof rng.pick, "function");
+    assertEquals(typeof rng.gaussian, "function");
+  });
+});
+
+Deno.test("deriveGameSeed", async (t) => {
+  await t.step("returns deterministic seed for same inputs", () => {
+    const seed1 = deriveGameSeed(42, "game-1");
+    const seed2 = deriveGameSeed(42, "game-1");
+    assertEquals(seed1, seed2);
+  });
+
+  await t.step("returns different seeds for different game identifiers", () => {
+    const seed1 = deriveGameSeed(42, "game-1");
+    const seed2 = deriveGameSeed(42, "game-2");
+    assertNotEquals(seed1, seed2);
+  });
+
+  await t.step("returns different seeds for different league seeds", () => {
+    const seed1 = deriveGameSeed(42, "game-1");
+    const seed2 = deriveGameSeed(43, "game-1");
+    assertNotEquals(seed1, seed2);
+  });
+
+  await t.step("returns a 32-bit unsigned integer", () => {
+    const seed = deriveGameSeed(12345, "week-1-game-3");
+    assertEquals(seed >= 0, true);
+    assertEquals(seed <= 0xFFFFFFFF, true);
+    assertEquals(Number.isInteger(seed), true);
+  });
+
+  await t.step("a week of games is reproducible from a league seed", () => {
+    const leagueSeed = 2026;
+    const gameIds = [
+      "week1-game1",
+      "week1-game2",
+      "week1-game3",
+      "week1-game4",
+    ];
+
+    const seeds1 = gameIds.map((id) => deriveGameSeed(leagueSeed, id));
+    const seeds2 = gameIds.map((id) => deriveGameSeed(leagueSeed, id));
+    assertEquals(seeds1, seeds2);
+
+    const uniqueSeeds = new Set(seeds1);
+    assertEquals(uniqueSeeds.size, gameIds.length);
+  });
+});

--- a/packages/shared/rng/rng.ts
+++ b/packages/shared/rng/rng.ts
@@ -1,0 +1,53 @@
+export function mulberry32(seed: number): () => number {
+  let state = seed >>> 0;
+  return () => {
+    state = (state + 0x6D2B79F5) >>> 0;
+    let t = state;
+    t = Math.imul(t ^ (t >>> 15), t | 1);
+    t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+export interface SeededRng {
+  next(): number;
+  int(min: number, max: number): number;
+  pick<T>(arr: readonly T[]): T;
+  gaussian(mean: number, stddev: number, min: number, max: number): number;
+}
+
+export function createRng(random: () => number): SeededRng {
+  return {
+    next: random,
+    int(min, max) {
+      return Math.floor(random() * (max - min + 1)) + min;
+    },
+    pick<T>(arr: readonly T[]): T {
+      return arr[Math.floor(random() * arr.length)];
+    },
+    gaussian(mean, stddev, min, max) {
+      const u1 = Math.max(random(), 1e-9);
+      const u2 = random();
+      const z = Math.sqrt(-2 * Math.log(u1)) * Math.cos(2 * Math.PI * u2);
+      const value = Math.round(mean + z * stddev);
+      return Math.max(min, Math.min(max, value));
+    },
+  };
+}
+
+export function createSeededRng(seed: number): SeededRng {
+  return createRng(mulberry32(seed));
+}
+
+export function deriveGameSeed(
+  leagueSeed: number,
+  gameIdentifier: string,
+): number {
+  let hash = leagueSeed >>> 0;
+  for (let i = 0; i < gameIdentifier.length; i++) {
+    hash = (hash ^ gameIdentifier.charCodeAt(i)) >>> 0;
+    hash = Math.imul(hash, 0x5BD1E995) >>> 0;
+    hash = (hash ^ (hash >>> 15)) >>> 0;
+  }
+  return hash >>> 0;
+}

--- a/server/features/coaches/coaches-generator.test.ts
+++ b/server/features/coaches/coaches-generator.test.ts
@@ -1,5 +1,5 @@
 import { assertEquals, assertNotEquals } from "@std/assert";
-import type { CoachRole } from "@zone-blitz/shared";
+import { type CoachRole, mulberry32 } from "@zone-blitz/shared";
 import {
   createCoachesGenerator,
   type NameGenerator,
@@ -29,16 +29,8 @@ const EXPECTED_ROLES: CoachRole[] = [
   "ST_ASSISTANT",
 ];
 
-// mulberry32 — small, deterministic RNG for reproducible distribution tests.
 function seededRandom(seed: number): () => number {
-  let state = seed >>> 0;
-  return () => {
-    state = (state + 0x6D2B79F5) >>> 0;
-    let t = state;
-    t = Math.imul(t ^ (t >>> 15), t | 1);
-    t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
-    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
-  };
+  return mulberry32(seed);
 }
 
 function fixedNameGenerator(): NameGenerator {

--- a/server/features/players/players-generator.test.ts
+++ b/server/features/players/players-generator.test.ts
@@ -1,5 +1,6 @@
 import { assertEquals } from "@std/assert";
 import {
+  mulberry32,
   NEUTRAL_BUCKETS,
   type NeutralBucket,
   neutralBucket,
@@ -24,16 +25,8 @@ const INPUT = {
   rosterSize: 53,
 };
 
-// mulberry32 — small, deterministic RNG for reproducible distribution tests.
 function seededRandom(seed: number): () => number {
-  let state = seed >>> 0;
-  return () => {
-    state = (state + 0x6D2B79F5) >>> 0;
-    let t = state;
-    t = Math.imul(t ^ (t >>> 15), t | 1);
-    t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
-    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
-  };
+  return mulberry32(seed);
 }
 
 function fixedNameGenerator(): NameGenerator {

--- a/server/features/simulation/mod.ts
+++ b/server/features/simulation/mod.ts
@@ -11,5 +11,10 @@ export type {
   PlayTag,
 } from "./events.ts";
 
-export { createRng, deriveGameSeed, mulberry32 } from "./rng.ts";
+export {
+  createRng,
+  createSeededRng,
+  deriveGameSeed,
+  mulberry32,
+} from "./rng.ts";
 export type { SeededRng } from "./rng.ts";

--- a/server/features/simulation/rng.ts
+++ b/server/features/simulation/rng.ts
@@ -1,49 +1,7 @@
-export function mulberry32(seed: number): () => number {
-  let state = seed >>> 0;
-  return () => {
-    state = (state + 0x6D2B79F5) >>> 0;
-    let t = state;
-    t = Math.imul(t ^ (t >>> 15), t | 1);
-    t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
-    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
-  };
-}
-
-export interface SeededRng {
-  next(): number;
-  int(min: number, max: number): number;
-  pick<T>(arr: readonly T[]): T;
-  gaussian(mean: number, stddev: number, min: number, max: number): number;
-}
-
-export function createRng(random: () => number): SeededRng {
-  return {
-    next: random,
-    int(min, max) {
-      return Math.floor(random() * (max - min + 1)) + min;
-    },
-    pick<T>(arr: readonly T[]): T {
-      return arr[Math.floor(random() * arr.length)];
-    },
-    gaussian(mean, stddev, min, max) {
-      const u1 = Math.max(random(), 1e-9);
-      const u2 = random();
-      const z = Math.sqrt(-2 * Math.log(u1)) * Math.cos(2 * Math.PI * u2);
-      const value = Math.round(mean + z * stddev);
-      return Math.max(min, Math.min(max, value));
-    },
-  };
-}
-
-export function deriveGameSeed(
-  leagueSeed: number,
-  gameIdentifier: string,
-): number {
-  let hash = leagueSeed >>> 0;
-  for (let i = 0; i < gameIdentifier.length; i++) {
-    hash = (hash ^ gameIdentifier.charCodeAt(i)) >>> 0;
-    hash = Math.imul(hash, 0x5BD1E995) >>> 0;
-    hash = (hash ^ (hash >>> 15)) >>> 0;
-  }
-  return hash >>> 0;
-}
+export {
+  createRng,
+  createSeededRng,
+  deriveGameSeed,
+  mulberry32,
+} from "@zone-blitz/shared";
+export type { SeededRng } from "@zone-blitz/shared";

--- a/server/shared/name-generator.ts
+++ b/server/shared/name-generator.ts
@@ -1,9 +1,12 @@
+import { createSeededRng, type SeededRng } from "@zone-blitz/shared";
+
 export interface NameGenerator {
   next(): { firstName: string; lastName: string };
 }
 
 export interface NameGeneratorOptions {
   seed?: number;
+  rng?: SeededRng;
   firstNames?: readonly string[];
   lastNames?: readonly string[];
 }
@@ -1308,32 +1311,19 @@ export const LAST_NAMES: readonly string[] = [
   "Zimmerman",
 ];
 
-// mulberry32 — small, fast, deterministic. A 32-bit seed is plenty for name
-// sampling; we are not using this for anything cryptographic.
-function mulberry32(seed: number): () => number {
-  let state = seed >>> 0;
-  return () => {
-    state = (state + 0x6D2B79F5) >>> 0;
-    let t = state;
-    t = Math.imul(t ^ (t >>> 15), t | 1);
-    t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
-    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
-  };
-}
-
 export function createNameGenerator(
   options: NameGeneratorOptions = {},
 ): NameGenerator {
   const firsts = options.firstNames ?? FIRST_NAMES;
   const lasts = options.lastNames ?? LAST_NAMES;
-  const seed = options.seed ?? ((Math.random() * 2 ** 32) >>> 0);
-  const rand = mulberry32(seed);
+  const rng = options.rng ??
+    createSeededRng(options.seed ?? ((Math.random() * 2 ** 32) >>> 0));
 
   return {
     next() {
       return {
-        firstName: firsts[Math.floor(rand() * firsts.length)],
-        lastName: lasts[Math.floor(rand() * lasts.length)],
+        firstName: rng.pick(firsts),
+        lastName: rng.pick(lasts),
       };
     },
   };


### PR DESCRIPTION
## Summary

Closes #210

- Extracts `mulberry32`, `createRng`, `createSeededRng`, `deriveGameSeed`, and `SeededRng` interface into `packages/shared/rng/` as a true shared primitive with no feature-level ownership
- `server/features/simulation/rng.ts` now re-exports from shared, keeping the public surface stable for existing consumers
- `server/shared/name-generator.ts` accepts an optional `rng: SeededRng` parameter (DI-friendly), dropping its private mulberry32 copy
- Test files in `coaches-generator.test.ts` and `players-generator.test.ts` import `mulberry32` from `@zone-blitz/shared` instead of re-implementing inline
- 100% test coverage on all new/modified files