### PR TITLE
feat(client): surface "No preseason (inaugural year)" on Year 1 league calendar

### DIFF
--- a/client/src/features/league/league-clock-display.test.tsx
+++ b/client/src/features/league/league-clock-display.test.tsx
@@ -224,6 +224,7 @@ describe("LeagueClockDisplay", () => {
           kind: "event",
           flavorDate: "Apr 24",
           advancedAt: "2026-01-01T00:00:00Z",
+          hasCompletedGenesis: true,
         }),
     });
 
@@ -232,5 +233,86 @@ describe("LeagueClockDisplay", () => {
     await waitFor(() => {
       expect(screen.getByText("2026")).toBeDefined();
     });
+  });
+
+  it("renders 'No preseason (inaugural year)' note in Year 1", async () => {
+    mockGetClock.mockResolvedValue({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          leagueId: "lg-1",
+          seasonYear: 1,
+          phase: "regular_season",
+          stepIndex: 0,
+          slug: "week_1",
+          kind: "week",
+          flavorDate: "Sep 7",
+          advancedAt: "2026-01-01T00:00:00Z",
+          hasCompletedGenesis: false,
+        }),
+    });
+
+    renderWithProviders({ leagueId: "lg-1", isCommissioner: false });
+
+    await waitFor(() => {
+      expect(screen.getByText("Week 1")).toBeDefined();
+    });
+    expect(
+      screen.getByText("No preseason (inaugural year)"),
+    ).toBeDefined();
+  });
+
+  it("does not render inaugural year note when hasCompletedGenesis is true", async () => {
+    mockGetClock.mockResolvedValue({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          leagueId: "lg-1",
+          seasonYear: 2,
+          phase: "preseason",
+          stepIndex: 0,
+          slug: "preseason_week_1",
+          kind: "week",
+          flavorDate: "Aug 10",
+          advancedAt: "2026-01-01T00:00:00Z",
+          hasCompletedGenesis: true,
+        }),
+    });
+
+    renderWithProviders({ leagueId: "lg-1", isCommissioner: false });
+
+    await waitFor(() => {
+      expect(screen.getByText("Preseason Week 1")).toBeDefined();
+    });
+    expect(
+      screen.queryByText("No preseason (inaugural year)"),
+    ).toBeNull();
+  });
+
+  it("does not render inaugural year note during genesis phases", async () => {
+    mockGetClock.mockResolvedValue({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          leagueId: "lg-1",
+          seasonYear: 1,
+          phase: "genesis_kickoff",
+          stepIndex: 0,
+          slug: "kickoff",
+          kind: "event",
+          flavorDate: null,
+          advancedAt: "2026-01-01T00:00:00Z",
+          hasCompletedGenesis: false,
+        }),
+    });
+
+    renderWithProviders({ leagueId: "lg-1", isCommissioner: false });
+
+    await waitFor(() => {
+      expect(screen.getByText("Kickoff")).toBeDefined();
+    });
+    expect(
+      screen.queryByText("No preseason (inaugural year)"),
+    ).toBeNull();
   });
 });

--- a/client/src/features/league/league-clock-display.tsx
+++ b/client/src/features/league/league-clock-display.tsx
@@ -3,6 +3,7 @@ import {
   AlertTriangleIcon,
   CalendarIcon,
   ChevronRightIcon,
+  InfoIcon,
 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
@@ -40,6 +41,9 @@ export function LeagueClockDisplay({
   const [error, setError] = useState<string | null>(null);
 
   if (!clock) return null;
+
+  const showInauguralYearNote = !clock.hasCompletedGenesis &&
+    !clock.phase.startsWith("genesis_");
 
   const handleAdvance = () => {
     setError(null);
@@ -94,6 +98,12 @@ export function LeagueClockDisplay({
           </Button>
         )}
       </div>
+      {showInauguralYearNote && (
+        <div className="flex items-center gap-1.5 text-xs text-muted-foreground">
+          <InfoIcon className="size-3" />
+          <span>No preseason (inaugural year)</span>
+        </div>
+      )}
       {error && (
         <Alert variant="destructive">
           <AlertTriangleIcon />

--- a/server/features/league-clock/league-clock.router.test.ts
+++ b/server/features/league-clock/league-clock.router.test.ts
@@ -19,6 +19,7 @@ function createMockClockState(
     kind: "event",
     flavorDate: null,
     advancedAt: new Date("2026-01-01T00:00:00Z"),
+    hasCompletedGenesis: true,
     ...overrides,
   };
 }

--- a/server/features/league-clock/league-clock.service.test.ts
+++ b/server/features/league-clock/league-clock.service.test.ts
@@ -1052,6 +1052,48 @@ Deno.test("league-clock.service", async (t) => {
       assertEquals(state.kind, "week");
       assertEquals(state.flavorDate, "Sep 7");
     });
+
+    await t.step(
+      "includes hasCompletedGenesis false for Year 1 league",
+      async () => {
+        const service = createService({
+          leagueClockRepo: {
+            getByLeagueId: () =>
+              Promise.resolve(
+                createMockClock({
+                  phase: "regular_season",
+                  stepIndex: 0,
+                  hasCompletedGenesis: false,
+                }),
+              ),
+          },
+        });
+
+        const state = await service.getClockState("league-1");
+        assertEquals(state.hasCompletedGenesis, false);
+      },
+    );
+
+    await t.step(
+      "includes hasCompletedGenesis true for Year 2+ league",
+      async () => {
+        const service = createService({
+          leagueClockRepo: {
+            getByLeagueId: () =>
+              Promise.resolve(
+                createMockClock({
+                  phase: "preseason",
+                  stepIndex: 0,
+                  hasCompletedGenesis: true,
+                }),
+              ),
+          },
+        });
+
+        const state = await service.getClockState("league-1");
+        assertEquals(state.hasCompletedGenesis, true);
+      },
+    );
   });
 
   await t.step("castVote", async (t) => {

--- a/server/features/league-clock/league-clock.service.ts
+++ b/server/features/league-clock/league-clock.service.ts
@@ -40,6 +40,7 @@ export interface ClockState {
   kind: string;
   flavorDate: string | null;
   advancedAt: Date;
+  hasCompletedGenesis: boolean;
 }
 
 export interface ReadyCheckState {
@@ -106,6 +107,7 @@ export function createLeagueClockService(deps: {
         kind: step?.kind ?? "",
         flavorDate: step?.flavorDate ?? null,
         advancedAt: clock.advancedAt,
+        hasCompletedGenesis: clock.hasCompletedGenesis,
       };
     },
 


### PR DESCRIPTION
## Summary

- Adds `hasCompletedGenesis` to the `ClockState` API response so the client can branch on the same signal the backend uses (not a client-side season-year heuristic)
- Renders a "No preseason (inaugural year)" note on the league clock display when `hasCompletedGenesis` is false and the league is past genesis phases
- Year 2+ leagues see preseason rendered as normal; the note is hidden during genesis phases themselves
- Tests cover Year 1 rendering, Year 2+ rendering, and genesis-phase rendering paths

Closes #255