### PR TITLE
feat(data): add passing-plays and rushing-plays calibration bands

### DIFF
--- a/data/R/bands/passing-plays.R
+++ b/data/R/bands/passing-plays.R
@@ -1,0 +1,168 @@
+#!/usr/bin/env Rscript
+# passing-plays.R — per-play passing distributions.
+#
+# For calibrating the pass-play outcome tree in
+# server/features/simulation/resolve-play.ts (synthesizeOutcome). Captures:
+#
+#   - Dropback outcome mix (completion, incompletion, sack, interception,
+#     scramble) — the rates a sim pass play should resolve to.
+#   - Yardage distributions by outcome — completion yards, sack yards,
+#     air yards, yards after catch — to tune the yardage buckets in the
+#     synthesizer.
+#   - Big-play rate (20+ yard completions) per dropback.
+#   - Outcome mix by down/distance context so the sim can reflect that
+#     long-down dropbacks sack more and complete less.
+#
+# Usage:
+#   Rscript data/R/bands/passing-plays.R [--seasons 2020:2024]
+
+suppressPackageStartupMessages({
+  library(nflreadr)
+  library(dplyr)
+})
+
+script_file <- (function() {
+  args <- commandArgs(trailingOnly = FALSE)
+  f <- grep("^--file=", args, value = TRUE)
+  if (length(f) > 0) normalizePath(sub("^--file=", "", f[1]), mustWork = FALSE) else NULL
+})()
+source(file.path(dirname(script_file), "..", "lib.R"))
+
+args <- commandArgs(trailingOnly = TRUE)
+seasons <- parse_seasons(args)
+
+cat("Loading pbp for seasons:", paste(range(seasons), collapse = "-"), "\n")
+pbp <- nflreadr::load_pbp(seasons)
+
+# A "dropback" is any pass play including sacks and scrambles — the QB
+# intended to pass. This is the denominator the sim's pass branch needs.
+dropbacks <- pbp |>
+  filter(
+    season_type == "REG",
+    qb_dropback == 1,
+    qb_kneel == 0,
+    qb_spike == 0,
+    is.na(two_point_conv_result)
+  ) |>
+  mutate(
+    outcome = case_when(
+      sack == 1                         ~ "sack",
+      interception == 1                 ~ "interception",
+      qb_scramble == 1                  ~ "scramble",
+      complete_pass == 1                ~ "complete",
+      incomplete_pass == 1              ~ "incomplete",
+      TRUE                              ~ "other"
+    ),
+    down_distance_bucket = case_when(
+      is.na(down)                       ~ "unknown",
+      down == 1                         ~ "1st",
+      down == 2 & ydstogo <= 3          ~ "2nd_short",
+      down == 2 & ydstogo >= 7          ~ "2nd_long",
+      down == 2                         ~ "2nd_medium",
+      down == 3 & ydstogo <= 3          ~ "3rd_short",
+      down == 3 & ydstogo >= 7          ~ "3rd_long",
+      down == 3                         ~ "3rd_medium",
+      down == 4                         ~ "4th",
+      TRUE                              ~ "other"
+    )
+  )
+
+cat("Dropbacks analyzed:", nrow(dropbacks), "\n")
+
+# ---- Outcome mix ----------------------------------------------------------
+
+outcome_counts <- dropbacks |>
+  count(outcome) |>
+  mutate(rate = n / sum(n))
+
+outcome_mix <- setNames(
+  lapply(seq_len(nrow(outcome_counts)), function(i) {
+    list(n = outcome_counts$n[i], rate = outcome_counts$rate[i])
+  }),
+  outcome_counts$outcome
+)
+
+# ---- Outcome mix by down/distance ----------------------------------------
+
+outcome_by_bucket <- dropbacks |>
+  count(down_distance_bucket, outcome) |>
+  group_by(down_distance_bucket) |>
+  mutate(rate = n / sum(n)) |>
+  ungroup()
+
+outcome_mix_by_bucket <- split(outcome_by_bucket, outcome_by_bucket$down_distance_bucket) |>
+  lapply(function(df) {
+    setNames(
+      lapply(seq_len(nrow(df)), function(i) {
+        list(n = df$n[i], rate = df$rate[i])
+      }),
+      df$outcome
+    )
+  })
+
+# ---- Yardage distributions by outcome ------------------------------------
+
+yardage_distributions <- list(
+  completion_yards       = distribution_summary(dropbacks$yards_gained[dropbacks$outcome == "complete"]),
+  sack_yards             = distribution_summary(dropbacks$yards_gained[dropbacks$outcome == "sack"]),
+  scramble_yards         = distribution_summary(dropbacks$yards_gained[dropbacks$outcome == "scramble"]),
+  air_yards_all_targeted = distribution_summary(dropbacks$air_yards[!is.na(dropbacks$air_yards)]),
+  air_yards_completions  = distribution_summary(dropbacks$air_yards[dropbacks$outcome == "complete"]),
+  yac_completions        = distribution_summary(dropbacks$yards_after_catch[dropbacks$outcome == "complete"])
+)
+
+# ---- Big-play rate -------------------------------------------------------
+
+big_play_20 <- dropbacks |>
+  filter(outcome == "complete") |>
+  summarise(
+    completions = n(),
+    big_plays_20 = sum(yards_gained >= 20, na.rm = TRUE),
+    rate = big_plays_20 / completions
+  )
+
+big_play_40 <- dropbacks |>
+  filter(outcome == "complete") |>
+  summarise(
+    completions = n(),
+    big_plays_40 = sum(yards_gained >= 40, na.rm = TRUE),
+    rate = big_plays_40 / completions
+  )
+
+# ---- Write the band ------------------------------------------------------
+
+summaries <- list(
+  outcome_mix = outcome_mix,
+  outcome_mix_by_down_distance = outcome_mix_by_bucket,
+  yardage = yardage_distributions,
+  big_play_rate = list(
+    twenty_plus_per_completion = list(
+      completions = big_play_20$completions,
+      big_plays = big_play_20$big_plays_20,
+      rate = big_play_20$rate
+    ),
+    forty_plus_per_completion = list(
+      completions = big_play_40$completions,
+      big_plays = big_play_40$big_plays_40,
+      rate = big_play_40$rate
+    )
+  )
+)
+
+out_path <- file.path(repo_root(), "data", "bands", "passing-plays.json")
+
+write_band(
+  out_path,
+  seasons,
+  summaries,
+  notes = paste0(
+    "Regular-season dropbacks only (qb_dropback == 1), excluding kneels, ",
+    "spikes, and two-point conversions. Outcome is a mutually-exclusive ",
+    "classification per dropback: sack > interception > scramble > complete ",
+    "> incomplete. down_distance_bucket splits 2nd/3rd downs into short (<=3), ",
+    "medium (4-6), long (>=7). Yardage distributions are conditional on the ",
+    "outcome (e.g., completion_yards is only over completed passes)."
+  )
+)
+
+cat("Wrote", out_path, "\n")

