### PR TITLE
docs(adr): collapse name and settings into one wizard page

### DIFF
--- a/docs/product/decisions/0027-mvp-league-creation-wizard.md
+++ b/docs/product/decisions/0027-mvp-league-creation-wizard.md
@@ -1,0 +1,85 @@
+# 0027 — MVP league creation wizard scope
+
+- **Date:** 2026-04-15
+- **Status:** Accepted
+- **Area:** [League Genesis](../north-star/league-genesis.md)
+
+## Context
+
+[League Genesis](../north-star/league-genesis.md) describes a rich founder
+journey: league charter, franchise establishment with per-slot identity
+declarations, competitive staff hiring against NPC owners, a generated founding
+player pool, a live allocation draft, founding free agency, and kickoff. That is
+the canonical long-run experience.
+
+It is also far more UI surface than we can ship as the first cut. The north-star
+doc intentionally describes the end-state; the MVP needs a narrow slice that
+gets a single-player founder from "click Create League" to "I'm in my dashboard"
+on day one without requiring every genesis phase to be interactively designed
+first. We need an ADR that states which slice of the founder journey is _in_ the
+wizard and which lives inside the in-dashboard genesis phase state machine from
+ADR 0018.
+
+## Decision
+
+**The MVP league creation wizard is a four-step linear flow that ends in the
+dashboard:**
+
+1. **League name** — a single required text input.
+2. **League settings preview** — all settings shown as inputs but read-only (see
+   ADR 0028). No configuration in v1.
+3. **Team select** — the founder picks one of the generated founding franchises
+   by its branding. No identity overrides in the wizard.
+4. **Generation** — a synchronous loading step that creates coaches, scouts, the
+   founding player pool, and the NPC franchises inline (see ADR 0030), then
+   lands the founder on the dashboard already in the first in-dashboard genesis
+   phase (see ADR 0031).
+
+**The rest of the founder journey — staff hiring, allocation draft, founding
+free agency, kickoff — does not live in the creation wizard. It lives inside the
+dashboard as the post-creation genesis phases defined by ADR 0018.** The
+wizard's job is to produce a league row and hand off to the phase state machine;
+it is not the place where the founder experiences the full narrative arc
+described in the north-star.
+
+## Alternatives considered
+
+- **Ship the full north-star founder journey as the wizard.** Faithful to the
+  vision, but it multiplies the design and implementation surface by roughly an
+  order of magnitude before a single game of football can be played. Rejected
+  for MVP; the north-star remains the target for the in-dashboard phase
+  experiences.
+- **Ship only league name + team select, no settings preview.** Slightly
+  shorter, but hides from the founder what they're agreeing to (schedule length,
+  cap rules, roster limits). Transparency at creation time is cheap and the
+  settings screen doubles as a preview of what the league _is_.
+- **Ship a two-pane wizard (settings + team picker together).** Compresses the
+  flow but conflates two distinct decisions. A linear four-step flow is easier
+  to reason about, easier to gate on validation, and easier to extend later when
+  settings become configurable and team identity becomes editable.
+- **Generate the league lazily on first dashboard interaction.** Avoids the
+  loading step. Rejected because downstream systems (coach rosters, founding
+  pool, NPC franchises) need to exist before any dashboard view can render, and
+  the spinner is a natural narrative beat — "the league is being founded."
+
+## Consequences
+
+- **Makes easier:** shipping a playable league-creation path quickly. Four
+  inputs, one POST, one redirect.
+- **Makes easier:** iterating on the in-dashboard genesis phases independently
+  of the wizard. The wizard hands off to the phase state machine at a known
+  point, so phase UI work doesn't block creation work and vice versa.
+- **Makes harder:** reaching full north-star fidelity. The rich founder moments
+  — declaring identity per franchise, the competitive staff-hiring market, the
+  live allocation draft — are deferred into later ADRs and later UI work. The
+  wizard as scoped here is a skeleton of the north-star vision, not a
+  realization of it.
+- **Makes harder:** multiplayer genesis. The wizard as scoped is single-player
+  only — it assumes one founder making choices for one franchise, with seven NPC
+  franchises auto-filled. Multiplayer claim flows will need a separate ADR when
+  we get there.
+- **Follow-up work:** ADRs 0028–0031 in this series pin down the specific
+  sub-decisions this ADR gestures at (readonly settings, 8-team default with no
+  count selector, synchronous generation, post-generation landing). The
+  in-dashboard phase UI work tracks against ADR 0018's step catalog, not this
+  ADR.

