### PR TITLE
feat(sim): model XP, two-point, safeties, and defensive TDs

### DIFF
--- a/server/features/simulation/derive-game-views.ts
+++ b/server/features/simulation/derive-game-views.ts
@@ -48,6 +48,12 @@ export function deriveBoxScore(
     const offenseBox = isHome ? box.home : box.away;
     const defenseBox = isHome ? box.away : box.home;
 
+    if (
+      event.outcome === "xp" || event.outcome === "two_point"
+    ) {
+      continue;
+    }
+
     if (event.outcome === "pass_complete") {
       offenseBox.passingYards += event.yardage;
       offenseBox.totalYards += event.yardage;

--- a/server/features/simulation/events.test.ts
+++ b/server/features/simulation/events.test.ts
@@ -145,6 +145,9 @@ Deno.test("PlayEvent types", async (t) => {
       "penalty",
       "kneel",
       "spike",
+      "xp",
+      "two_point",
+      "safety",
     ];
     assertExists(outcomes);
   });
@@ -171,6 +174,7 @@ Deno.test("PlayEvent types", async (t) => {
       "injury_miss_weeks",
       "injury_miss_season",
       "injury_career_ending",
+      "return_td",
     ];
     assertExists(tags);
   });

--- a/server/features/simulation/events.ts
+++ b/server/features/simulation/events.ts
@@ -30,7 +30,10 @@ export type PlayOutcome =
   | "penalty"
   | "kneel"
   | "spike"
-  | "kickoff";
+  | "kickoff"
+  | "xp"
+  | "two_point"
+  | "safety";
 
 export type InjurySeverity =
   | "shake_off"
@@ -62,7 +65,8 @@ export type PlayTag =
   | "injury_miss_weeks"
   | "injury_miss_season"
   | "injury_career_ending"
-  | "onside";
+  | "onside"
+  | "return_td";
 
 export type PlayEvent = {
   gameId: string;

--- a/server/features/simulation/mod.ts
+++ b/server/features/simulation/mod.ts
@@ -56,5 +56,16 @@ export type { SeasonInput, SeasonResult } from "./simulate-season.ts";
 export { computeSeasonAggregates } from "./season-aggregates.ts";
 export type { SeasonAggregates } from "./season-aggregates.ts";
 
+export {
+  conversionDecision,
+  detectSafety,
+  findKicker,
+  findTurnoverDefender,
+  resolveExtraPoint,
+  resolveReturnTd,
+  resolveTwoPointConversion,
+} from "./scoring.ts";
+export type { ConversionChoice } from "./scoring.ts";
+
 export { seedSweep } from "./seed-sweep.ts";
 export type { BandStats, SweepResult } from "./seed-sweep.ts";

--- a/server/features/simulation/resolve-play.test.ts
+++ b/server/features/simulation/resolve-play.test.ts
@@ -1,4 +1,4 @@
-import { assertEquals, assertNotEquals } from "@std/assert";
+import { assertEquals, assertExists, assertNotEquals } from "@std/assert";
 import {
   PLAYER_ATTRIBUTE_KEYS,
   type PlayerAttributes,
@@ -1339,6 +1339,163 @@ Deno.test("determinism: same roster + staff + seed produces byte-identical PlayE
       JSON.stringify(events2[i]),
       `Play ${i} diverged`,
     );
+  }
+});
+
+Deno.test("synthesizeOutcome emits safety when offense driven behind own goal line", () => {
+  const runCall: OffensiveCall = {
+    concept: "inside_zone",
+    personnel: "11",
+    formation: "shotgun",
+    motion: "none",
+  };
+  const coverageCall: DefensiveCall = {
+    front: "4-3",
+    coverage: "cover_3",
+    pressure: "four_man",
+  };
+  let safetyFound = false;
+  for (let seed = 0; seed < 500; seed++) {
+    const rng = makeRng(seed);
+    const state = makeGameState({
+      situation: makeSituation({ yardLine: 2 }),
+    });
+    const contribs: MatchupContribution[] = [
+      {
+        matchup: {
+          type: "run_block",
+          attacker: makePlayer("ot1", "OT"),
+          defender: makePlayer("idl1", "IDL"),
+        },
+        attackerFit: "neutral",
+        defenderFit: "neutral",
+        score: -25,
+      },
+    ];
+    const event = synthesizeOutcome(
+      runCall,
+      coverageCall,
+      contribs,
+      state,
+      rng,
+    );
+    if (event.outcome === "safety") {
+      assertEquals(event.tags.includes("safety"), true);
+      safetyFound = true;
+      break;
+    }
+  }
+  assertEquals(
+    safetyFound,
+    true,
+    "Should emit safety when offense tackled in own end zone",
+  );
+});
+
+Deno.test("synthesizeOutcome emits return_td on turnovers", () => {
+  const passCall: OffensiveCall = {
+    concept: "dropback",
+    personnel: "11",
+    formation: "shotgun",
+    motion: "none",
+  };
+  const coverageCall: DefensiveCall = {
+    front: "4-3",
+    coverage: "cover_3",
+    pressure: "four_man",
+  };
+  let returnTdFound = false;
+  for (let seed = 0; seed < 5000 && !returnTdFound; seed++) {
+    const rng = makeRng(seed);
+    const contribs: MatchupContribution[] = [
+      {
+        matchup: {
+          type: "pass_protection",
+          attacker: makePlayer("ot1", "OT"),
+          defender: makePlayer("edge1", "EDGE"),
+        },
+        attackerFit: "neutral",
+        defenderFit: "neutral",
+        score: 10,
+      },
+      {
+        matchup: {
+          type: "route_coverage",
+          attacker: makePlayer("wr1", "WR"),
+          defender: makePlayer("cb1", "CB", { speed: 90, acceleration: 88 }),
+        },
+        attackerFit: "neutral",
+        defenderFit: "neutral",
+        score: -20,
+      },
+    ];
+    const event = synthesizeOutcome(
+      passCall,
+      coverageCall,
+      contribs,
+      makeGameState(),
+      rng,
+    );
+    if (event.tags.includes("return_td")) {
+      assertEquals(event.tags.includes("turnover"), true);
+      assertEquals(event.tags.includes("touchdown"), true);
+      returnTdFound = true;
+    }
+  }
+  assertEquals(returnTdFound, true, "Should emit return_td on some turnovers");
+});
+
+Deno.test("synthesizeOutcome return_td tags defender with touchdown", () => {
+  const passCall: OffensiveCall = {
+    concept: "dropback",
+    personnel: "11",
+    formation: "shotgun",
+    motion: "none",
+  };
+  const coverageCall: DefensiveCall = {
+    front: "4-3",
+    coverage: "cover_3",
+    pressure: "four_man",
+  };
+  for (let seed = 0; seed < 5000; seed++) {
+    const rng = makeRng(seed);
+    const contribs: MatchupContribution[] = [
+      {
+        matchup: {
+          type: "pass_protection",
+          attacker: makePlayer("ot1", "OT"),
+          defender: makePlayer("edge1", "EDGE"),
+        },
+        attackerFit: "neutral",
+        defenderFit: "neutral",
+        score: 10,
+      },
+      {
+        matchup: {
+          type: "route_coverage",
+          attacker: makePlayer("wr1", "WR"),
+          defender: makePlayer("cb1", "CB", { speed: 90, acceleration: 88 }),
+        },
+        attackerFit: "neutral",
+        defenderFit: "neutral",
+        score: -20,
+      },
+    ];
+    const event = synthesizeOutcome(
+      passCall,
+      coverageCall,
+      contribs,
+      makeGameState(),
+      rng,
+    );
+    if (event.tags.includes("return_td")) {
+      const defenderParticipant = event.participants.find(
+        (p) => p.tags.includes("return_td"),
+      );
+      assertExists(defenderParticipant);
+      assertEquals(defenderParticipant!.tags.includes("touchdown"), true);
+      break;
+    }
   }
 });
 

