### PR TITLE
docs(adr): deprecate established mode; genesis is the only creation flow

### DIFF
--- a/docs/product/decisions/0017-league-genesis-default-creation-flow.md
+++ b/docs/product/decisions/0017-league-genesis-default-creation-flow.md
@@ -1,7 +1,8 @@
 # 0017 — League genesis as the default creation flow
 
 - **Date:** 2026-04-15
-- **Status:** Accepted
+- **Status:** Superseded by
+  [0021 — Deprecate established mode; genesis is the only creation flow](./0021-deprecate-established-mode.md)
 - **Area:** [League Genesis](../north-star/league-genesis.md),
   [League Management](../north-star/league-management.md)
 

--- a/docs/product/decisions/0018-genesis-phase-state-machine.md
+++ b/docs/product/decisions/0018-genesis-phase-state-machine.md
@@ -64,6 +64,6 @@ genesis phases from re-entering after the first transition into Year 2.
     the phase can advance — e.g., all franchises established, all staff hired,
     allocation draft complete)
   - Wire the `has_completed_genesis` guard into the phase-advance handler so
-    Year 2+ can never re-enter a genesis phase
-  - Seed existing established-mode leagues (if any are created) with a
-    post-genesis clock state to skip the sequence cleanly
+    Year 2+ can never re-enter a genesis phase. The flag is set only by the
+    `GENESIS_KICKOFF → PRESEASON` transition; per ADR 0021, no alternate seed
+    path exists.

--- a/docs/product/decisions/0021-deprecate-established-mode.md
+++ b/docs/product/decisions/0021-deprecate-established-mode.md
@@ -1,0 +1,95 @@
+# 0021 — Deprecate established mode; genesis is the only creation flow
+
+- **Date:** 2026-04-15
+- **Status:** Accepted
+- **Supersedes:**
+  [0017 — League genesis as the default creation flow](./0017-league-genesis-default-creation-flow.md)
+- **Area:** [League Genesis](../north-star/league-genesis.md),
+  [League Management](../north-star/league-management.md)
+
+## Context
+
+ADR 0017 made League Genesis the canonical creation flow while keeping
+"established mode" — dropping the user into a mature league with pre-generated
+fictional history — available as a secondary path. That compromise has not aged
+well:
+
+- **Dual-path framing leaks everywhere.** North-star docs keep drawing contrasts
+  against established mode ("in an established league, you inherit…"), which
+  reframes genesis as _a_ mode rather than _the_ mode.
+- **Every system inherits a shadow spec.** Trading, salary cap, drafting, and
+  league management each carry "how this works in established mode" caveats that
+  we never intend to build. Each caveat is a tax on both the docs and on
+  decision-making.
+- **ADR 0018 carries a dead-weight branch.** The `has_completed_genesis` flag
+  exists solely so established-mode leagues can skip genesis. If no league is
+  ever created in established mode, the flag and its handling are pure
+  complexity.
+- **The scrappy-upstart identity is the product.** Genesis is not the default
+  choice among viable creation flows — it is the creative premise of Zone Blitz.
+  Leaving an established-mode escape hatch signals that the premise is
+  negotiable, which undercuts it.
+
+ADR 0017's "established mode as secondary path" framing has never been invested
+in and is not going to be. Keeping it on the books as a supported mode creates
+alignment drift with no offsetting benefit.
+
+## Decision
+
+**Established mode is removed from the product. Every Zone Blitz league is
+created through League Genesis. There is no alternate creation flow.**
+
+Concretely:
+
+- The north-star docs describe a single creation path: genesis. No dual-path
+  framing, no "in an established league…" contrasts, no "this works the same in
+  both modes" disclaimers.
+- The phase state machine (ADR 0018) assumes every league begins in
+  `GENESIS_CHARTER`. The `has_completed_genesis` flag on `league_clock` is still
+  used to guard Year 2+ against re-entering genesis phases, but it is only ever
+  set by completing genesis — never seeded by a bypass path.
+- Creation UI has one entry point: "Create League" → genesis. There is no mode
+  toggle, no "Start with a mature league" option, no established-mode preset.
+- Follow-up systems (trading, free agency, cap, drafting, staff hiring) drop any
+  established-mode caveats. Each system documents one experience: the one a
+  genesis-founded league lives through.
+
+## Alternatives considered
+
+- **Keep ADR 0017 as-is (established mode available but not invested in).**
+  Status quo. Rejected because the dual-path framing is actively harmful to doc
+  and product coherence even when the second path is unbuilt. A mode that ships
+  as "technically supported but not recommended" is worse than one that doesn't
+  ship.
+- **Ship established mode as a first-class alternative.** Rejected again, for
+  the same reasons ADR 0017 rejected it: doubled design surface, fragmented
+  decisions, and dilution of the scrappy-upstart identity that is Zone Blitz's
+  distinctive bet.
+- **Defer the decision; let the code decide.** Rejected because docs and
+  decision-making are already paying the dual-path tax, and every new ADR has to
+  decide whether to acknowledge established mode. Collapsing the ambiguity now
+  is cheaper than collapsing it later.
+
+## Consequences
+
+- **Makes easier:** every downstream system documents one flow. No "how this
+  works in established mode" appendices. Each north-star doc gets shorter and
+  more opinionated.
+- **Makes easier:** onboarding and UI. No mode toggle on Create League. No
+  preset selector. The founder's first decision is "what's the league called,"
+  not "which kind of league do I want."
+- **Makes easier:** ADR 0018's state-machine story. `has_completed_genesis`
+  becomes a simple latch set by the `GENESIS_KICKOFF → PRESEASON` transition; no
+  alternate seed path to reason about.
+- **Makes harder:** the 32-team-day-one use case is no longer served. A user who
+  wants a mature league has to play one into existence — which is the intended
+  Zone Blitz experience, but will disappoint users who come in expecting a
+  classic-sim start.
+- **Follow-up work:**
+  - Update ADR 0017 status to Superseded with a pointer to this ADR.
+  - Amend ADR 0018 to drop the "seed established-mode leagues with post-genesis
+    clock state" follow-up bullet.
+  - Sweep the north-star docs (`league-genesis.md`, `league-management.md`,
+    `trading.md`) to remove dual-path framing and established-mode interaction
+    sections.
+  - When creation UI is implemented, it has one path. No mode toggle.