--- a/docs/product/decisions/0027-mvp-league-creation-wizard.md
+++ b/docs/product/decisions/0027-mvp-league-creation-wizard.md
@@ -22,15 +22,16 @@ ADR 0018.
 
 ## Decision
 
-**The MVP league creation wizard is a four-step linear flow that ends in the
+**The MVP league creation wizard is a three-step linear flow that ends in the
 dashboard:**
 
-1. **League name** — a single required text input.
-2. **League settings preview** — all settings shown as inputs but read-only (see
-   ADR 0028). No configuration in v1.
-3. **Team select** — the founder picks one of the generated founding franchises
+1. **League identity & settings** — a single page with the required league-name
+   input at the top and the full league settings preview below it as disabled
+   inputs (see ADR 0028). The founder names the league and reviews everything
+   else it implies in one screen, then advances with a single Continue.
+2. **Team select** — the founder picks one of the generated founding franchises
    by its branding. No identity overrides in the wizard.
-4. **Generation** — a synchronous loading step that creates coaches, scouts, the
+3. **Generation** — a synchronous loading step that creates coaches, scouts, the
    founding player pool, and the NPC franchises inline (see ADR 0030), then
    lands the founder on the dashboard already in the first in-dashboard genesis
    phase (see ADR 0031).
@@ -52,11 +53,16 @@ described in the north-star.
 - **Ship only league name + team select, no settings preview.** Slightly
   shorter, but hides from the founder what they're agreeing to (schedule length,
   cap rules, roster limits). Transparency at creation time is cheap and the
-  settings screen doubles as a preview of what the league _is_.
-- **Ship a two-pane wizard (settings + team picker together).** Compresses the
-  flow but conflates two distinct decisions. A linear four-step flow is easier
-  to reason about, easier to gate on validation, and easier to extend later when
-  settings become configurable and team identity becomes editable.
+  settings preview doubles as a description of what the league _is_.
+- **Split league name and settings preview into two separate pages.** Earlier
+  draft of this ADR. Rejected: the settings screen is read-only, so it's a
+  review surface, not a decision surface — pairing it with the one real input on
+  that step (the name) keeps the wizard one beat shorter without losing any of
+  the transparency the preview provides.
+- **Ship a wizard with settings and team picker on the same page.** Compresses
+  the flow further but conflates two genuinely different decisions: declaring
+  what the league is vs. choosing which franchise inside it is yours. The
+  team-select grid also wants the full page width that combining would steal.
 - **Generate the league lazily on first dashboard interaction.** Avoids the
   loading step. Rejected because downstream systems (coach rosters, founding
   pool, NPC franchises) need to exist before any dashboard view can render, and
@@ -64,8 +70,8 @@ described in the north-star.
 
 ## Consequences
 
-- **Makes easier:** shipping a playable league-creation path quickly. Four
-  inputs, one POST, one redirect.
+- **Makes easier:** shipping a playable league-creation path quickly. Three
+  steps, one POST, one redirect.
 - **Makes easier:** iterating on the in-dashboard genesis phases independently
   of the wizard. The wizard hands off to the phase state machine at a known
   point, so phase UI work doesn't block creation work and vice versa.

--- a/docs/product/decisions/0028-readonly-league-settings-mvp.md
+++ b/docs/product/decisions/0028-readonly-league-settings-mvp.md
@@ -7,14 +7,15 @@
 
 ## Context
 
-ADR 0027 establishes the MVP creation wizard as a four-step flow. Step 2 is a
-"league settings" screen. The north-star doc describes several
-founder-configurable knobs — founding franchise count, schedule length,
-conference/division structure, rules package (cap, roster limits, draft rounds).
-Building real editors for each of those is a significant design and validation
-project, and picking defaults that work well for the MVP would be undermined if
-we also let the founder override them before we've validated the defaults in
-play.
+ADR 0027 establishes the MVP creation wizard as a three-step flow. Step 1
+combines the league-name input with the league settings preview on a single
+page; this ADR governs the settings half of that page. The north-star doc
+describes several founder-configurable knobs — founding franchise count,
+schedule length, conference/division structure, rules package (cap, roster
+limits, draft rounds). Building real editors for each of those is a significant
+design and validation project, and picking defaults that work well for the MVP
+would be undermined if we also let the founder override them before we've
+validated the defaults in play.
 
 We still want the founder to _see_ what they're agreeing to. Hiding settings
 entirely would make the league feel arbitrary ("why is my schedule 10 games?")
