### PR TITLE
feat(data): add position stat concentration bands

### DIFF
--- a/data/R/bands/position-concentration.R
+++ b/data/R/bands/position-concentration.R
@@ -1,0 +1,215 @@
+#!/usr/bin/env Rscript
+# position-concentration.R — per-position stat concentration bands.
+#
+# Computes how much of a team's season totals flow to the top-1, top-3,
+# and top-5 players at each position group. This captures the "star
+# concentration" pattern the sim's assignment logic must reproduce:
+# RB1 carries the load, WR1/WR2 soak most targets, etc.
+#
+# Metrics:
+#   - RB carry share (top-1/3/5 % of team carries)
+#   - RB target share
+#   - WR target share
+#   - TE target share
+#   - QB attempt share (starter vs. backup)
+#   - LB tackle share
+#   - CB snap share (from load_snap_counts)
+#
+# Usage:
+#   Rscript data/R/bands/position-concentration.R [--seasons 2020:2024]
+
+suppressPackageStartupMessages({
+  library(nflreadr)
+  library(dplyr)
+})
+
+script_file <- (function() {
+  args <- commandArgs(trailingOnly = FALSE)
+  f <- grep("^--file=", args, value = TRUE)
+  if (length(f) > 0) normalizePath(sub("^--file=", "", f[1]), mustWork = FALSE) else NULL
+})()
+source(file.path(dirname(script_file), "..", "lib.R"))
+
+args <- commandArgs(trailingOnly = TRUE)
+seasons <- parse_seasons(args)
+
+cat("Loading player stats for seasons:", paste(range(seasons), collapse = "-"), "\n")
+player_stats <- nflreadr::load_player_stats(seasons)
+
+reg_stats <- player_stats |>
+  filter(season_type == "REG")
+
+cat("Regular-season player-week rows:", nrow(reg_stats), "\n")
+
+# Aggregate to per-player per-team-season totals.
+player_season <- reg_stats |>
+  group_by(season, team, player_id, player_name, position, position_group) |>
+  summarise(
+    carries         = sum(carries, na.rm = TRUE),
+    targets         = sum(targets, na.rm = TRUE),
+    receptions      = sum(receptions, na.rm = TRUE),
+    pass_attempts   = sum(attempts, na.rm = TRUE),
+    tackles         = sum(def_tackles_solo, na.rm = TRUE) +
+                      sum(def_tackles_with_assist, na.rm = TRUE),
+    .groups = "drop"
+  )
+
+# --- Helper: compute top-k share for a metric within a position group --------
+#
+# For each team-season, ranks players by the metric descending, then computes
+# the share of the team-season total going to the top-1, top-3, and top-5.
+# Returns one row per team-season with share columns.
+compute_topk_share <- function(data, pos_filter, metric_col, min_team_total = 10) {
+  pos_data <- data |>
+    filter(position_group %in% pos_filter, .data[[metric_col]] > 0)
+
+  team_totals <- pos_data |>
+    group_by(season, team) |>
+    summarise(team_total = sum(.data[[metric_col]], na.rm = TRUE), .groups = "drop") |>
+    filter(team_total >= min_team_total)
+
+  ranked <- pos_data |>
+    inner_join(team_totals, by = c("season", "team")) |>
+    group_by(season, team) |>
+    arrange(desc(.data[[metric_col]]), .by_group = TRUE) |>
+    mutate(rank = row_number()) |>
+    ungroup()
+
+  ranked |>
+    group_by(season, team, team_total) |>
+    summarise(
+      top1 = sum(.data[[metric_col]][rank <= 1], na.rm = TRUE),
+      top3 = sum(.data[[metric_col]][rank <= 3], na.rm = TRUE),
+      top5 = sum(.data[[metric_col]][rank <= 5], na.rm = TRUE),
+      .groups = "drop"
+    ) |>
+    mutate(
+      top1_share = top1 / team_total,
+      top3_share = top3 / team_total,
+      top5_share = top5 / team_total
+    )
+}
+
+# --- Offensive concentration -------------------------------------------------
+
+cat("Computing RB carry share...\n")
+rb_carry <- compute_topk_share(player_season, "RB", "carries")
+
+cat("Computing RB target share...\n")
+rb_target <- compute_topk_share(player_season, "RB", "targets")
+
+cat("Computing WR target share...\n")
+wr_target <- compute_topk_share(player_season, "WR", "targets")
+
+cat("Computing TE target share...\n")
+te_target <- compute_topk_share(player_season, "TE", "targets")
+
+cat("Computing QB attempt share...\n")
+qb_attempt <- compute_topk_share(player_season, "QB", "pass_attempts", min_team_total = 100)
+
+# --- Defensive concentration -------------------------------------------------
+
+cat("Computing LB tackle share...\n")
+lb_tackle <- compute_topk_share(player_season, "LB", "tackles")
+
+# --- CB snap share from load_snap_counts() -----------------------------------
+
+cat("Loading snap counts for CB snap share...\n")
+snaps <- nflreadr::load_snap_counts(seasons)
+
+cb_snaps <- snaps |>
+  filter(
+    game_type == "REG",
+    position %in% c("CB", "DB")
+  ) |>
+  group_by(season, team, player, pfr_player_id) |>
+  summarise(
+    defense_snaps = sum(defense_snaps, na.rm = TRUE),
+    .groups = "drop"
+  )
+
+cb_team_totals <- cb_snaps |>
+  group_by(season, team) |>
+  summarise(team_total = sum(defense_snaps, na.rm = TRUE), .groups = "drop") |>
+  filter(team_total > 0)
+
+cb_ranked <- cb_snaps |>
+  inner_join(cb_team_totals, by = c("season", "team")) |>
+  group_by(season, team) |>
+  arrange(desc(defense_snaps), .by_group = TRUE) |>
+  mutate(rank = row_number()) |>
+  ungroup()
+
+cb_snap_share <- cb_ranked |>
+  group_by(season, team, team_total) |>
+  summarise(
+    top1 = sum(defense_snaps[rank <= 1], na.rm = TRUE),
+    top3 = sum(defense_snaps[rank <= 3], na.rm = TRUE),
+    top5 = sum(defense_snaps[rank <= 5], na.rm = TRUE),
+    .groups = "drop"
+  ) |>
+  mutate(
+    top1_share = top1 / team_total,
+    top3_share = top3 / team_total,
+    top5_share = top5 / team_total
+  )
+
+# --- Build summaries ---------------------------------------------------------
+
+summarize_shares <- function(df) {
+  list(
+    top1_share = distribution_summary(df$top1_share),
+    top3_share = distribution_summary(df$top3_share),
+    top5_share = distribution_summary(df$top5_share)
+  )
+}
+
+summaries <- list(
+  rb_carry_share  = summarize_shares(rb_carry),
+  rb_target_share = summarize_shares(rb_target),
+  wr_target_share = summarize_shares(wr_target),
+  te_target_share = summarize_shares(te_target),
+  qb_attempt_share = summarize_shares(qb_attempt),
+  lb_tackle_share = summarize_shares(lb_tackle),
+  cb_snap_share   = summarize_shares(cb_snap_share)
+)
+
+cat("Team-seasons per metric:\n")
+cat("  RB carry:", nrow(rb_carry), "\n")
+cat("  RB target:", nrow(rb_target), "\n")
+cat("  WR target:", nrow(wr_target), "\n")
+cat("  TE target:", nrow(te_target), "\n")
+cat("  QB attempt:", nrow(qb_attempt), "\n")
+cat("  LB tackle:", nrow(lb_tackle), "\n")
+cat("  CB snap:", nrow(cb_snap_share), "\n")
+
+out_path <- file.path(repo_root(), "data", "bands", "position-concentration.json")
+
+write_band(
+  out_path,
+  seasons,
+  summaries,
+  notes = paste0(
+    "Per-team-season position stat concentration. For each metric, players are ",
+    "ranked within their position group by the counting stat (carries, targets, ",
+    "pass attempts, tackles, or defensive snaps), and the share going to top-1, ",
+    "top-3, and top-5 players is computed. ",
+    "Mid-season QB changes are handled naturally: weekly stats are summed to ",
+    "season totals per player, so a starter benched in week 8 accumulates only ",
+    "8 weeks of attempts, and the replacement accumulates the rest. The QB ",
+    "attempt share top-1 captures the starter's dominance (or lack thereof in ",
+    "a committee/injury season). ",
+    "Injured starters are handled the same way: a player who misses games ",
+    "accumulates fewer counting stats, so their share drops and the backup's ",
+    "share rises. This correctly reflects real NFL concentration variance — ",
+    "healthy teams have higher top-1 concentration, injury-plagued teams have ",
+    "more diffuse distributions. ",
+    "CB snap share uses load_snap_counts() (defense_snaps column) rather than ",
+    "load_participation() because snap counts are available for all seasons in ",
+    "the window while participation data stopped updating after 2023. ",
+    "Regular season only. Minimum team totals applied to filter out noise ",
+    "(10 for most metrics, 100 for QB pass attempts)."
+  )
+)
+
+cat("Wrote", out_path, "\n")