--- a/data/R/bands/rushing-plays.R
+++ b/data/R/bands/rushing-plays.R
@@ -1,0 +1,140 @@
+#!/usr/bin/env Rscript
+# rushing-plays.R — per-play rushing distributions.
+#
+# For calibrating the rush branch of the sim's synthesizer. Captures:
+#
+#   - Overall rush yardage distribution.
+#   - Yardage by down/distance and by field zone (backed-up, midfield,
+#     red zone) so the sim can reflect that red-zone runs look different.
+#   - Big-play rate (10+, 20+, 40+ yard gains) per rush.
+#   - Stuff rate (0 or negative yard runs) per rush.
+#   - Fumble rate per rush and per rush TD.
+#
+# Note: splitting QB designed runs from RB/WR runs requires a roster position
+# join — see issue #248 (position stat concentration) for that work.
+#
+# Usage:
+#   Rscript data/R/bands/rushing-plays.R [--seasons 2020:2024]
+
+suppressPackageStartupMessages({
+  library(nflreadr)
+  library(dplyr)
+})
+
+script_file <- (function() {
+  args <- commandArgs(trailingOnly = FALSE)
+  f <- grep("^--file=", args, value = TRUE)
+  if (length(f) > 0) normalizePath(sub("^--file=", "", f[1]), mustWork = FALSE) else NULL
+})()
+source(file.path(dirname(script_file), "..", "lib.R"))
+
+args <- commandArgs(trailingOnly = TRUE)
+seasons <- parse_seasons(args)
+
+cat("Loading pbp for seasons:", paste(range(seasons), collapse = "-"), "\n")
+pbp <- nflreadr::load_pbp(seasons)
+
+# Rushes include designed QB runs but exclude scrambles (those are pass plays).
+# Kneels and spikes are excluded even though kneels are technically rushes.
+rushes <- pbp |>
+  filter(
+    season_type == "REG",
+    rush == 1,
+    qb_scramble == 0,
+    qb_kneel == 0,
+    is.na(two_point_conv_result)
+  ) |>
+  mutate(
+    down_distance_bucket = case_when(
+      is.na(down)                       ~ "unknown",
+      down == 1                         ~ "1st",
+      down == 2 & ydstogo <= 3          ~ "2nd_short",
+      down == 2 & ydstogo >= 7          ~ "2nd_long",
+      down == 2                         ~ "2nd_medium",
+      down == 3 & ydstogo <= 3          ~ "3rd_short",
+      down == 3 & ydstogo >= 7          ~ "3rd_long",
+      down == 3                         ~ "3rd_medium",
+      down == 4 & ydstogo <= 2          ~ "4th_short",
+      down == 4                         ~ "4th_long",
+      TRUE                              ~ "other"
+    ),
+    field_zone = case_when(
+      is.na(yardline_100)               ~ "unknown",
+      yardline_100 >= 90                ~ "own_deep",
+      yardline_100 >= 50                ~ "own_side",
+      yardline_100 >= 20                ~ "opp_side",
+      yardline_100 >= 10                ~ "red_zone_outer",
+      TRUE                              ~ "red_zone_inner"
+    )
+  )
+
+cat("Rushes analyzed:", nrow(rushes), "\n")
+
+# ---- Overall yardage distribution -----------------------------------------
+
+overall <- distribution_summary(rushes$yards_gained)
+
+# ---- By down/distance -----------------------------------------------------
+
+by_bucket <- split(rushes$yards_gained, rushes$down_distance_bucket) |>
+  lapply(distribution_summary)
+
+# ---- By field zone --------------------------------------------------------
+
+by_zone <- split(rushes$yards_gained, rushes$field_zone) |>
+  lapply(distribution_summary)
+
+# ---- Big-play and stuff rates --------------------------------------------
+
+rate_stats <- rushes |>
+  summarise(
+    n             = n(),
+    stuffs        = sum(yards_gained <= 0, na.rm = TRUE),
+    gains_5plus   = sum(yards_gained >= 5, na.rm = TRUE),
+    gains_10plus  = sum(yards_gained >= 10, na.rm = TRUE),
+    gains_20plus  = sum(yards_gained >= 20, na.rm = TRUE),
+    gains_40plus  = sum(yards_gained >= 40, na.rm = TRUE),
+    touchdowns    = sum(rush_touchdown == 1, na.rm = TRUE),
+    fumbles       = sum(fumble == 1, na.rm = TRUE),
+    fumbles_lost  = sum(fumble_lost == 1, na.rm = TRUE)
+  )
+
+rates <- list(
+  n_rushes                   = rate_stats$n,
+  stuff_rate                 = rate_stats$stuffs / rate_stats$n,
+  gain_5_plus_rate           = rate_stats$gains_5plus / rate_stats$n,
+  gain_10_plus_rate          = rate_stats$gains_10plus / rate_stats$n,
+  gain_20_plus_rate          = rate_stats$gains_20plus / rate_stats$n,
+  gain_40_plus_rate          = rate_stats$gains_40plus / rate_stats$n,
+  touchdown_rate             = rate_stats$touchdowns / rate_stats$n,
+  fumble_rate                = rate_stats$fumbles / rate_stats$n,
+  fumble_lost_rate           = rate_stats$fumbles_lost / rate_stats$n
+)
+
+# ---- Write the band ------------------------------------------------------
+
+summaries <- list(
+  overall = overall,
+  by_down_distance = by_bucket,
+  by_field_zone = by_zone,
+  rates = rates
+)
+
+out_path <- file.path(repo_root(), "data", "bands", "rushing-plays.json")
+
+write_band(
+  out_path,
+  seasons,
+  summaries,
+  notes = paste0(
+    "Regular-season rushes only (rush == 1), excluding QB scrambles (those ",
+    "are classified as dropbacks in passing-plays.json), kneels, and two-",
+    "point conversions. down_distance_bucket splits non-1st downs into short ",
+    "(<=3 or <=2 on 4th), medium (4-6), long (>=7). field_zone uses ",
+    "yardline_100 (yards from opponent endzone): own_deep >=90, own_side ",
+    "50-89, opp_side 20-49, red_zone_outer 10-19, red_zone_inner <10. ",
+    "rates are per-rush fractions over the full window."
+  )
+)
+
+cat("Wrote", out_path, "\n")