@@ -22,12 +23,13 @@ and leave the founder guessing at what the product has decided on their behalf.
 
 ## Decision
 
-**The MVP league settings screen displays every relevant league setting as a
-disabled form input prefilled with its default value. No setting is editable in
-v1.** The screen is a preview, not a configurator. Settings shown include — but
-are not limited to — founding franchise count, regular-season schedule length,
-conference/division structure, roster limits, salary cap figures, and draft
-rounds.
+**The MVP league settings preview — rendered below the league-name input on the
+wizard's first page — displays every relevant league setting as a disabled form
+input prefilled with its default value. No setting is editable in v1.** The
+preview is a description of the league being created, not a configurator.
+Settings shown include — but are not limited to — founding franchise count,
+regular-season schedule length, conference/division structure, roster limits,
+salary cap figures, and draft rounds.
 
 The founder advances past this screen with a single "Continue" action. There is
 no per-field save; the settings are locked in at league-creation time from the
@@ -44,19 +46,21 @@ current MVP defaults.
   editable later" to the founder without any extra copy, which is exactly the
   roadmap we expect. Using real form controls now also means the screen becomes
   editable by flipping a `disabled` flag later, not by rebuilding the screen.
-- **Make one or two settings editable (e.g., league name is editable, everything
-  else is readonly).** League name is its own step (ADR 0027 step 1), so it
-  doesn't belong on this screen. For everything else, partial editability
-  creates an awkward "why can I change this but not that" question. All-readonly
-  is cleaner.
+- **Make one or two settings editable alongside the league-name input.** League
+  name is the only editable field on this page; for everything else, partial
+  editability creates an awkward "why can I change this but not that" question.
+  The name is genuinely the founder's to declare; the rest are product defaults.
+  All-readonly for the settings half is cleaner.
 - **Let the founder pick from a small set of presets (short/medium/long season,
   small/medium cap, etc.) rather than editing raw values.** A reasonable future
   direction, but still more design than the MVP needs. Deferred.
 
 ## Consequences
 
-- **Makes easier:** shipping step 2 of the wizard. It's a static form with a
-  Continue button; there is no validation, no cross-field logic, no write path.
+- **Makes easier:** shipping the wizard's first page. The settings half is a
+  static block of disabled inputs alongside the one real input (league name);
+  there is no validation, no cross-field logic, and no write path on the
+  settings side.
 - **Makes easier:** changing the defaults before first public release. Because
   no founder can override them, tuning the defaults in code propagates cleanly
   to every new league without data-migration concerns.

