### PR TITLE
docs(north-star): align remaining docs with the genesis-first vision

### DIFF
--- a/docs/product/north-star/coaches.md
+++ b/docs/product/north-star/coaches.md
@@ -807,6 +807,39 @@ On game day, the coaching staff's hidden attributes drive:
 
 ---
 
+## League Genesis
+
+This document describes coaching in a mature Zone Blitz league — candidates
+cycling through the annual coaching carousel, reputations accrued across
+seasons, coaching trees traced through a league with real history.
+
+A brand-new genesis league starts without any of that. See
+[League Genesis](./league-genesis.md); the coaching-specific points:
+
+- **Every coach is generated uniquely per league.** When a league is created,
+  its entire coaching universe is generated alongside it. No recurring names
+  across save files, no shared pool between leagues. The head coach you hire
+  today exists in this league and only this league — a one-of-one with a career
+  arc that will only ever play out here.
+- **Genesis hiring is contested.** A single shared candidate pool is released at
+  league founding, and every franchise (human-run and NPC alike) hires from it
+  at the same time. If you wait on an elite coordinator, an NPC franchise may
+  hire them first. Candidates have preferences — market tier, philosophy,
+  existing staff — and make real choices about where to sign. Multiplayer can
+  produce real-time bidding wars between two human operators for the same head
+  coach.
+- **Gems and busts apply to coaches too.** The uncertainty that shapes the
+  allocation draft applies to staff. The acclaimed veteran may prove rigid. The
+  unheralded position coach may become a future hall-of-fame head coach if
+  someone takes the chance. Your front office is a draft pick, and it hits or
+  misses the same way a first-round player selection does.
+- **No prior coaching tree yet.** The first league-generated coaches become the
+  founders of the league's coaching trees. Over decades, the next generations
+  descend from them — but in Year 1, there are no "Shanahan disciples" or
+  "Belichick branches" yet. That heritage has to be built.
+
+---
+
 ## What Makes Coaching Fun
 
 The coaching system is fun because it creates the most consequential and most

--- a/docs/product/north-star/drafting.md
+++ b/docs/product/north-star/drafting.md
@@ -358,6 +358,32 @@ story that evolves.
 
 ---
 
+## League Genesis
+
+This document describes drafting in a mature Zone Blitz league — rookie classes
+scouted over the preceding year, draft order seeded by prior-season standings, a
+full rookie-draft cycle slotted into the offseason.
+
+Year 1 of a newly founded league is different. See
+[League Genesis](./league-genesis.md) for the canonical rules; the draft-
+specific points:
+
+- **No Year 1 rookie draft.** Every player — including rookie-age talent —
+  enters the league through the founding player pool and the **allocation
+  draft**, which is Year 1's only draft. Draft order is randomized, since no
+  prior standings exist to seed from.
+- **Year 2 is the first real rookie draft.** It uses the core mechanics
+  documented here, with draft order set by Year 1 standings. Every subsequent
+  offseason follows the standard cycle.
+- **Founding-era uncertainty is amplified.** Scouts are brand new, the player
+  pool is a mix of unconventional archetypes (raw college athletes,
+  practice-squad journeymen, back-end vets, middling pros with something to
+  prove), and attributes are normalized to the league's own scale. Gems and
+  busts are more frequent in the allocation draft than in any later rookie draft
+  because no one has evaluation history yet.
+
+---
+
 ## What Makes Drafting Fun
 
 The draft is fun because of **meaningful uncertainty**. You're making

--- a/docs/product/north-star/free-agency-and-contracts.md
+++ b/docs/product/north-star/free-agency-and-contracts.md
@@ -232,3 +232,31 @@ you're not the only one trying to sign the top corner.
   sign-and-trade deals
 - League chat blows up during the free agency frenzy — trash talk, gloating over
   steals, lamenting missed targets