--- a/server/features/simulation/resolve-play.ts
+++ b/server/features/simulation/resolve-play.ts
@@ -591,11 +591,53 @@ export function synthesizeOutcome(
     tags.push("injury");
   }
 
+  // Safety: offense driven behind their own goal line
+  const resultYardLine = state.situation.yardLine + yardage;
+  if (resultYardLine <= 0 && !tags.includes("turnover")) {
+    outcome = "safety";
+    yardage = -state.situation.yardLine;
+    tags.push("safety");
+  }
+
   const yardsToEndzone = 100 - state.situation.yardLine;
   if (yardage >= yardsToEndzone && !tags.includes("turnover")) {
     outcome = "touchdown";
     yardage = yardsToEndzone;
     tags.push("touchdown");
+  }
+
+  // Defensive return TD on turnovers
+  if (tags.includes("turnover") && outcome !== "safety") {
+    const turnoverDefender = contributions.find((c) => {
+      if (outcome === "interception") {
+        return c.matchup.type === "route_coverage" && c.score < -10;
+      }
+      return c.matchup.type === "pass_rush" ||
+        c.matchup.type === "run_defense" ||
+        c.matchup.type === "run_block";
+    });
+    const defender = turnoverDefender?.matchup.defender;
+    const speed = defender?.attributes.speed ?? 50;
+    const acceleration = defender?.attributes.acceleration ?? 50;
+    const avgAttr = (speed + acceleration) / 2;
+    const returnTdProb = 0.02 + (avgAttr - 30) * (0.06 / 60);
+    if (rng.next() < Math.max(0.01, Math.min(0.10, returnTdProb))) {
+      tags.push("return_td", "touchdown");
+      if (defender) {
+        const existingIdx = participants.findIndex(
+          (p) => p.playerId === defender.playerId,
+        );
+        if (existingIdx >= 0) {
+          participants[existingIdx].tags.push("return_td", "touchdown");
+        } else {
+          participants.push({
+            role: outcome === "interception" ? "route_coverage" : "run_defense",
+            playerId: defender.playerId,
+            tags: ["return_td", "touchdown"],
+          });
+        }
+      }
+    }
   }
 
   return {

--- a/server/features/simulation/scoring.test.ts
+++ b/server/features/simulation/scoring.test.ts
@@ -1,0 +1,465 @@
+import { assertEquals } from "@std/assert";
+import {
+  PLAYER_ATTRIBUTE_KEYS,
+  type PlayerAttributes,
+  type SchemeFingerprint,
+} from "@zone-blitz/shared";
+import { createRng, mulberry32 } from "./rng.ts";
+import type { SeededRng } from "./rng.ts";
+import type {
+  CoachingMods,
+  GameState,
+  PlayerRuntime,
+  TeamRuntime,
+} from "./resolve-play.ts";
+import type { PlayEvent } from "./events.ts";
+import {
+  conversionDecision,
+  detectSafety,
+  findKicker,
+  findTurnoverDefender,
+  resolveExtraPoint,
+  resolveReturnTd,
+  resolveTwoPointConversion,
+} from "./scoring.ts";
+
+function makeAttributes(
+  overrides: Partial<PlayerAttributes> = {},
+): PlayerAttributes {
+  const base: Partial<PlayerAttributes> = {};
+  for (const key of PLAYER_ATTRIBUTE_KEYS) {
+    (base as Record<string, number>)[key] = 50;
+    (base as Record<string, number>)[`${key}Potential`] = 50;
+  }
+  return { ...base, ...overrides } as PlayerAttributes;
+}
+
+function makePlayer(
+  id: string,
+  bucket: PlayerRuntime["neutralBucket"],
+  overrides: Partial<PlayerAttributes> = {},
+): PlayerRuntime {
+  return {
+    playerId: id,
+    neutralBucket: bucket,
+    attributes: makeAttributes(overrides),
+  };
+}
+
+function makeRng(seed = 42): SeededRng {
+  return createRng(mulberry32(seed));
+}
+
+function makeFingerprint(): SchemeFingerprint {
+  return {
+    offense: {
+      runPassLean: 50,
+      tempo: 50,
+      personnelWeight: 50,
+      formationUnderCenterShotgun: 50,
+      preSnapMotionRate: 50,
+      passingStyle: 50,
+      passingDepth: 50,
+      runGameBlocking: 50,
+      rpoIntegration: 50,
+    },
+    defense: {
+      frontOddEven: 50,
+      gapResponsibility: 50,
+      subPackageLean: 50,
+      coverageManZone: 50,
+      coverageShell: 50,
+      cornerPressOff: 50,
+      pressureRate: 50,
+      disguiseRate: 50,
+    },
+    overrides: {},
+  };
+}
+
+function makeCoachingMods(): CoachingMods {
+  return { schemeFitBonus: 0, situationalBonus: 0 };
+}
+
+function makeOffense(): PlayerRuntime[] {
+  return [
+    makePlayer("qb1", "QB"),
+    makePlayer("rb1", "RB"),
+    makePlayer("wr1", "WR"),
+    makePlayer("wr2", "WR"),
+    makePlayer("te1", "TE"),
+    makePlayer("ot1", "OT"),
+    makePlayer("ot2", "OT"),
+    makePlayer("iol1", "IOL"),
+    makePlayer("iol2", "IOL"),
+    makePlayer("iol3", "IOL"),
+  ];
+}
+
+function makeDefense(): PlayerRuntime[] {
+  return [
+    makePlayer("edge1", "EDGE"),
+    makePlayer("edge2", "EDGE"),
+    makePlayer("idl1", "IDL"),
+    makePlayer("idl2", "IDL"),
+    makePlayer("lb1", "LB"),
+    makePlayer("lb2", "LB"),
+    makePlayer("cb1", "CB"),
+    makePlayer("cb2", "CB"),
+    makePlayer("s1", "S"),
+    makePlayer("s2", "S"),
+  ];
+}
+
+function makeGameState(overrides: Partial<GameState> = {}): GameState {
+  return {
+    gameId: "game-1",
+    driveIndex: 0,
+    playIndex: 0,
+    quarter: 1,
+    clock: "15:00",
+    situation: { down: 1, distance: 10, yardLine: 30 },
+    offenseTeamId: "team-a",
+    defenseTeamId: "team-b",
+    ...overrides,
+  };
+}
+
+function makeTeamRuntime(
+  overrides: Partial<TeamRuntime> & { onField?: PlayerRuntime[] } = {},
+): TeamRuntime {
+  return {
+    fingerprint: makeFingerprint(),
+    onField: makeOffense(),
+    coachingMods: makeCoachingMods(),
+    ...overrides,
+  };
+}
+
+// ── conversionDecision ─────────────────────────────────────────────
+
+Deno.test("conversionDecision", async (t) => {
+  await t.step("defaults to XP with neutral aggressiveness", () => {
+    assertEquals(conversionDecision(0, 1, "15:00", 50), "xp");
+  });
+
+  await t.step("goes for 2 when down 2 in Q4", () => {
+    assertEquals(conversionDecision(-2, 4, "5:00", 50), "two_point");
+  });
+
+  await t.step("goes for 2 when down 8 in any quarter", () => {
+    assertEquals(conversionDecision(-8, 1, "15:00", 50), "two_point");
+    assertEquals(conversionDecision(-8, 4, "2:00", 50), "two_point");
+  });
+
+  await t.step("goes for 2 when down 15 in Q3+", () => {
+    assertEquals(conversionDecision(-15, 3, "10:00", 50), "two_point");
+    assertEquals(conversionDecision(-15, 4, "5:00", 50), "two_point");
+  });
+
+  await t.step("does not go for 2 when down 15 in Q1", () => {
+    assertEquals(conversionDecision(-15, 1, "12:00", 50), "xp");
+  });
+
+  await t.step("aggressive coach goes for 2 in Q4", () => {
+    assertEquals(conversionDecision(0, 4, "10:00", 85), "two_point");
+  });
+
+  await t.step(
+    "aggressive coach still kicks XP early unless threshold met",
+    () => {
+      assertEquals(conversionDecision(0, 1, "15:00", 85), "xp");
+    },
+  );
+
+  await t.step("very aggressive coach goes for 2 even early", () => {
+    assertEquals(conversionDecision(0, 1, "15:00", 95), "two_point");
+  });
+
+  await t.step("2PT rate across sweep lands in NFL bands (5-10%)", () => {
+    let twoPtCount = 0;
+    const total = 1000;
+    for (let i = 0; i < total; i++) {
+      const quarter = ((i % 4) + 1) as 1 | 2 | 3 | 4;
+      const diff = (i % 21) - 10;
+      const aggressiveness = 40 + (i % 30);
+      const choice = conversionDecision(diff, quarter, "8:00", aggressiveness);
+      if (choice === "two_point") twoPtCount++;
+    }
+    const rate = twoPtCount / total;
+    assertEquals(
+      rate >= 0.03 && rate <= 0.15,
+      true,
+      `2PT rate ${rate} outside NFL bands`,
+    );
+  });
+});
+
+// ── resolveExtraPoint ──────────────────────────────────────────────
+
+Deno.test("resolveExtraPoint", async (t) => {
+  await t.step("high-accuracy kicker makes XP at high rate", () => {
+    const kicker = makePlayer("k1", "K", { kickingAccuracy: 85 });
+    let made = 0;
+    const total = 200;
+    for (let i = 0; i < total; i++) {
+      if (resolveExtraPoint(kicker, makeRng(i))) made++;
+    }
+    assertEquals(
+      made / total > 0.90,
+      true,
+      `XP rate ${made / total} too low for elite kicker`,
+    );
+  });
+
+  await t.step("low-accuracy kicker misses more often", () => {
+    const kicker = makePlayer("k1", "K", { kickingAccuracy: 30 });
+    let missed = 0;
+    const total = 500;
+    for (let i = 0; i < total; i++) {
+      if (!resolveExtraPoint(kicker, makeRng(i))) missed++;
+    }
+    assertEquals(missed > 0, true, "Low-accuracy kicker should miss some XPs");
+  });
+
+  await t.step("handles undefined kicker gracefully", () => {
+    const rng = makeRng();
+    const result = resolveExtraPoint(undefined, rng);
+    assertEquals(typeof result, "boolean");
+  });
+
+  await t.step(
+    "XP success rate in NFL range (~88-98%) for average kicker",
+    () => {
+      const kicker = makePlayer("k1", "K", { kickingAccuracy: 50 });
+      let made = 0;
+      const total = 1000;
+      for (let i = 0; i < total; i++) {
+        if (resolveExtraPoint(kicker, makeRng(i))) made++;
+      }
+      const rate = made / total;
+      assertEquals(
+        rate >= 0.85 && rate <= 0.99,
+        true,
+        `XP rate ${rate} outside range`,
+      );
+    },
+  );
+});
+
+// ── resolveTwoPointConversion ──────────────────────────────────────
+
+Deno.test("resolveTwoPointConversion", async (t) => {
+  await t.step("returns a PlayEvent with outcome two_point", () => {
+    const rng = makeRng();
+    const state = makeGameState();
+    const offense = makeTeamRuntime({ onField: makeOffense() });
+    const defense = makeTeamRuntime({ onField: makeDefense() });
+
+    const event = resolveTwoPointConversion(state, offense, defense, rng);
+    assertEquals(event.outcome, "two_point");
+  });
+
+  await t.step("successful conversion has two_point_conversion tag", () => {
+    let foundSuccess = false;
+    for (let seed = 0; seed < 200 && !foundSuccess; seed++) {
+      const rng = makeRng(seed);
+      const state = makeGameState();
+      const offense = makeTeamRuntime({ onField: makeOffense() });
+      const defense = makeTeamRuntime({ onField: makeDefense() });
+
+      const event = resolveTwoPointConversion(state, offense, defense, rng);
+      if (event.tags.includes("two_point_conversion")) {
+        foundSuccess = true;
+        assertEquals(event.outcome, "two_point");
+      }
+    }
+    assertEquals(foundSuccess, true, "Should find at least one successful 2PT");
+  });
+
+  await t.step("failed conversion does not have touchdown tag", () => {
+    for (let seed = 0; seed < 100; seed++) {
+      const rng = makeRng(seed);
+      const state = makeGameState();
+      const offense = makeTeamRuntime({ onField: makeOffense() });
+      const defense = makeTeamRuntime({ onField: makeDefense() });
+
+      const event = resolveTwoPointConversion(state, offense, defense, rng);
+      assertEquals(event.tags.includes("touchdown"), false);
+    }
+  });
+
+  await t.step(
+    "2PT conversion rate in NFL range (~45-55%) over many seeds",
+    () => {
+      let success = 0;
+      const total = 500;
+      for (let seed = 0; seed < total; seed++) {
+        const rng = makeRng(seed);
+        const state = makeGameState();
+        const offense = makeTeamRuntime({ onField: makeOffense() });
+        const defense = makeTeamRuntime({ onField: makeDefense() });
+
+        const event = resolveTwoPointConversion(state, offense, defense, rng);
+        if (event.tags.includes("two_point_conversion")) success++;
+      }
+      const rate = success / total;
+      assertEquals(
+        rate >= 0.20 && rate <= 0.70,
+        true,
+        `2PT success rate ${rate} outside bounds`,
+      );
+    },
+  );
+});
+
+// ── detectSafety ───────────────────────────────────────────────────
+
+Deno.test("detectSafety", async (t) => {
+  await t.step("sack at the 2-yard line into end zone is a safety", () => {
+    assertEquals(detectSafety(-5, 2, "sack"), true);
+  });
+
+  await t.step(
+    "tackle at the 1-yard line for loss into end zone is a safety",
+    () => {
+      assertEquals(detectSafety(-3, 1, "rush"), true);
+    },
+  );
+
+  await t.step("normal play at mid-field is not a safety", () => {
+    assertEquals(detectSafety(-2, 30, "sack"), false);
+  });
+
+  await t.step("play at own 5 with small loss is not a safety", () => {
+    assertEquals(detectSafety(-3, 5, "rush"), false);
+  });
+
+  await t.step("play exactly at goal line (result = 0) is a safety", () => {
+    assertEquals(detectSafety(-3, 3, "rush"), true);
+  });
+
+  await t.step("field goal is never a safety", () => {
+    assertEquals(detectSafety(-5, 2, "field_goal"), false);
+  });
+
+  await t.step("punt is never a safety", () => {
+    assertEquals(detectSafety(-5, 2, "punt"), false);
+  });
+});
+
+// ── resolveReturnTd ────────────────────────────────────────────────
+
+Deno.test("resolveReturnTd", async (t) => {
+  await t.step("fast defender has higher return TD chance", () => {
+    const fastDefender = makePlayer("cb1", "CB", {
+      speed: 90,
+      acceleration: 88,
+    });
+    let tdCount = 0;
+    const total = 1000;
+    for (let i = 0; i < total; i++) {
+      if (resolveReturnTd(fastDefender, makeRng(i))) tdCount++;
+    }
+    assertEquals(
+      tdCount > 0,
+      true,
+      "Fast defender should score some return TDs",
+    );
+    assertEquals(
+      tdCount / total <= 0.15,
+      true,
+      "Return TD rate should not exceed 15%",
+    );
+  });
+
+  await t.step("slow defender has lower return TD chance", () => {
+    const slowDefender = makePlayer("lb1", "LB", {
+      speed: 30,
+      acceleration: 30,
+    });
+    let tdCount = 0;
+    const total = 1000;
+    for (let i = 0; i < total; i++) {
+      if (resolveReturnTd(slowDefender, makeRng(i))) tdCount++;
+    }
+    assertEquals(
+      tdCount / total < 0.05,
+      true,
+      `Slow defender rate ${tdCount / total} too high`,
+    );
+  });
+
+  await t.step("handles undefined defender", () => {
+    const rng = makeRng();
+    const result = resolveReturnTd(undefined, rng);
+    assertEquals(typeof result, "boolean");
+  });
+
+  await t.step("overall return TD rate in NFL range (1-10%)", () => {
+    const defender = makePlayer("cb1", "CB", { speed: 50, acceleration: 50 });
+    let tdCount = 0;
+    const total = 2000;
+    for (let i = 0; i < total; i++) {
+      if (resolveReturnTd(defender, makeRng(i))) tdCount++;
+    }
+    const rate = tdCount / total;
+    assertEquals(
+      rate >= 0.01 && rate <= 0.10,
+      true,
+      `Return TD rate ${rate} outside range`,
+    );
+  });
+});
+
+// ── findKicker ─────────────────────────────────────────────────────
+
+Deno.test("findKicker", async (t) => {
+  await t.step("finds K player in roster", () => {
+    const players = [
+      makePlayer("qb1", "QB"),
+      makePlayer("k1", "K"),
+      makePlayer("rb1", "RB"),
+    ];
+    const kicker = findKicker(players);
+    assertEquals(kicker?.playerId, "k1");
+  });
+
+  await t.step("returns undefined when no K in roster", () => {
+    const players = [makePlayer("qb1", "QB"), makePlayer("rb1", "RB")];
+    assertEquals(findKicker(players), undefined);
+  });
+});
+
+// ── findTurnoverDefender ───────────────────────────────────────────
+
+Deno.test("findTurnoverDefender", async (t) => {
+  await t.step("finds interception participant", () => {
+    const event = {
+      participants: [
+        { role: "route_coverage", playerId: "cb1", tags: ["interception"] },
+        { role: "pass_protection", playerId: "ot1", tags: [] },
+      ],
+    } as PlayEvent;
+    assertEquals(findTurnoverDefender(event), "cb1");
+  });
+
+  await t.step("falls back to defensive participant for fumbles", () => {
+    const event = {
+      participants: [
+        { role: "run_block", playerId: "ot1", tags: [] },
+        { role: "run_defense", playerId: "lb1", tags: [] },
+      ],
+    } as unknown as PlayEvent;
+    assertEquals(findTurnoverDefender(event), "lb1");
+  });
+
+  await t.step("returns undefined with no defensive participants", () => {
+    const event = {
+      participants: [
+        { role: "ball_carrier", playerId: "rb1", tags: [] },
+      ],
+    } as unknown as PlayEvent;
+    assertEquals(findTurnoverDefender(event), undefined);
+  });
+});

--- a/server/features/simulation/scoring.ts
+++ b/server/features/simulation/scoring.ts
@@ -1,0 +1,127 @@
+import type { PlayEvent, PlayOutcome } from "./events.ts";
+import type { GameState, PlayerRuntime, TeamRuntime } from "./resolve-play.ts";
+import { resolvePlay } from "./resolve-play.ts";
+import type { SeededRng } from "./rng.ts";
+
+export type ConversionChoice = "xp" | "two_point";
+
+export function conversionDecision(
+  scoreDiff: number,
+  quarter: 1 | 2 | 3 | 4 | "OT",
+  _clock: string,
+  hcAggressiveness: number,
+): ConversionChoice {
+  // NFL 2PT attempt rate is ~5-8%. Go for 2 when trailing by specific amounts
+  // late, or when coach aggressiveness is high enough.
+  const q = typeof quarter === "number" ? quarter : 5;
+
+  // Down 2: a successful 2PT ties instead of trailing by 1
+  if (scoreDiff === -2 && q >= 4) return "two_point";
+  // Down 8: need TD+2PT to tie
+  if (scoreDiff === -8) return "two_point";
+  // Down 15: two scores, need at least one 2PT
+  if (scoreDiff === -15 && q >= 3) return "two_point";
+
+  // Aggressive coaches go for 2 more often late
+  const aggressivenessThreshold = q >= 4 ? 80 : 92;
+  if (hcAggressiveness >= aggressivenessThreshold) {
+    return "two_point";
+  }
+
+  return "xp";
+}
+
+export function resolveExtraPoint(
+  kicker: PlayerRuntime | undefined,
+  rng: SeededRng,
+): boolean {
+  const accuracy = kicker?.attributes.kickingAccuracy ?? 50;
+  // NFL XP success rate ~94%. Scale from ~88% (accuracy=30) to ~98% (accuracy=90).
+  const baseProbability = 0.88 + (accuracy - 30) * (0.10 / 60);
+  const probability = Math.max(0.80, Math.min(0.99, baseProbability));
+  return rng.next() < probability;
+}
+
+export function resolveTwoPointConversion(
+  gameState: GameState,
+  offense: TeamRuntime,
+  defense: TeamRuntime,
+  rng: SeededRng,
+): PlayEvent {
+  const twoPointState: GameState = {
+    ...gameState,
+    situation: { down: 1, distance: 2, yardLine: 98 },
+  };
+
+  const event = resolvePlay(twoPointState, offense, defense, rng);
+  const naturallyScored = event.outcome === "touchdown" ||
+    (event.yardage >= 2 && !event.tags.includes("turnover"));
+
+  // Goal-line defense compression: the matchup pipeline doesn't model
+  // stacked-box goal-line formations, so apply a compression roll to
+  // bring 2PT success rates into NFL range (~48%).
+  const success = naturallyScored && rng.next() < 0.50;
+
+  return {
+    ...event,
+    outcome: "two_point" as PlayOutcome,
+    tags: success
+      ? [...event.tags.filter((t) => t !== "touchdown"), "two_point_conversion"]
+      : event.tags.filter((t) => t !== "touchdown" && t !== "first_down"),
+  };
+}
+
+export function detectSafety(
+  yardage: number,
+  yardLine: number,
+  outcome: PlayOutcome,
+): boolean {
+  // Safety occurs when the offense is tackled/grounded in their own end zone.
+  // yardLine is offense-relative (own 1 = closest to own end zone).
+  // A play that pushes the ball carrier behind the goal line (yardLine + yardage <= 0)
+  // is a safety.
+  if (outcome === "field_goal" || outcome === "punt") return false;
+  const resultYard = yardLine + yardage;
+  return resultYard <= 0;
+}
+
+export function resolveReturnTd(
+  defender: PlayerRuntime | undefined,
+  rng: SeededRng,
+): boolean {
+  // NFL return TD rate on turnovers ~3-5%.
+  // Driven by defender speed and open-field attributes.
+  const speed = defender?.attributes.speed ?? 50;
+  const acceleration = defender?.attributes.acceleration ?? 50;
+  const avgAttr = (speed + acceleration) / 2;
+  // Scale from ~2% (attr=30) to ~8% (attr=90)
+  const probability = 0.02 + (avgAttr - 30) * (0.06 / 60);
+  return rng.next() < Math.max(0.01, Math.min(0.10, probability));
+}
+
+export function findKicker(
+  players: PlayerRuntime[],
+): PlayerRuntime | undefined {
+  return players.find((p) => p.neutralBucket === "K");
+}
+
+export function findTurnoverDefender(
+  event: PlayEvent,
+): string | undefined {
+  const intParticipant = event.participants.find((p) =>
+    p.tags.includes("interception")
+  );
+  if (intParticipant) return intParticipant.playerId;
+
+  const fumbleRecovery = event.participants.find((p) =>
+    p.tags.includes("fumble_recovery")
+  );
+  if (fumbleRecovery) return fumbleRecovery.playerId;
+
+  // For fumbles without a tagged recovery player, pick the first defensive participant
+  const defensiveParticipant = event.participants.find((p) =>
+    p.role === "pass_rush" || p.role === "route_coverage" ||
+    p.role === "run_defense"
+  );
+  return defensiveParticipant?.playerId;
+}

--- a/server/features/simulation/simulate-game.test.ts
+++ b/server/features/simulation/simulate-game.test.ts
@@ -525,6 +525,231 @@ Deno.test("simulateGame", async (t) => {
   });
 
   await t.step(
+    "touchdowns followed by conversion events (xp or two_point)",
+    () => {
+      const result = simulateGame({
+        home: makeTeam("home"),
+        away: makeTeam("away"),
+        seed: 42,
+      });
+
+      const tdEvents = result.events.filter(
+        (e) => e.outcome === "touchdown",
+      );
+      assertGreater(tdEvents.length, 0, "Should have touchdowns");
+
+      for (const tdEvent of tdEvents) {
+        const tdIdx = result.events.indexOf(tdEvent);
+        const nextEvent = result.events[tdIdx + 1];
+        if (nextEvent) {
+          assertEquals(
+            nextEvent.outcome === "xp" || nextEvent.outcome === "two_point",
+            true,
+            `Event after TD should be xp or two_point, got ${nextEvent.outcome}`,
+          );
+        }
+      }
+    },
+  );
+
+  await t.step(
+    "scores are not multiples of 7 — missed XPs and 2PTs create variety",
+    () => {
+      let nonMultipleOf7 = false;
+      for (let seed = 1; seed <= 50 && !nonMultipleOf7; seed++) {
+        const result = simulateGame({
+          home: makeTeam("home"),
+          away: makeTeam("away"),
+          seed,
+        });
+        if (
+          result.finalScore.home % 7 !== 0 ||
+          result.finalScore.away % 7 !== 0
+        ) {
+          nonMultipleOf7 = true;
+        }
+      }
+      assertEquals(
+        nonMultipleOf7,
+        true,
+        "Should see non-multiples-of-7 scores",
+      );
+    },
+  );
+
+  await t.step(
+    "XP events appear with outcome xp",
+    () => {
+      let foundXp = false;
+      for (let seed = 1; seed <= 20 && !foundXp; seed++) {
+        const result = simulateGame({
+          home: makeTeam("home"),
+          away: makeTeam("away"),
+          seed,
+        });
+        const xpEvents = result.events.filter((e) => e.outcome === "xp");
+        if (xpEvents.length > 0) {
+          foundXp = true;
+        }
+      }
+      assertEquals(foundXp, true, "Should find XP events");
+    },
+  );
+
+  await t.step(
+    "safeties emit safety outcome and award 2 points to defense",
+    () => {
+      // Use a team with weak OL to increase sack rate and safety probability
+      const weakOlTeam: SimTeam = {
+        ...makeTeam("weak"),
+        starters: [
+          makePlayer("w-qb", "QB"),
+          makePlayer("w-rb", "RB"),
+          makePlayer("w-wr1", "WR"),
+          makePlayer("w-wr2", "WR"),
+          makePlayer("w-te", "TE"),
+          makePlayer("w-ot1", "OT", { passBlocking: 20, strength: 20 }),
+          makePlayer("w-ot2", "OT", { passBlocking: 20, strength: 20 }),
+          makePlayer("w-iol1", "IOL", { passBlocking: 20, strength: 20 }),
+          makePlayer("w-iol2", "IOL", { passBlocking: 20, strength: 20 }),
+          makePlayer("w-iol3", "IOL", { passBlocking: 20, strength: 20 }),
+          makePlayer("w-edge1", "EDGE"),
+          makePlayer("w-edge2", "EDGE"),
+          makePlayer("w-idl1", "IDL"),
+          makePlayer("w-idl2", "IDL"),
+          makePlayer("w-lb1", "LB"),
+          makePlayer("w-lb2", "LB"),
+          makePlayer("w-cb1", "CB"),
+          makePlayer("w-cb2", "CB"),
+          makePlayer("w-s1", "S"),
+          makePlayer("w-s2", "S"),
+          makePlayer("w-k", "K"),
+          makePlayer("w-p", "K"),
+        ],
+      };
+      const strongDlTeam: SimTeam = {
+        ...makeTeam("strong"),
+        starters: [
+          makePlayer("s-qb", "QB"),
+          makePlayer("s-rb", "RB"),
+          makePlayer("s-wr1", "WR"),
+          makePlayer("s-wr2", "WR"),
+          makePlayer("s-te", "TE"),
+          makePlayer("s-ot1", "OT"),
+          makePlayer("s-ot2", "OT"),
+          makePlayer("s-iol1", "IOL"),
+          makePlayer("s-iol2", "IOL"),
+          makePlayer("s-iol3", "IOL"),
+          makePlayer("s-edge1", "EDGE", {
+            passRushing: 90,
+            acceleration: 85,
+            strength: 85,
+          }),
+          makePlayer("s-edge2", "EDGE", {
+            passRushing: 90,
+            acceleration: 85,
+            strength: 85,
+          }),
+          makePlayer("s-idl1", "IDL", {
+            passRushing: 85,
+            strength: 85,
+          }),
+          makePlayer("s-idl2", "IDL", {
+            passRushing: 85,
+            strength: 85,
+          }),
+          makePlayer("s-lb1", "LB"),
+          makePlayer("s-lb2", "LB"),
+          makePlayer("s-cb1", "CB"),
+          makePlayer("s-cb2", "CB"),
+          makePlayer("s-s1", "S"),
+          makePlayer("s-s2", "S"),
+          makePlayer("s-k", "K"),
+          makePlayer("s-p", "K"),
+        ],
+      };
+
+      let safetyFound = false;
+      for (let seed = 1; seed <= 2000 && !safetyFound; seed++) {
+        const result = simulateGame({
+          home: weakOlTeam,
+          away: strongDlTeam,
+          seed,
+        });
+        const safetyEvents = result.events.filter(
+          (e) => e.outcome === "safety",
+        );
+        if (safetyEvents.length > 0) {
+          safetyFound = true;
+          assertEquals(result.finalScore.home >= 0, true);
+          assertEquals(result.finalScore.away >= 0, true);
+        }
+      }
+      assertEquals(
+        safetyFound,
+        true,
+        "Should find safety events across many seeds",
+      );
+    },
+  );
+
+  await t.step(
+    "return TDs produce return_td tagged events",
+    () => {
+      let returnTdFound = false;
+      for (let seed = 1; seed <= 500 && !returnTdFound; seed++) {
+        const result = simulateGame({
+          home: makeTeam("home"),
+          away: makeTeam("away"),
+          seed,
+        });
+        const returnTdEvents = result.events.filter(
+          (e) => e.tags.includes("return_td"),
+        );
+        if (returnTdEvents.length > 0) {
+          returnTdFound = true;
+          for (const event of returnTdEvents) {
+            assertEquals(event.tags.includes("turnover"), true);
+            assertEquals(event.tags.includes("touchdown"), true);
+          }
+        }
+      }
+      assertEquals(
+        returnTdFound,
+        true,
+        "Should find return TD events across many seeds",
+      );
+    },
+  );
+
+  await t.step(
+    "return TDs followed by conversion events",
+    () => {
+      for (let seed = 1; seed <= 500; seed++) {
+        const result = simulateGame({
+          home: makeTeam("home"),
+          away: makeTeam("away"),
+          seed,
+        });
+        const returnTdEvents = result.events.filter(
+          (e) => e.tags.includes("return_td"),
+        );
+        for (const rtd of returnTdEvents) {
+          const idx = result.events.indexOf(rtd);
+          const nextEvent = result.events[idx + 1];
+          if (nextEvent) {
+            assertEquals(
+              nextEvent.outcome === "xp" || nextEvent.outcome === "two_point",
+              true,
+              `Event after return TD should be xp or two_point, got ${nextEvent.outcome}`,
+            );
+          }
+        }
+      }
+    },
+  );
+
+  await t.step(
     "events have monotonically increasing play indices within drives",
     () => {
       const result = simulateGame({
@@ -574,16 +799,31 @@ Deno.test("simulateGame", async (t) => {
 
     for (let i = 0; i < result.events.length - 1; i++) {
       const event = result.events[i];
-      if (
-        event.outcome === "touchdown" ||
-        event.outcome === "field_goal"
-      ) {
+      if (event.outcome === "field_goal") {
         const nextEvent = result.events[i + 1];
         assertEquals(
           nextEvent.outcome,
           "kickoff",
-          `Expected kickoff after ${event.outcome} at event index ${i}`,
+          `Expected kickoff after field_goal at event index ${i}`,
         );
+      }
+      if (event.outcome === "touchdown") {
+        // TD → conversion (xp/two_point) → kickoff
+        const conversionEvent = result.events[i + 1];
+        assertEquals(
+          conversionEvent.outcome === "xp" ||
+            conversionEvent.outcome === "two_point",
+          true,
+          `Expected conversion after TD at event index ${i}, got ${conversionEvent?.outcome}`,
+        );
+        if (i + 2 < result.events.length) {
+          const kickoffEvent = result.events[i + 2];
+          assertEquals(
+            kickoffEvent.outcome,
+            "kickoff",
+            `Expected kickoff after conversion at event index ${i + 2}`,
+          );
+        }
       }
     }
   });

--- a/server/features/simulation/simulate-game.ts
+++ b/server/features/simulation/simulate-game.ts
@@ -4,6 +4,7 @@ import type {
   GameResult,
   InjurySeverity,
   PlayEvent,
+  PlayOutcome,
   PlayTag,
 } from "./events.ts";
 import type {
@@ -21,6 +22,11 @@ import {
   deriveDriveLog,
   deriveInjuryReport,
 } from "./derive-game-views.ts";
+import {
+  conversionDecision,
+  resolveExtraPoint,
+  resolveTwoPointConversion,
+} from "./scoring.ts";
 
 export interface SimTeam {
   teamId: string;
@@ -145,7 +151,9 @@ function shouldClockStop(event: PlayEvent): boolean {
     event.outcome === "touchdown" ||
     event.outcome === "field_goal" ||
     event.outcome === "punt" ||
-    event.outcome === "kickoff"
+    event.outcome === "kickoff" ||
+    event.outcome === "safety" ||
+    event.tags.includes("return_td")
   );
 }
 
@@ -357,18 +365,119 @@ export function simulateGame(input: SimulationInput): GameResult {
     }
   }
 
+  function resolveConversion(scoringTeamId: string): void {
+    const scoringTeam = scoringTeamId === input.home.teamId
+      ? input.home
+      : input.away;
+    const defendingTeam = scoringTeamId === input.home.teamId
+      ? input.away
+      : input.home;
+    const isHome = scoringTeamId === input.home.teamId;
+
+    const diff = isHome
+      ? state.homeScore - state.awayScore
+      : state.awayScore - state.homeScore;
+    const choice = conversionDecision(
+      diff,
+      state.quarter,
+      formatClock(state.clock),
+      scoringTeam.coachingMods.situationalBonus * 10 + 50,
+    );
+
+    if (choice === "xp") {
+      const kicker = findKicker(isHome ? "home" : "away");
+      const made = resolveExtraPoint(kicker, rng);
+      const xpEvent: PlayEvent = {
+        gameId,
+        driveIndex: state.driveIndex,
+        playIndex: state.playIndex,
+        quarter: state.quarter,
+        clock: formatClock(state.clock),
+        situation: { down: 1, distance: 0, yardLine: 85 },
+        offenseTeamId: scoringTeamId,
+        defenseTeamId: scoringTeamId === input.home.teamId
+          ? input.away.teamId
+          : input.home.teamId,
+        call: {
+          concept: "extra_point",
+          personnel: "special_teams",
+          formation: "field_goal",
+          motion: "none",
+        },
+        coverage: {
+          front: "field_goal_block",
+          coverage: "none",
+          pressure: "none",
+        },
+        participants: [{
+          role: "kicker",
+          playerId: kicker.playerId,
+          tags: made ? ["xp_made"] : ["xp_missed"],
+        }],
+        outcome: "xp" as PlayOutcome,
+        yardage: 0,
+        tags: made ? [] : ["xp_missed" as PlayTag],
+      };
+      events.push(xpEvent);
+      state.playIndex++;
+      state.globalPlayIndex++;
+      if (made) {
+        if (isHome) state.homeScore += 1;
+        else state.awayScore += 1;
+      }
+    } else {
+      const offense = buildTeamRuntime(
+        scoringTeam,
+        rosters,
+        isHome ? "home" : "away",
+      );
+      const defense = buildTeamRuntime(
+        defendingTeam,
+        rosters,
+        isHome ? "away" : "home",
+      );
+      const conversionEvent = resolveTwoPointConversion(
+        buildGameState(),
+        offense,
+        defense,
+        rng,
+      );
+      events.push(conversionEvent);
+      state.playIndex++;
+      state.globalPlayIndex++;
+      if (conversionEvent.tags.includes("two_point_conversion")) {
+        if (isHome) state.homeScore += 2;
+        else state.awayScore += 2;
+      }
+    }
+  }
+
   function handleScoring(event: PlayEvent): boolean {
     if (event.outcome === "touchdown") {
       const isHome = event.offenseTeamId === input.home.teamId;
-      if (isHome) state.homeScore += 7;
-      else state.awayScore += 7;
+      if (isHome) state.homeScore += 6;
+      else state.awayScore += 6;
+
+      resolveConversion(event.offenseTeamId);
 
       const scoringSide: "home" | "away" = isHome ? "home" : "away";
       performKickoff(scoringSide);
       return true;
     }
 
-    if (event.tags.includes("safety")) {
+    if (event.tags.includes("return_td")) {
+      const isHome = event.defenseTeamId === input.home.teamId;
+      if (isHome) state.homeScore += 6;
+      else state.awayScore += 6;
+
+      resolveConversion(event.defenseTeamId);
+
+      const scoringSide: "home" | "away" = isHome ? "home" : "away";
+      performKickoff(scoringSide);
+      return true;
+    }
+
+    if (event.outcome === "safety") {
       const isHome = event.offenseTeamId === input.home.teamId;
       if (isHome) state.awayScore += 2;
       else state.homeScore += 2;
@@ -383,6 +492,7 @@ export function simulateGame(input: SimulationInput): GameResult {
 
   function handleTurnover(event: PlayEvent): boolean {
     if (!event.tags.includes("turnover")) return false;
+    if (event.tags.includes("return_td")) return false;
 
     const turnoverYardLine = Math.max(
       1,


### PR DESCRIPTION
## Summary

- Replace hardcoded 7-point touchdowns with TD (6 pts) + conversion event flow: XP resolved from kicker `kickingAccuracy` attribute, 2PT runs the full matchup pipeline from the 2-yard line with goal-line compression
- Add `ConversionDecision` function that picks XP vs 2PT based on score differential, quarter, clock, and HC aggressiveness — aggregate 2PT attempt rates land inside NFL bands (~5-10%)
- Implement real safety triggers: offense driven behind own goal line emits `outcome: "safety"` with 2-point defensive credit and free-kick drive start
- Implement defensive return TDs (pick-6, fumble-6): post-turnover return-TD probability driven by defender speed and acceleration attributes, defensive players tagged with touchdown on box score
- Extend `PlayOutcome` union with `"xp" | "two_point" | "safety"` and `PlayTag` with `"return_td"` — additive changes, no breaking impact on existing consumers
- Box score derivation updated to skip conversion events from yardage tallies

Closes #282

🤖 Generated with [Claude Code](https://claude.com/claude-code)