--- a/docs/product/decisions/0028-readonly-league-settings-mvp.md
+++ b/docs/product/decisions/0028-readonly-league-settings-mvp.md
@@ -1,0 +1,73 @@
+# 0028 — Readonly league settings in MVP creation wizard
+
+- **Date:** 2026-04-15
+- **Status:** Accepted
+- **Area:** [League Genesis](../north-star/league-genesis.md),
+  [League Management](../north-star/league-management.md)
+
+## Context
+
+ADR 0027 establishes the MVP creation wizard as a four-step flow. Step 2 is a
+"league settings" screen. The north-star doc describes several
+founder-configurable knobs — founding franchise count, schedule length,
+conference/division structure, rules package (cap, roster limits, draft rounds).
+Building real editors for each of those is a significant design and validation
+project, and picking defaults that work well for the MVP would be undermined if
+we also let the founder override them before we've validated the defaults in
+play.
+
+We still want the founder to _see_ what they're agreeing to. Hiding settings
+entirely would make the league feel arbitrary ("why is my schedule 10 games?")
+and leave the founder guessing at what the product has decided on their behalf.
+
+## Decision
+
+**The MVP league settings screen displays every relevant league setting as a
+disabled form input prefilled with its default value. No setting is editable in
+v1.** The screen is a preview, not a configurator. Settings shown include — but
+are not limited to — founding franchise count, regular-season schedule length,
+conference/division structure, roster limits, salary cap figures, and draft
+rounds.
+
+The founder advances past this screen with a single "Continue" action. There is
+no per-field save; the settings are locked in at league-creation time from the
+current MVP defaults.
+
+## Alternatives considered
+
+- **Hide the settings screen entirely.** Simpler, but leaves the founder without
+  any sense of what league they're creating. The 10-game schedule or the
+  two-division structure is going to surface eventually; better to surface it at
+  creation time.
+- **Show settings as static text (no inputs).** Lower implementation effort than
+  disabled inputs. Rejected because disabled inputs telegraph "this will be
+  editable later" to the founder without any extra copy, which is exactly the
+  roadmap we expect. Using real form controls now also means the screen becomes
+  editable by flipping a `disabled` flag later, not by rebuilding the screen.
+- **Make one or two settings editable (e.g., league name is editable, everything
+  else is readonly).** League name is its own step (ADR 0027 step 1), so it
+  doesn't belong on this screen. For everything else, partial editability
+  creates an awkward "why can I change this but not that" question. All-readonly
+  is cleaner.
+- **Let the founder pick from a small set of presets (short/medium/long season,
+  small/medium cap, etc.) rather than editing raw values.** A reasonable future
+  direction, but still more design than the MVP needs. Deferred.
+
+## Consequences
+
+- **Makes easier:** shipping step 2 of the wizard. It's a static form with a
+  Continue button; there is no validation, no cross-field logic, no write path.
+- **Makes easier:** changing the defaults before first public release. Because
+  no founder can override them, tuning the defaults in code propagates cleanly
+  to every new league without data-migration concerns.
+- **Makes easier:** future editability. Each disabled input is already wired to
+  a real setting value, so enabling a setting becomes a matter of removing
+  `disabled`, writing a validation rule, and persisting the edit.
+- **Makes harder:** users who want to configure their league at creation time.
+  They cannot, until a follow-up ADR opens specific settings for edit. This is
+  an intentional MVP constraint, not a permanent one.
+- **Follow-up work:** once the MVP has shipped and defaults are validated by
+  real play, open follow-up ADRs to progressively enable individual settings for
+  edit. Schedule length and cap figures are the most likely first candidates
+  because they're the most tangible at creation time. Founding franchise count
+  is _not_ on that list for the MVP — see ADR 0029.

--- a/docs/product/decisions/0029-eight-team-default-no-count-selector.md
+++ b/docs/product/decisions/0029-eight-team-default-no-count-selector.md
@@ -1,0 +1,77 @@
+# 0029 — Default 8 founding franchises with no count selector in MVP
+
+- **Date:** 2026-04-15
+- **Status:** Accepted
+- **Area:** [League Genesis](../north-star/league-genesis.md)
+
+## Context
+
+[League Genesis](../north-star/league-genesis.md) calls for a small founding
+league — 8 franchises by default, configurable down to 4 or up to a larger
+custom number — with expansion as the long-run path to 32 and beyond. The
+north-star doc treats the count as configurable; ADR 0028 locks all settings as
+readonly for the MVP.
+
+This ADR exists to pin down the specific case of franchise count, because it
+shapes more than any other single setting:
+
+- The team-select screen (ADR 0027 step 3) needs a concrete list of founding
+  franchises to present.
+- The founding player pool needs to be sized for a specific number of rosters.
+- The generation step (ADR 0030) needs to know how many NPC franchises and their
+  coaching staffs to create.
+- The schedule length, division structure, and playoff bracket in ADR 0028's
+  settings preview are all derived from the franchise count.
+
+Leaving the count variable — even behind a readonly input — would imply that a
+future "unlock this" switch changes one number. It doesn't; it changes the whole
+downstream generation pipeline.
+
+## Decision
+
+**Every MVP-created league has exactly 8 founding franchises. There is no
+founder-facing control for franchise count — not even a disabled one — in the
+MVP wizard.** The count is a hardcoded constant in the creation pipeline and in
+the settings preview screen's derived values (schedule length, division
+structure, etc. are all stated against the 8-team assumption).
+
+Expansion remains the long-run path to larger league sizes, per the north-star
+doc and ADR 0025. The MVP ships with no expansion UI either, but nothing in this
+ADR forecloses it.
+
+## Alternatives considered
+
+- **Expose franchise count as a readonly input per ADR 0028's pattern.**
+  Consistent with the rest of the settings screen, but misleading: every other
+  readonly input is a value whose edit would be a small follow-up, while
+  franchise count is structurally different — making it editable is a
+  significant systems project (generation, team-select, schedule, divisions,
+  allocation draft all parameterize on it). Omitting it from the settings screen
+  is more honest about that.
+- **Expose franchise count as the one editable setting in the MVP.** The
+  opposite extreme. Rejected because the defaults for schedule length, division
+  structure, and playoff bracket were tuned against 8; letting the founder pick
+  12 or 16 at creation time means every derived default either needs its own
+  scaling logic or produces a visibly mis-tuned league.
+- **Support a small set of franchise-count presets (e.g., 6, 8, 12).** Cleaner
+  than free-form input and less scope than "configurable." Still a meaningful
+  systems project for MVP, and the north-star's recommended default is
+  already 8. Deferred until we have a real reason to offer more.
+
+## Consequences
+
+- **Makes easier:** every downstream system that currently parameterizes on
+  franchise count. For the MVP they can take 8 as a constant.
+- **Makes easier:** generating a plausible team-select screen (ADR 0027 step 3).
+  The pool of founding franchises surfaced to the founder is exactly 8 branded
+  teams, one of which they'll claim and seven of which become NPC franchises.
+- **Makes easier:** calibrating the founding player pool size, the schedule
+  length, and the division structure. Each has a single target to design
+  against.
+- **Makes harder:** founders who want a bigger or smaller league on day one.
+  They can't have one. The intent is that expansion (ADR 0025) is the long-run
+  answer, and the MVP simply doesn't ship expansion yet.
+- **Follow-up work:** when a later ADR opens franchise count to configuration,
+  it needs to address how derived defaults (schedule, cap, divisions) scale with
+  count and where the branching lives in the generation pipeline. It is not a
+  one-line change.