+
+## League Genesis
+
+This document describes free agency in a mature Zone Blitz league — a recurring
+annual cycle with established market tiers, comparable deals, and historical
+precedent setting expectations.
+
+A genesis league's first "free agency" is structurally different. See
+[League Genesis](./league-genesis.md); the FA-specific points:
+
+- **Founding free agency is the mop-up after the allocation draft.** Everyone
+  unsigned from the founding player pool — including rookie-age talent that
+  would be undrafted rookies in a mature league — becomes a free agent at once.
+  There is no distinction between veteran and UDFA pools yet because the league
+  has never distinguished them.
+- **Economics are compressed.** Contracts are short, guaranteed money is modest,
+  and the market has no precedent to anchor against. See
+  [Salary Cap — League Genesis](./salary-cap.md#league-genesis) for the full
+  early-league economic arc.
+- **Year 2 is the first normal free agency.** Once Year 1 ends and the first
+  offseason begins, free agency runs the standard cycle described here —
+  tampering window, frenzy, second wave, comp pick accrual. The stars of Year 1
+  become the league's first real free agents with leverage.
+- **Staff hiring is its own contested market.** Genesis also introduces
+  competitive hiring for coaches and scouts — a shared candidate pool contested
+  across all franchises. See
+  [League Genesis — Staff Hiring](./league-genesis.md#phase-3-staff-hiring) and
+  [Coaches](./coaches.md) for the bidding mechanics.

--- a/docs/product/north-star/game-simulation.md
+++ b/docs/product/north-star/game-simulation.md
@@ -336,6 +336,31 @@ For the season:
 - Power rankings (algorithmic, team strength estimate)
 - Strength of schedule impact
 
+## League Genesis
+
+Zone Blitz's canonical creation flow is a brand-new startup league. See
+[League Genesis](./league-genesis.md) for the full vision. Simulation- specific
+implications:
+
+- **Year 1 has no preseason.** A newly founded league does not have the
+  infrastructure for exhibition games — no prior-year schedule to reference, no
+  media apparatus for preseason coverage, no stadium warm-up tradition. The sim
+  skips the preseason phase entirely in Year 1 and opens with the regular
+  season. Starting in Year 2, preseason runs normally.
+- **Compressed Year 1 regular season.** An 8-team founding league plays a
+  shorter regular-season schedule (~10–12 games) than the standard 17-game
+  season. The sim should treat schedule length as a league parameter rather than
+  a hard-coded 17.
+- **Attributes are normalized per league.** The sim consumes player attributes
+  on their league-local scale — a 90+ rating in a genesis league is the league's
+  top tier, full stop, without reference to any external scale. See
+  [Player Attributes](./player-attributes.md).
+- **Founding-era talent has wider variance.** The founding player pool contains
+  unconventional archetypes with less established production history. Sim
+  outcomes in Year 1 should reflect that — more upside surprises, more
+  disappointing performances from highly-drafted allocation picks, more
+  practice-squad-to-star stories.
+
 ## Related decisions
 
 - [0015 — Simulation resolution model: play-by-play core with fast-mode parity](../decisions/0015-simulation-resolution-model.md)

--- a/docs/product/north-star/league-management.md
+++ b/docs/product/north-star/league-management.md
@@ -5,43 +5,91 @@ and structure within which all the strategic decisions play out. It needs to
 support both single-player franchise experiences and online multiplayer leagues
 seamlessly.
 
+> **The canonical creation flow is League Genesis** — a brand-new startup league
+> that founds small (8 teams by default), runs a one-time genesis sequence, and
+> grows via expansion over many seasons. See
+> [League Genesis](./league-genesis.md) for the full vision. This document
+> covers the league **as a running system** across both a genesis-founded league
+> and an established-mode league.
+
 ## League Modes
 
 ### Single-Player Franchise
 
-You control one team. The other 31 are NPC-controlled. The full experience:
+You control one franchise as its owner/GM. The others are NPC-controlled. The
+full experience:
 
-- Complete control over your team's front office, coaching, and roster
-- NPC teams operate autonomously with distinct AI personalities
+- Complete control over your franchise's front office, coaching, and roster
+- NPC franchises operate autonomously with distinct owner/GM AI personalities
 - Play at your own pace — advance the season whenever you're ready
 - The challenge is building and sustaining a dynasty against competent AI
   opponents over many seasons
 
 ### Multiplayer League
 
-Multiple human GMs, with NPC teams filling remaining slots:
+Multiple human owner/GMs, with NPC franchises filling remaining slots:
 
-- Up to 32 human-controlled teams (one per team)
-- Remaining teams are NPC-controlled
+- Up to one human operator per franchise
+- Remaining franchises are NPC-controlled
 - Commissioner role with league management tools
 - Synchronized season advancement (everyone must be ready to advance)
-- Real-time events: live drafts, trade deadlines, free agency windows
+- Real-time events: live drafts, trade deadlines, free agency windows, expansion
+  votes
 
 ### League Creation Options
 
-When creating a league, the commissioner (or single-player GM) configures:
+When creating a league, the commissioner (or single-player founder) configures:
 
-- **Number of teams**: Standard 32, or custom (24, 28, 36, etc.)
-- **Schedule length**: Standard 17-game season, or custom
-- **Salary cap settings**: Cap amount, growth rate, floor percentage
-- **Draft settings**: Number of rounds, pick timer, trade-up rules
-- **Roster limits**: Active roster size, practice squad size, IR spots
-- **Difficulty / AI aggressiveness**: How tough NPC opponents are
-- **Custom rules**: Optional tweaks to standard NFL-style rules
+- **Creation mode**: **Genesis** (the default — brand-new startup league with a
+  founding sequence; see [League Genesis](./league-genesis.md)) or
+  **Established** (jump into a mature league with fictional history; secondary
+  path)
+- **Founding franchise count**: genesis default is **8**, configurable. The
+  league grows from there via expansion over many seasons — see
+  [Expansion](#expansion) below
+- **Schedule length**: scales with league size. An 8-team league defaults to a
+  shorter regular season (~10–12 games); 32 teams gets the standard 17-game
+  season
+- **Salary cap settings**: cap amount, growth rate, floor percentage
+- **Draft settings**: rounds, pick timer, trade-up rules
+- **Roster limits**: active roster size, practice squad size, IR spots
+- **Difficulty / AI aggressiveness**: how tough NPC opponents are
+- **Custom rules**: optional tweaks to standard NFL-style rules
+
+## Expansion
+
+A genesis-founded league is explicitly designed to grow. Expansion happens
+through an **ownership vote** — every franchise (human-run and NPC alike) gets
+one vote on any expansion proposal. Proposals can originate from any owner,
+including you. If the vote passes, the league runs an expansion cycle
+(establishment of new franchises, an expansion draft protecting/exposing
+existing players, rookie-draft adjustments, and schedule/division realignment)
+between seasons.
+
+Natural scaling milestones unlock structural features as the league grows:
+
+- **12 teams**: three divisions of four; a meaningful unbalanced schedule
+- **16 teams**: four-division conference structure; a full wild-card playoff
+  round
+- **24 teams**: dual-conference structure with full inter-conference play
+- **32 teams**: the canonical "mature league" size
+- **Beyond 32**: expansion can continue for leagues that want a larger footprint
+
+See
+[League Genesis — Expansion Over Time](./league-genesis.md#expansion-over-time)
+for the full narrative and voting mechanics.
 
 ## Season Structure
 
-The season follows a calendar that creates natural pacing and drama:
+The season follows a calendar that creates natural pacing and drama.
+
+> **Year 1 of a genesis league uses a different calendar.** The founding
+> sequence (charter, franchise establishment, staff hiring, founding pool,
+> allocation draft, free agency) replaces the normal offseason, and **Year 1 has
+> no preseason** — the league doesn't yet have the infrastructure for exhibition
+> games. Starting in Year 2, the league settles into the calendar described
+> below. See
+> [League Genesis — The Inaugural Calendar](./league-genesis.md#the-inaugural-calendar).
 
 ### Offseason
 

--- a/docs/product/north-star/npc-ai.md
+++ b/docs/product/north-star/npc-ai.md
@@ -185,6 +185,33 @@ Separate from the front office, coaching AI handles:
 - Development focus — coaches prioritize developing certain players based on the
   team's needs
 
+## League Genesis
+
+In Zone Blitz, the owner and GM are a fused role (see
+[League Genesis](./league-genesis.md)). For NPC franchises, this means a
+**single AI persona** owns the franchise and runs football operations — no
+separate "owner AI" applying pressure to a separate "GM AI." That persona makes
+franchise-level calls (identity, relocation, expansion votes, non-cap spending)
+alongside football-operations calls (roster, cap, draft, trades, coaching hires)
+from the same personality model.
+
+Genesis-era NPC behavior adds specific responsibilities:
+
+- **Expansion voting.** When an expansion proposal is tabled, every NPC persona
+  casts a vote according to its personality and self-interest — a small-market,
+  conservative persona may vote against talent dilution; an ambitious persona
+  may welcome a larger stage; a recently-successful persona may want to lock in
+  structural advantages before new teams catch up.
+- **Contested staff hiring.** NPC personas compete against you and each other
+  for the shared candidate pool of coaches and scouts during Phase 3 of genesis.
+  They pursue hires with the same urgency you do — a good hire for them is one
+  you don't get.
+- **Founding-era philosophy.** Each NPC franchise declares a build philosophy at
+  genesis (win-now, build-through-the-draft, balanced) that shapes
+  decision-making in the allocation draft and early free-agency windows.
+  Philosophy should feel like a consistent lens, not a switch that flips every
+  offseason.
+
 ## What Makes Good NPC AI
 
 The best NPC AI creates **stories**:

--- a/docs/product/north-star/player-attributes.md
+++ b/docs/product/north-star/player-attributes.md
@@ -8,15 +8,54 @@ incomplete lens of your coaches and scouts.
 
 ## Design Philosophy
 
+### Attributes are normalized to _this_ league
+
+The first thing to understand about Zone Blitz attributes: the scale is
+**league-local**, not an external measurement against real-world professional
+football. A 95 in your league is the best in your league, period — not a
+guarantee that the player would be a 95 in the NFL or any other reference
+league.
+
+In particular: a young [genesis league](./league-genesis.md) draws from a
+founding player pool that is genuinely more modest than the NFL's talent
+population — raw college athletes, practice-squad journeymen, back-end vets,
+middling pros looking for a new shot. The league normalizes attributes across
+that pool anyway, because that's the talent the league actually has. The
+league's top quarterback in Year 1 rates as a top quarterback, full stop.
+Whether he would have started in the NFL is not a question this game needs to
+answer — and, realistically, a 90+ player in a young Zone Blitz league is
+probably closer to an NFL starter than an NFL superstar in absolute terms.
+
+This matters because:
+
+- **The scale floats with the league's talent level.** A league that has
+  accumulated twenty years of generational rookies has a different effective
+  ceiling than a Year 1 genesis league — even though both use the same 0-100
+  range.
+- **Comparisons across saves are meaningless.** The 95 QB in your current save
+  is not directly comparable to the 95 QB in your friend's save. Each league's
+  attributes reflect that league's talent distribution.
+- **Stars are stars within their league.** The simulation, media, awards, and
+  record book all treat league-top attributes as the top. The league doesn't
+  hedge its own superlatives against external reality.
+- **As the league matures, the ceiling rises.** Later-generation draftees,
+  coached by the league's accumulated knowledge, pass on improved development to
+  the generation after them. The absolute level of the league's best players
+  grows over decades of simulated play.
+
+The real-world references below are **illustrative scale anchors, not literal
+equivalences.** They help calibrate the feel of each tier, not promise that an
+85 in your league would actually be Patrick Mahomes in ours.
+
 ### A true 0-100 scale
 
 Most sports games treat 0-100 as a 50-100 scale in disguise. A "50 overall"
 player is the worst player in the game — which raises the question: what are
 0-49 for? This game uses the full range, and every number means something.
 
-The scale is calibrated to professional football:
+The scale is calibrated to professional football within the current league:
 
-| Range     | What it means                                                  | Real-world example                         |
+| Range     | What it means                                                  | Scale anchor (illustrative only)           |
 | --------- | -------------------------------------------------------------- | ------------------------------------------ |
 | 95-100    | Generational. One per decade at a position, maybe.             | Peak Tom Brady, Joe Montana, Walter Payton |
 | 85-94     | Elite. Perennial All-Pro, franchise-defining.                  | Patrick Mahomes, prime Aaron Donald        |
@@ -29,10 +68,10 @@ The scale is calibrated to professional football:
 | 1-14      | Shouldn't be on a professional football field.                 | Guy off the street                         |
 | 0         | Horrendous. Cannot perform this skill at a professional level. | A punter trying to play linebacker         |
 
-**50 is the line.** Above it, you're a starter somewhere in this league. Below
-it, you're fighting for your job. The further above 50, the harder you are to
-replace. The further below, the more your team is hoping the guy behind you
-develops.
+**50 is the line — within your league.** Above it, you're a starter somewhere in
+this league. Below it, you're fighting for your job. A young league whose 50s
+and 60s would be 30s and 40s on an NFL scale doesn't care: inside the league,
+those ratings mark the starter/backup boundary all the same.
 
 ### Bell curve distribution
 

--- a/docs/product/north-star/salary-cap.md
+++ b/docs/product/north-star/salary-cap.md
@@ -518,6 +518,34 @@ authentic.
 
 ---
 
+## League Genesis
+
+The cap and contract structure described above applies to a mature Zone Blitz
+league. A brand-new genesis league operates under a deliberately compressed
+economic regime that evolves as the league proves itself. See
+[League Genesis](./league-genesis.md) for the full vision; the cap-specific
+points:
+
+- **Early-league economics are flat.** For the first several seasons, contracts
+  are short, guaranteed money is modest, and no class of mega-deals distorts the
+  market. A young league has no television contract funding record-setting cap
+  growth, players are taking bets on an unproven institution, and no one has
+  accumulated the leverage that produces franchise-defining deals.
+- **The starting cap is level.** Every franchise enters Year 1 with the same cap
+  space. The allocation draft and founding free agency are the only moment in
+  league history when the financial playing field is perfectly even.
+- **The cap curve bends upward as the league matures.** Free-agency cycles
+  produce stars with real leverage. Expansion and media interest grow league
+  revenue. The cap itself grows with them, and a generation of football in
+  produces the league's first genuinely franchise-defining contracts — moments
+  that matter precisely because the player's career was built entirely inside
+  this league's record.
+- **Non-cap spending still applies.** Facilities, scouting department size,
+  analytics infrastructure — all of it is funded outside the cap and differs by
+  market and operator choice, exactly as in a mature league.
+
+---
+
 ## What Makes Cap Management Fun
 
 Cap management is fun when it creates **meaningful strategic choices with

--- a/docs/product/north-star/schemes-and-strategy.md
+++ b/docs/product/north-star/schemes-and-strategy.md
@@ -1544,6 +1544,14 @@ and both are roster decisions.
 This creates one of the game's deepest strategic questions: do you hire coaches
 who fit your current players, or draft players who fit the coaches you want?
 
+In a genesis league (see [League Genesis](./league-genesis.md)), this question
+lands at league founding: you hire your staff _before_ the allocation draft, so
+your staff's scheme preferences actively shape which founding-pool players fit
+your roster. The coordinator you pick in Phase 3 is betting on the players
+you'll draft in Phase 5, and the founding-pool archetypes (raw college athletes,
+practice-squad journeymen, back-end vets, middling pros) won't all fit every
+scheme equally.
+
 ---
 
 ## Related decisions

--- a/docs/product/north-star/scouting.md
+++ b/docs/product/north-star/scouting.md
@@ -789,7 +789,33 @@ your approach over time based on actual results.
 
 ---
 
-## What Makes Scouting Fun
+## League Genesis
+
+This document describes scouting in a mature Zone Blitz league. In a brand-new
+genesis league, scouting starts from zero — no accuracy track record, no
+long-tenured scouts, no prior draft classes to calibrate against. See
+[League Genesis](./league-genesis.md) for the full context; the scouting-
+specific points:
+
+- **Scouts are generated uniquely per league.** Same rule as coaches — the
+  entire scouting universe is generated at league creation and never shared
+  across save files. The scouts you hire at founding are one-of-one evaluators
+  whose careers will only play out in this league.
+- **Genesis hiring is contested.** Scouts are part of the same shared candidate
+  pool as coaches and are hired in parallel across all franchises. See
+  [Coaches — League Genesis](./coaches.md#league-genesis) for how the bidding
+  works.
+- **Year 1 scouting covers the founding player pool.** The first evaluation work
+  your scouts do is on the veteran pool heading into the allocation draft — an
+  unusual pool of archetypes (raw college athletes, practice- squad journeymen,
+  back-end vets, middling pros) that no scouting methodology has ever calibrated
+  against. Gems and busts are more frequent here than in any later evaluation
+  cycle.
+- **The first rookie-class scouting cycle runs through Year 1.** While the
+  league is playing its inaugural season, your scouts are evaluating the rookie
+  class that will be drafted in the Year 2 offseason — the first true rookie
+  draft in league history. Scouting department investment made during genesis
+  hiring directly shapes the quality of those reports.
 
 Scouting is fun because it's a **skill you develop as a player**, not just a
 system you optimize. In year 1, you're guessing. By year 5, you've learned which

--- a/docs/product/north-star/statistics.md
+++ b/docs/product/north-star/statistics.md
@@ -94,3 +94,8 @@ players carry their stats.
   stats are its exhaust.
 - **[Media](./media.md):** narratives, grades, and awards draw on stats but are
   not stats themselves.
+- **[League Genesis](./league-genesis.md):** Year 1 of a genesis league runs a
+  shorter regular season and no preseason, so stat distributions for the
+  inaugural year will look different than Year 2+. The league's first
+  statistical leaders are the first ever — every leaderboard entry in a genesis
+  league's record book was written by a human or NPC operator at this table.

--- a/docs/product/north-star/trading.md
+++ b/docs/product/north-star/trading.md
@@ -182,3 +182,22 @@ In multiplayer, the system should discourage but not over-police:
 - Transparent trade history lets the league self-police
 - NPC teams never make lopsided trades, so the AI sets a baseline for
   "reasonable"
+
+## League Genesis
+
+Trading applies the same way in both genesis and established leagues — the
+mechanics are identical. A few genesis-specific notes worth flagging (see
+[League Genesis](./league-genesis.md) for full context):
+
+- **There are no trades during Year 1's allocation draft or founding free
+  agency.** Trade markets open once the regular season begins and operate
+  normally from there.
+- **Draft-pick trading for the Year 2 rookie draft is live during Year 1.** The
+  first real rookie draft is coming, and picks in it can be traded as soon as
+  the Year 1 regular season begins. Year 2 draft order is still unset until Year
+  1 standings resolve, which adds real uncertainty to valuing those picks
+  mid-season.
+- **Expansion drafts have their own protection/exposure rules** (see
+  [League Management — Expansion](./league-management.md#expansion)), not
+  standard trade mechanics. A franchise cannot trade its way out of exposing
+  players to an expansion draft.


### PR DESCRIPTION
## Summary

- Adds a \"League Genesis\" section to every north-star doc the genesis vision materially changes, plus backlinks on the docs that are genesis-neutral but benefit from pointing at league-genesis.md for context
- **drafting.md / coaches.md / scouting.md**: allocation draft is Year 1's only draft, Year 2 is the first real rookie draft, every coach and scout is generated uniquely per league, genesis hiring is contested, gems/busts apply to staff
- **league-management.md**: canonical creation flow is genesis (8-team default), expansion mechanics via ownership vote, scaling milestones from 8 → 32, Year 1 calendar has no preseason
- **salary-cap.md / free-agency-and-contracts.md**: early-league economics are flat, starting cap is level, the curve bends upward as the league matures
- **game-simulation.md**: Year 1 has no preseason and a compressed regular season, attributes are normalized per league, founding-era talent has wider variance
- **player-attributes.md**: new \"Attributes are normalized to _this_ league\" subsection establishing the scale is league-local, not an external measurement
- **statistics.md / npc-ai.md / schemes-and-strategy.md / trading.md**: backlinks and targeted genesis notes where each system interacts with the genesis flow

This completes step 3 of the genesis-first north-star rollout. Next: file the foundational ADRs that ratify the decisions these docs now assert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)