### PR TITLE
feat(sim): resolve real kickoffs, returns, and onside attempts

### DIFF
--- a/server/features/simulation/derive-game-views.ts
+++ b/server/features/simulation/derive-game-views.ts
@@ -42,6 +42,8 @@ export function deriveBoxScore(
   };
 
   for (const event of events) {
+    if (event.outcome === "kickoff") continue;
+
     const isHome = event.offenseTeamId === homeTeamId;
     const offenseBox = isHome ? box.home : box.away;
     const defenseBox = isHome ? box.away : box.home;
@@ -92,6 +94,7 @@ export function deriveDriveLog(events: PlayEvent[]): DriveSummary[] {
 
   const driveMap = new Map<number, PlayEvent[]>();
   for (const event of events) {
+    if (event.outcome === "kickoff") continue;
     const list = driveMap.get(event.driveIndex);
     if (list) {
       list.push(event);

--- a/server/features/simulation/events.ts
+++ b/server/features/simulation/events.ts
@@ -29,7 +29,8 @@ export type PlayOutcome =
   | "punt"
   | "penalty"
   | "kneel"
-  | "spike";
+  | "spike"
+  | "kickoff";
 
 export type InjurySeverity =
   | "shake_off"
@@ -60,7 +61,8 @@ export type PlayTag =
   | "injury_miss_game"
   | "injury_miss_weeks"
   | "injury_miss_season"
-  | "injury_career_ending";
+  | "injury_career_ending"
+  | "onside";
 
 export type PlayEvent = {
   gameId: string;

--- a/server/features/simulation/mod.ts
+++ b/server/features/simulation/mod.ts
@@ -23,6 +23,8 @@ export {
 export type { SeededRng } from "./rng.ts";
 
 export { resolvePlay } from "./resolve-play.ts";
+export { resolveKickoff } from "./resolve-kickoff.ts";
+export type { KickoffContext, KickoffResult } from "./resolve-kickoff.ts";
 export {
   deriveBoxScore,
   deriveDriveLog,

--- a/server/features/simulation/resolve-kickoff.test.ts
+++ b/server/features/simulation/resolve-kickoff.test.ts
@@ -1,0 +1,332 @@
+import { assertEquals, assertGreater } from "@std/assert";
+import {
+  PLAYER_ATTRIBUTE_KEYS,
+  type PlayerAttributes,
+} from "@zone-blitz/shared";
+import type { PlayerRuntime } from "./resolve-play.ts";
+import { createSeededRng } from "./rng.ts";
+import { type KickoffContext, resolveKickoff } from "./resolve-kickoff.ts";
+
+function makeAttributes(
+  overrides: Partial<PlayerAttributes> = {},
+): PlayerAttributes {
+  const base: Partial<PlayerAttributes> = {};
+  for (const key of PLAYER_ATTRIBUTE_KEYS) {
+    (base as Record<string, number>)[key] = 50;
+    (base as Record<string, number>)[`${key}Potential`] = 50;
+  }
+  return { ...base, ...overrides } as PlayerAttributes;
+}
+
+function makePlayer(
+  id: string,
+  bucket: PlayerRuntime["neutralBucket"],
+  overrides: Partial<PlayerAttributes> = {},
+): PlayerRuntime {
+  return {
+    playerId: id,
+    neutralBucket: bucket,
+    attributes: makeAttributes(overrides),
+  };
+}
+
+function makeKickoffContext(
+  overrides: Partial<KickoffContext> = {},
+): KickoffContext {
+  return {
+    gameId: "test-game",
+    driveIndex: 0,
+    playIndex: 0,
+    quarter: 1,
+    clock: "15:00",
+    kickingTeamId: "team-a",
+    receivingTeamId: "team-b",
+    kicker: makePlayer("k1", "K", { kickingPower: 70 }),
+    returner: makePlayer("ret1", "WR", {
+      speed: 80,
+      elusiveness: 70,
+      ballCarrying: 65,
+    }),
+    coverageUnit: [
+      makePlayer("cov1", "LB", { speed: 60, tackling: 70 }),
+      makePlayer("cov2", "S", { speed: 70, tackling: 65 }),
+    ],
+    scoreDifferential: 0,
+    ...overrides,
+  };
+}
+
+Deno.test("resolveKickoff", async (t) => {
+  await t.step("returns a PlayEvent with outcome kickoff", () => {
+    const rng = createSeededRng(42);
+    const ctx = makeKickoffContext();
+    const result = resolveKickoff(ctx, rng);
+
+    assertEquals(result.event.outcome, "kickoff");
+    assertEquals(result.event.gameId, "test-game");
+    assertEquals(result.event.offenseTeamId, "team-a");
+    assertEquals(result.event.defenseTeamId, "team-b");
+    assertEquals(result.event.call.concept, "kickoff");
+    assertEquals(result.event.call.personnel, "special_teams");
+    assertEquals(result.event.coverage.front, "kick_return");
+  });
+
+  await t.step(
+    "starting yard line is between 1 and 99 for non-TD results",
+    () => {
+      for (let seed = 1; seed <= 100; seed++) {
+        const rng = createSeededRng(seed);
+        const ctx = makeKickoffContext();
+        const result = resolveKickoff(ctx, rng);
+        if (!result.isReturnTouchdown) {
+          assertGreater(result.startingYardLine, 0);
+          assertEquals(result.startingYardLine <= 99, true);
+        }
+      }
+    },
+  );
+
+  await t.step("touchback yields yard line 25", () => {
+    let foundTouchback = false;
+    for (let seed = 1; seed <= 200; seed++) {
+      const rng = createSeededRng(seed);
+      const ctx = makeKickoffContext({
+        kicker: makePlayer("k1", "K", { kickingPower: 99 }),
+      });
+      const result = resolveKickoff(ctx, rng);
+      if (
+        result.startingYardLine === 25 &&
+        !result.isOnsideRecovery &&
+        !result.isReturnTouchdown
+      ) {
+        foundTouchback = true;
+        break;
+      }
+    }
+    assertEquals(foundTouchback, true);
+  });
+
+  await t.step("return produces variable starting yard line", () => {
+    const yardLines = new Set<number>();
+    for (let seed = 1; seed <= 200; seed++) {
+      const rng = createSeededRng(seed);
+      const ctx = makeKickoffContext();
+      const result = resolveKickoff(ctx, rng);
+      if (!result.isOnsideRecovery && !result.isReturnTouchdown) {
+        yardLines.add(result.startingYardLine);
+      }
+    }
+    assertGreater(yardLines.size, 3);
+  });
+
+  await t.step("out-of-bounds yields yard line 40", () => {
+    let foundOOB = false;
+    for (let seed = 1; seed <= 500; seed++) {
+      const rng = createSeededRng(seed);
+      const ctx = makeKickoffContext();
+      const result = resolveKickoff(ctx, rng);
+      if (result.startingYardLine === 40 && !result.isOnsideRecovery) {
+        foundOOB = true;
+        break;
+      }
+    }
+    assertEquals(foundOOB, true);
+  });
+
+  await t.step("kicker with high power produces more touchbacks", () => {
+    let strongTouchbacks = 0;
+    let weakTouchbacks = 0;
+    const trials = 500;
+
+    for (let seed = 1; seed <= trials; seed++) {
+      const rngStrong = createSeededRng(seed);
+      const ctxStrong = makeKickoffContext({
+        kicker: makePlayer("k1", "K", { kickingPower: 95 }),
+      });
+      const strongResult = resolveKickoff(ctxStrong, rngStrong);
+      if (
+        strongResult.startingYardLine === 25 && !strongResult.isOnsideRecovery
+      ) {
+        strongTouchbacks++;
+      }
+
+      const rngWeak = createSeededRng(seed + 10000);
+      const ctxWeak = makeKickoffContext({
+        kicker: makePlayer("k1", "K", { kickingPower: 30 }),
+      });
+      const weakResult = resolveKickoff(ctxWeak, rngWeak);
+      if (weakResult.startingYardLine === 25 && !weakResult.isOnsideRecovery) {
+        weakTouchbacks++;
+      }
+    }
+
+    assertGreater(strongTouchbacks, weakTouchbacks);
+  });
+
+  await t.step("onside kick only attempted when trailing late", () => {
+    let onsideFound = false;
+    for (let seed = 1; seed <= 300; seed++) {
+      const rng = createSeededRng(seed);
+      const ctx = makeKickoffContext({
+        scoreDifferential: 0,
+        quarter: 1,
+        clock: "15:00",
+      });
+      const result = resolveKickoff(ctx, rng);
+      if (result.event.tags.includes("onside")) {
+        onsideFound = true;
+      }
+    }
+    assertEquals(onsideFound, false);
+  });
+
+  await t.step(
+    "trailing team in Q4 final minutes can elect onside kick",
+    () => {
+      let onsideFound = false;
+      for (let seed = 1; seed <= 500; seed++) {
+        const rng = createSeededRng(seed);
+        const ctx = makeKickoffContext({
+          scoreDifferential: -10,
+          quarter: 4,
+          clock: "4:30",
+        });
+        const result = resolveKickoff(ctx, rng);
+        if (result.event.tags.includes("onside")) {
+          onsideFound = true;
+          break;
+        }
+      }
+      assertEquals(onsideFound, true);
+    },
+  );
+
+  await t.step("onside recovery rate is within NFL-realistic range", () => {
+    let onsideAttempts = 0;
+    let onsideRecoveries = 0;
+    const trials = 2000;
+
+    for (let seed = 1; seed <= trials; seed++) {
+      const rng = createSeededRng(seed);
+      const ctx = makeKickoffContext({
+        scoreDifferential: -10,
+        quarter: 4,
+        clock: "2:00",
+      });
+      const result = resolveKickoff(ctx, rng);
+      if (result.event.tags.includes("onside")) {
+        onsideAttempts++;
+        if (result.isOnsideRecovery) {
+          onsideRecoveries++;
+        }
+      }
+    }
+
+    assertGreater(onsideAttempts, 0);
+    const recoveryRate = onsideRecoveries / onsideAttempts;
+    assertGreater(recoveryRate, 0.05);
+    assertEquals(recoveryRate < 0.25, true);
+  });
+
+  await t.step(
+    "onside recovery gives kicking team ball around midfield",
+    () => {
+      let foundRecovery = false;
+      for (let seed = 1; seed <= 2000; seed++) {
+        const rng = createSeededRng(seed);
+        const ctx = makeKickoffContext({
+          scoreDifferential: -10,
+          quarter: 4,
+          clock: "2:00",
+        });
+        const result = resolveKickoff(ctx, rng);
+        if (result.isOnsideRecovery) {
+          foundRecovery = true;
+          assertGreater(result.startingYardLine, 0);
+          assertEquals(result.startingYardLine <= 60, true);
+          break;
+        }
+      }
+      assertEquals(foundRecovery, true);
+    },
+  );
+
+  await t.step("return TD sets isReturnTouchdown flag", () => {
+    let foundReturnTD = false;
+    for (let seed = 1; seed <= 5000; seed++) {
+      const rng = createSeededRng(seed);
+      const ctx = makeKickoffContext({
+        returner: makePlayer("ret1", "WR", {
+          speed: 99,
+          elusiveness: 99,
+          ballCarrying: 99,
+        }),
+      });
+      const result = resolveKickoff(ctx, rng);
+      if (result.isReturnTouchdown) {
+        foundReturnTD = true;
+        assertEquals(result.event.tags.includes("touchdown"), true);
+        break;
+      }
+    }
+    assertEquals(foundReturnTD, true);
+  });
+
+  await t.step("kicker is tagged as participant", () => {
+    const rng = createSeededRng(42);
+    const ctx = makeKickoffContext();
+    const result = resolveKickoff(ctx, rng);
+
+    const kickerParticipant = result.event.participants.find(
+      (p) => p.role === "kicker",
+    );
+    assertEquals(kickerParticipant?.playerId, "k1");
+  });
+
+  await t.step("returner is tagged as participant on returns", () => {
+    let foundReturn = false;
+    for (let seed = 1; seed <= 100; seed++) {
+      const rng = createSeededRng(seed);
+      const ctx = makeKickoffContext();
+      const result = resolveKickoff(ctx, rng);
+      if (
+        !result.isOnsideRecovery &&
+        result.startingYardLine !== 25 &&
+        result.startingYardLine !== 40
+      ) {
+        foundReturn = true;
+        const returnerParticipant = result.event.participants.find(
+          (p) => p.role === "returner",
+        );
+        assertEquals(returnerParticipant?.playerId, "ret1");
+        break;
+      }
+    }
+    assertEquals(foundReturn, true);
+  });
+
+  await t.step("determinism: same seed produces identical result", () => {
+    const ctx = makeKickoffContext();
+
+    const rng1 = createSeededRng(42);
+    const result1 = resolveKickoff(ctx, rng1);
+
+    const rng2 = createSeededRng(42);
+    const result2 = resolveKickoff(ctx, rng2);
+
+    assertEquals(result1.event, result2.event);
+    assertEquals(result1.startingYardLine, result2.startingYardLine);
+    assertEquals(result1.isOnsideRecovery, result2.isOnsideRecovery);
+    assertEquals(result1.isReturnTouchdown, result2.isReturnTouchdown);
+  });
+
+  await t.step("situation reflects kickoff position", () => {
+    const rng = createSeededRng(42);
+    const ctx = makeKickoffContext();
+    const result = resolveKickoff(ctx, rng);
+
+    assertEquals(result.event.situation.down, 1);
+    assertEquals(result.event.situation.distance, 10);
+    assertEquals(result.event.situation.yardLine, 35);
+  });
+});

--- a/server/features/simulation/resolve-kickoff.ts
+++ b/server/features/simulation/resolve-kickoff.ts
@@ -1,0 +1,243 @@
+import type { PlayEvent, PlayTag } from "./events.ts";
+import type { PlayerRuntime } from "./resolve-play.ts";
+import type { SeededRng } from "./rng.ts";
+
+export interface KickoffContext {
+  gameId: string;
+  driveIndex: number;
+  playIndex: number;
+  quarter: 1 | 2 | 3 | 4;
+  clock: string;
+  kickingTeamId: string;
+  receivingTeamId: string;
+  kicker: PlayerRuntime;
+  returner: PlayerRuntime | undefined;
+  coverageUnit: PlayerRuntime[];
+  scoreDifferential: number;
+}
+
+export interface KickoffResult {
+  event: PlayEvent;
+  startingYardLine: number;
+  isOnsideRecovery: boolean;
+  isReturnTouchdown: boolean;
+}
+
+const KICKOFF_YARD_LINE = 35;
+const TOUCHBACK_YARD_LINE = 25;
+const OOB_YARD_LINE = 40;
+const OOB_RATE = 0.03;
+const SQUIB_RATE = 0.05;
+const ONSIDE_RECOVERY_RATE = 0.12;
+const ONSIDE_ELECTION_THRESHOLD_SECONDS = 300;
+
+function parseClockSeconds(clock: string): number {
+  const [mins, secs] = clock.split(":").map(Number);
+  return mins * 60 + secs;
+}
+
+function shouldElectOnside(
+  scoreDifferential: number,
+  quarter: number,
+  clock: string,
+): boolean {
+  if (scoreDifferential >= 0) return false;
+  if (quarter < 4) return false;
+  return parseClockSeconds(clock) <= ONSIDE_ELECTION_THRESHOLD_SECONDS;
+}
+
+function computeTouchbackRate(kickingPower: number): number {
+  const normalized = (kickingPower - 30) / 70;
+  return Math.max(0.1, Math.min(0.85, 0.2 + normalized * 0.65));
+}
+
+function computeReturnDistance(
+  returnerSpeed: number,
+  returnerElusiveness: number,
+  coverageSpeed: number,
+  coverageTackling: number,
+  rng: SeededRng,
+): number {
+  const returnerRating = (returnerSpeed * 0.6 + returnerElusiveness * 0.4) /
+    100;
+  const coverageRating = (coverageSpeed * 0.5 + coverageTackling * 0.5) / 100;
+
+  const baseReturn = 15 + rng.int(0, 20);
+  const bonus = (returnerRating - coverageRating) * 15;
+  return Math.max(5, Math.round(baseReturn + bonus));
+}
+
+function averageAttribute(
+  players: PlayerRuntime[],
+  attr: "speed" | "tackling",
+): number {
+  if (players.length === 0) return 50;
+  let sum = 0;
+  for (const p of players) {
+    sum += p.attributes[attr];
+  }
+  return sum / players.length;
+}
+
+export function resolveKickoff(
+  ctx: KickoffContext,
+  rng: SeededRng,
+): KickoffResult {
+  const tags: PlayTag[] = [];
+  const participants = [
+    { role: "kicker", playerId: ctx.kicker.playerId, tags: [] as string[] },
+  ];
+
+  const isOnside = shouldElectOnside(
+    ctx.scoreDifferential,
+    ctx.quarter,
+    ctx.clock,
+  );
+
+  if (isOnside) {
+    tags.push("onside" as PlayTag);
+
+    const recovered = rng.next() < ONSIDE_RECOVERY_RATE;
+    const yardLine = KICKOFF_YARD_LINE + rng.int(8, 15);
+
+    const event = buildEvent(ctx, tags, participants, 0);
+
+    return {
+      event,
+      startingYardLine: recovered ? yardLine : 100 - yardLine,
+      isOnsideRecovery: recovered,
+      isReturnTouchdown: false,
+    };
+  }
+
+  const kickingPower = ctx.kicker.attributes.kickingPower;
+  const touchbackRate = computeTouchbackRate(kickingPower);
+
+  if (rng.next() < OOB_RATE) {
+    const event = buildEvent(ctx, tags, participants, 0);
+    return {
+      event,
+      startingYardLine: OOB_YARD_LINE,
+      isOnsideRecovery: false,
+      isReturnTouchdown: false,
+    };
+  }
+
+  if (rng.next() < SQUIB_RATE) {
+    const returnDist = rng.int(5, 15);
+    if (ctx.returner) {
+      participants.push({
+        role: "returner",
+        playerId: ctx.returner.playerId,
+        tags: [],
+      });
+    }
+    const startYard = Math.min(99, Math.max(1, 30 + returnDist));
+    const event = buildEvent(ctx, tags, participants, returnDist);
+    return {
+      event,
+      startingYardLine: startYard,
+      isOnsideRecovery: false,
+      isReturnTouchdown: false,
+    };
+  }
+
+  if (rng.next() < touchbackRate) {
+    const event = buildEvent(ctx, tags, participants, 0);
+    return {
+      event,
+      startingYardLine: TOUCHBACK_YARD_LINE,
+      isOnsideRecovery: false,
+      isReturnTouchdown: false,
+    };
+  }
+
+  if (!ctx.returner) {
+    const event = buildEvent(ctx, tags, participants, 0);
+    return {
+      event,
+      startingYardLine: TOUCHBACK_YARD_LINE,
+      isOnsideRecovery: false,
+      isReturnTouchdown: false,
+    };
+  }
+
+  participants.push({
+    role: "returner",
+    playerId: ctx.returner.playerId,
+    tags: [],
+  });
+
+  const covSpeed = averageAttribute(ctx.coverageUnit, "speed");
+  const covTackling = averageAttribute(ctx.coverageUnit, "tackling");
+
+  const returnDist = computeReturnDistance(
+    ctx.returner.attributes.speed,
+    ctx.returner.attributes.elusiveness,
+    covSpeed,
+    covTackling,
+    rng,
+  );
+
+  const catchYard = rng.int(2, 8);
+  const startYard = Math.min(99, Math.max(1, catchYard + returnDist));
+
+  const returnTDChance = (ctx.returner.attributes.speed / 100) * 0.015 +
+    (ctx.returner.attributes.elusiveness / 100) * 0.01;
+
+  if (rng.next() < returnTDChance) {
+    tags.push("touchdown");
+    const event = buildEvent(ctx, tags, participants, 100 - catchYard);
+    return {
+      event,
+      startingYardLine: 0,
+      isOnsideRecovery: false,
+      isReturnTouchdown: true,
+    };
+  }
+
+  const event = buildEvent(ctx, tags, participants, returnDist);
+  return {
+    event,
+    startingYardLine: startYard,
+    isOnsideRecovery: false,
+    isReturnTouchdown: false,
+  };
+}
+
+function buildEvent(
+  ctx: KickoffContext,
+  tags: PlayTag[],
+  participants: { role: string; playerId: string; tags: string[] }[],
+  yardage: number,
+): PlayEvent {
+  return {
+    gameId: ctx.gameId,
+    driveIndex: ctx.driveIndex,
+    playIndex: ctx.playIndex,
+    quarter: ctx.quarter,
+    clock: ctx.clock,
+    situation: {
+      down: 1,
+      distance: 10,
+      yardLine: KICKOFF_YARD_LINE,
+    },
+    offenseTeamId: ctx.kickingTeamId,
+    defenseTeamId: ctx.receivingTeamId,
+    call: {
+      concept: "kickoff",
+      personnel: "special_teams",
+      formation: "kickoff",
+      motion: "none",
+    },
+    coverage: {
+      front: "kick_return",
+      coverage: "none",
+      pressure: "none",
+    },
+    participants,
+    outcome: "kickoff",
+    yardage,
+    tags,
+  };
+}

--- a/server/features/simulation/simulate-game.test.ts
+++ b/server/features/simulation/simulate-game.test.ts
@@ -535,6 +535,7 @@ Deno.test("simulateGame", async (t) => {
 
       const byDrive = new Map<number, PlayEvent[]>();
       for (const event of result.events) {
+        if (event.outcome === "kickoff") continue;
         const list = byDrive.get(event.driveIndex) ?? [];
         list.push(event);
         byDrive.set(event.driveIndex, list);
@@ -548,6 +549,126 @@ Deno.test("simulateGame", async (t) => {
           );
         }
       }
+    },
+  );
+
+  await t.step("kickoff events emitted at start of game", () => {
+    const result = simulateGame({
+      home: makeTeam("home"),
+      away: makeTeam("away"),
+      seed: 42,
+    });
+
+    const firstEvent = result.events[0];
+    assertEquals(firstEvent.outcome, "kickoff");
+    assertEquals(firstEvent.call.concept, "kickoff");
+    assertEquals(firstEvent.call.personnel, "special_teams");
+  });
+
+  await t.step("kickoff events emitted after every score", () => {
+    const result = simulateGame({
+      home: makeTeam("home"),
+      away: makeTeam("away"),
+      seed: 42,
+    });
+
+    for (let i = 0; i < result.events.length - 1; i++) {
+      const event = result.events[i];
+      if (
+        event.outcome === "touchdown" ||
+        event.outcome === "field_goal"
+      ) {
+        const nextEvent = result.events[i + 1];
+        assertEquals(
+          nextEvent.outcome,
+          "kickoff",
+          `Expected kickoff after ${event.outcome} at event index ${i}`,
+        );
+      }
+    }
+  });
+
+  await t.step("multiple kickoff events exist across a full game", () => {
+    const result = simulateGame({
+      home: makeTeam("home"),
+      away: makeTeam("away"),
+      seed: 42,
+    });
+
+    const kickoffs = result.events.filter((e) => e.outcome === "kickoff");
+    assertGreater(kickoffs.length, 1);
+  });
+
+  await t.step("kickoff event has kicker participant", () => {
+    const result = simulateGame({
+      home: makeTeam("home"),
+      away: makeTeam("away"),
+      seed: 42,
+    });
+
+    const kickoffs = result.events.filter((e) => e.outcome === "kickoff");
+    for (const ko of kickoffs) {
+      const kicker = ko.participants.find((p) => p.role === "kicker");
+      assertEquals(kicker !== undefined, true);
+    }
+  });
+
+  await t.step("kickoff yardage does not pollute box score", () => {
+    const result = simulateGame({
+      home: makeTeam("home"),
+      away: makeTeam("away"),
+      seed: 42,
+    });
+
+    let homePassing = 0;
+    let homeRushing = 0;
+    let awayPassing = 0;
+    let awayRushing = 0;
+
+    for (const event of result.events) {
+      if (event.outcome === "kickoff") continue;
+
+      const isHome = event.offenseTeamId === "team-home";
+      if (event.outcome === "pass_complete") {
+        if (isHome) homePassing += event.yardage;
+        else awayPassing += event.yardage;
+      } else if (event.outcome === "rush") {
+        if (isHome) homeRushing += event.yardage;
+        else awayRushing += event.yardage;
+      } else if (event.outcome === "sack") {
+        if (isHome) homePassing += event.yardage;
+        else awayPassing += event.yardage;
+      }
+    }
+
+    assertEquals(result.boxScore.home.passingYards, homePassing);
+    assertEquals(result.boxScore.home.rushingYards, homeRushing);
+    assertEquals(result.boxScore.away.passingYards, awayPassing);
+    assertEquals(result.boxScore.away.rushingYards, awayRushing);
+  });
+
+  await t.step(
+    "onside kicks can occur when trailing in Q4 final minutes",
+    () => {
+      let foundOnside = false;
+      for (let seed = 1; seed <= 5000 && !foundOnside; seed++) {
+        const result = simulateGame({
+          home: makeTeam("home"),
+          away: makeTeam("away"),
+          seed,
+        });
+
+        const onsideEvents = result.events.filter((e) =>
+          e.tags.includes("onside" as PlayEvent["tags"][number])
+        );
+        if (onsideEvents.length > 0) {
+          foundOnside = true;
+          for (const e of onsideEvents) {
+            assertEquals(e.outcome, "kickoff");
+          }
+        }
+      }
+      assertEquals(foundOnside, true);
     },
   );
 });

--- a/server/features/simulation/simulate-game.ts
+++ b/server/features/simulation/simulate-game.ts
@@ -14,6 +14,8 @@ import type {
 } from "./resolve-play.ts";
 import type { SchemeFingerprint } from "@zone-blitz/shared";
 import { resolvePlay } from "./resolve-play.ts";
+import { resolveKickoff } from "./resolve-kickoff.ts";
+import type { KickoffContext } from "./resolve-kickoff.ts";
 import {
   deriveBoxScore,
   deriveDriveLog,
@@ -142,7 +144,8 @@ function shouldClockStop(event: PlayEvent): boolean {
     event.tags.includes("turnover") ||
     event.outcome === "touchdown" ||
     event.outcome === "field_goal" ||
-    event.outcome === "punt"
+    event.outcome === "punt" ||
+    event.outcome === "kickoff"
   );
 }
 
@@ -165,14 +168,14 @@ export function simulateGame(input: SimulationInput): GameResult {
     clock: QUARTER_SECONDS,
     homeScore: 0,
     awayScore: 0,
-    possession: "away",
-    yardLine: 25,
+    possession: "home",
+    yardLine: 35,
     down: 1,
     distance: 10,
     driveIndex: 0,
     playIndex: 0,
     globalPlayIndex: 0,
-    driveStartYardLine: 25,
+    driveStartYardLine: 35,
     drivePlays: 0,
     driveYards: 0,
   };
@@ -198,6 +201,98 @@ export function simulateGame(input: SimulationInput): GameResult {
 
   function switchPossession(): void {
     state.possession = state.possession === "home" ? "away" : "home";
+  }
+
+  function findKicker(side: "home" | "away"): PlayerRuntime {
+    const team = side === "home" ? input.home : input.away;
+    const active = side === "home" ? rosters.homeActive : rosters.awayActive;
+    const available = active.filter(
+      (p) => !rosters.injuredPlayerIds.has(p.playerId),
+    );
+    return (
+      available.find((p) => p.neutralBucket === "K") ??
+        team.starters.find((p) => p.neutralBucket === "K") ??
+        team.starters[0]
+    );
+  }
+
+  function findReturner(side: "home" | "away"): PlayerRuntime | undefined {
+    const active = side === "home" ? rosters.homeActive : rosters.awayActive;
+    const available = active.filter(
+      (p) => !rosters.injuredPlayerIds.has(p.playerId),
+    );
+    return (
+      available.find((p) => p.neutralBucket === "WR") ??
+        available.find((p) => p.neutralBucket === "RB")
+    );
+  }
+
+  function findCoverageUnit(side: "home" | "away"): PlayerRuntime[] {
+    const active = side === "home" ? rosters.homeActive : rosters.awayActive;
+    return active
+      .filter((p) => !rosters.injuredPlayerIds.has(p.playerId))
+      .filter(
+        (p) =>
+          p.neutralBucket === "LB" ||
+          p.neutralBucket === "S" ||
+          p.neutralBucket === "CB",
+      )
+      .slice(0, 4);
+  }
+
+  function performKickoff(kickingSide: "home" | "away"): void {
+    const receivingSide = kickingSide === "home" ? "away" : "home";
+    const kickingTeamId = kickingSide === "home"
+      ? input.home.teamId
+      : input.away.teamId;
+    const receivingTeamId = receivingSide === "home"
+      ? input.home.teamId
+      : input.away.teamId;
+
+    const kickerScore = kickingSide === "home"
+      ? state.homeScore
+      : state.awayScore;
+    const receiverScore = receivingSide === "home"
+      ? state.homeScore
+      : state.awayScore;
+
+    const ctx: KickoffContext = {
+      gameId,
+      driveIndex: state.driveIndex,
+      playIndex: state.playIndex,
+      quarter: state.quarter,
+      clock: formatClock(state.clock),
+      kickingTeamId,
+      receivingTeamId,
+      kicker: findKicker(kickingSide),
+      returner: findReturner(receivingSide),
+      coverageUnit: findCoverageUnit(kickingSide),
+      scoreDifferential: receiverScore - kickerScore,
+    };
+
+    const result = resolveKickoff(ctx, rng);
+    events.push(result.event);
+    state.globalPlayIndex++;
+
+    if (result.isReturnTouchdown) {
+      const isReceiverHome = receivingSide === "home";
+      if (isReceiverHome) state.homeScore += 7;
+      else state.awayScore += 7;
+
+      state.possession = kickingSide;
+      startNewDrive(25);
+      performKickoff(receivingSide);
+      return;
+    }
+
+    if (result.isOnsideRecovery) {
+      state.possession = kickingSide;
+      startNewDrive(result.startingYardLine);
+      return;
+    }
+
+    state.possession = receivingSide;
+    startNewDrive(result.startingYardLine);
   }
 
   function buildGameState(): GameState {
@@ -268,8 +363,8 @@ export function simulateGame(input: SimulationInput): GameResult {
       if (isHome) state.homeScore += 7;
       else state.awayScore += 7;
 
-      switchPossession();
-      startNewDrive(25);
+      const scoringSide: "home" | "away" = isHome ? "home" : "away";
+      performKickoff(scoringSide);
       return true;
     }
 
@@ -278,8 +373,8 @@ export function simulateGame(input: SimulationInput): GameResult {
       if (isHome) state.awayScore += 2;
       else state.homeScore += 2;
 
-      switchPossession();
-      startNewDrive(25);
+      const concedingSide: "home" | "away" = isHome ? "home" : "away";
+      performKickoff(concedingSide);
       return true;
     }
 
@@ -348,8 +443,8 @@ export function simulateGame(input: SimulationInput): GameResult {
         state.drivePlays++;
         state.globalPlayIndex++;
         state.playIndex++;
-        switchPossession();
-        startNewDrive(25);
+        const kickingSide: "home" | "away" = isHome ? "home" : "away";
+        performKickoff(kickingSide);
       } else {
         fgEvent.outcome = "pass_incomplete" as typeof fgEvent.outcome;
         fgEvent.tags.push("penalty");
@@ -468,6 +563,8 @@ export function simulateGame(input: SimulationInput): GameResult {
     return false;
   }
 
+  performKickoff("home");
+
   for (
     let q = 1 as 1 | 2 | 3 | 4;
     q <= 4;
@@ -477,10 +574,10 @@ export function simulateGame(input: SimulationInput): GameResult {
     state.clock = QUARTER_SECONDS;
 
     if (q === 3) {
-      switchPossession();
-      const secondHalfReceiver = state.possession;
-      state.possession = secondHalfReceiver;
-      startNewDrive(25);
+      const secondHalfKicker: "home" | "away" = state.possession === "home"
+        ? "home"
+        : "away";
+      performKickoff(secondHalfKicker);
     }
 
     while (state.clock > 0) {


### PR DESCRIPTION
## Summary

- Kickoffs are now first-class `PlayEvent`s emitted at the start of each half and after every score, replacing hardcoded `startNewDrive(25)` calls.
- `resolveKickoff()` consumes kicker leg strength, returner speed/elusiveness, and coverage-unit speed/tackling to produce touchback, return (variable distance), out-of-bounds, squib, onside, and return TD outcomes.
- Onside kicks are elected by trailing teams inside the final 5 minutes of Q4 with ~12% NFL-realistic recovery rate.
- `PlayOutcome` gains `"kickoff"`, `PlayTag` gains `"onside"`.
- Return TDs score immediately and trigger another kickoff (defensive-TD pipeline).
- Box score and drive log derivation correctly exclude kickoff events from offensive stats.

Closes #283

🤖 Generated with [Claude Code](https://claude.com/claude-code)