### PR TITLE
docs(adr): file foundational league-genesis ADRs

### DIFF
--- a/docs/product/decisions/0017-league-genesis-default-creation-flow.md
+++ b/docs/product/decisions/0017-league-genesis-default-creation-flow.md
@@ -1,0 +1,62 @@
+# 0017 — League genesis as the default creation flow
+
+- **Date:** 2026-04-15
+- **Status:** Proposed
+- **Area:** [League Genesis](../north-star/league-genesis.md),
+  [League Management](../north-star/league-management.md)
+
+## Context
+
+Most franchise sims hand the user a league that already has fifty years of
+fictional history. Zone Blitz's north-star vision is the opposite: every new
+league is a brand-new startup league (XFL/UFL/AAF-style) that founds small,
+grows via expansion, and generates its entire history from Year 1 forward.
+
+[League Genesis](../north-star/league-genesis.md) documents this vision in
+detail. This ADR ratifies the headline decision: _genesis is the canonical
+creation flow, not an optional mode_. Every other genesis-related decision
+(phase state machine, per-league unique coaches, allocation draft, expansion
+voting, etc.) descends from this one.
+
+## Decision
+
+**Zone Blitz's canonical league-creation flow is League Genesis: a brand-new
+startup league that founds with a small number of franchises (default 8), runs a
+one-time genesis phase sequence, and grows via expansion over many seasons.**
+Established-mode league creation (mature league with fictional pre-generated
+history) remains available as a secondary path but is not the default and is not
+where we invest product work first.
+
+## Alternatives considered
+
+- **Established mode as the default.** The pattern other franchise sims follow.
+  Rejected because it forecloses the founding-era story that is Zone Blitz's
+  most distinctive design bet, and because simulated pre-history produces a
+  "borrowed" weight rather than one the user earned.
+- **Both modes equal.** Supporting both paths as first-class experiences.
+  Rejected because it doubles design and UI surface area and fragments follow-up
+  ADRs (every genesis mechanic would need an established-mode parallel). Making
+  genesis canonical keeps decisions coherent; established mode can be a
+  derivative of the same systems.
+- **Genesis as the only mode.** Simpler, but closes the door on users who
+  explicitly want to drop into a mature league with immediate depth. Keeping
+  established mode available preserves that option without investing in it as
+  the default.
+
+## Consequences
+
+- **Makes easier:** coherent decision-making across north-star systems (staff
+  hiring, drafting, salary cap, free agency, schedule) — each can optimize for
+  the genesis flow and document deltas for the established path.
+- **Makes easier:** onboarding. A founder-facing UI that walks through 8
+  franchises, a handful of staff hires, and one allocation draft is less
+  intimidating than 32 franchises and multiple drafts at creation time.
+- **Makes harder:** the 32-team-league-day-one use case. Users who want the
+  classic experience will need to opt into established mode and accept that it
+  is the secondary path.
+- **Follow-up work:** ADR 0018 (genesis phase state machine) and ADR 0019
+  (inaugural Year 1 calendar) ratify the structural mechanics this decision
+  implies. Additional ADRs will cover per-league unique coach/scout generation,
+  contested staff hiring, founding pool composition, allocation-draft-only Year
+  1, expansion by ownership vote, and early-league salary economics — tracked as
+  follow-up issues.