--- a/data/README.md
+++ b/data/README.md
@@ -15,10 +15,11 @@ data/
     setup.R           # verifies package install, prints versions
     lib.R             # shared helpers (season windows, JSON writer)
     bands/
-      team-game.R     # per-team-per-game distributions (first-cut)
-      passing-plays.R # per-dropback outcome tree and yardage distributions
-      rushing-plays.R # per-rush yardage and outcome distributions
-      situational.R   # 4th-down, 2-point, and onside kick decision rates
+      team-game.R              # per-team-per-game distributions (first-cut)
+      passing-plays.R          # per-dropback outcome tree + yardage
+      rushing-plays.R          # per-rush yardage + gain thresholds
+      situational.R            # 4th-down, 2-point, and onside kick decision rates
+      position-concentration.R # top-k share by position group
   bands/              # generated JSON artifacts — checked in
   cache/              # nflreadr disk cache — gitignored
 ```
@@ -75,6 +76,16 @@ without depending on network or R at test time. Regenerate them when:
   success rate, onside kick attempt rate by late-game situation (trailing
   margin, last 5 min of Q4) and recovery rate. All metrics are aggregate rates
   with sample counts.
+- **`position-concentration.json`** — per-team-season stat concentration by
+  position group. For each metric (RB carries, RB/WR/TE targets, QB pass
+  attempts, LB tackles, CB defensive snaps), ranks players within the position
+  group and computes the share going to the top-1, top-3, and top-5 players.
+  Captures the "star concentration" pattern: RB1 averages ~57% of team carries,
+  WR1 averages ~38% of WR targets, QB1 averages ~81% of pass attempts. Uses
+  `load_player_stats()` for offensive/defensive counting stats and
+  `load_snap_counts()` for CB snap share. Mid-season QB changes and injured
+  starters are handled naturally — weekly stats are summed per player, so a
+  starter who misses games accumulates less and the backup's share rises.
 
 ## Planned bands (follow-up work)
 
@@ -84,8 +95,6 @@ and are tracked as GitHub issues labeled `ready-for-agent`:
 
 - **Special-teams outcomes** (#247) — FG success by distance bucket, punt net
   yards distribution, kickoff return distribution, return-TD rate
-- **Position stat concentration** (#248) — RB1/RB2/RB3 carry share, WR1/WR2/slot
-  target share, CB1 coverage share
 - **Injury rates by position** (#249) — separate source (`nflverse` injury
   tables)
 

--- a/data/bands/position-concentration.json
+++ b/data/bands/position-concentration.json
@@ -1,0 +1,273 @@
+{
+  "generated_at": "2026-04-15T18:11:07Z",
+  "seasons": [2020, 2021, 2022, 2023, 2024],
+  "notes": "Per-team-season position stat concentration. For each metric, players are ranked within their position group by the counting stat (carries, targets, pass attempts, tackles, or defensive snaps), and the share going to top-1, top-3, and top-5 players is computed. Mid-season QB changes are handled naturally: weekly stats are summed to season totals per player, so a starter benched in week 8 accumulates only 8 weeks of attempts, and the replacement accumulates the rest. The QB attempt share top-1 captures the starter's dominance (or lack thereof in a committee/injury season). Injured starters are handled the same way: a player who misses games accumulates fewer counting stats, so their share drops and the backup's share rises. This correctly reflects real NFL concentration variance — healthy teams have higher top-1 concentration, injury-plagued teams have more diffuse distributions. CB snap share uses load_snap_counts() (defense_snaps column) rather than load_participation() because snap counts are available for all seasons in the window while participation data stopped updating after 2023. Regular season only. Minimum team totals applied to filter out noise (10 for most metrics, 100 for QB pass attempts).",
+  "bands": {
+    "rb_carry_share": {
+      "top1_share": {
+        "n": 160,
+        "mean": 0.5722,
+        "sd": 0.1299,
+        "min": 0.2516,
+        "p10": 0.4013,
+        "p25": 0.4863,
+        "p50": 0.568,
+        "p75": 0.6666,
+        "p90": 0.7461,
+        "max": 0.8995
+      },
+      "top3_share": {
+        "n": 160,
+        "mean": 0.9395,
+        "sd": 0.0637,
+        "min": 0.6516,
+        "p10": 0.8475,
+        "p25": 0.9087,
+        "p50": 0.9654,
+        "p75": 0.9886,
+        "p90": 1,
+        "max": 1
+      },
+      "top5_share": {
+        "n": 160,
+        "mean": 0.9944,
+        "sd": 0.0128,
+        "min": 0.9194,
+        "p10": 0.9809,
+        "p25": 0.9966,
+        "p50": 1,
+        "p75": 1,
+        "p90": 1,
+        "max": 1
+      }
+    },
+    "rb_target_share": {
+      "top1_share": {
+        "n": 160,
+        "mean": 0.5377,
+        "sd": 0.124,
+        "min": 0.2556,
+        "p10": 0.3723,
+        "p25": 0.4565,
+        "p50": 0.5353,
+        "p75": 0.6283,
+        "p90": 0.6957,
+        "max": 0.8624
+      },
+      "top3_share": {
+        "n": 160,
+        "mean": 0.9194,
+        "sd": 0.0797,
+        "min": 0.6617,
+        "p10": 0.7972,
+        "p25": 0.8788,
+        "p50": 0.9389,
+        "p75": 0.9834,
+        "p90": 1,
+        "max": 1
+      },
+      "top5_share": {
+        "n": 160,
+        "mean": 0.9916,
+        "sd": 0.0205,
+        "min": 0.8571,
+        "p10": 0.9702,
+        "p25": 0.9921,
+        "p50": 1,
+        "p75": 1,
+        "p90": 1,
+        "max": 1
+      }
+    },
+    "wr_target_share": {
+      "top1_share": {
+        "n": 160,
+        "mean": 0.3838,
+        "sd": 0.0724,
+        "min": 0.1849,
+        "p10": 0.283,
+        "p25": 0.3379,
+        "p50": 0.3837,
+        "p75": 0.436,
+        "p90": 0.467,
+        "max": 0.5833
+      },
+      "top3_share": {
+        "n": 160,
+        "mean": 0.8044,
+        "sd": 0.0952,
+        "min": 0.5042,
+        "p10": 0.6759,
+        "p25": 0.7392,
+        "p50": 0.8104,
+        "p75": 0.881,
+        "p90": 0.9276,
+        "max": 0.9594
+      },
+      "top5_share": {
+        "n": 160,
+        "mean": 0.9545,
+        "sd": 0.0462,
+        "min": 0.7353,
+        "p10": 0.8837,
+        "p25": 0.9333,
+        "p50": 0.968,
+        "p75": 0.9884,
+        "p90": 1,
+        "max": 1
+      }
+    },
+    "te_target_share": {
+      "top1_share": {
+        "n": 160,
+        "mean": 0.6388,
+        "sd": 0.156,
+        "min": 0.3194,
+        "p10": 0.429,
+        "p25": 0.5143,
+        "p50": 0.6347,
+        "p75": 0.7671,
+        "p90": 0.8463,
+        "max": 0.9483
+      },
+      "top3_share": {
+        "n": 160,
+        "mean": 0.9674,
+        "sd": 0.0456,
+        "min": 0.8015,
+        "p10": 0.8954,
+        "p25": 0.95,
+        "p50": 0.986,
+        "p75": 1,
+        "p90": 1,
+        "max": 1
+      },
+      "top5_share": {
+        "n": 160,
+        "mean": 0.9996,
+        "sd": 0.0025,
+        "min": 0.9783,
+        "p10": 1,
+        "p25": 1,
+        "p50": 1,
+        "p75": 1,
+        "p90": 1,
+        "max": 1
+      }
+    },
+    "qb_attempt_share": {
+      "top1_share": {
+        "n": 160,
+        "mean": 0.8104,
+        "sd": 0.1869,
+        "min": 0.3269,
+        "p10": 0.5108,
+        "p25": 0.675,
+        "p50": 0.8748,
+        "p75": 0.9763,
+        "p90": 0.9968,
+        "max": 1
+      },
+      "top3_share": {
+        "n": 160,
+        "mean": 0.994,
+        "sd": 0.0253,
+        "min": 0.7804,
+        "p10": 0.9954,
+        "p25": 1,
+        "p50": 1,
+        "p75": 1,
+        "p90": 1,
+        "max": 1
+      },
+      "top5_share": {
+        "n": 160,
+        "mean": 1,
+        "sd": 0,
+        "min": 1,
+        "p10": 1,
+        "p25": 1,
+        "p50": 1,
+        "p75": 1,
+        "p90": 1,
+        "max": 1
+      }
+    },
+    "lb_tackle_share": {
+      "top1_share": {
+        "n": 160,
+        "mean": 0.3388,
+        "sd": 0.0795,
+        "min": 0.16,
+        "p10": 0.2347,
+        "p25": 0.2802,
+        "p50": 0.334,
+        "p75": 0.3877,
+        "p90": 0.4446,
+        "max": 0.5615
+      },
+      "top3_share": {
+        "n": 160,
+        "mean": 0.7258,
+        "sd": 0.1152,
+        "min": 0.395,
+        "p10": 0.5818,
+        "p25": 0.6459,
+        "p50": 0.7325,
+        "p75": 0.8135,
+        "p90": 0.8647,
+        "max": 0.9667
+      },
+      "top5_share": {
+        "n": 160,
+        "mean": 0.8907,
+        "sd": 0.0822,
+        "min": 0.5843,
+        "p10": 0.7828,
+        "p25": 0.8492,
+        "p50": 0.9042,
+        "p75": 0.9522,
+        "p90": 0.9819,
+        "max": 1
+      }
+    },
+    "cb_snap_share": {
+      "top1_share": {
+        "n": 160,
+        "mean": 0.3194,
+        "sd": 0.0516,
+        "min": 0.1689,
+        "p10": 0.2541,
+        "p25": 0.2836,
+        "p50": 0.3196,
+        "p75": 0.3519,
+        "p90": 0.3756,
+        "max": 0.471
+      },
+      "top3_share": {
+        "n": 160,
+        "mean": 0.7595,
+        "sd": 0.0954,
+        "min": 0.4487,
+        "p10": 0.6508,
+        "p25": 0.7069,
+        "p50": 0.7595,
+        "p75": 0.8135,
+        "p90": 0.8892,
+        "max": 0.972
+      },
+      "top5_share": {
+        "n": 160,
+        "mean": 0.9369,
+        "sd": 0.0613,
+        "min": 0.6332,
+        "p10": 0.8667,
+        "p25": 0.9045,
+        "p50": 0.9549,
+        "p75": 0.9807,
+        "p90": 0.9944,
+        "max": 1
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Closes #248

- Adds `data/R/bands/position-concentration.R` script that computes per-team-season stat concentration across position groups: RB carry share, RB/WR/TE target share, QB attempt share, LB tackle share, and CB defensive snap share — each with top-1/top-3/top-5 distribution summaries.
- Generates `data/bands/position-concentration.json` artifact (2020–2024 regular seasons, 160 team-seasons) for the sim calibration harness.
- Updates `data/README.md` with the new band description and layout entry.
- Mid-season QB changes and injured starters are handled naturally: weekly stats aggregate per player, so a benched/injured starter's share drops and the backup's rises. CB snap share uses `load_snap_counts()` instead of `load_participation()` (which stopped after 2023).

🤖 Generated with [Claude Code](https://claude.com/claude-code)