--- a/docs/product/decisions/README.md
+++ b/docs/product/decisions/README.md
@@ -53,7 +53,8 @@ as superseded.
   `computeCapHit` / `computeDeadCap`; void years in, post-June-1 and incentives
   deferred (Proposed)
 - [0017 — League genesis as the default creation flow](./0017-league-genesis-default-creation-flow.md)
-  — genesis is canonical; established mode is the secondary path (Accepted)
+  — genesis is canonical; established mode is the secondary path (Superseded
+  by 0021)
 - [0018 — Genesis phase state machine](./0018-genesis-phase-state-machine.md) —
   extends ADR 0014 with a one-shot genesis phase sequence sharing the same
   `league_clock` row (Accepted)
@@ -62,3 +63,6 @@ as superseded.
   size; Year 2+ uses the recurring calendar (Accepted)
 - [0020 — Phase-gated sidebar navigation](./0020-phase-gated-sidebar-navigation.md)
   — UI sidebar surfaces are gated by the active league phase (Proposed)
+- [0021 — Deprecate established mode; genesis is the only creation flow](./0021-deprecate-established-mode.md)
+  — removes the established-mode escape hatch; every league begins at genesis
+  (Accepted, supersedes 0017)

--- a/docs/product/north-star/league-genesis.md
+++ b/docs/product/north-star/league-genesis.md
@@ -80,18 +80,19 @@ is the design, not a gap to fill later.
 
 ### Genesis is about declaration, not management
 
-In an established league, you inherit: a roster, a cap situation, a fan base
-with expectations. During genesis, you _found_: name the stadium, pick the
+Later-league GMs manage what they already have: a roster, a cap situation, a fan
+base with expectations. During genesis, you _found_: name the stadium, pick the
 colors, choose a build philosophy, select the franchise cornerstone. The tone of
 decision-making is different, and the UI should reflect that — genesis screens
 are about declaration, not management.
 
-### Established mode still exists
+### Genesis is the only way a league begins
 
-Some players will want to skip genesis and jump into a mature league with
-fictional history. That mode is supported too (see
-[League Management](./league-management.md)), but it is the secondary path.
-Genesis is the default and the canonical experience.
+There is no alternate creation flow. Zone Blitz does not offer a "jump into a
+mature league with fictional history" mode. Every league — single-player or
+multiplayer — begins at genesis and earns its history one season at a time. See
+[0021 — Deprecate established mode](../decisions/0021-deprecate-established-mode.md)
+for the decision that retired the old dual-path framing.
 
 ---
 
@@ -544,8 +545,8 @@ As the league grows, previously-locked structural features unlock:
 - **16 teams**: four-division conference structure; a full wild-card playoff
   round
 - **24 teams**: dual-conference structure with full inter-conference play
