### PR TITLE
feat(simulation): implement resolvePlay pipeline consuming scheme fingerprint and fit

### DIFF
--- a/server/features/simulation/mod.ts
+++ b/server/features/simulation/mod.ts
@@ -13,3 +13,22 @@ export type {
 
 export { createRng, deriveGameSeed, mulberry32 } from "./rng.ts";
 export type { SeededRng } from "./rng.ts";
+
+export { resolvePlay } from "./resolve-play.ts";
+export {
+  drawDefensiveCall,
+  drawOffensiveCall,
+  identifyMatchups,
+  rollMatchup,
+  synthesizeOutcome,
+} from "./resolve-play.ts";
+export type {
+  CoachingMods,
+  GameState,
+  Matchup,
+  MatchupContribution,
+  MatchupType,
+  PlayerRuntime,
+  Situation,
+  TeamRuntime,
+} from "./resolve-play.ts";

--- a/server/features/simulation/resolve-play.test.ts
+++ b/server/features/simulation/resolve-play.test.ts
@@ -1,0 +1,1359 @@
+import { assertEquals, assertNotEquals } from "@std/assert";
+import {
+  PLAYER_ATTRIBUTE_KEYS,
+  type PlayerAttributes,
+  type SchemeFingerprint,
+} from "@zone-blitz/shared";
+import { createRng, mulberry32 } from "./rng.ts";
+import type { SeededRng } from "./rng.ts";
+import type { DefensiveCall, OffensiveCall } from "./events.ts";
+import {
+  type CoachingMods,
+  drawDefensiveCall,
+  drawOffensiveCall,
+  type GameState,
+  identifyMatchups,
+  type MatchupContribution,
+  type PlayerRuntime,
+  resolvePlay,
+  rollMatchup,
+  type Situation,
+  synthesizeOutcome,
+  type TeamRuntime,
+} from "./resolve-play.ts";
+
+function makeAttributes(
+  overrides: Partial<PlayerAttributes> = {},
+): PlayerAttributes {
+  const base: Partial<PlayerAttributes> = {};
+  for (const key of PLAYER_ATTRIBUTE_KEYS) {
+    (base as Record<string, number>)[key] = 50;
+    (base as Record<string, number>)[`${key}Potential`] = 50;
+  }
+  return { ...base, ...overrides } as PlayerAttributes;
+}
+
+function makeFingerprint(
+  overrides: Partial<SchemeFingerprint> = {},
+): SchemeFingerprint {
+  return {
+    offense: {
+      runPassLean: 50,
+      tempo: 50,
+      personnelWeight: 50,
+      formationUnderCenterShotgun: 50,
+      preSnapMotionRate: 50,
+      passingStyle: 50,
+      passingDepth: 50,
+      runGameBlocking: 50,
+      rpoIntegration: 50,
+    },
+    defense: {
+      frontOddEven: 50,
+      gapResponsibility: 50,
+      subPackageLean: 50,
+      coverageManZone: 50,
+      coverageShell: 50,
+      cornerPressOff: 50,
+      pressureRate: 50,
+      disguiseRate: 50,
+    },
+    overrides: {},
+    ...overrides,
+  };
+}
+
+function makeSituation(overrides: Partial<Situation> = {}): Situation {
+  return { down: 1, distance: 10, yardLine: 30, ...overrides };
+}
+
+function makeRng(seed = 42): SeededRng {
+  return createRng(mulberry32(seed));
+}
+
+function makePlayer(
+  id: string,
+  bucket: PlayerRuntime["neutralBucket"],
+  overrides: Partial<PlayerAttributes> = {},
+): PlayerRuntime {
+  return {
+    playerId: id,
+    neutralBucket: bucket,
+    attributes: makeAttributes(overrides),
+  };
+}
+
+function makeCoachingMods(
+  overrides: Partial<CoachingMods> = {},
+): CoachingMods {
+  return { schemeFitBonus: 0, situationalBonus: 0, ...overrides };
+}
+
+function makeOffense(): PlayerRuntime[] {
+  return [
+    makePlayer("qb1", "QB"),
+    makePlayer("rb1", "RB"),
+    makePlayer("wr1", "WR"),
+    makePlayer("wr2", "WR"),
+    makePlayer("te1", "TE"),
+    makePlayer("ot1", "OT"),
+    makePlayer("ot2", "OT"),
+    makePlayer("iol1", "IOL"),
+    makePlayer("iol2", "IOL"),
+    makePlayer("iol3", "IOL"),
+  ];
+}
+
+function makeDefense(): PlayerRuntime[] {
+  return [
+    makePlayer("edge1", "EDGE"),
+    makePlayer("edge2", "EDGE"),
+    makePlayer("idl1", "IDL"),
+    makePlayer("idl2", "IDL"),
+    makePlayer("lb1", "LB"),
+    makePlayer("lb2", "LB"),
+    makePlayer("cb1", "CB"),
+    makePlayer("cb2", "CB"),
+    makePlayer("s1", "S"),
+    makePlayer("s2", "S"),
+  ];
+}
+
+function makeGameState(overrides: Partial<GameState> = {}): GameState {
+  return {
+    gameId: "game-1",
+    driveIndex: 0,
+    playIndex: 0,
+    quarter: 1,
+    clock: "15:00",
+    situation: makeSituation(),
+    offenseTeamId: "team-a",
+    defenseTeamId: "team-b",
+    ...overrides,
+  };
+}
+
+function makeTeamRuntime(
+  overrides: Partial<TeamRuntime> & { onField?: PlayerRuntime[] } = {},
+): TeamRuntime {
+  return {
+    fingerprint: makeFingerprint(),
+    onField: makeOffense(),
+    coachingMods: makeCoachingMods(),
+    ...overrides,
+  };
+}
+
+// ── drawOffensiveCall ───────────────────────────────────────────────
+
+Deno.test("drawOffensiveCall", async (t) => {
+  await t.step("returns an OffensiveCall with all required fields", () => {
+    const rng = makeRng();
+    const fp = makeFingerprint();
+    const call = drawOffensiveCall(fp, makeSituation(), rng);
+    assertEquals(typeof call.concept, "string");
+    assertEquals(typeof call.personnel, "string");
+    assertEquals(typeof call.formation, "string");
+    assertEquals(typeof call.motion, "string");
+  });
+
+  await t.step(
+    "run-heavy runPassLean produces more run concepts over many calls",
+    () => {
+      const fp = makeFingerprint({
+        offense: {
+          runPassLean: 10,
+          tempo: 50,
+          personnelWeight: 50,
+          formationUnderCenterShotgun: 50,
+          preSnapMotionRate: 50,
+          passingStyle: 50,
+          passingDepth: 50,
+          runGameBlocking: 50,
+          rpoIntegration: 50,
+        },
+      });
+      const runConcepts = new Set([
+        "inside_zone",
+        "outside_zone",
+        "power",
+        "counter",
+        "draw",
+        "rpo",
+      ]);
+      let runCount = 0;
+      const total = 200;
+      const rng = makeRng(123);
+      for (let i = 0; i < total; i++) {
+        const call = drawOffensiveCall(fp, makeSituation(), rng);
+        if (runConcepts.has(call.concept)) runCount++;
+      }
+      assertEquals(runCount / total > 0.6, true);
+    },
+  );
+
+  await t.step(
+    "pass-heavy runPassLean produces more pass concepts over many calls",
+    () => {
+      const fp = makeFingerprint({
+        offense: {
+          runPassLean: 90,
+          tempo: 50,
+          personnelWeight: 50,
+          formationUnderCenterShotgun: 50,
+          preSnapMotionRate: 50,
+          passingStyle: 50,
+          passingDepth: 50,
+          runGameBlocking: 50,
+          rpoIntegration: 50,
+        },
+      });
+      const passConcepts = new Set([
+        "screen",
+        "quick_pass",
+        "play_action",
+        "dropback",
+        "deep_shot",
+      ]);
+      let passCount = 0;
+      const total = 200;
+      const rng = makeRng(123);
+      for (let i = 0; i < total; i++) {
+        const call = drawOffensiveCall(fp, makeSituation(), rng);
+        if (passConcepts.has(call.concept)) passCount++;
+      }
+      assertEquals(passCount / total > 0.6, true);
+    },
+  );
+
+  await t.step(
+    "shotgun-leaning formation produces shotgun/pistol formations",
+    () => {
+      const fp = makeFingerprint({
+        offense: {
+          runPassLean: 50,
+          tempo: 50,
+          personnelWeight: 50,
+          formationUnderCenterShotgun: 90,
+          preSnapMotionRate: 50,
+          passingStyle: 50,
+          passingDepth: 50,
+          runGameBlocking: 50,
+          rpoIntegration: 50,
+        },
+      });
+      const rng = makeRng(42);
+      const formations = new Set<string>();
+      for (let i = 0; i < 100; i++) {
+        const call = drawOffensiveCall(fp, makeSituation(), rng);
+        formations.add(call.formation);
+      }
+      for (const f of formations) {
+        assertEquals(
+          f === "shotgun" || f === "pistol",
+          true,
+          `unexpected formation: ${f}`,
+        );
+      }
+    },
+  );
+
+  await t.step("handles null offensive tendencies gracefully", () => {
+    const fp = makeFingerprint({ offense: null });
+    const rng = makeRng();
+    const call = drawOffensiveCall(fp, makeSituation(), rng);
+    assertEquals(typeof call.concept, "string");
+  });
+});
+
+// ── drawDefensiveCall ───────────────────────────────────────────────
+
+Deno.test("drawDefensiveCall", async (t) => {
+  await t.step("returns a DefensiveCall with all required fields", () => {
+    const rng = makeRng();
+    const fp = makeFingerprint();
+    const call = drawDefensiveCall(fp, makeSituation(), rng);
+    assertEquals(typeof call.front, "string");
+    assertEquals(typeof call.coverage, "string");
+    assertEquals(typeof call.pressure, "string");
+  });
+
+  await t.step(
+    "high pressureRate produces more blitz calls over many draws",
+    () => {
+      const fp = makeFingerprint({
+        defense: {
+          frontOddEven: 50,
+          gapResponsibility: 50,
+          subPackageLean: 50,
+          coverageManZone: 50,
+          coverageShell: 50,
+          cornerPressOff: 50,
+          pressureRate: 95,
+          disguiseRate: 50,
+        },
+      });
+      let blitzCount = 0;
+      const total = 200;
+      const rng = makeRng(123);
+      for (let i = 0; i < total; i++) {
+        const call = drawDefensiveCall(fp, makeSituation(), rng);
+        if (call.pressure !== "four_man") blitzCount++;
+      }
+      assertEquals(blitzCount / total > 0.5, true);
+    },
+  );
+
+  await t.step(
+    "man-leaning coverageManZone prefers man coverages",
+    () => {
+      const fp = makeFingerprint({
+        defense: {
+          frontOddEven: 50,
+          gapResponsibility: 50,
+          subPackageLean: 50,
+          coverageManZone: 10,
+          coverageShell: 50,
+          cornerPressOff: 50,
+          pressureRate: 50,
+          disguiseRate: 50,
+        },
+      });
+      const manCoverages = new Set(["cover_0", "cover_1"]);
+      let manCount = 0;
+      const total = 200;
+      const rng = makeRng(42);
+      for (let i = 0; i < total; i++) {
+        const call = drawDefensiveCall(fp, makeSituation(), rng);
+        if (manCoverages.has(call.coverage)) manCount++;
+      }
+      assertEquals(manCount / total > 0.5, true);
+    },
+  );
+
+  await t.step("handles null defensive tendencies gracefully", () => {
+    const fp = makeFingerprint({ defense: null });
+    const rng = makeRng();
+    const call = drawDefensiveCall(fp, makeSituation(), rng);
+    assertEquals(typeof call.front, "string");
+  });
+});
+
+// ── identifyMatchups ────────────────────────────────────────────────
+
+Deno.test("identifyMatchups", async (t) => {
+  await t.step("returns run_block matchups for a run play", () => {
+    const call: OffensiveCall = {
+      concept: "inside_zone",
+      personnel: "11",
+      formation: "shotgun",
+      motion: "none",
+    };
+    const coverage: DefensiveCall = {
+      front: "4-3",
+      coverage: "cover_3",
+      pressure: "four_man",
+    };
+    const matchups = identifyMatchups(
+      call,
+      coverage,
+      makeOffense(),
+      makeDefense(),
+    );
+
+    const runMatchups = matchups.filter((m) => m.type === "run_block");
+    assertEquals(runMatchups.length > 0, true);
+  });
+
+  await t.step(
+    "returns pass_protection and route_coverage matchups for a pass play",
+    () => {
+      const call: OffensiveCall = {
+        concept: "dropback",
+        personnel: "11",
+        formation: "shotgun",
+        motion: "none",
+      };
+      const coverage: DefensiveCall = {
+        front: "nickel",
+        coverage: "cover_2",
+        pressure: "four_man",
+      };
+      const matchups = identifyMatchups(
+        call,
+        coverage,
+        makeOffense(),
+        makeDefense(),
+      );
+
+      const protectionMatchups = matchups.filter(
+        (m) => m.type === "pass_protection",
+      );
+      const routeMatchups = matchups.filter(
+        (m) => m.type === "route_coverage",
+      );
+      assertEquals(protectionMatchups.length > 0, true);
+      assertEquals(routeMatchups.length > 0, true);
+    },
+  );
+
+  await t.step("adds pass_rush matchups when blitz is called", () => {
+    const call: OffensiveCall = {
+      concept: "dropback",
+      personnel: "11",
+      formation: "shotgun",
+      motion: "none",
+    };
+    const coverage: DefensiveCall = {
+      front: "nickel",
+      coverage: "cover_1",
+      pressure: "man_blitz",
+    };
+    const matchups = identifyMatchups(
+      call,
+      coverage,
+      makeOffense(),
+      makeDefense(),
+    );
+
+    const passRushMatchups = matchups.filter(
+      (m) => m.type === "pass_rush",
+    );
+    assertEquals(passRushMatchups.length > 0, true);
+  });
+
+  await t.step("handles empty player arrays gracefully", () => {
+    const call: OffensiveCall = {
+      concept: "dropback",
+      personnel: "11",
+      formation: "shotgun",
+      motion: "none",
+    };
+    const coverage: DefensiveCall = {
+      front: "4-3",
+      coverage: "cover_3",
+      pressure: "four_man",
+    };
+    const matchups = identifyMatchups(call, coverage, [], []);
+    assertEquals(matchups.length, 0);
+  });
+});
+
+// ── rollMatchup ─────────────────────────────────────────────────────
+
+Deno.test("rollMatchup", async (t) => {
+  await t.step("returns a MatchupContribution with correct structure", () => {
+    const rng = makeRng();
+    const result = rollMatchup({
+      attacker: makePlayer("ot1", "OT", { passBlocking: 80 }),
+      defender: makePlayer("edge1", "EDGE", { passRushing: 60 }),
+      schemeFitAttacker: "fits",
+      schemeFitDefender: "neutral",
+      coaching: {
+        offense: makeCoachingMods(),
+        defense: makeCoachingMods(),
+      },
+      situation: makeSituation(),
+      matchupType: "pass_protection",
+      rng,
+    });
+    assertEquals(typeof result.score, "number");
+    assertEquals(result.matchup.type, "pass_protection");
+    assertEquals(result.attackerFit, "fits");
+    assertEquals(result.defenderFit, "neutral");
+  });
+
+  await t.step(
+    "scheme-fit ideal attacker vs miscast defender skews score positively",
+    () => {
+      let positiveCount = 0;
+      const trials = 50;
+      for (let i = 0; i < trials; i++) {
+        const rng = makeRng(i);
+        const result = rollMatchup({
+          attacker: makePlayer("ot1", "OT", {
+            passBlocking: 85,
+            strength: 80,
+            agility: 80,
+          }),
+          defender: makePlayer("edge1", "EDGE", {
+            passRushing: 40,
+            acceleration: 40,
+            strength: 40,
+          }),
+          schemeFitAttacker: "ideal",
+          schemeFitDefender: "miscast",
+          coaching: {
+            offense: makeCoachingMods(),
+            defense: makeCoachingMods(),
+          },
+          situation: makeSituation(),
+          matchupType: "pass_protection",
+          rng,
+        });
+        if (result.score > 0) positiveCount++;
+      }
+      assertEquals(positiveCount / trials > 0.7, true);
+    },
+  );
+
+  await t.step("score is bounded to [-50, 50]", () => {
+    for (let seed = 0; seed < 100; seed++) {
+      const rng = makeRng(seed);
+      const result = rollMatchup({
+        attacker: makePlayer("wr1", "WR"),
+        defender: makePlayer("cb1", "CB"),
+        schemeFitAttacker: "neutral",
+        schemeFitDefender: "neutral",
+        coaching: {
+          offense: makeCoachingMods(),
+          defense: makeCoachingMods(),
+        },
+        situation: makeSituation(),
+        matchupType: "route_coverage",
+        rng,
+      });
+      assertEquals(result.score >= -50 && result.score <= 50, true);
+    }
+  });
+
+  await t.step("uses true attributes, not scouting-projected", () => {
+    const rng = makeRng(42);
+    const attacker = makePlayer("wr1", "WR", {
+      routeRunning: 95,
+      speed: 95,
+      catching: 95,
+    });
+    const result = rollMatchup({
+      attacker,
+      defender: makePlayer("cb1", "CB"),
+      schemeFitAttacker: "neutral",
+      schemeFitDefender: "neutral",
+      coaching: {
+        offense: makeCoachingMods(),
+        defense: makeCoachingMods(),
+      },
+      situation: makeSituation(),
+      matchupType: "route_coverage",
+      rng,
+    });
+    assertEquals(typeof result.score, "number");
+  });
+});
+
+// ── synthesizeOutcome ───────────────────────────────────────────────
+
+Deno.test("synthesizeOutcome", async (t) => {
+  const runCall: OffensiveCall = {
+    concept: "inside_zone",
+    personnel: "11",
+    formation: "shotgun",
+    motion: "none",
+  };
+  const passCall: OffensiveCall = {
+    concept: "dropback",
+    personnel: "11",
+    formation: "shotgun",
+    motion: "none",
+  };
+  const coverageCall: DefensiveCall = {
+    front: "4-3",
+    coverage: "cover_3",
+    pressure: "four_man",
+  };
+
+  await t.step("produces a PlayEvent with all required fields", () => {
+    const rng = makeRng();
+    const state = makeGameState();
+    const contribs: MatchupContribution[] = [
+      {
+        matchup: {
+          type: "run_block",
+          attacker: makePlayer("ot1", "OT"),
+          defender: makePlayer("idl1", "IDL"),
+        },
+        attackerFit: "neutral",
+        defenderFit: "neutral",
+        score: 5,
+      },
+    ];
+
+    const event = synthesizeOutcome(
+      runCall,
+      coverageCall,
+      contribs,
+      state,
+      rng,
+    );
+    assertEquals(event.gameId, "game-1");
+    assertEquals(event.driveIndex, 0);
+    assertEquals(event.playIndex, 0);
+    assertEquals(event.quarter, 1);
+    assertEquals(typeof event.outcome, "string");
+    assertEquals(typeof event.yardage, "number");
+    assertEquals(Array.isArray(event.tags), true);
+    assertEquals(Array.isArray(event.participants), true);
+  });
+
+  await t.step(
+    "run play with dominant blocking yields positive yardage",
+    () => {
+      let positiveYardageCount = 0;
+      const trials = 30;
+      for (let i = 0; i < trials; i++) {
+        const rng = makeRng(i);
+        const contribs: MatchupContribution[] = [
+          {
+            matchup: {
+              type: "run_block",
+              attacker: makePlayer("ot1", "OT"),
+              defender: makePlayer("idl1", "IDL"),
+            },
+            attackerFit: "neutral",
+            defenderFit: "neutral",
+            score: 20,
+          },
+        ];
+        const event = synthesizeOutcome(
+          runCall,
+          coverageCall,
+          contribs,
+          makeGameState(),
+          rng,
+        );
+        if (event.yardage > 0) positiveYardageCount++;
+      }
+      assertEquals(positiveYardageCount / trials > 0.9, true);
+    },
+  );
+
+  await t.step(
+    "pass play with terrible protection yields sack outcome",
+    () => {
+      let sackCount = 0;
+      const trials = 30;
+      for (let i = 0; i < trials; i++) {
+        const rng = makeRng(i);
+        const contribs: MatchupContribution[] = [
+          {
+            matchup: {
+              type: "pass_protection",
+              attacker: makePlayer("ot1", "OT"),
+              defender: makePlayer("edge1", "EDGE"),
+            },
+            attackerFit: "neutral",
+            defenderFit: "neutral",
+            score: -20,
+          },
+        ];
+        const event = synthesizeOutcome(
+          passCall,
+          coverageCall,
+          contribs,
+          makeGameState(),
+          rng,
+        );
+        if (event.outcome === "sack" || event.outcome === "fumble") {
+          sackCount++;
+        }
+      }
+      assertEquals(sackCount / trials > 0.8, true);
+    },
+  );
+
+  await t.step("touchdown scored when yardage reaches endzone", () => {
+    let touchdownFound = false;
+    for (let seed = 0; seed < 100; seed++) {
+      const rng = makeRng(seed);
+      const state = makeGameState({
+        situation: makeSituation({ yardLine: 95 }),
+      });
+      const contribs: MatchupContribution[] = [
+        {
+          matchup: {
+            type: "run_block",
+            attacker: makePlayer("rb1", "RB"),
+            defender: makePlayer("lb1", "LB"),
+          },
+          attackerFit: "neutral",
+          defenderFit: "neutral",
+          score: 20,
+        },
+      ];
+      const event = synthesizeOutcome(
+        runCall,
+        coverageCall,
+        contribs,
+        state,
+        rng,
+      );
+      if (event.outcome === "touchdown") {
+        assertEquals(event.tags.includes("touchdown"), true);
+        assertEquals(event.yardage, 5);
+        touchdownFound = true;
+        break;
+      }
+    }
+    assertEquals(touchdownFound, true);
+  });
+
+  await t.step("tags first_down when yardage meets distance", () => {
+    const rng = makeRng(5);
+    const state = makeGameState({
+      situation: makeSituation({ down: 1, distance: 3 }),
+    });
+    const contribs: MatchupContribution[] = [
+      {
+        matchup: {
+          type: "run_block",
+          attacker: makePlayer("ot1", "OT"),
+          defender: makePlayer("idl1", "IDL"),
+        },
+        attackerFit: "neutral",
+        defenderFit: "neutral",
+        score: 10,
+      },
+    ];
+    const event = synthesizeOutcome(
+      runCall,
+      coverageCall,
+      contribs,
+      state,
+      rng,
+    );
+    if (event.yardage >= 3) {
+      assertEquals(event.tags.includes("first_down"), true);
+    }
+  });
+});
+
+// ── additional coverage tests ────────────────────────────────────────
+
+Deno.test("drawOffensiveCall short yardage increases run probability", () => {
+  const fp = makeFingerprint();
+  let runCount = 0;
+  const total = 200;
+  const runConcepts = new Set([
+    "inside_zone",
+    "outside_zone",
+    "power",
+    "counter",
+    "draw",
+    "rpo",
+  ]);
+  for (let i = 0; i < total; i++) {
+    const rng = makeRng(i);
+    const call = drawOffensiveCall(
+      fp,
+      makeSituation({ down: 3, distance: 2 }),
+      rng,
+    );
+    if (runConcepts.has(call.concept)) runCount++;
+  }
+  assertEquals(runCount / total > 0.5, true);
+});
+
+Deno.test("drawOffensiveCall long yardage with deep passing depth adds deep_shot", () => {
+  const fp = makeFingerprint({
+    offense: {
+      runPassLean: 90,
+      tempo: 50,
+      personnelWeight: 50,
+      formationUnderCenterShotgun: 50,
+      preSnapMotionRate: 50,
+      passingStyle: 50,
+      passingDepth: 80,
+      runGameBlocking: 50,
+      rpoIntegration: 50,
+    },
+  });
+  let deepShotFound = false;
+  for (let i = 0; i < 200; i++) {
+    const rng = makeRng(i);
+    const call = drawOffensiveCall(
+      fp,
+      makeSituation({ down: 2, distance: 12 }),
+      rng,
+    );
+    if (call.concept === "deep_shot") {
+      deepShotFound = true;
+      break;
+    }
+  }
+  assertEquals(deepShotFound, true);
+});
+
+Deno.test("drawOffensiveCall high RPO integration includes rpo concept", () => {
+  const fp = makeFingerprint({
+    offense: {
+      runPassLean: 10,
+      tempo: 50,
+      personnelWeight: 50,
+      formationUnderCenterShotgun: 50,
+      preSnapMotionRate: 50,
+      passingStyle: 50,
+      passingDepth: 50,
+      runGameBlocking: 50,
+      rpoIntegration: 80,
+    },
+  });
+  let rpoFound = false;
+  for (let i = 0; i < 200; i++) {
+    const rng = makeRng(i);
+    const call = drawOffensiveCall(fp, makeSituation(), rng);
+    if (call.concept === "rpo") {
+      rpoFound = true;
+      break;
+    }
+  }
+  assertEquals(rpoFound, true);
+});
+
+Deno.test("drawOffensiveCall heavy personnel weight selects heavy packages", () => {
+  const fp = makeFingerprint({
+    offense: {
+      runPassLean: 50,
+      tempo: 50,
+      personnelWeight: 80,
+      formationUnderCenterShotgun: 50,
+      preSnapMotionRate: 50,
+      passingStyle: 50,
+      passingDepth: 50,
+      runGameBlocking: 50,
+      rpoIntegration: 50,
+    },
+  });
+  const heavyGroups = new Set(["12", "21", "22"]);
+  let heavyCount = 0;
+  const total = 100;
+  for (let i = 0; i < total; i++) {
+    const rng = makeRng(i);
+    const call = drawOffensiveCall(fp, makeSituation(), rng);
+    if (heavyGroups.has(call.personnel)) heavyCount++;
+  }
+  assertEquals(heavyCount, total);
+});
+
+Deno.test("drawOffensiveCall under-center leaning formation picks UC formations", () => {
+  const fp = makeFingerprint({
+    offense: {
+      runPassLean: 50,
+      tempo: 50,
+      personnelWeight: 50,
+      formationUnderCenterShotgun: 10,
+      preSnapMotionRate: 50,
+      passingStyle: 50,
+      passingDepth: 50,
+      runGameBlocking: 50,
+      rpoIntegration: 50,
+    },
+  });
+  const ucFormations = new Set(["under_center", "singleback", "i_form"]);
+  let ucCount = 0;
+  const total = 100;
+  for (let i = 0; i < total; i++) {
+    const rng = makeRng(i);
+    const call = drawOffensiveCall(fp, makeSituation(), rng);
+    if (ucFormations.has(call.formation)) ucCount++;
+  }
+  assertEquals(ucCount, total);
+});
+
+Deno.test("drawDefensiveCall sub-package heavy picks nickel or dime fronts", () => {
+  const fp = makeFingerprint({
+    defense: {
+      frontOddEven: 50,
+      gapResponsibility: 50,
+      subPackageLean: 80,
+      coverageManZone: 50,
+      coverageShell: 50,
+      cornerPressOff: 50,
+      pressureRate: 50,
+      disguiseRate: 50,
+    },
+  });
+  const subFronts = new Set(["nickel", "dime"]);
+  let subCount = 0;
+  const total = 100;
+  for (let i = 0; i < total; i++) {
+    const rng = makeRng(i);
+    const call = drawDefensiveCall(fp, makeSituation(), rng);
+    if (subFronts.has(call.front)) subCount++;
+  }
+  assertEquals(subCount, total);
+});
+
+Deno.test("drawDefensiveCall odd front lean picks 3-4", () => {
+  const fp = makeFingerprint({
+    defense: {
+      frontOddEven: 20,
+      gapResponsibility: 50,
+      subPackageLean: 30,
+      coverageManZone: 50,
+      coverageShell: 50,
+      cornerPressOff: 50,
+      pressureRate: 50,
+      disguiseRate: 50,
+    },
+  });
+  const rng = makeRng();
+  const call = drawDefensiveCall(fp, makeSituation(), rng);
+  assertEquals(call.front, "3-4");
+});
+
+Deno.test("drawDefensiveCall even front lean picks 4-3", () => {
+  const fp = makeFingerprint({
+    defense: {
+      frontOddEven: 80,
+      gapResponsibility: 50,
+      subPackageLean: 30,
+      coverageManZone: 50,
+      coverageShell: 50,
+      cornerPressOff: 50,
+      pressureRate: 50,
+      disguiseRate: 50,
+    },
+  });
+  const rng = makeRng();
+  const call = drawDefensiveCall(fp, makeSituation(), rng);
+  assertEquals(call.front, "4-3");
+});
+
+Deno.test("drawDefensiveCall man coverage with low shell picks cover_0 or cover_1", () => {
+  const fp = makeFingerprint({
+    defense: {
+      frontOddEven: 50,
+      gapResponsibility: 50,
+      subPackageLean: 50,
+      coverageManZone: 10,
+      coverageShell: 30,
+      cornerPressOff: 50,
+      pressureRate: 50,
+      disguiseRate: 50,
+    },
+  });
+  const manCoverages = new Set(["cover_0", "cover_1"]);
+  const rng = makeRng();
+  for (let i = 0; i < 50; i++) {
+    const call = drawDefensiveCall(fp, makeSituation(), rng);
+    assertEquals(manCoverages.has(call.coverage), true);
+  }
+});
+
+Deno.test("drawDefensiveCall zone coverage with high shell picks cover_2/4/6", () => {
+  const fp = makeFingerprint({
+    defense: {
+      frontOddEven: 50,
+      gapResponsibility: 50,
+      subPackageLean: 50,
+      coverageManZone: 80,
+      coverageShell: 80,
+      cornerPressOff: 50,
+      pressureRate: 50,
+      disguiseRate: 50,
+    },
+  });
+  const zoneCoverages = new Set(["cover_2", "cover_4", "cover_6"]);
+  const rng = makeRng();
+  for (let i = 0; i < 50; i++) {
+    const call = drawDefensiveCall(fp, makeSituation(), rng);
+    assertEquals(zoneCoverages.has(call.coverage), true);
+  }
+});
+
+Deno.test("drawDefensiveCall pass situation boosts blitz probability", () => {
+  const fp = makeFingerprint({
+    defense: {
+      frontOddEven: 50,
+      gapResponsibility: 50,
+      subPackageLean: 50,
+      coverageManZone: 50,
+      coverageShell: 50,
+      cornerPressOff: 50,
+      pressureRate: 60,
+      disguiseRate: 50,
+    },
+  });
+  let blitzCount = 0;
+  const total = 200;
+  for (let i = 0; i < total; i++) {
+    const rng = makeRng(i);
+    const call = drawDefensiveCall(
+      fp,
+      makeSituation({ down: 3, distance: 8 }),
+      rng,
+    );
+    if (call.pressure !== "four_man") blitzCount++;
+  }
+  assertEquals(blitzCount / total > 0.5, true);
+});
+
+Deno.test("rollMatchup applies situation modifiers for 3rd and long pass rush", () => {
+  const rng = makeRng(42);
+  const result = rollMatchup({
+    attacker: makePlayer("ot1", "OT"),
+    defender: makePlayer("edge1", "EDGE"),
+    schemeFitAttacker: "neutral",
+    schemeFitDefender: "neutral",
+    coaching: {
+      offense: makeCoachingMods(),
+      defense: makeCoachingMods(),
+    },
+    situation: makeSituation({ down: 3, distance: 10 }),
+    matchupType: "pass_protection",
+    rng,
+  });
+  assertEquals(typeof result.score, "number");
+});
+
+Deno.test("rollMatchup applies red zone situation modifier", () => {
+  const rng = makeRng(42);
+  const result = rollMatchup({
+    attacker: makePlayer("wr1", "WR"),
+    defender: makePlayer("cb1", "CB"),
+    schemeFitAttacker: "neutral",
+    schemeFitDefender: "neutral",
+    coaching: {
+      offense: makeCoachingMods(),
+      defense: makeCoachingMods(),
+    },
+    situation: makeSituation({ yardLine: 5 }),
+    matchupType: "route_coverage",
+    rng,
+  });
+  assertEquals(typeof result.score, "number");
+});
+
+Deno.test("synthesizeOutcome handles interception on terrible coverage", () => {
+  const passCall: OffensiveCall = {
+    concept: "dropback",
+    personnel: "11",
+    formation: "shotgun",
+    motion: "none",
+  };
+  const coverageCall: DefensiveCall = {
+    front: "4-3",
+    coverage: "cover_3",
+    pressure: "four_man",
+  };
+  let intFound = false;
+  for (let seed = 0; seed < 2000; seed++) {
+    const rng = makeRng(seed);
+    const contribs: MatchupContribution[] = [
+      {
+        matchup: {
+          type: "pass_protection",
+          attacker: makePlayer("ot1", "OT"),
+          defender: makePlayer("edge1", "EDGE"),
+        },
+        attackerFit: "neutral",
+        defenderFit: "neutral",
+        score: 10,
+      },
+      {
+        matchup: {
+          type: "route_coverage",
+          attacker: makePlayer("wr1", "WR"),
+          defender: makePlayer("cb1", "CB"),
+        },
+        attackerFit: "neutral",
+        defenderFit: "neutral",
+        score: -20,
+      },
+    ];
+    const event = synthesizeOutcome(
+      passCall,
+      coverageCall,
+      contribs,
+      makeGameState(),
+      rng,
+    );
+    if (event.outcome === "interception") {
+      assertEquals(event.tags.includes("interception"), true);
+      assertEquals(event.tags.includes("turnover"), true);
+      intFound = true;
+      break;
+    }
+  }
+  assertEquals(intFound, true);
+});
+
+Deno.test("synthesizeOutcome handles big pass play", () => {
+  const passCall: OffensiveCall = {
+    concept: "dropback",
+    personnel: "11",
+    formation: "shotgun",
+    motion: "none",
+  };
+  const coverageCall: DefensiveCall = {
+    front: "4-3",
+    coverage: "cover_3",
+    pressure: "four_man",
+  };
+  const rng = makeRng(42);
+  const contribs: MatchupContribution[] = [
+    {
+      matchup: {
+        type: "route_coverage",
+        attacker: makePlayer("wr1", "WR"),
+        defender: makePlayer("cb1", "CB"),
+      },
+      attackerFit: "neutral",
+      defenderFit: "neutral",
+      score: 15,
+    },
+  ];
+  const event = synthesizeOutcome(
+    passCall,
+    coverageCall,
+    contribs,
+    makeGameState(),
+    rng,
+  );
+  assertEquals(
+    event.outcome === "pass_complete" || event.outcome === "touchdown",
+    true,
+  );
+  assertEquals(event.tags.includes("big_play"), true);
+});
+
+Deno.test("synthesizeOutcome handles moderate pass completion", () => {
+  const passCall: OffensiveCall = {
+    concept: "dropback",
+    personnel: "11",
+    formation: "shotgun",
+    motion: "none",
+  };
+  const coverageCall: DefensiveCall = {
+    front: "4-3",
+    coverage: "cover_3",
+    pressure: "four_man",
+  };
+  const rng = makeRng(42);
+  const contribs: MatchupContribution[] = [
+    {
+      matchup: {
+        type: "route_coverage",
+        attacker: makePlayer("wr1", "WR"),
+        defender: makePlayer("cb1", "CB"),
+      },
+      attackerFit: "neutral",
+      defenderFit: "neutral",
+      score: 0,
+    },
+  ];
+  const event = synthesizeOutcome(
+    passCall,
+    coverageCall,
+    contribs,
+    makeGameState(),
+    rng,
+  );
+  assertEquals(
+    event.outcome === "pass_complete" || event.outcome === "touchdown",
+    true,
+  );
+});
+
+Deno.test("synthesizeOutcome handles pressure without sack", () => {
+  const passCall: OffensiveCall = {
+    concept: "dropback",
+    personnel: "11",
+    formation: "shotgun",
+    motion: "none",
+  };
+  const coverageCall: DefensiveCall = {
+    front: "4-3",
+    coverage: "cover_3",
+    pressure: "four_man",
+  };
+  const rng = makeRng(42);
+  const contribs: MatchupContribution[] = [
+    {
+      matchup: {
+        type: "pass_protection",
+        attacker: makePlayer("ot1", "OT"),
+        defender: makePlayer("edge1", "EDGE"),
+      },
+      attackerFit: "neutral",
+      defenderFit: "neutral",
+      score: -10,
+    },
+    {
+      matchup: {
+        type: "route_coverage",
+        attacker: makePlayer("wr1", "WR"),
+        defender: makePlayer("cb1", "CB"),
+      },
+      attackerFit: "neutral",
+      defenderFit: "neutral",
+      score: 0,
+    },
+  ];
+  const event = synthesizeOutcome(
+    passCall,
+    coverageCall,
+    contribs,
+    makeGameState(),
+    rng,
+  );
+  assertEquals(event.tags.includes("pressure"), true);
+});
+
+Deno.test("synthesizeOutcome handles negative run blocking", () => {
+  const runCall: OffensiveCall = {
+    concept: "inside_zone",
+    personnel: "11",
+    formation: "shotgun",
+    motion: "none",
+  };
+  const coverageCall: DefensiveCall = {
+    front: "4-3",
+    coverage: "cover_3",
+    pressure: "four_man",
+  };
+  const rng = makeRng(42);
+  const contribs: MatchupContribution[] = [
+    {
+      matchup: {
+        type: "run_block",
+        attacker: makePlayer("ot1", "OT"),
+        defender: makePlayer("idl1", "IDL"),
+      },
+      attackerFit: "neutral",
+      defenderFit: "neutral",
+      score: -25,
+    },
+  ];
+  const event = synthesizeOutcome(
+    runCall,
+    coverageCall,
+    contribs,
+    makeGameState(),
+    rng,
+  );
+  assertEquals(event.yardage <= 0, true);
+});
+
+Deno.test("synthesizeOutcome handles slightly negative run blocking", () => {
+  const runCall: OffensiveCall = {
+    concept: "inside_zone",
+    personnel: "11",
+    formation: "shotgun",
+    motion: "none",
+  };
+  const coverageCall: DefensiveCall = {
+    front: "4-3",
+    coverage: "cover_3",
+    pressure: "four_man",
+  };
+  const rng = makeRng(42);
+  const contribs: MatchupContribution[] = [
+    {
+      matchup: {
+        type: "run_block",
+        attacker: makePlayer("ot1", "OT"),
+        defender: makePlayer("idl1", "IDL"),
+      },
+      attackerFit: "neutral",
+      defenderFit: "neutral",
+      score: -10,
+    },
+  ];
+  const event = synthesizeOutcome(
+    runCall,
+    coverageCall,
+    contribs,
+    makeGameState(),
+    rng,
+  );
+  assertEquals(event.yardage >= 0 && event.yardage <= 3, true);
+});
+
+// ── resolvePlay (integration) ───────────────────────────────────────
+
+Deno.test("resolvePlay", async (t) => {
+  await t.step("returns a complete PlayEvent", () => {
+    const rng = makeRng();
+    const state = makeGameState();
+    const offense = makeTeamRuntime({ onField: makeOffense() });
+    const defense = makeTeamRuntime({ onField: makeDefense() });
+
+    const event = resolvePlay(state, offense, defense, rng);
+    assertEquals(event.gameId, "game-1");
+    assertEquals(event.offenseTeamId, "team-a");
+    assertEquals(event.defenseTeamId, "team-b");
+    assertEquals(typeof event.outcome, "string");
+    assertEquals(typeof event.yardage, "number");
+  });
+
+  await t.step(
+    "consumes computeSchemeFit from the schemes feature as an import",
+    () => {
+      const rng = makeRng(99);
+      const state = makeGameState();
+      const offense = makeTeamRuntime({ onField: makeOffense() });
+      const defense = makeTeamRuntime({ onField: makeDefense() });
+
+      const event = resolvePlay(state, offense, defense, rng);
+      assertEquals(typeof event.outcome, "string");
+    },
+  );
+});
+
+// ── Determinism ─────────────────────────────────────────────────────
+
+Deno.test("determinism: same roster + staff + seed produces byte-identical PlayEvent sequence", () => {
+  const seed = 12345;
+  const state = makeGameState();
+  const offense = makeTeamRuntime({ onField: makeOffense() });
+  const defense = makeTeamRuntime({ onField: makeDefense() });
+
+  const events1: ReturnType<typeof resolvePlay>[] = [];
+  const events2: ReturnType<typeof resolvePlay>[] = [];
+
+  for (let i = 0; i < 20; i++) {
+    const rng1 = createRng(mulberry32(seed + i));
+    const rng2 = createRng(mulberry32(seed + i));
+    events1.push(
+      resolvePlay(
+        { ...state, playIndex: i },
+        offense,
+        defense,
+        rng1,
+      ),
+    );
+    events2.push(
+      resolvePlay(
+        { ...state, playIndex: i },
+        offense,
+        defense,
+        rng2,
+      ),
+    );
+  }
+
+  for (let i = 0; i < events1.length; i++) {
+    assertEquals(
+      JSON.stringify(events1[i]),
+      JSON.stringify(events2[i]),
+      `Play ${i} diverged`,
+    );
+  }
+});
+
+Deno.test("determinism: different seeds produce different sequences", () => {
+  const state = makeGameState();
+  const offense = makeTeamRuntime({ onField: makeOffense() });
+  const defense = makeTeamRuntime({ onField: makeDefense() });
+
+  const rng1 = makeRng(111);
+  const rng2 = makeRng(222);
+
+  const event1 = resolvePlay(state, offense, defense, rng1);
+  const event2 = resolvePlay(state, offense, defense, rng2);
+
+  const str1 = JSON.stringify(event1);
+  const str2 = JSON.stringify(event2);
+  assertNotEquals(str1, str2);
+});

--- a/server/features/simulation/resolve-play.ts
+++ b/server/features/simulation/resolve-play.ts
@@ -1,0 +1,660 @@
+import type {
+  NeutralBucket,
+  PlayerAttributes,
+  SchemeFingerprint,
+  SchemeFitLabel,
+} from "@zone-blitz/shared";
+import type {
+  DefensiveCall,
+  OffensiveCall,
+  PlayEvent,
+  PlayOutcome,
+  PlayTag,
+} from "./events.ts";
+import type { SeededRng } from "./rng.ts";
+import { computeSchemeFit } from "../schemes/fit.ts";
+import type { PlayerForFit } from "../schemes/fit.ts";
+
+export interface Situation {
+  down: 1 | 2 | 3 | 4;
+  distance: number;
+  yardLine: number;
+}
+
+export interface GameState {
+  gameId: string;
+  driveIndex: number;
+  playIndex: number;
+  quarter: 1 | 2 | 3 | 4 | "OT";
+  clock: string;
+  situation: Situation;
+  offenseTeamId: string;
+  defenseTeamId: string;
+}
+
+export interface PlayerRuntime {
+  playerId: string;
+  neutralBucket: NeutralBucket;
+  attributes: PlayerAttributes;
+}
+
+export interface TeamRuntime {
+  fingerprint: SchemeFingerprint;
+  onField: PlayerRuntime[];
+  coachingMods: CoachingMods;
+}
+
+export interface CoachingMods {
+  schemeFitBonus: number;
+  situationalBonus: number;
+}
+
+export type MatchupType =
+  | "pass_protection"
+  | "pass_rush"
+  | "route_coverage"
+  | "run_block"
+  | "run_defense";
+
+export interface Matchup {
+  type: MatchupType;
+  attacker: PlayerRuntime;
+  defender: PlayerRuntime;
+}
+
+export interface MatchupContribution {
+  matchup: Matchup;
+  attackerFit: SchemeFitLabel;
+  defenderFit: SchemeFitLabel;
+  score: number;
+}
+
+const FORMATIONS = [
+  "shotgun",
+  "under_center",
+  "pistol",
+  "singleback",
+  "i_form",
+] as const;
+
+const DEFENSIVE_FRONTS = ["3-4", "4-3", "nickel", "dime"] as const;
+const COVERAGES = [
+  "cover_0",
+  "cover_1",
+  "cover_2",
+  "cover_3",
+  "cover_4",
+  "cover_6",
+] as const;
+
+const RUN_CONCEPTS = new Set([
+  "inside_zone",
+  "outside_zone",
+  "power",
+  "counter",
+  "draw",
+]);
+const PASS_CONCEPTS = new Set([
+  "screen",
+  "quick_pass",
+  "play_action",
+  "dropback",
+  "deep_shot",
+]);
+
+const FIT_MODIFIER: Record<SchemeFitLabel, number> = {
+  ideal: 10,
+  fits: 5,
+  neutral: 0,
+  poor: -5,
+  miscast: -10,
+};
+
+const MATCHUP_ATTR_KEYS: Record<MatchupType, {
+  attacker: readonly (keyof PlayerAttributes)[];
+  defender: readonly (keyof PlayerAttributes)[];
+}> = {
+  pass_protection: {
+    attacker: ["passBlocking", "strength", "agility"],
+    defender: ["passRushing", "acceleration", "strength"],
+  },
+  pass_rush: {
+    attacker: ["passRushing", "acceleration", "agility"],
+    defender: ["passBlocking", "strength", "agility"],
+  },
+  route_coverage: {
+    attacker: ["routeRunning", "speed", "catching"],
+    defender: ["manCoverage", "zoneCoverage", "speed"],
+  },
+  run_block: {
+    attacker: ["runBlocking", "strength", "acceleration"],
+    defender: ["blockShedding", "strength", "runDefense"],
+  },
+  run_defense: {
+    attacker: ["blockShedding", "tackling", "runDefense"],
+    defender: ["runBlocking", "strength", "acceleration"],
+  },
+};
+
+export function drawOffensiveCall(
+  fingerprint: SchemeFingerprint,
+  situation: Situation,
+  rng: SeededRng,
+): OffensiveCall {
+  const offense = fingerprint.offense;
+  const runPassLean = offense?.runPassLean ?? 50;
+
+  const isShortYardage = situation.down >= 3 && situation.distance <= 3;
+  const isLongYardage = situation.distance >= 7;
+
+  let runProbability = (100 - runPassLean) / 100;
+  if (isShortYardage) runProbability += 0.2;
+  if (isLongYardage) runProbability -= 0.2;
+  runProbability = Math.max(0.1, Math.min(0.9, runProbability));
+
+  const isRun = rng.next() < runProbability;
+
+  let concept: string;
+  if (isRun) {
+    const runConcepts = [...RUN_CONCEPTS];
+    if ((offense?.rpoIntegration ?? 50) > 60) runConcepts.push("rpo");
+    concept = rng.pick(runConcepts);
+  } else {
+    const passConcepts = [...PASS_CONCEPTS];
+    if (isLongYardage && (offense?.passingDepth ?? 50) > 50) {
+      passConcepts.push("deep_shot");
+    }
+    concept = rng.pick(passConcepts);
+  }
+
+  const personnelWeight = offense?.personnelWeight ?? 50;
+  const heavyPersonnel = personnelWeight > 60;
+  const personnel = heavyPersonnel
+    ? rng.pick(["12", "21", "22"] as const)
+    : rng.pick(["11", "10"] as const);
+
+  const formationLean = offense?.formationUnderCenterShotgun ?? 50;
+  const formation = formationLean > 60
+    ? rng.pick(["shotgun", "pistol"] as const)
+    : formationLean < 40
+    ? rng.pick(["under_center", "singleback", "i_form"] as const)
+    : rng.pick(FORMATIONS);
+
+  const motionRate = offense?.preSnapMotionRate ?? 50;
+  const motion = rng.next() * 100 < motionRate
+    ? rng.pick(["jet", "orbit", "shift"] as const)
+    : "none";
+
+  return { concept, personnel, formation, motion };
+}
+
+export function drawDefensiveCall(
+  fingerprint: SchemeFingerprint,
+  situation: Situation,
+  rng: SeededRng,
+): DefensiveCall {
+  const defense = fingerprint.defense;
+
+  const frontLean = defense?.frontOddEven ?? 50;
+  const subPackage = defense?.subPackageLean ?? 50;
+  let front: string;
+  if (subPackage > 65) {
+    front = rng.pick(["nickel", "dime"] as const);
+  } else if (frontLean < 40) {
+    front = "3-4";
+  } else if (frontLean > 60) {
+    front = "4-3";
+  } else {
+    front = rng.pick(DEFENSIVE_FRONTS);
+  }
+
+  const manZone = defense?.coverageManZone ?? 50;
+  const shell = defense?.coverageShell ?? 50;
+  let coverage: string;
+  if (manZone < 35) {
+    coverage = shell < 50
+      ? rng.pick(["cover_0", "cover_1"] as const)
+      : "cover_1";
+  } else if (manZone > 65) {
+    coverage = shell > 60
+      ? rng.pick(["cover_2", "cover_4", "cover_6"] as const)
+      : "cover_3";
+  } else {
+    coverage = rng.pick(COVERAGES);
+  }
+
+  const pressureRate = defense?.pressureRate ?? 50;
+  const isPassSituation = situation.down >= 3 && situation.distance >= 5;
+  let blitzProb = pressureRate / 100;
+  if (isPassSituation) blitzProb += 0.15;
+  blitzProb = Math.max(0.05, Math.min(0.8, blitzProb));
+
+  let pressure: string;
+  if (rng.next() < blitzProb) {
+    pressure = manZone < 50
+      ? rng.pick(["man_blitz", "all_out"] as const)
+      : rng.pick(["zone_blitz", "man_blitz"] as const);
+  } else {
+    pressure = "four_man";
+  }
+
+  return { front, coverage, pressure };
+}
+
+const OFFENSIVE_POSITIONS = new Set<NeutralBucket>([
+  "QB",
+  "RB",
+  "WR",
+  "TE",
+  "OT",
+  "IOL",
+]);
+const DEFENSIVE_POSITIONS = new Set<NeutralBucket>([
+  "EDGE",
+  "IDL",
+  "LB",
+  "CB",
+  "S",
+]);
+
+export function identifyMatchups(
+  call: OffensiveCall,
+  coverage: DefensiveCall,
+  offenseOnField: PlayerRuntime[],
+  defenseOnField: PlayerRuntime[],
+): Matchup[] {
+  const matchups: Matchup[] = [];
+
+  const offensivePlayers = offenseOnField.filter((p) =>
+    OFFENSIVE_POSITIONS.has(p.neutralBucket)
+  );
+  const defensivePlayers = defenseOnField.filter((p) =>
+    DEFENSIVE_POSITIONS.has(p.neutralBucket)
+  );
+
+  const isRunPlay = RUN_CONCEPTS.has(call.concept);
+  const isBlitz = coverage.pressure !== "four_man";
+
+  const oLinemen = offensivePlayers.filter((p) =>
+    p.neutralBucket === "OT" || p.neutralBucket === "IOL"
+  );
+  const passRushers = defensivePlayers.filter((p) =>
+    p.neutralBucket === "EDGE" || p.neutralBucket === "IDL"
+  );
+  const receivers = offensivePlayers.filter((p) =>
+    p.neutralBucket === "WR" || p.neutralBucket === "TE"
+  );
+  const coveragePlayers = defensivePlayers.filter((p) =>
+    p.neutralBucket === "CB" || p.neutralBucket === "S" ||
+    p.neutralBucket === "LB"
+  );
+  const runBlockers = offensivePlayers.filter((p) =>
+    p.neutralBucket === "OT" || p.neutralBucket === "IOL" ||
+    p.neutralBucket === "TE" || p.neutralBucket === "RB"
+  );
+  const runDefenders = defensivePlayers.filter((p) =>
+    p.neutralBucket === "IDL" || p.neutralBucket === "EDGE" ||
+    p.neutralBucket === "LB"
+  );
+
+  if (isRunPlay) {
+    const pairCount = Math.min(runBlockers.length, runDefenders.length);
+    for (let i = 0; i < pairCount; i++) {
+      matchups.push({
+        type: "run_block",
+        attacker: runBlockers[i],
+        defender: runDefenders[i],
+      });
+    }
+  } else {
+    const protectionPairs = Math.min(oLinemen.length, passRushers.length);
+    for (let i = 0; i < protectionPairs; i++) {
+      matchups.push({
+        type: "pass_protection",
+        attacker: oLinemen[i],
+        defender: passRushers[i],
+      });
+    }
+
+    if (isBlitz) {
+      const blitzers = coveragePlayers.filter((p) => p.neutralBucket === "LB");
+      const extraBlockers = offensivePlayers.filter((p) =>
+        p.neutralBucket === "RB"
+      );
+      const blitzPairs = Math.min(blitzers.length, extraBlockers.length);
+      for (let i = 0; i < blitzPairs; i++) {
+        matchups.push({
+          type: "pass_rush",
+          attacker: blitzers[i],
+          defender: extraBlockers[i],
+        });
+      }
+    }
+
+    const coverDBs = coveragePlayers.filter((p) =>
+      p.neutralBucket === "CB" || p.neutralBucket === "S"
+    );
+    const routePairs = Math.min(receivers.length, coverDBs.length);
+    for (let i = 0; i < routePairs; i++) {
+      matchups.push({
+        type: "route_coverage",
+        attacker: receivers[i],
+        defender: coverDBs[i],
+      });
+    }
+  }
+
+  return matchups;
+}
+
+export function rollMatchup(
+  input: {
+    attacker: PlayerRuntime;
+    defender: PlayerRuntime;
+    schemeFitAttacker: SchemeFitLabel;
+    schemeFitDefender: SchemeFitLabel;
+    coaching: { offense: CoachingMods; defense: CoachingMods };
+    situation: Situation;
+    matchupType: MatchupType;
+    rng: SeededRng;
+  },
+): MatchupContribution {
+  const keys = MATCHUP_ATTR_KEYS[input.matchupType];
+
+  let attackerScore = 0;
+  for (const attr of keys.attacker) {
+    attackerScore += input.attacker.attributes[attr] ?? 0;
+  }
+  attackerScore /= keys.attacker.length;
+
+  let defenderScore = 0;
+  for (const attr of keys.defender) {
+    defenderScore += input.defender.attributes[attr] ?? 0;
+  }
+  defenderScore /= keys.defender.length;
+
+  const fitModAttacker = FIT_MODIFIER[input.schemeFitAttacker];
+  const fitModDefender = FIT_MODIFIER[input.schemeFitDefender];
+
+  const coachingModAttacker = input.coaching.offense.schemeFitBonus +
+    input.coaching.offense.situationalBonus;
+  const coachingModDefender = input.coaching.defense.schemeFitBonus +
+    input.coaching.defense.situationalBonus;
+
+  let situationMod = 0;
+  if (input.situation.down === 3 && input.situation.distance >= 8) {
+    if (
+      input.matchupType === "pass_rush" ||
+      input.matchupType === "pass_protection"
+    ) {
+      situationMod = 3;
+    }
+  }
+  if (input.situation.yardLine <= 10) {
+    situationMod += 2;
+  }
+
+  const perturbation = input.rng.gaussian(0, 5, -15, 15);
+
+  const rawScore = (attackerScore + fitModAttacker + coachingModAttacker) -
+    (defenderScore + fitModDefender + coachingModDefender) +
+    situationMod + perturbation;
+
+  const score = Math.max(-50, Math.min(50, rawScore));
+
+  return {
+    matchup: {
+      type: input.matchupType,
+      attacker: input.attacker,
+      defender: input.defender,
+    },
+    attackerFit: input.schemeFitAttacker,
+    defenderFit: input.schemeFitDefender,
+    score,
+  };
+}
+
+export function synthesizeOutcome(
+  call: OffensiveCall,
+  coverage: DefensiveCall,
+  contributions: MatchupContribution[],
+  state: GameState,
+  rng: SeededRng,
+): PlayEvent {
+  const isRunPlay = RUN_CONCEPTS.has(call.concept);
+  const avgScore = contributions.length > 0
+    ? contributions.reduce((sum, c) => sum + c.score, 0) / contributions.length
+    : 0;
+
+  const participants = contributions.map((c) => ({
+    role: c.matchup.type,
+    playerId: c.matchup.attacker.playerId,
+    tags: [] as string[],
+  }));
+
+  const tags: PlayTag[] = [];
+  let outcome: PlayOutcome;
+  let yardage: number;
+
+  if (isRunPlay) {
+    const blockingContribs = contributions.filter(
+      (c) => c.matchup.type === "run_block" || c.matchup.type === "run_defense",
+    );
+    const blockScore = blockingContribs.length > 0
+      ? blockingContribs.reduce((s, c) => s + c.score, 0) /
+        blockingContribs.length
+      : avgScore;
+
+    if (blockScore < -20) {
+      yardage = rng.int(-3, 0);
+    } else if (blockScore < -5) {
+      yardage = rng.int(0, 3);
+    } else if (blockScore > 15) {
+      yardage = rng.int(8, 25);
+      tags.push("big_play");
+    } else {
+      yardage = rng.int(2, 7);
+    }
+
+    if (rng.next() < 0.015) {
+      outcome = "fumble";
+      tags.push("fumble", "turnover");
+    } else {
+      outcome = "rush";
+    }
+
+    if (yardage >= state.situation.distance) {
+      tags.push("first_down");
+    }
+
+    const rb = contributions.find(
+      (c) => c.matchup.attacker.neutralBucket === "RB",
+    );
+    if (rb) {
+      const idx = participants.findIndex(
+        (p) => p.playerId === rb.matchup.attacker.playerId,
+      );
+      if (idx >= 0) participants[idx].tags.push("ball_carrier");
+    }
+  } else {
+    const protectionContribs = contributions.filter(
+      (c) =>
+        c.matchup.type === "pass_protection" ||
+        c.matchup.type === "pass_rush",
+    );
+    const protectionScore = protectionContribs.length > 0
+      ? protectionContribs.reduce((s, c) => s + c.score, 0) /
+        protectionContribs.length
+      : avgScore;
+
+    if (protectionScore < -15) {
+      outcome = "sack";
+      yardage = rng.int(-10, -3);
+      tags.push("sack", "pressure");
+
+      const rusher = contributions.find((c) =>
+        c.matchup.type === "pass_rush" ||
+        (c.matchup.type === "pass_protection" &&
+          c.score < 0)
+      );
+      if (rusher) {
+        const idx = participants.findIndex(
+          (p) => p.playerId === rusher.matchup.defender.playerId,
+        );
+        if (idx >= 0) {
+          participants[idx].tags.push("sack");
+        } else {
+          participants.push({
+            role: "pass_rush",
+            playerId: rusher.matchup.defender.playerId,
+            tags: ["sack"],
+          });
+        }
+      }
+
+      if (rng.next() < 0.08) {
+        outcome = "fumble";
+        tags.push("fumble", "turnover");
+      }
+    } else {
+      if (protectionScore < -5) {
+        tags.push("pressure");
+      }
+
+      const routeContribs = contributions.filter(
+        (c) => c.matchup.type === "route_coverage",
+      );
+      const coverageScore = routeContribs.length > 0
+        ? routeContribs.reduce((s, c) => s + c.score, 0) /
+          routeContribs.length
+        : avgScore;
+
+      if (coverageScore > 10) {
+        outcome = "pass_complete";
+        yardage = rng.int(8, 30);
+        tags.push("big_play");
+        const target = routeContribs.find((c) => c.score > 0);
+        if (target) {
+          const idx = participants.findIndex(
+            (p) => p.playerId === target.matchup.attacker.playerId,
+          );
+          if (idx >= 0) participants[idx].tags.push("target", "reception");
+        }
+      } else if (coverageScore > -5) {
+        outcome = "pass_complete";
+        yardage = rng.int(3, 12);
+        const target = routeContribs[0];
+        if (target) {
+          const idx = participants.findIndex(
+            (p) => p.playerId === target.matchup.attacker.playerId,
+          );
+          if (idx >= 0) participants[idx].tags.push("target", "reception");
+        }
+      } else if (coverageScore < -15 && rng.next() < 0.15) {
+        outcome = "interception";
+        yardage = 0;
+        tags.push("interception", "turnover");
+
+        const interceptor = routeContribs.find((c) => c.score < -10);
+        if (interceptor) {
+          const idx = participants.findIndex(
+            (p) => p.playerId === interceptor.matchup.defender.playerId,
+          );
+          if (idx >= 0) {
+            participants[idx].tags.push("interception");
+          } else {
+            participants.push({
+              role: "route_coverage",
+              playerId: interceptor.matchup.defender.playerId,
+              tags: ["interception"],
+            });
+          }
+        }
+      } else {
+        outcome = "pass_incomplete";
+        yardage = 0;
+      }
+
+      if (
+        outcome === "pass_complete" && yardage >= state.situation.distance
+      ) {
+        tags.push("first_down");
+      }
+    }
+  }
+
+  if (rng.next() < 0.05) {
+    tags.push("penalty");
+  }
+
+  if (rng.next() < 0.005) {
+    tags.push("injury");
+  }
+
+  const yardsToEndzone = 100 - state.situation.yardLine;
+  if (yardage >= yardsToEndzone && !tags.includes("turnover")) {
+    outcome = "touchdown";
+    yardage = yardsToEndzone;
+    tags.push("touchdown");
+  }
+
+  return {
+    gameId: state.gameId,
+    driveIndex: state.driveIndex,
+    playIndex: state.playIndex,
+    quarter: state.quarter,
+    clock: state.clock,
+    situation: state.situation,
+    offenseTeamId: state.offenseTeamId,
+    defenseTeamId: state.defenseTeamId,
+    call,
+    coverage,
+    participants,
+    outcome: outcome!,
+    yardage: yardage!,
+    tags,
+  };
+}
+
+export function resolvePlay(
+  state: GameState,
+  offense: TeamRuntime,
+  defense: TeamRuntime,
+  rng: SeededRng,
+): PlayEvent {
+  const call = drawOffensiveCall(offense.fingerprint, state.situation, rng);
+  const coverage = drawDefensiveCall(defense.fingerprint, state.situation, rng);
+  const matchups = identifyMatchups(
+    call,
+    coverage,
+    offense.onField,
+    defense.onField,
+  );
+
+  const contributions = matchups.map((m) => {
+    const attackerForFit: PlayerForFit = {
+      neutralBucket: m.attacker.neutralBucket,
+      attributes: m.attacker.attributes,
+    };
+    const defenderForFit: PlayerForFit = {
+      neutralBucket: m.defender.neutralBucket,
+      attributes: m.defender.attributes,
+    };
+
+    return rollMatchup({
+      attacker: m.attacker,
+      defender: m.defender,
+      schemeFitAttacker: computeSchemeFit(attackerForFit, offense.fingerprint),
+      schemeFitDefender: computeSchemeFit(defenderForFit, defense.fingerprint),
+      coaching: {
+        offense: offense.coachingMods,
+        defense: defense.coachingMods,
+      },
+      situation: state.situation,
+      matchupType: m.type,
+      rng,
+    });
+  });
+
+  return synthesizeOutcome(call, coverage, contributions, state, rng);
+}


### PR DESCRIPTION
## Summary

- Implements the deterministic per-play resolution pipeline from ADR 0015: play call → matchup identification → per-matchup attribute rolls → scheme-fit + coaching modifiers → situation modifiers → RNG draw → `PlayEvent`.
- Exports `resolvePlay`, `drawOffensiveCall`, `drawDefensiveCall`, `identifyMatchups`, `rollMatchup`, and `synthesizeOutcome` from `server/features/simulation/resolve-play.ts`.
- Consumes `computeSchemeFit` from the schemes feature as a pure function import — no parallel implementation, no caching.
- Determinism verified: same roster + staff + seed produces byte-identical `PlayEvent` sequences across runs.

Closes #202

🤖 Generated with [Claude Code](https://claude.com/claude-code)