--- a/docs/product/decisions/0018-genesis-phase-state-machine.md
+++ b/docs/product/decisions/0018-genesis-phase-state-machine.md
@@ -1,0 +1,69 @@
+# 0018 — Genesis phase state machine
+
+- **Date:** 2026-04-15
+- **Status:** Proposed
+- **Area:** [League Genesis](../north-star/league-genesis.md),
+  [League Management](../north-star/league-management.md),
+  [0014 — Season calendar and phase state machine](./0014-season-calendar-phase-state-machine.md)
+
+## Context
+
+ADR 0017 ratifies League Genesis as the canonical creation flow. Genesis
+introduces a one-shot sequence of setup phases — league charter, franchise
+establishment, staff hiring, founding player pool, allocation draft, free
+agency, kickoff — that doesn't exist in subsequent offseasons.
+
+ADR 0014 defines the recurring season-calendar state machine as an ordered phase
+enum + per-phase step catalog on a single `league_clock` row, with
+user-initiated advance and gated transitions. Genesis requires distinct entry
+phases that run exactly once, before any recurring calendar starts. Without a
+ratified extension, implementations will either hack genesis into the recurring
+offseason (conceptually wrong) or build a parallel state machine (duplicated
+logic, drift risk).
+
+## Decision
+
+**Extend ADR 0014's phase enum with a one-shot genesis phase sequence that runs
+exactly once per league, before the first preseason/regular-season cycle.** The
+genesis phases — `GENESIS_CHARTER`, `GENESIS_FRANCHISE_ESTABLISHMENT`,
+`GENESIS_STAFF_HIRING`, `GENESIS_FOUNDING_POOL`, `GENESIS_ALLOCATION_DRAFT`,
+`GENESIS_FREE_AGENCY`, `GENESIS_KICKOFF` — share the same `league_clock` row and
+the same user-initiated-advance / gated-transition rules as recurring phases. A
+`has_completed_genesis` (or equivalent) flag on the clock row prevents the
+genesis phases from re-entering after the first transition into Year 2.
+
+## Alternatives considered
+
+- **Separate `genesis_clock` table/state machine.** Cleanly isolates one- shot
+  phases from recurring ones. Rejected because it duplicates advance logic,
+  ready-check enforcement, and UI components; any future change to advance rules
+  has to be made twice.
+- **Fold genesis steps into the recurring offseason as special first-year
+  branches.** Reuses the recurring state machine. Rejected because the phases
+  are semantically different (charter and franchise establishment have no analog
+  in Year 2+) and the branching logic would bloat every recurring phase.
+- **Treat genesis as out-of-band pre-league setup (no clock row until Year 1
+  kickoff).** Simple, but loses the shared advance/ready-check mechanics that
+  multiplayer genesis needs. A league being founded collectively by eight human
+  owner/GMs is exactly the kind of gated multi-step process the clock state
+  machine was built for.
+
+## Consequences
+
+- **Makes easier:** one advance mechanism, one ready-check mechanism, one
+  transition API used uniformly across genesis and recurring phases. UI for
+  "ready up" on a genesis step works the same as for a regular-season week.
+- **Makes easier:** testing — genesis can be driven by the same phase-advance
+  test harness ADR 0014 establishes.
+- **Makes harder:** phase enum grows (seven additional values) and each new
+  genesis phase needs its own step catalog. Worth it for the uniformity.
+- **Follow-up work:**
+  - Implement the genesis phases against ADR 0014's `league_clock` schema;
+    extend the phase enum migration
+  - Define the step catalog for each genesis phase (what counts as "done" before
+    the phase can advance — e.g., all franchises established, all staff hired,
+    allocation draft complete)
+  - Wire the `has_completed_genesis` guard into the phase-advance handler so
+    Year 2+ can never re-enter a genesis phase
+  - Seed existing established-mode leagues (if any are created) with a
+    post-genesis clock state to skip the sequence cleanly