--- a/docs/product/decisions/0029-eight-team-default-no-count-selector.md
+++ b/docs/product/decisions/0029-eight-team-default-no-count-selector.md
@@ -15,7 +15,7 @@ readonly for the MVP.
 This ADR exists to pin down the specific case of franchise count, because it
 shapes more than any other single setting:
 
-- The team-select screen (ADR 0027 step 3) needs a concrete list of founding
+- The team-select screen (ADR 0027 step 2) needs a concrete list of founding
   franchises to present.
 - The founding player pool needs to be sized for a specific number of rosters.
 - The generation step (ADR 0030) needs to know how many NPC franchises and their
@@ -62,7 +62,7 @@ ADR forecloses it.
 
 - **Makes easier:** every downstream system that currently parameterizes on
   franchise count. For the MVP they can take 8 as a constant.
-- **Makes easier:** generating a plausible team-select screen (ADR 0027 step 3).
+- **Makes easier:** generating a plausible team-select screen (ADR 0027 step 2).
   The pool of founding franchises surfaced to the founder is exactly 8 branded
   teams, one of which they'll claim and seven of which become NPC franchises.
 - **Makes easier:** calibrating the founding player pool size, the schedule

--- a/docs/product/decisions/0030-synchronous-league-generation-with-progress-ui.md
+++ b/docs/product/decisions/0030-synchronous-league-generation-with-progress-ui.md
@@ -1,0 +1,84 @@
+# 0030 — Synchronous league generation with progress UI
+
+- **Date:** 2026-04-15
+- **Status:** Accepted
+- **Area:** [League Genesis](../north-star/league-genesis.md),
+  [Coaches](../north-star/coaches.md), [Scouting](../north-star/scouting.md)
+
+## Context
+
+After the founder submits the team-select step (ADR 0027 step 3), the system
+needs to create a substantial amount of per-league content before the dashboard
+can render:
+
+- 8 franchise rows (one claimed by the founder, seven NPC) with identities
+- Per-league unique coaches and scouts generated for every franchise (ADR 0022 —
+  per-league unique coach/scout generation)
+- The founding player pool (ADR 0026)
+- Initial league-clock state positioned at the first in-dashboard genesis phase
+  (ADR 0031)
+
+This work is not instantaneous — it involves generating and persisting hundreds
+of entities — but it's also not so slow that it needs a background job with
+resumability. The question is whether the wizard's fourth step is a synchronous
+"create everything then redirect" request with a loading state, or an
+asynchronous job the founder polls or gets pushed updates about.
+
+## Decision
+
+**League generation in the MVP runs synchronously during the wizard's fourth
+step. The founder's browser shows a loading spinner with descriptive progress
+copy ("Creating coaches and league foundation…") while the server generates
+coaches, scouts, NPC franchises, and the founding player pool in a single
+transaction (or logically-atomic sequence). When generation completes, the
+server responds and the client redirects straight into the dashboard.**
+
+There is no background job, no polling endpoint, no resumability, and no
+partial-success state in v1. If generation fails, the league is not created and
+the founder sees an error state they can retry from step 3.
+
+The loading UI may surface a small number of named progress milestones —
+"creating coaches", "assembling the founding player pool", "founding the league"
+— but these are narrative, not a real-time progress bar tied to server events.
+The server runs generation to completion and the client waits.
+
+## Alternatives considered
+
+- **Background job with polling/streaming progress.** More robust if generation
+  gets slow, but adds a job queue, a progress channel, and a reconnection story
+  before the MVP needs any of that. Defer until generation actually becomes slow
+  enough to matter.
+- **Lazy generation — create minimal league on submit, generate coaches / pool
+  on first dashboard access.** Avoids the spinner but spreads the cost into
+  dashboard rendering, where a slow load is _worse_ because it masquerades as a
+  broken app rather than an understood setup step. Also complicates the mental
+  model: is the league "done" after submit or not?
+- **Pre-generate leagues into a pool and assign on claim.** Fastest perceived
+  creation time, but ADR 0022 requires coaches and scouts to be unique per
+  league — that uniqueness is a hook the north-star uses for long-run narrative
+  value, not a generation-time optimization target. Pre-generation would either
+  violate that uniqueness or produce pools of leagues that go unused.
+- **Silent spinner with no progress copy.** Works, but the north-star explicitly
+  frames genesis as a narrative moment. Naming what's happening ("creating
+  coaches", "founding the league") sets the tone in a way a generic spinner does
+  not, and it's essentially free.
+
+## Consequences
+
+- **Makes easier:** the server implementation. One request, one transaction, one
+  response. Failure modes are "it worked" or "it didn't"; there's no partial
+  state to reconcile.
+- **Makes easier:** the client implementation. A single in-flight request with a
+  loading state, no websocket or polling loop.
+- **Makes easier:** observability. Generation is a single server operation, so
+  its duration and failure rate are one metric each.
+- **Makes harder:** scaling generation runtime. If generation grows past a few
+  seconds, the synchronous request starts to feel broken even with good loading
+  copy. We accept this as a future problem; when it becomes real, migrating to a
+  job + polling/streaming is a discrete follow-up.
+- **Makes harder:** resuming a mid-failure generation. There is no resume — a
+  failed generation leaves no league and the founder restarts from team select.
+  This is acceptable because partial leagues are worse than no league.
+- **Follow-up work:** instrument generation duration from day one so we know
+  when the synchronous model starts to strain. When it does, the follow-up ADR
+  covers the job-based migration.

