### PR TITLE
feat(league): surface seasonLength driven by franchise count

### DIFF
--- a/packages/shared/league/derive-default-season-length.test.ts
+++ b/packages/shared/league/derive-default-season-length.test.ts
@@ -1,0 +1,42 @@
+import { assertEquals, assertThrows } from "@std/assert";
+import { deriveDefaultSeasonLength } from "./derive-default-season-length.ts";
+
+Deno.test("deriveDefaultSeasonLength", async (t) => {
+  await t.step("returns 10 for an 8-team league", () => {
+    assertEquals(deriveDefaultSeasonLength(8), 10);
+  });
+
+  await t.step("returns 11 for a 12-team league", () => {
+    assertEquals(deriveDefaultSeasonLength(12), 11);
+  });
+
+  await t.step("returns 12 for a 16-team league", () => {
+    assertEquals(deriveDefaultSeasonLength(16), 12);
+  });
+
+  await t.step("returns 17 for a 32-team league", () => {
+    assertEquals(deriveDefaultSeasonLength(32), 17);
+  });
+
+  await t.step("clamps to minimum of 10 for very small leagues", () => {
+    assertEquals(deriveDefaultSeasonLength(4), 10);
+  });
+
+  await t.step("scales beyond 32 teams", () => {
+    const result = deriveDefaultSeasonLength(40);
+    assertEquals(result, 19);
+  });
+
+  await t.step("throws for non-positive franchise count", () => {
+    assertThrows(
+      () => deriveDefaultSeasonLength(0),
+      Error,
+      "positive",
+    );
+    assertThrows(
+      () => deriveDefaultSeasonLength(-1),
+      Error,
+      "positive",
+    );
+  });
+});

--- a/packages/shared/league/derive-default-season-length.ts
+++ b/packages/shared/league/derive-default-season-length.ts
@@ -1,0 +1,19 @@
+const MIN_SEASON_LENGTH = 10;
+const ANCHOR_TEAMS = 8;
+const ANCHOR_LENGTH = 10;
+const GAMES_PER_TEAM = 7 / 24;
+
+/**
+ * Maps franchise count to a default regular-season length.
+ *
+ * Anchored at 8 teams → 10 games and 32 teams → 17 games, with linear
+ * interpolation/extrapolation. Floors at 10 games for very small leagues.
+ */
+export function deriveDefaultSeasonLength(franchiseCount: number): number {
+  if (franchiseCount <= 0) {
+    throw new Error("Franchise count must be positive");
+  }
+
+  const raw = ANCHOR_LENGTH + (franchiseCount - ANCHOR_TEAMS) * GAMES_PER_TEAM;
+  return Math.max(MIN_SEASON_LENGTH, Math.round(raw));
+}

--- a/packages/shared/mod.ts
+++ b/packages/shared/mod.ts
@@ -208,5 +208,8 @@ export {
 } from "./rng/mod.ts";
 export type { SeededRng } from "./rng/mod.ts";
 
+// League
+export { deriveDefaultSeasonLength } from "./league/derive-default-season-length.ts";
+
 // Errors
 export { DomainError } from "./errors/domain-error.ts";

--- a/packages/shared/schemas/league.ts
+++ b/packages/shared/schemas/league.ts
@@ -1,8 +1,12 @@
 import { z } from "zod";
-import type { ZodObject, ZodString } from "zod";
+import type { ZodNumber, ZodObject, ZodOptional, ZodString } from "zod";
 