-- **32 teams**: the canonical "mature league" size — the structure most
-  established-mode leagues ship with
+- **32 teams**: the canonical "mature league" size — the structure most other
+  franchise sims ship with at creation time
 - **Beyond 32**: expansion can continue for leagues that want a larger
   footprint, though returns diminish and scheduling complexity grows
 
@@ -569,13 +570,6 @@ Expansion is not a quiet administrative event. It's a league moment:
 
 A league that expands from 8 to 16 over twenty seasons has a richer history than
 a league that was 16 the whole time. The growth itself is part of the record.
-
-### Interaction with established mode
-
-Players who skip genesis and start in established mode pick their final league
-size up front — no expansion arc, no founding-era history. That mode remains
-available, but it trades away one of the things that makes the genesis path
-distinctive.
 
 ---
 
@@ -677,8 +671,8 @@ kickoff occurs, the commissioner role settles into its standard shape.
 Genesis is where franchise identity is first declared. Everything in
 [Teams & Branding](./teams-and-branding.md) applies from the moment a franchise
 is established — colors theme the dashboard, market tier shapes appeal and
-pressure, stadium name anchors lore. Relocation remains an established-league
-event; it does not occur during genesis.
+pressure, stadium name anchors lore. Relocation is a later-league event; it does
+not occur during genesis.
 
 ### Drafting
 
@@ -807,5 +801,7 @@ season coverage patterns. See [Media](./media.md).
 ## Related decisions
 
 - [0017 — League genesis as the default creation flow](../decisions/0017-league-genesis-default-creation-flow.md)
+  (superseded by 0021)
 - [0018 — Genesis phase state machine](../decisions/0018-genesis-phase-state-machine.md)
 - [0019 — Inaugural Year 1 calendar (no preseason)](../decisions/0019-inaugural-year-one-calendar.md)
+- [0021 — Deprecate established mode; genesis is the only creation flow](../decisions/0021-deprecate-established-mode.md)

--- a/docs/product/north-star/league-management.md
+++ b/docs/product/north-star/league-management.md
@@ -40,10 +40,6 @@ Multiple human owner/GMs, with NPC franchises filling remaining slots:
 
 When creating a league, the commissioner (or single-player founder) configures:
 
-- **Creation mode**: **Genesis** (the default — brand-new startup league with a
-  founding sequence; see [League Genesis](./league-genesis.md)) or
-  **Established** (jump into a mature league with fictional history; secondary
-  path)
 - **Founding franchise count**: genesis default is **8**, configurable. The
   league grows from there via expansion over many seasons — see
   [Expansion](#expansion) below

--- a/docs/product/north-star/league-management.md
+++ b/docs/product/north-star/league-management.md
@@ -9,8 +9,8 @@ seamlessly.
 > that founds small (8 teams by default), runs a one-time genesis sequence, and
 > grows via expansion over many seasons. See
 > [League Genesis](./league-genesis.md) for the full vision. This document
-> covers the league **as a running system** across both a genesis-founded league
-> and an established-mode league.
+> covers the league **as a running system** from Year 2 onward, once genesis has
+> completed and the league has entered its recurring annual rhythm.
 
 ## League Modes
 

--- a/docs/product/north-star/trading.md
+++ b/docs/product/north-star/trading.md
@@ -185,8 +185,8 @@ In multiplayer, the system should discourage but not over-police:
 
 ## League Genesis
 
-Trading applies the same way in both genesis and established leagues — the
-mechanics are identical. A few genesis-specific notes worth flagging (see
+Every league starts at genesis, so trading's baseline is the inaugural year. A
+few genesis-specific notes worth flagging (see
 [League Genesis](./league-genesis.md) for full context):
 
 - **There are no trades during Year 1's allocation draft or founding free


### PR DESCRIPTION
## Summary

- Files **ADR 0021** superseding ADR 0017. Every Zone Blitz league now begins at genesis — there is no alternate "jump into a mature league" flow. The established-mode escape hatch is removed from the product.
- **Sweeps the north-star docs** to eliminate dual-path framing: `league-genesis.md` loses the "Established mode still exists" subsection and the "Interaction with established mode" section; `league-management.md` loses the Creation-mode toggle and reframes itself as a Year-2-onward document; `trading.md` drops the "applies the same way in both modes" line.
- **Amends ADR 0018**: `has_completed_genesis` is now only ever set by the `GENESIS_KICKOFF → PRESEASON` transition. No seed path for established-mode leagues, because there are none.
- Flips **ADR 0017** to Superseded with a pointer to 0021; updates the decisions README accordingly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)