--- a/docs/product/decisions/0030-synchronous-league-generation-with-progress-ui.md
+++ b/docs/product/decisions/0030-synchronous-league-generation-with-progress-ui.md
@@ -7,7 +7,7 @@
 
 ## Context
 
-After the founder submits the team-select step (ADR 0027 step 3), the system
+After the founder submits the team-select step (ADR 0027 step 2), the system
 needs to create a substantial amount of per-league content before the dashboard
 can render:
 
@@ -35,7 +35,7 @@ server responds and the client redirects straight into the dashboard.**
 
 There is no background job, no polling endpoint, no resumability, and no
 partial-success state in v1. If generation fails, the league is not created and
-the founder sees an error state they can retry from step 3.
+the founder sees an error state they can retry from the team-select step.
 
 The loading UI may surface a small number of named progress milestones —
 "creating coaches", "assembling the founding player pool", "founding the league"

--- a/docs/product/decisions/0031-post-generation-land-in-first-genesis-phase.md
+++ b/docs/product/decisions/0031-post-generation-land-in-first-genesis-phase.md
@@ -1,0 +1,94 @@
+# 0031 — Post-generation landing on the first in-dashboard genesis phase
+
+- **Date:** 2026-04-15
+- **Status:** Accepted
+- **Area:** [League Genesis](../north-star/league-genesis.md),
+  [0014 — Season calendar and phase state machine](./0014-season-calendar-phase-state-machine.md),
+  [0018 — Genesis phase state machine](./0018-genesis-phase-state-machine.md),
+  [0020 — Phase-gated sidebar navigation](./0020-phase-gated-sidebar-navigation.md)
+
+## Context
+
+ADR 0027 defines the MVP wizard as ending with generation and a redirect to the
+dashboard. ADR 0018 defines the genesis phase state machine as a linear sequence
+of phases owned by the `league_clock` row, starting with `GENESIS_CHARTER` and
+ending with `GENESIS_KICKOFF → PRESEASON`.
+
+The MVP wizard itself completes the work that would have lived in
+`GENESIS_CHARTER` (league name, settings) and a slice of
+`GENESIS_FRANCHISE_ESTABLISHMENT` (the founder's team claim, plus auto-
+assignment of the other seven NPC franchises). When generation finishes, some
+early phases are already substantively done and subsequent phases — staff
+hiring, allocation draft, free agency, kickoff — still need to happen inside the
+dashboard against the phase state machine and phase-gated navigation (ADR 0020).
+
+The question is: after the redirect, what phase is the `league_clock` in, and
+what does the dashboard show?
+
+## Decision
+
+**When generation completes, the server persists the league with its
+`league_clock` positioned on the first in-dashboard genesis phase — the earliest
+phase whose work has not been completed by the wizard — and the client redirects
+the founder directly into the dashboard view for that phase.** There is no
+summary screen, no "League created!" confirmation page, and no intermediate
+dashboard home state. The founder lands inside the phase state machine already
+in motion.
+
+Concretely, the wizard's first three steps plus generation cover league charter
+and the auto-establishment of franchises; the founder arrives in the dashboard
+at the next phase in ADR 0018's sequence (staff hiring under the current
+sequencing). If ADR 0018's sequence changes, this ADR's landing-phase follows it
+— the rule is "first phase whose work is not already complete," not a hardcoded
+phase name.
+
+Phase-gated sidebar navigation (ADR 0020) applies from the first dashboard
+render: the founder sees only the nav entries that are valid for the current
+phase, which keeps the first view focused on what genesis needs next rather than
+on the mature-league surface.
+
+## Alternatives considered
+
+- **Land on a "league created" confirmation / summary screen.** Gives the
+  founder a moment to review what was generated. Rejected because the wizard
+  already represents that moment (team select, settings preview, a named
+  generation step) and a standalone confirmation is filler. If we want a
+  league-summary view it should be a real dashboard page, not a one-shot screen.
+- **Land on a generic dashboard home with the phase state as a sidebar
+  concern.** The classic "here's everything" landing. Rejected because in the
+  genesis period most of "everything" is empty or pre-state; showing it invites
+  confusion. ADR 0020's phase-gated nav is the right answer and landing straight
+  into the active phase is consistent with it.
+- **Start the league in `GENESIS_CHARTER` even though the wizard already did
+  that work, and let the founder advance through it.** Honest about the state
+  machine but wastes the founder's time replaying decisions they just made. The
+  work being done counts as the phase being done.
+- **Skip all genesis phases and land the founder in preseason/Week 1.** The
+  other extreme — treats generation as "the league is fully founded." This
+  collapses the entire founder journey (staff hiring, allocation draft, founding
+  free agency) and directly contradicts the north-star. The MVP defers the
+  _richness_ of those phases, not their existence.
+
+## Consequences
+
+- **Makes easier:** routing. One redirect target — `/league/:id/dashboard` —
+  whose content is driven by the current phase. No branch on a post-creation
+  summary view.
+- **Makes easier:** reasoning about the `league_clock` as the single source of
+  truth for "where is this league." The wizard writes it once at generation time
+  and the dashboard reads it from then on.
+- **Makes easier:** future changes to which wizard steps do which phase's work.
+  If we later move staff hiring into the wizard, the starting phase shifts
+  forward; if we pull something out, it shifts back. The rule — "earliest
+  incomplete phase" — absorbs that without a code-path rewrite.
+- **Makes harder:** onboarding copy. Because there's no confirmation screen, the
+  dashboard's first-render copy has to orient a founder who just arrived. This
+  work lives in the phase UI itself, which is where it belongs.
+- **Follow-up work:**
+  - Wire the wizard's generation endpoint to set the `league_clock` to the
+    correct starting phase per ADR 0018's current sequence
+  - Verify phase-gated nav (ADR 0020) renders sensibly for a founder on their
+    very first dashboard render — this is the one render where _every_ piece of
+    UI is seeing the league for the first time
+  - Revisit this ADR if ADR 0018's phase sequence is reordered; the
+    landing-phase rule remains the same but the concrete phase name will change