-export const createLeagueSchema: ZodObject<{ name: ZodString }> = z.object({
+export const createLeagueSchema: ZodObject<{
+  name: ZodString;
+  seasonLength: ZodOptional<ZodNumber>;
+}> = z.object({
   name: z.string().min(1).max(100),
+  seasonLength: z.number().int().min(1).optional(),
 });
 
 export const assignUserTeamSchema: ZodObject<{ userTeamId: ZodString }> = z

--- a/packages/shared/types/league.ts
+++ b/packages/shared/types/league.ts
@@ -40,4 +40,5 @@ export interface LeagueListItem extends League {
 
 export interface NewLeague {
   name: string;
+  seasonLength?: number;
 }

--- a/server/features/league/league.repository.ts
+++ b/server/features/league/league.repository.ts
@@ -36,7 +36,12 @@ export function createLeagueRepository(deps: {
       log.debug({ name: input.name }, "creating league");
       const [league] = await (tx ?? deps.db)
         .insert(leagues)
-        .values({ name: input.name })
+        .values({
+          name: input.name,
+          ...(input.seasonLength !== undefined && {
+            seasonLength: input.seasonLength,
+          }),
+        })
         .returning();
       return league;
     },

--- a/server/features/league/league.service.test.ts
+++ b/server/features/league/league.service.test.ts
@@ -1,6 +1,6 @@
 import { assertEquals, assertRejects } from "@std/assert";
 import { createLeagueService } from "./league.service.ts";
-import { DomainError } from "@zone-blitz/shared";
+import { deriveDefaultSeasonLength, DomainError } from "@zone-blitz/shared";
 import pino from "pino";
 import type { League } from "@zone-blitz/shared";
 import type { Executor } from "../../db/connection.ts";
@@ -333,8 +333,18 @@ Deno.test("league.service", async (t) => {
     let seasonCreated = false;
     let personnelCalled = false;
     let scheduleCalled = false;
+    const derivedLength = deriveDefaultSeasonLength(1);
 
     const service = createService({
+      leagueRepo: {
+        create: (input) =>
+          Promise.resolve(
+            createMockLeague({
+              id: "new-id",
+              seasonLength: input.seasonLength ?? 17,
+            }),
+          ),
+      },
       seasonService: {
         create: (input) => {
           seasonCreated = true;
@@ -372,7 +382,7 @@ Deno.test("league.service", async (t) => {
         generate: (input) => {
           scheduleCalled = true;
           assertEquals(input.seasonId, "season-1");
-          assertEquals(input.seasonLength, 17);
+          assertEquals(input.seasonLength, derivedLength);
           return Promise.resolve({ gameCount: 0 });
         },
       },
@@ -386,26 +396,66 @@ Deno.test("league.service", async (t) => {
   });
 
   await t.step(
-    "create forwards the league's seasonLength into the schedule service",
+    "create derives seasonLength from franchise count when not overridden",
     async () => {
-      let receivedSeasonLength: number | undefined;
+      let repoReceivedLength: number | undefined;
+      let scheduleReceivedLength: number | undefined;
+
       const service = createService({
         leagueRepo: {
-          create: () =>
-            Promise.resolve(
-              createMockLeague({ id: "new-id", seasonLength: 14 }),
-            ),
+          create: (input) => {
+            repoReceivedLength = input.seasonLength;
+            return Promise.resolve(
+              createMockLeague({
+                id: "new-id",
+                seasonLength: input.seasonLength ?? 17,
+              }),
+            );
+          },
         },
         scheduleService: {
           generate: (input) => {
-            receivedSeasonLength = input.seasonLength;
+            scheduleReceivedLength = input.seasonLength;
             return Promise.resolve({ gameCount: 0 });
           },
         },
       });
 
-      await service.create({ name: "Short Season" });
-      assertEquals(receivedSeasonLength, 14);
+      await service.create({ name: "Derived Season" });
+      assertEquals(repoReceivedLength, deriveDefaultSeasonLength(1));
+      assertEquals(scheduleReceivedLength, deriveDefaultSeasonLength(1));
+    },
+  );
+
+  await t.step(
+    "create respects an explicit seasonLength override",
+    async () => {
+      let repoReceivedLength: number | undefined;
+      let scheduleReceivedLength: number | undefined;
+
+      const service = createService({
+        leagueRepo: {
+          create: (input) => {
+            repoReceivedLength = input.seasonLength;
+            return Promise.resolve(
+              createMockLeague({
+                id: "new-id",
+                seasonLength: input.seasonLength ?? 17,
+              }),
+            );
+          },
+        },
+        scheduleService: {
+          generate: (input) => {
+            scheduleReceivedLength = input.seasonLength;
+            return Promise.resolve({ gameCount: 0 });
+          },
+        },
+      });
+
+      await service.create({ name: "Custom Season", seasonLength: 14 });
+      assertEquals(repoReceivedLength, 14);
+      assertEquals(scheduleReceivedLength, 14);
     },
   );
 

--- a/server/features/league/league.service.ts
+++ b/server/features/league/league.service.ts
@@ -1,4 +1,4 @@
-import { DomainError } from "@zone-blitz/shared";
+import { deriveDefaultSeasonLength, DomainError } from "@zone-blitz/shared";
 import type pino from "pino";
 import type { TransactionRunner } from "../../db/transaction-runner.ts";
 import type { LeagueRepository } from "./league.repository.interface.ts";
@@ -78,8 +78,14 @@ export function createLeagueService(deps: {
         );
       }
 
+      const seasonLength = input.seasonLength ??
+        deriveDefaultSeasonLength(teams.length);
+
       return await deps.txRunner.run(async (tx) => {
-        const league = await deps.leagueRepo.create(input, tx);
+        const league = await deps.leagueRepo.create(
+          { ...input, seasonLength },
+          tx,
+        );
 
         const season = await deps.seasonService.create(
           { leagueId: league.id },


### PR DESCRIPTION
## Summary

- Adds `deriveDefaultSeasonLength` function in the shared package that maps franchise count to a default regular-season length using linear interpolation (8 teams → 10 games, 32 teams → 17 games), per ADR 0019's guidance.
- Updates `NewLeague` type and `createLeagueSchema` to accept an optional `seasonLength` override, allowing commissioners to set a custom value at league creation.
- League creation now computes the default from the founding franchise count and threads it through to the repository and schedule generator, replacing reliance on the hard-coded DB default of 17.
- Tests cover derivation for representative league sizes (4, 8, 12, 16, 32, 40), explicit override, and integration with the schedule service.

Closes #253