### PR TITLE
feat(ui-league): add visibleInPhases to NavItem and useLeagueClock hook

### DIFF
--- a/client/src/features/league/layout.test.tsx
+++ b/client/src/features/league/layout.test.tsx
@@ -6,7 +6,7 @@ import {
   waitFor,
 } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { LeagueLayout } from "./layout.tsx";
 
 vi.mock("@tanstack/react-router", () => ({
@@ -51,6 +51,9 @@ const mockTouch = vi.fn().mockResolvedValue({
   json: () => Promise.resolve({ id: 1 }),
 });
 
+let mockPhase = "offseason_review";
+const mockClockGet = vi.fn();
+
 vi.mock("../../api.ts", () => ({
   api: {
     api: {
@@ -76,20 +79,7 @@ vi.mock("../../api.ts", () => ({
       },
       "league-clock": {
         [":leagueId"]: {
-          $get: vi.fn().mockResolvedValue({
-            ok: true,
-            json: () =>
-              Promise.resolve({
-                leagueId: "1",
-                seasonYear: 2026,
-                phase: "offseason_review",
-                stepIndex: 0,
-                slug: "awards_ceremony",
-                kind: "event",
-                flavorDate: "Feb 8",
-                advancedAt: "2026-01-01T00:00:00Z",
-              }),
-          }),
+          $get: (...args: unknown[]) => mockClockGet(...args),
           advance: {
             $post: vi.fn().mockResolvedValue({
               ok: true,
@@ -112,6 +102,26 @@ function renderWithProviders() {
     </QueryClientProvider>,
   );
 }
+
+beforeEach(() => {
+  mockPhase = "offseason_review";
+  mockClockGet.mockImplementation(() =>
+    Promise.resolve({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          leagueId: "1",
+          seasonYear: 2026,
+          phase: mockPhase,
+          stepIndex: 0,
+          slug: "awards_ceremony",
+          kind: "event",
+          flavorDate: "Feb 8",
+          advancedAt: "2026-01-01T00:00:00Z",
+        }),
+    })
+  );
+});
 
 afterEach(() => {
   cleanup();
@@ -236,17 +246,82 @@ describe("LeagueLayout", () => {
     ["Roster", "/leagues/1/roster"],
     ["Coaches", "/leagues/1/coaches"],
     ["Scouts", "/leagues/1/scouts"],
-    ["Draft", "/leagues/1/draft"],
-    ["Trades", "/leagues/1/trades"],
-    ["Free Agency", "/leagues/1/free-agency"],
     ["Salary Cap", "/leagues/1/salary-cap"],
-    ["Standings", "/leagues/1/standings"],
-    ["Schedule", "/leagues/1/schedule"],
     ["Media", "/leagues/1/media"],
     ["Owner", "/leagues/1/owner"],
-  ])("renders a %s nav link pointing to %s", (name, href) => {
+  ])(
+    "renders a %s nav link pointing to %s in offseason_review phase",
+    (name, href) => {
+      renderWithProviders();
+      const link = screen.getByRole("link", { name });
+      expect(link.getAttribute("href")).toBe(href);
+    },
+  );
+
+  it("renders all nav links in regular_season phase", async () => {
+    mockPhase = "regular_season";
     renderWithProviders();
-    const link = screen.getByRole("link", { name });
-    expect(link.getAttribute("href")).toBe(href);
+
+    await waitFor(() => {
+      expect(screen.getByRole("link", { name: "Roster" })).toBeDefined();
+    });
+
+    for (
+      const [name, href] of [
+        ["Roster", "/leagues/1/roster"],
+        ["Coaches", "/leagues/1/coaches"],
+        ["Scouts", "/leagues/1/scouts"],
+        ["Trades", "/leagues/1/trades"],
+        ["Free Agency", "/leagues/1/free-agency"],
+        ["Salary Cap", "/leagues/1/salary-cap"],
+        ["Standings", "/leagues/1/standings"],
+        ["Schedule", "/leagues/1/schedule"],
+        ["Opponents", "/leagues/1/opponents"],
+        ["Media", "/leagues/1/media"],
+        ["Owner", "/leagues/1/owner"],
+      ]
+    ) {
+      const link = screen.getByRole("link", { name });
+      expect(link.getAttribute("href")).toBe(href);
+    }
+  });
+
+  it("hides phase-gated nav items in genesis_charter", async () => {
+    mockPhase = "genesis_charter";
+    renderWithProviders();
+
+    await waitFor(() => {
+      expect(screen.getByRole("link", { name: "Home" })).toBeDefined();
+    });
+
+    expect(screen.getByRole("link", { name: "Owner" })).toBeDefined();
+    expect(screen.queryByRole("link", { name: "Roster" })).toBeNull();
+    expect(screen.queryByRole("link", { name: "Draft" })).toBeNull();
+    expect(screen.queryByRole("link", { name: "Standings" })).toBeNull();
+  });
+
+  it("shows all nav items when phase is loading", () => {
+    mockClockGet.mockImplementation(() => new Promise(() => {}));
+    renderWithProviders();
+
+    expect(screen.getByRole("link", { name: "Home" })).toBeDefined();
+    expect(screen.getByRole("link", { name: "Roster" })).toBeDefined();
+    expect(screen.getByRole("link", { name: "Draft" })).toBeDefined();
+    expect(screen.getByRole("link", { name: "Standings" })).toBeDefined();
+  });
+
+  it("collapses empty nav groups in early genesis phases", async () => {
+    mockPhase = "genesis_charter";
+    renderWithProviders();
+
+    await waitFor(() => {
+      expect(screen.getByRole("link", { name: "Home" })).toBeDefined();
+    });
+
+    const labels = Array.from(
+      document.querySelectorAll('[data-sidebar="group-label"]'),
+    ).map((el) => el.textContent);
+    expect(labels).toContain("Team");
+    expect(labels).not.toContain("Team Building");
   });
 });

--- a/client/src/features/league/layout.tsx
+++ b/client/src/features/league/layout.tsx
@@ -1,22 +1,6 @@
-import { useEffect } from "react";
+import { useEffect, useMemo } from "react";
 import { Link, Outlet, useParams } from "@tanstack/react-router";
-import {
-  ArrowLeftIcon,
-  ArrowLeftRightIcon,
-  CalendarIcon,
-  ClipboardListIcon,
-  CrownIcon,
-  DollarSignIcon,
-  HomeIcon,
-  ListOrderedIcon,
-  NewspaperIcon,
-  SearchIcon,
-  SettingsIcon,
-  TrophyIcon,
-  UserIcon,
-  UserPlusIcon,
-  UsersIcon,
-} from "lucide-react";
+import { ArrowLeftIcon, SettingsIcon, UserIcon } from "lucide-react";
 import {
   Sidebar,
   SidebarContent,
@@ -35,54 +19,30 @@ import {
 } from "@/components/ui/sidebar";
 import { UserMenu } from "../../components/user-menu.tsx";
 import { useLeague } from "../../hooks/use-league.ts";
+import { useLeagueClock } from "../../hooks/use-league-clock.ts";
 import { useTouchLeague } from "../../hooks/use-leagues.ts";
+import type { LeaguePhase } from "../../types/league-phase.ts";
 import { LeagueClockDisplay } from "./league-clock-display.tsx";
+import { navGroups } from "./nav-config.ts";
+import type { NavGroup } from "./nav-config.ts";
 
-type NavItem = {
-  label: string;
-  path: string;
-  Icon: typeof HomeIcon;
-};
-
-type NavGroup = {
-  label: string;
-  items: NavItem[];
-};
-
-const navGroups: NavGroup[] = [
-  {
-    label: "Team",
-    items: [
-      { label: "Home", path: "", Icon: HomeIcon },
-      { label: "Roster", path: "roster", Icon: UsersIcon },
-      { label: "Coaches", path: "coaches", Icon: ClipboardListIcon },
-      { label: "Scouts", path: "scouts", Icon: SearchIcon },
-    ],
-  },
-  {
-    label: "Team Building",
-    items: [
-      { label: "Draft", path: "draft", Icon: ListOrderedIcon },
-      { label: "Trades", path: "trades", Icon: ArrowLeftRightIcon },
-      { label: "Free Agency", path: "free-agency", Icon: UserPlusIcon },
-      { label: "Salary Cap", path: "salary-cap", Icon: DollarSignIcon },
-    ],
-  },
-  {
-    label: "League",
-    items: [
-      { label: "Standings", path: "standings", Icon: TrophyIcon },
-      { label: "Schedule", path: "schedule", Icon: CalendarIcon },
-      { label: "Opponents", path: "opponents", Icon: UsersIcon },
-      { label: "Media", path: "media", Icon: NewspaperIcon },
-      { label: "Owner", path: "owner", Icon: CrownIcon },
-    ],
-  },
-];
+function filterNavGroups(
+  groups: NavGroup[],
+  phase: LeaguePhase | undefined,
+): NavGroup[] {
+  if (!phase) return groups;
+  return groups
+    .map((group) => ({
+      ...group,
+      items: group.items.filter((item) => item.visibleInPhases(phase)),
+    }))
+    .filter((group) => group.items.length > 0);
+}
 
 export function LeagueLayout() {
   const { leagueId } = useParams({ strict: false });
   const { data: league } = useLeague(leagueId ?? "");
+  const { data: clock } = useLeagueClock(leagueId ?? "");
   const touchLeague = useTouchLeague();
 
   useEffect(() => {
@@ -91,6 +51,12 @@ export function LeagueLayout() {
     }
   }, [leagueId]);
 
+  const phase = clock?.phase as LeaguePhase | undefined;
+  const filteredGroups = useMemo(
+    () => filterNavGroups(navGroups, phase),
+    [phase],
+  );
+
   const basePath = `/leagues/${leagueId}`;
 
   return (
@@ -98,7 +64,7 @@ export function LeagueLayout() {
       <Sidebar collapsible="icon">
         <LeagueSidebarHeader name={league?.name} />
         <SidebarContent>
-          {navGroups.map((group) => (
+          {filteredGroups.map((group) => (
             <SidebarGroup key={group.label}>
               <SidebarGroupLabel>{group.label}</SidebarGroupLabel>
               <SidebarGroupContent>

--- a/client/src/features/league/nav-config.test.ts
+++ b/client/src/features/league/nav-config.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, it } from "vitest";
+import { navGroups } from "./nav-config.ts";
+import type { LeaguePhase } from "../../types/league-phase.ts";
+import { LEAGUE_PHASES } from "../../types/league-phase.ts";
+
+function visibleLabels(phase: LeaguePhase): string[] {
+  return navGroups
+    .flatMap((g) => g.items)
+    .filter((item) => item.visibleInPhases(phase))
+    .map((item) => item.label);
+}
+
+describe("navGroups", () => {
+  it("every nav item has a visibleInPhases function", () => {
+    for (const group of navGroups) {
+      for (const item of group.items) {
+        expect(typeof item.visibleInPhases).toBe("function");
+      }
+    }
+  });
+
+  it("Home is visible in all phases", () => {
+    for (const phase of LEAGUE_PHASES) {
+      expect(visibleLabels(phase)).toContain("Home");
+    }
+  });
+
+  it("Owner is visible in all phases", () => {
+    for (const phase of LEAGUE_PHASES) {
+      expect(visibleLabels(phase)).toContain("Owner");
+    }
+  });
+
+  it("shows only genesis-appropriate items in genesis_charter", () => {
+    const visible = visibleLabels("genesis_charter");
+    expect(visible).toContain("Home");
+    expect(visible).toContain("Owner");
+    expect(visible).not.toContain("Roster");
+    expect(visible).not.toContain("Coaches");
+    expect(visible).not.toContain("Draft");
+    expect(visible).not.toContain("Standings");
+    expect(visible).not.toContain("Schedule");
+  });
+
+  it("shows Coaches and Scouts from genesis_staff_hiring onward", () => {
+    expect(visibleLabels("genesis_charter")).not.toContain("Coaches");
+    expect(visibleLabels("genesis_franchise_establishment")).not.toContain(
+      "Coaches",
+    );
+    expect(visibleLabels("genesis_staff_hiring")).toContain("Coaches");
+    expect(visibleLabels("genesis_staff_hiring")).toContain("Scouts");
+    expect(visibleLabels("regular_season")).toContain("Coaches");
+    expect(visibleLabels("regular_season")).toContain("Scouts");
+  });
+
+  it("shows Roster from genesis_allocation_draft onward", () => {
+    expect(visibleLabels("genesis_staff_hiring")).not.toContain("Roster");
+    expect(visibleLabels("genesis_allocation_draft")).toContain("Roster");
+    expect(visibleLabels("regular_season")).toContain("Roster");
+  });
+
+  it("shows Salary Cap from genesis_allocation_draft onward", () => {
+    expect(visibleLabels("genesis_founding_pool")).not.toContain("Salary Cap");
+    expect(visibleLabels("genesis_allocation_draft")).toContain("Salary Cap");
+  });
+
+  it("shows Media from genesis_franchise_establishment onward", () => {
+    expect(visibleLabels("genesis_charter")).not.toContain("Media");
+    expect(visibleLabels("genesis_franchise_establishment")).toContain("Media");
+    expect(visibleLabels("regular_season")).toContain("Media");
+  });
+
+  it("shows Draft only in draft-relevant phases", () => {
+    expect(visibleLabels("genesis_allocation_draft")).toContain("Draft");
+    expect(visibleLabels("pre_draft")).toContain("Draft");
+    expect(visibleLabels("draft")).toContain("Draft");
+    expect(visibleLabels("udfa")).toContain("Draft");
+    expect(visibleLabels("regular_season")).not.toContain("Draft");
+    expect(visibleLabels("preseason")).not.toContain("Draft");
+  });
+
+  it("shows Free Agency in free-agency-relevant phases", () => {
+    expect(visibleLabels("genesis_free_agency")).toContain("Free Agency");
+    expect(visibleLabels("legal_tampering")).toContain("Free Agency");
+    expect(visibleLabels("free_agency")).toContain("Free Agency");
+    expect(visibleLabels("udfa")).toContain("Free Agency");
+    expect(visibleLabels("regular_season")).toContain("Free Agency");
+    expect(visibleLabels("genesis_charter")).not.toContain("Free Agency");
+  });
+
+  it("shows Trades from preseason onward", () => {
+    expect(visibleLabels("genesis_free_agency")).not.toContain("Trades");
+    expect(visibleLabels("preseason")).toContain("Trades");
+    expect(visibleLabels("regular_season")).toContain("Trades");
+  });
+
+  it("shows Standings from regular_season onward", () => {
+    expect(visibleLabels("preseason")).not.toContain("Standings");
+    expect(visibleLabels("regular_season")).toContain("Standings");
+    expect(visibleLabels("playoffs")).toContain("Standings");
+  });
+
+  it("shows Schedule from preseason onward", () => {
+    expect(visibleLabels("offseason_program")).not.toContain("Schedule");
+    expect(visibleLabels("preseason")).toContain("Schedule");
+    expect(visibleLabels("regular_season")).toContain("Schedule");
+  });
+
+  it("shows Opponents from preseason onward", () => {
+    expect(visibleLabels("offseason_program")).not.toContain("Opponents");
+    expect(visibleLabels("preseason")).toContain("Opponents");
+    expect(visibleLabels("regular_season")).toContain("Opponents");
+  });
+
+  it("every item is visible in at least one phase", () => {
+    for (const group of navGroups) {
+      for (const item of group.items) {
+        const visibleInAny = LEAGUE_PHASES.some((p) => item.visibleInPhases(p));
+        expect(visibleInAny, `${item.label} is never visible`).toBe(true);
+      }
+    }
+  });
+});

--- a/client/src/features/league/nav-config.ts
+++ b/client/src/features/league/nav-config.ts
@@ -1,0 +1,160 @@
+import {
+  ArrowLeftRightIcon,
+  CalendarIcon,
+  ClipboardListIcon,
+  CrownIcon,
+  DollarSignIcon,
+  HomeIcon,
+  ListOrderedIcon,
+  NewspaperIcon,
+  SearchIcon,
+  TrophyIcon,
+  UserPlusIcon,
+  UsersIcon,
+} from "lucide-react";
+import type { LeaguePhase } from "../../types/league-phase.ts";
+import { LEAGUE_PHASES } from "../../types/league-phase.ts";
+
+export type NavItem = {
+  label: string;
+  path: string;
+  Icon: typeof HomeIcon;
+  visibleInPhases: (phase: LeaguePhase) => boolean;
+};
+
+export type NavGroup = {
+  label: string;
+  items: NavItem[];
+};
+
+const phaseIndex = Object.fromEntries(
+  LEAGUE_PHASES.map((p, i) => [p, i]),
+) as Record<LeaguePhase, number>;
+
+function fromPhaseOnward(
+  startPhase: LeaguePhase,
+): (phase: LeaguePhase) => boolean {
+  const startIdx = phaseIndex[startPhase];
+  return (phase) => phaseIndex[phase] >= startIdx;
+}
+
+function inPhases(...phases: LeaguePhase[]): (phase: LeaguePhase) => boolean {
+  const set = new Set<LeaguePhase>(phases);
+  return (phase) => set.has(phase);
+}
+
+function always(): boolean {
+  return true;
+}
+
+const fromStaffHiring = fromPhaseOnward("genesis_staff_hiring");
+const fromAllocationDraft = fromPhaseOnward("genesis_allocation_draft");
+const fromEstablishment = fromPhaseOnward("genesis_franchise_establishment");
+const fromPreseason = fromPhaseOnward("preseason");
+const fromRegularSeason = fromPhaseOnward("regular_season");
+
+const draftPhases = inPhases(
+  "genesis_allocation_draft",
+  "pre_draft",
+  "draft",
+  "udfa",
+);
+
+const freeAgencyPhases = inPhases(
+  "genesis_free_agency",
+  "legal_tampering",
+  "free_agency",
+  "udfa",
+  "regular_season",
+);
+
+export const navGroups: NavGroup[] = [
+  {
+    label: "Team",
+    items: [
+      { label: "Home", path: "", Icon: HomeIcon, visibleInPhases: always },
+      {
+        label: "Roster",
+        path: "roster",
+        Icon: UsersIcon,
+        visibleInPhases: fromAllocationDraft,
+      },
+      {
+        label: "Coaches",
+        path: "coaches",
+        Icon: ClipboardListIcon,
+        visibleInPhases: fromStaffHiring,
+      },
+      {
+        label: "Scouts",
+        path: "scouts",
+        Icon: SearchIcon,
+        visibleInPhases: fromStaffHiring,
+      },
+    ],
+  },
+  {
+    label: "Team Building",
+    items: [
+      {
+        label: "Draft",
+        path: "draft",
+        Icon: ListOrderedIcon,
+        visibleInPhases: draftPhases,
+      },
+      {
+        label: "Trades",
+        path: "trades",
+        Icon: ArrowLeftRightIcon,
+        visibleInPhases: fromPreseason,
+      },
+      {
+        label: "Free Agency",
+        path: "free-agency",
+        Icon: UserPlusIcon,
+        visibleInPhases: freeAgencyPhases,
+      },
+      {
+        label: "Salary Cap",
+        path: "salary-cap",
+        Icon: DollarSignIcon,
+        visibleInPhases: fromAllocationDraft,
+      },
+    ],
+  },
+  {
+    label: "League",
+    items: [
+      {
+        label: "Standings",
+        path: "standings",
+        Icon: TrophyIcon,
+        visibleInPhases: fromRegularSeason,
+      },
+      {
+        label: "Schedule",
+        path: "schedule",
+        Icon: CalendarIcon,
+        visibleInPhases: fromPreseason,
+      },
+      {
+        label: "Opponents",
+        path: "opponents",
+        Icon: UsersIcon,
+        visibleInPhases: fromPreseason,
+      },
+      {
+        label: "Media",
+        path: "media",
+        Icon: NewspaperIcon,
+        visibleInPhases: fromEstablishment,
+      },
+      {
+        label: "Owner",
+        path: "owner",
+        Icon: CrownIcon,
+        visibleInPhases: always,
+      },
+    ],
+  },
+];

--- a/client/src/types/league-phase.ts
+++ b/client/src/types/league-phase.ts
@@ -1,0 +1,25 @@
+export const LEAGUE_PHASES = [
+  "genesis_charter",
+  "genesis_franchise_establishment",
+  "genesis_staff_hiring",
+  "genesis_founding_pool",
+  "genesis_allocation_draft",
+  "genesis_free_agency",
+  "genesis_kickoff",
+  "offseason_review",
+  "coaching_carousel",
+  "tag_window",
+  "restricted_fa",
+  "legal_tampering",
+  "free_agency",
+  "pre_draft",
+  "draft",
+  "udfa",
+  "offseason_program",
+  "preseason",
+  "regular_season",
+  "playoffs",
+  "offseason_rollover",
+] as const;
+
+export type LeaguePhase = (typeof LEAGUE_PHASES)[number];


### PR DESCRIPTION
## Summary

- Extends `NavItem` type with a `visibleInPhases: (phase: LeaguePhase) => boolean` predicate so every sidebar link declares which phases it belongs in. Always-on items (Home, Settings, All Leagues, Profile, Owner) return `true` unconditionally.
- Introduces a client-side `LeaguePhase` type (`client/src/types/league-phase.ts`) mirroring the server's `league_phase` enum, including all genesis phases (`genesis_charter`, `genesis_franchise_establishment`, `genesis_staff_hiring`, `genesis_founding_pool`, `genesis_allocation_draft`, `genesis_free_agency`).
- Layout now calls the existing `useLeagueClock` hook to read the current phase and filters nav items/groups accordingly. Empty groups collapse when no items are visible.
- When phase is loading or unknown, all nav items render (no flash of empty sidebar).
- Extracts nav config to `nav-config.ts` for independent testability with 15 dedicated tests covering the phase→visibility mapping.

Closes #278

🤖 Generated with [Claude Code](https://claude.com/claude-code)