--- a/docs/product/decisions/README.md
+++ b/docs/product/decisions/README.md
@@ -80,7 +80,7 @@ as superseded.
   returns, overtime, penalty mechanics, defensive scores, 4th-down decisioning,
   clock management, and assignment-based matchups as in-scope (Accepted)
 - [0027 — MVP league creation wizard scope](./0027-mvp-league-creation-wizard.md)
-  — four-step wizard (name → readonly settings → team select → generation →
+  — three-step wizard (name + readonly settings → team select → generation →
   dashboard); defers the rich founder journey into the in-dashboard phase state
   machine (Accepted)
 - [0028 — Readonly league settings in MVP creation wizard](./0028-readonly-league-settings-mvp.md)

--- a/docs/product/decisions/README.md
+++ b/docs/product/decisions/README.md
@@ -79,3 +79,19 @@ as superseded.
   — retires ADR 0015's v1 deferral list; commits XP/2PT, real kickoffs and
   returns, overtime, penalty mechanics, defensive scores, 4th-down decisioning,
   clock management, and assignment-based matchups as in-scope (Accepted)
+- [0027 — MVP league creation wizard scope](./0027-mvp-league-creation-wizard.md)
+  — four-step wizard (name → readonly settings → team select → generation →
+  dashboard); defers the rich founder journey into the in-dashboard phase state
+  machine (Accepted)
+- [0028 — Readonly league settings in MVP creation wizard](./0028-readonly-league-settings-mvp.md)
+  — settings shown as disabled inputs for transparency; nothing is editable at
+  creation time in v1 (Accepted)
+- [0029 — Default 8 founding franchises with no count selector in MVP](./0029-eight-team-default-no-count-selector.md)
+  — franchise count hardcoded to 8; no founder-facing control, even readonly
+  (Accepted)
+- [0030 — Synchronous league generation with progress UI](./0030-synchronous-league-generation-with-progress-ui.md)
+  — coaches, scouts, founding pool, NPC franchises generated inline during a
+  loading step; no background job, no resumability in v1 (Accepted)
+- [0031 — Post-generation landing on the first in-dashboard genesis phase](./0031-post-generation-land-in-first-genesis-phase.md)
+  — after generation the founder lands straight in the dashboard at the earliest
+  incomplete genesis phase; no confirmation screen (Accepted)

--- a/docs/product/north-star/league-genesis.md
+++ b/docs/product/north-star/league-genesis.md
@@ -810,3 +810,8 @@ season coverage patterns. See [Media](./media.md).
 - [0024 — Allocation draft as Year 1's only draft](../decisions/0024-allocation-draft-as-year-one-only-draft.md)
 - [0025 — Expansion by ownership vote](../decisions/0025-expansion-by-ownership-vote.md)
 - [0026 — Founding player pool composition and attribute normalization](../decisions/0026-founding-pool-composition-and-attribute-normalization.md)
+- [0027 — MVP league creation wizard scope](../decisions/0027-mvp-league-creation-wizard.md)
+- [0028 — Readonly league settings in MVP creation wizard](../decisions/0028-readonly-league-settings-mvp.md)
+- [0029 — Default 8 founding franchises with no count selector in MVP](../decisions/0029-eight-team-default-no-count-selector.md)
+- [0030 — Synchronous league generation with progress UI](../decisions/0030-synchronous-league-generation-with-progress-ui.md)
+- [0031 — Post-generation landing on the first in-dashboard genesis phase](../decisions/0031-post-generation-land-in-first-genesis-phase.md)


### PR DESCRIPTION
## Summary

- Refines ADR 0027 from a four-step to a three-step wizard: the league-name input and the readonly settings preview now share the first page.
- The settings preview is read-only — a description, not a decision — so pairing it with the one real input on that step removes a navigation beat without sacrificing transparency.
- ADRs 0028, 0029, and 0030 updated for the new step numbering and the combined-page framing.
- Follow-up to #306.