--- a/docs/product/decisions/0019-inaugural-year-one-calendar.md
+++ b/docs/product/decisions/0019-inaugural-year-one-calendar.md
@@ -1,0 +1,91 @@
+# 0019 — Inaugural Year 1 calendar (no preseason)
+
+- **Date:** 2026-04-15
+- **Status:** Proposed
+- **Area:** [League Genesis](../north-star/league-genesis.md),
+  [League Management](../north-star/league-management.md),
+  [Game Simulation](../north-star/game-simulation.md),
+  [0014 — Season calendar and phase state machine](./0014-season-calendar-phase-state-machine.md),
+  [0018 — Genesis phase state machine](./0018-genesis-phase-state-machine.md)
+
+## Context
+
+Zone Blitz's canonical league-creation flow (ADR 0017) produces a brand-new
+startup league with genesis-era phases running before Year 1 kickoff. The
+recurring calendar documented in
+[League Management](../north-star/league-management.md) assumes a mature league
+with preseason, an established weekly cadence, and a 17-game season scaled for
+32 teams.
+
+That calendar doesn't apply verbatim to Year 1 of a genesis league. A startup
+league has no preseason infrastructure (no stadium test runs, no media apparatus
+for exhibition coverage, no prior-year schedule to reference) and an 8-team
+league plays a compressed regular season. Without a ratified Year 1 calendar,
+implementations will either run a nonsensical "preseason" in Year 1 or silently
+skip phases the state machine still expects to visit.
+
+## Decision
+
+**Year 1 of a genesis league follows a distinct calendar:**
+
+1. **Founding window** — the genesis phase sequence from ADR 0018 runs (charter
+   → franchise establishment → staff hiring → founding pool → allocation draft →
+   free agency → kickoff). This replaces the normal offseason.
+2. **Brief training camp** — the single evaluation window before Week 1. Roster
+   cuts happen here.
+3. **No preseason games in Year 1.** The `PRESEASON` phase is skipped entirely
+   the first time around; the clock advances directly from genesis kickoff into
+   the regular season.
+4. **Regular season scaled to league size** — an 8-team league defaults to
+   ~10–12 games; schedule length is a league parameter, not a hard-coded 17.
+   Plays on the standard weekly cadence.
+5. **Playoffs and championship** — the first-ever playoffs and the first league
+   championship.
+6. **First real offseason (post-Year-1)** — the league enters the normal
+   recurring calendar. The **first true rookie draft** happens here, ordered by
+   Year 1 standings.
+
+**Year 2 and beyond use the standard recurring calendar** documented in League
+Management, including preseason, which the league now has the institutional
+infrastructure to run. Genesis-era phases are one-shot and do not recur.
+
+## Alternatives considered
+
+- **Run a normal preseason in Year 1 too.** Consistent with Year 2+, and gives
+  the sim an extra evaluation window. Rejected because it breaks the
+  startup-league fiction (you don't have preseason stadiums booked in the same
+  offseason you founded the franchise), and because an 8-team league running a
+  4-game preseason + 12-game regular season + playoffs has too much abstracted
+  football crammed into Year 1.
+- **Skip preseason forever.** Rejected because preseason carries real mechanical
+  weight in Year 2+ (depth-chart battles, bubble-player evaluation, cut-downs)
+  that the league should have once the infrastructure exists. Year 1 is the
+  exception, not the rule.
+- **Hard-code a 17-game Year 1 regular season regardless of league size.**
+  Rejected because it makes 8-team leagues play either absurdly repetitive
+  schedules (every opponent ~2.4 times) or drawn-out seasons that dilute the
+  novelty of founding-era football.
+
+## Consequences
+
+- **Makes easier:** the genesis narrative lands cleanly — founding, training
+  camp, kickoff, season. No confusing exhibition-game block in the middle.
+- **Makes easier:** scheduling — schedule length as a league parameter
+  generalizes to expansion cycles (when the league grows from 8 to 12, the
+  schedule naturally lengthens) without special cases.
+- **Makes harder:** the phase state machine has to branch on
+  `has_completed_genesis` (from ADR 0018) when advancing past kickoff: in Year 1
+  it goes directly to REGULAR_SEASON, in Year 2+ it goes through PRESEASON. The
+  advance-handler tests must cover both branches.
+- **Makes harder:** stats normalization — Year 1 produces a shorter season so
+  leaderboard thresholds and awards eligibility have to account for game count
+  variability. This also applies to expansion-era seasons as the league grows.
+- **Follow-up work:**
+  - Implement the Year 1 → Year 2 calendar branch in the phase-advance handler
+  - Surface `scheduleLength` as a league setting, driven by franchise count,
+    with explicit override allowed
+  - Update statistics systems to handle variable regular-season length (already
+    partially implied by `[statistics.md]`'s genesis backlink)
+  - UI: make Year 1's missing preseason explicit rather than silent — the
+    season-overview screen should show "No preseason (inaugural year)" instead
+    of an empty preseason tab

--- a/docs/product/decisions/README.md
+++ b/docs/product/decisions/README.md
@@ -52,3 +52,11 @@ as superseded.
   — parent `contracts` + `contract_years` + `contract_bonus_prorations`; pure
   `computeCapHit` / `computeDeadCap`; void years in, post-June-1 and incentives
   deferred (Proposed)
+- [0017 — League genesis as the default creation flow](./0017-league-genesis-default-creation-flow.md)
+  — genesis is canonical; established mode is the secondary path (Proposed)
+- [0018 — Genesis phase state machine](./0018-genesis-phase-state-machine.md) —
+  extends ADR 0014 with a one-shot genesis phase sequence sharing the same
+  `league_clock` row (Proposed)
+- [0019 — Inaugural Year 1 calendar (no preseason)](./0019-inaugural-year-one-calendar.md)
+  — Year 1 skips preseason and uses a compressed regular season scaled to league
+  size; Year 2+ uses the recurring calendar (Proposed)

--- a/docs/product/north-star/league-genesis.md
+++ b/docs/product/north-star/league-genesis.md
@@ -803,3 +803,9 @@ season coverage patterns. See [Media](./media.md).
 - "There was no preseason in Year 1 — the league didn't have one yet. We went
   straight from training camp into a Week 1 that nobody had a read on. Half the
   league's depth charts looked nothing like what people expected."
+
+## Related decisions
+
+- [0017 — League genesis as the default creation flow](../decisions/0017-league-genesis-default-creation-flow.md)
+- [0018 — Genesis phase state machine](../decisions/0018-genesis-phase-state-machine.md)
+- [0019 — Inaugural Year 1 calendar (no preseason)](../decisions/0019-inaugural-year-one-calendar.md)

--- a/docs/product/north-star/league-management.md
+++ b/docs/product/north-star/league-management.md
@@ -215,3 +215,6 @@ made is recorded, and you can look back and trace the consequences.
 ## Related decisions
 
 - [0014 — Season calendar and phase state machine](../decisions/0014-season-calendar-phase-state-machine.md)
+- [0017 — League genesis as the default creation flow](../decisions/0017-league-genesis-default-creation-flow.md)
+- [0018 — Genesis phase state machine](../decisions/0018-genesis-phase-state-machine.md)
+- [0019 — Inaugural Year 1 calendar (no preseason)](../decisions/0019-inaugural-year-one-calendar.md)


### PR DESCRIPTION
## Summary

- **ADR 0017**: ratifies League Genesis as the canonical league-creation flow; established mode remains available but is the secondary path
- **ADR 0018**: extends ADR 0014's phase state machine with a one-shot genesis phase sequence (charter → franchise establishment → staff hiring → founding pool → allocation draft → free agency → kickoff) sharing the same \`league_clock\` row
- **ADR 0019**: documents the inaugural Year 1 calendar — no preseason, compressed regular season scaled to league size, first real rookie draft deferred to the Year 2 offseason
- All three filed as **Proposed**. Backlinks added from league-genesis.md, league-management.md, and the decisions README
- Follow-up ADRs (per-league unique coach/scout generation, contested staff hiring, founding pool composition, allocation-draft-only Year 1, expansion by ownership vote, early-league salary economics) will be tracked as GitHub issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)