--- a/data/README.md
+++ b/data/README.md
@@ -54,19 +54,33 @@ without depending on network or R at test time. Regenerate them when:
   split, completion %, YPA, YPC, sacks, turnovers, penalties, points). Each
   metric carries mean, standard deviation, and percentile breakpoints
   (p10/p25/p50/p75/p90) plus min/max, across all team-games in the window.
+- **`passing-plays.json`** — per-dropback outcome tree and yardage
+  distributions. Captures the rate at which a pass attempt resolves to
+  complete/incomplete/sack/interception/scramble (overall and broken out by
+  down/distance bucket), plus conditional yardage distributions (completion
+  yards, sack yards, scramble yards, air yards, YAC), plus big-play rates (20+
+  and 40+ yard completions). This is the direct calibration source for the pass
+  branch of the sim's play synthesizer.
+- **`rushing-plays.json`** — per-rush yardage distribution overall, by
+  down/distance bucket, and by field zone (own_deep / own_side / opp_side /
+  red_zone_outer / red_zone_inner), plus stuff rate, gain-threshold rates
+  (5+/10+/20+/40+), touchdown rate, and fumble rates. Direct calibration source
+  for the rush branch of the sim's play synthesizer.
 
 ## Planned bands (follow-up work)
 
 These map to
-[`docs/product/north-star/game-simulation.md`](../docs/product/north-star/game-simulation.md#calibration):
+[`docs/product/north-star/game-simulation.md`](../docs/product/north-star/game-simulation.md#calibration)
+and are tracked as GitHub issues labeled `ready-for-agent`:
 
-- Situational rates (4th-down go-for-it by field zone, 2-point attempts by score
-  diff, onside kick attempt/recovery rates)
-- Special-teams outcomes (FG success by distance bucket, punt net yards
-  distribution, kickoff return distribution, return-TD rate)
-- Position stat concentration (RB1/RB2/RB3 carry share, WR1/WR2/slot target
-  share, CB1 coverage share)
-- Injury rates by position (separate source — `nflverse` injury tables)
+- **Situational rates** (#246) — 4th-down go-for-it by field zone, 2-point
+  attempts by score diff, onside kick attempt/recovery rates
+- **Special-teams outcomes** (#247) — FG success by distance bucket, punt net
+  yards distribution, kickoff return distribution, return-TD rate
+- **Position stat concentration** (#248) — RB1/RB2/RB3 carry share, WR1/WR2/slot
+  target share, CB1 coverage share
+- **Injury rates by position** (#249) — separate source (`nflverse` injury
+  tables)
 
 ## Why R
 

--- a/data/bands/passing-plays.json
+++ b/data/bands/passing-plays.json
@@ -1,0 +1,293 @@
+{
+  "generated_at": "2026-04-15T17:16:16Z",
+  "seasons": [2020, 2021, 2022, 2023, 2024],
+  "notes": "Regular-season dropbacks only (qb_dropback == 1), excluding kneels, spikes, and two-point conversions. Outcome is a mutually-exclusive classification per dropback: sack > interception > scramble > complete > incomplete. down_distance_bucket splits 2nd/3rd downs into short (<=3), medium (4-6), long (>=7). Yardage distributions are conditional on the outcome (e.g., completion_yards is only over completed passes).",
+  "bands": {
+    "outcome_mix": {
+      "complete": {
+        "n": 58919,
+        "rate": 0.5791
+      },
+      "incomplete": {
+        "n": 29586,
+        "rate": 0.2908
+      },
+      "interception": {
+        "n": 2070,
+        "rate": 0.0203
+      },
+      "sack": {
+        "n": 6400,
+        "rate": 0.0629
+      },
+      "scramble": {
+        "n": 4775,
+        "rate": 0.0469
+      }
+    },
+    "outcome_mix_by_down_distance": {
+      "1st": {
+        "complete": {
+          "n": 22900,
+          "rate": 0.6122
+        },
+        "incomplete": {
+          "n": 10440,
+          "rate": 0.2791
+        },
+        "interception": {
+          "n": 681,
+          "rate": 0.0182
+        },
+        "sack": {
+          "n": 1834,
+          "rate": 0.049
+        },
+        "scramble": {
+          "n": 1550,
+          "rate": 0.0414
+        }
+      },
+      "2nd_long": {
+        "complete": {
+          "n": 14550,
+          "rate": 0.6074
+        },
+        "incomplete": {
+          "n": 6544,
+          "rate": 0.2732
+        },
+        "interception": {
+          "n": 462,
+          "rate": 0.0193
+        },
+        "sack": {
+          "n": 1330,
+          "rate": 0.0555
+        },
+        "scramble": {
+          "n": 1068,
+          "rate": 0.0446
+        }
+      },
+      "2nd_medium": {
+        "complete": {
+          "n": 4228,
+          "rate": 0.5995
+        },
+        "incomplete": {
+          "n": 2061,
+          "rate": 0.2922
+        },
+        "interception": {
+          "n": 112,
+          "rate": 0.0159
+        },
+        "sack": {
+          "n": 334,
+          "rate": 0.0474
+        },
+        "scramble": {
+          "n": 318,
+          "rate": 0.0451
+        }
+      },
+      "2nd_short": {
+        "complete": {
+          "n": 2076,
+          "rate": 0.6133
+        },
+        "incomplete": {
+          "n": 984,
+          "rate": 0.2907
+        },
+        "interception": {
+          "n": 46,
+          "rate": 0.0136
+        },
+        "sack": {
+          "n": 150,
+          "rate": 0.0443
+        },
+        "scramble": {
+          "n": 129,
+          "rate": 0.0381
+        }
+      },
+      "3rd_long": {
+        "complete": {
+          "n": 7309,
+          "rate": 0.5018
+        },
+        "incomplete": {
+          "n": 4523,
+          "rate": 0.3105
+        },
+        "interception": {
+          "n": 383,
+          "rate": 0.0263
+        },
+        "sack": {
+          "n": 1500,
+          "rate": 0.103
+        },
+        "scramble": {
+          "n": 850,
+          "rate": 0.0584
+        }
+      },
+      "3rd_medium": {
+        "complete": {
+          "n": 3885,
+          "rate": 0.499
+        },
+        "incomplete": {
+          "n": 2537,
+          "rate": 0.3258
+        },
+        "interception": {
+          "n": 194,
+          "rate": 0.0249
+        },
+        "sack": {
+          "n": 723,
+          "rate": 0.0929
+        },
+        "scramble": {
+          "n": 447,
+          "rate": 0.0574
+        }
+      },
+      "3rd_short": {
+        "complete": {
+          "n": 2820,
+          "rate": 0.5456
+        },
+        "incomplete": {
+          "n": 1613,
+          "rate": 0.3121
+        },
+        "interception": {
+          "n": 100,
+          "rate": 0.0193
+        },
+        "sack": {
+          "n": 355,
+          "rate": 0.0687
+        },
+        "scramble": {
+          "n": 281,
+          "rate": 0.0544
+        }
+      },
+      "4th": {
+        "complete": {
+          "n": 1151,
+          "rate": 0.4731
+        },
+        "incomplete": {
+          "n": 884,
+          "rate": 0.3633
+        },
+        "interception": {
+          "n": 92,
+          "rate": 0.0378
+        },
+        "sack": {
+          "n": 174,
+          "rate": 0.0715
+        },
+        "scramble": {
+          "n": 132,
+          "rate": 0.0543
+        }
+      }
+    },
+    "yardage": {
+      "completion_yards": {
+        "n": 58919,
+        "mean": 10.9629,
+        "sd": 9.8643,
+        "min": -24,
+        "p10": 2,
+        "p25": 5,
+        "p50": 8,
+        "p75": 14,
+        "p90": 22,
+        "max": 98
+      },
+      "sack_yards": {
+        "n": 6400,
+        "mean": -6.6952,
+        "sd": 3.6667,
+        "min": -30,
+        "p10": -11,
+        "p25": -9,
+        "p50": -7,
+        "p75": -4,
+        "p90": -1,
+        "max": 0
+      },
+      "scramble_yards": {
+        "n": 4775,
+        "mean": 7.4197,
+        "sd": 5.9958,
+        "min": -1,
+        "p10": 2,
+        "p25": 3,
+        "p50": 6,
+        "p75": 10,
+        "p90": 14,
+        "max": 61
+      },
+      "air_yards_all_targeted": {
+        "n": 90566,
+        "mean": 7.7893,
+        "sd": 10.1285,
+        "min": -20,
+        "p10": -3,
+        "p25": 1,
+        "p50": 5,
+        "p75": 12,
+        "p90": 21,
+        "max": 65
+      },
+      "air_yards_completions": {
+        "n": 58918,
+        "mean": 5.7771,
+        "sd": 8.4193,
+        "min": -14,
+        "p10": -3,
+        "p25": 0,
+        "p50": 4,
+        "p75": 9,
+        "p90": 17,
+        "max": 62
+      },
+      "yac_completions": {
+        "n": 58917,
+        "mean": 5.179,
+        "sd": 6.6566,
+        "min": -11,
+        "p10": 0,
+        "p25": 1,
+        "p50": 3,
+        "p75": 7,
+        "p90": 13,
+        "max": 87
+      }
+    },
+    "big_play_rate": {
+      "twenty_plus_per_completion": {
+        "completions": 58919,
+        "big_plays": 8050,
+        "rate": 0.1366
+      },
+      "forty_plus_per_completion": {
+        "completions": 58919,
+        "big_plays": 1319,
+        "rate": 0.0224
+      }
+    }
+  }
+}

--- a/data/bands/rushing-plays.json
+++ b/data/bands/rushing-plays.json
@@ -1,0 +1,214 @@
+{
+  "generated_at": "2026-04-15T17:17:23Z",
+  "seasons": [2020, 2021, 2022, 2023, 2024],
+  "notes": "Regular-season rushes only (rush == 1), excluding QB scrambles (those are classified as dropbacks in passing-plays.json), kneels, and two-point conversions. down_distance_bucket splits non-1st downs into short (<=3 or <=2 on 4th), medium (4-6), long (>=7). field_zone uses yardline_100 (yards from opponent endzone): own_deep >=90, own_side 50-89, opp_side 20-49, red_zone_outer 10-19, red_zone_inner <10. rates are per-rush fractions over the full window.",
+  "bands": {
+    "overall": {
+      "n": 67046,
+      "mean": 4.2165,
+      "sd": 6.1134,
+      "min": -28,
+      "p10": 0,
+      "p25": 1,
+      "p50": 3,
+      "p75": 6,
+      "p90": 10,
+      "max": 98
+    },
+    "by_down_distance": {
+      "1st": {
+        "n": 37134,
+        "mean": 4.299,
+        "sd": 6.0845,
+        "min": -20,
+        "p10": 0,
+        "p25": 1,
+        "p50": 3,
+        "p75": 6,
+        "p90": 10,
+        "max": 98
+      },
+      "2nd_long": {
+        "n": 9643,
+        "mean": 4.5834,
+        "sd": 6.3683,
+        "min": -12,
+        "p10": 0,
+        "p25": 1,
+        "p50": 3,
+        "p75": 6,
+        "p90": 10,
+        "max": 82
+      },
+      "2nd_medium": {
+        "n": 6273,
+        "mean": 4.2477,
+        "sd": 6.0337,
+        "min": -12,
+        "p10": 0,
+        "p25": 1,
+        "p50": 3,
+        "p75": 6,
+        "p90": 10,
+        "max": 74
+      },
+      "2nd_short": {
+        "n": 5805,
+        "mean": 3.7116,
+        "sd": 5.4101,
+        "min": -11,
+        "p10": 0,
+        "p25": 1,
+        "p50": 2,
+        "p75": 5,
+        "p90": 9,
+        "max": 72
+      },
+      "3rd_long": {
+        "n": 1162,
+        "mean": 5.6997,
+        "sd": 6.7339,
+        "min": -7,
+        "p10": 0,
+        "p25": 2,
+        "p50": 5,
+        "p75": 8,
+        "p90": 13,
+        "max": 74
+      },
+      "3rd_medium": {
+        "n": 786,
+        "mean": 4.729,
+        "sd": 7.214,
+        "min": -9,
+        "p10": 0,
+        "p25": 1,
+        "p50": 3,
+        "p75": 6,
+        "p90": 10,
+        "max": 72
+      },
+      "3rd_short": {
+        "n": 4899,
+        "mean": 3.4146,
+        "sd": 6.2655,
+        "min": -9,
+        "p10": 0,
+        "p25": 0,
+        "p50": 2,
+        "p75": 4,
+        "p90": 8,
+        "max": 79
+      },
+      "4th_long": {
+        "n": 90,
+        "mean": 4.6667,
+        "sd": 12.4341,
+        "min": -28,
+        "p10": -2,
+        "p25": 0,
+        "p50": 3,
+        "p75": 5.75,
+        "p90": 14.5,
+        "max": 73
+      },
+      "4th_short": {
+        "n": 1248,
+        "mean": 2.5513,
+        "sd": 4.8808,
+        "min": -23,
+        "p10": 0,
+        "p25": 0,
+        "p50": 2,
+        "p75": 3,
+        "p90": 6,
+        "max": 50
+      },
+      "unknown": {
+        "n": 6,
+        "mean": 0,
+        "sd": 0,
+        "min": 0,
+        "p10": 0,
+        "p25": 0,
+        "p50": 0,
+        "p75": 0,
+        "p90": 0,
+        "max": 0
+      }
+    },
+    "by_field_zone": {
+      "opp_side": {
+        "n": 20596,
+        "mean": 4.3773,
+        "sd": 5.898,
+        "min": -12,
+        "p10": 0,
+        "p25": 1,
+        "p50": 3,
+        "p75": 6,
+        "p90": 11,
+        "max": 49
+      },
+      "own_deep": {
+        "n": 2109,
+        "mean": 4.3594,
+        "sd": 6.6267,
+        "min": -10,
+        "p10": 0,
+        "p25": 1,
+        "p50": 3,
+        "p75": 6,
+        "p90": 10,
+        "max": 98
+      },
+      "own_side": {
+        "n": 33020,
+        "mean": 4.6388,
+        "sd": 6.7828,
+        "min": -28,
+        "p10": 0,
+        "p25": 1,
+        "p50": 3,
+        "p75": 6,
+        "p90": 11,
+        "max": 87
+      },
+      "red_zone_inner": {
+        "n": 5802,
+        "mean": 1.6746,
+        "sd": 2.3876,
+        "min": -12,
+        "p10": -1,
+        "p25": 0,
+        "p50": 1,
+        "p75": 3,
+        "p90": 5,
+        "max": 9
+      },
+      "red_zone_outer": {
+        "n": 5519,
+        "mean": 3.7077,
+        "sd": 4.2399,
+        "min": -20,
+        "p10": -1,
+        "p25": 1,
+        "p50": 3,
+        "p75": 6,
+        "p90": 10,
+        "max": 19
+      }
+    },
+    "rates": {
+      "n_rushes": 67082,
+      "stuff_rate": 0.2003,
+      "gain_5_plus_rate": 0.3366,
+      "gain_10_plus_rate": 0.1049,
+      "gain_20_plus_rate": 0.0228,
+      "gain_40_plus_rate": 0.0045,
+      "touchdown_rate": 0.0348,
+      "fumble_rate": 0.0156,
+      "fumble_lost_rate": 0.0065
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- Adds `data/bands/passing-plays.json` — full per-dropback outcome tree (complete 57.9% / incomplete 29.1% / sack 6.3% / INT 2.0% / scramble 4.7%), outcome mix broken out by down/distance bucket, conditional yardage distributions (completion yards mean 10.96 / sd 9.86 / p90 22.0, sack yards, scramble yards, air yards, YAC), and big-play rates (13.7% of completions are 20+ yards, 1.0% are 40+). Sourced from 101,750 regular-season dropbacks, 2020–2024.
- Adds `data/bands/rushing-plays.json` — per-rush yardage distribution overall (mean 4.22, sd 6.11, p50 3, p90 10) and broken out by down/distance and field zone (red_zone_inner YPC 1.68 vs. own_side 4.64), plus stuff rate (20.0%), gain thresholds (10+ 10.5%, 20+ 2.3%, 40+ 0.45%), touchdown rate (3.5%), and fumble rates. Sourced from 67,082 regular-season rushes, 2020–2024.
- These are the direct calibration sources for the pass and rush branches of `server/features/simulation/resolve-play.ts` — the current hand-tuned `rng.int()` yardage buckets can now be tested against real NFL distributions.

Follow-up bands tracked as #246 (situational) / #247 (special teams) / #248 (position concentration) / #249 (injuries).