### PR TITLE
feat(contracts): add pure computeCapHit, computeDeadCap, computeHeadlineValue

### DIFF
--- a/packages/shared/contracts/cap-engine.test.ts
+++ b/packages/shared/contracts/cap-engine.test.ts
@@ -1,0 +1,607 @@
+import { assertEquals } from "@std/assert";
+import {
+  type CapContractInput,
+  computeCapHit,
+  computeDeadCap,
+  computeHeadlineValue,
+} from "./cap-engine.ts";
+
+function makeContract(
+  overrides: Partial<CapContractInput> = {},
+): CapContractInput {
+  return {
+    years: [],
+    bonusProrations: [],
+    optionBonuses: [],
+    ...overrides,
+  };
+}
+
+// ---------- computeCapHit ----------
+
+Deno.test("computeCapHit: returns 0 for a year not in the contract", () => {
+  const contract = makeContract({
+    years: [
+      {
+        leagueYear: 2024,
+        base: 1_000_000,
+        rosterBonus: 0,
+        workoutBonus: 0,
+        perGameRosterBonus: 0,
+        guaranteeType: "none",
+        isVoid: false,
+      },
+    ],
+  });
+  assertEquals(computeCapHit(contract, 2025), 0);
+});
+
+Deno.test("computeCapHit: sums base, roster, workout, and PGRB for a real year", () => {
+  const contract = makeContract({
+    years: [
+      {
+        leagueYear: 2024,
+        base: 5_000_000,
+        rosterBonus: 1_000_000,
+        workoutBonus: 500_000,
+        perGameRosterBonus: 850_000,
+        guaranteeType: "full",
+        isVoid: false,
+      },
+    ],
+  });
+  assertEquals(computeCapHit(contract, 2024), 7_350_000);
+});
+
+Deno.test("computeCapHit: includes prorated signing bonus", () => {
+  const contract = makeContract({
+    years: [
+      {
+        leagueYear: 2024,
+        base: 1_000_000,
+        rosterBonus: 0,
+        workoutBonus: 0,
+        perGameRosterBonus: 0,
+        guaranteeType: "none",
+        isVoid: false,
+      },
+      {
+        leagueYear: 2025,
+        base: 1_000_000,
+        rosterBonus: 0,
+        workoutBonus: 0,
+        perGameRosterBonus: 0,
+        guaranteeType: "none",
+        isVoid: false,
+      },
+    ],
+    bonusProrations: [
+      { amount: 10_000_000, firstYear: 2024, years: 5, source: "signing" },
+    ],
+  });
+  // 1_000_000 base + floor(10_000_000 / 5) = 1_000_000 + 2_000_000
+  assertEquals(computeCapHit(contract, 2024), 3_000_000);
+  assertEquals(computeCapHit(contract, 2025), 3_000_000);
+});
+
+Deno.test("computeCapHit: void years return only proration", () => {
+  const contract = makeContract({
+    years: [
+      {
+        leagueYear: 2024,
+        base: 5_000_000,
+        rosterBonus: 1_000_000,
+        workoutBonus: 500_000,
+        perGameRosterBonus: 200_000,
+        guaranteeType: "full",
+        isVoid: false,
+      },
+      {
+        leagueYear: 2025,
+        base: 0,
+        rosterBonus: 0,
+        workoutBonus: 0,
+        perGameRosterBonus: 0,
+        guaranteeType: "none",
+        isVoid: true,
+      },
+    ],
+    bonusProrations: [
+      { amount: 4_000_000, firstYear: 2024, years: 2, source: "signing" },
+    ],
+  });
+  assertEquals(computeCapHit(contract, 2025), 2_000_000);
+});
+
+Deno.test("computeCapHit: sums multiple proration slices (signing + restructure)", () => {
+  const contract = makeContract({
+    years: [
+      {
+        leagueYear: 2025,
+        base: 2_000_000,
+        rosterBonus: 0,
+        workoutBonus: 0,
+        perGameRosterBonus: 0,
+        guaranteeType: "none",
+        isVoid: false,
+      },
+    ],
+    bonusProrations: [
+      { amount: 10_000_000, firstYear: 2024, years: 5, source: "signing" },
+      { amount: 5_000_000, firstYear: 2025, years: 3, source: "restructure" },
+    ],
+  });
+  // base + floor(10M/5) + floor(5M/3)
+  // 2_000_000 + 2_000_000 + 1_666_666 = 5_666_666
+  assertEquals(computeCapHit(contract, 2025), 5_666_666);
+});
+
+Deno.test("computeCapHit: excludes proration slices outside their window", () => {
+  const contract = makeContract({
+    years: [
+      {
+        leagueYear: 2024,
+        base: 1_000_000,
+        rosterBonus: 0,
+        workoutBonus: 0,
+        perGameRosterBonus: 0,
+        guaranteeType: "none",
+        isVoid: false,
+      },
+    ],
+    bonusProrations: [
+      { amount: 10_000_000, firstYear: 2025, years: 5, source: "signing" },
+    ],
+  });
+  assertEquals(computeCapHit(contract, 2024), 1_000_000);
+});
+
+Deno.test("computeCapHit: rounding residue lands on the final proration year", () => {
+  const contract = makeContract({
+    years: [
+      {
+        leagueYear: 2024,
+        base: 0,
+        rosterBonus: 0,
+        workoutBonus: 0,
+        perGameRosterBonus: 0,
+        guaranteeType: "none",
+        isVoid: false,
+      },
+      {
+        leagueYear: 2025,
+        base: 0,
+        rosterBonus: 0,
+        workoutBonus: 0,
+        perGameRosterBonus: 0,
+        guaranteeType: "none",
+        isVoid: false,
+      },
+      {
+        leagueYear: 2026,
+        base: 0,
+        rosterBonus: 0,
+        workoutBonus: 0,
+        perGameRosterBonus: 0,
+        guaranteeType: "none",
+        isVoid: false,
+      },
+    ],
+    bonusProrations: [
+      { amount: 10_000_000, firstYear: 2024, years: 3, source: "signing" },
+    ],
+  });
+  // floor(10M/3) = 3_333_333 for years 2024 and 2025
+  // final year gets 10M - 2*3_333_333 = 3_333_334
+  assertEquals(computeCapHit(contract, 2024), 3_333_333);
+  assertEquals(computeCapHit(contract, 2025), 3_333_333);
+  assertEquals(computeCapHit(contract, 2026), 3_333_334);
+});
+
+Deno.test("computeCapHit: unexercised option bonuses contribute nothing", () => {
+  const contract = makeContract({
+    years: [
+      {
+        leagueYear: 2024,
+        base: 1_000_000,
+        rosterBonus: 0,
+        workoutBonus: 0,
+        perGameRosterBonus: 0,
+        guaranteeType: "none",
+        isVoid: false,
+      },
+    ],
+    optionBonuses: [
+      {
+        amount: 50_000_000,
+        exerciseYear: 2025,
+        prorationYears: 5,
+        exercisedAt: null,
+      },
+    ],
+  });
+  assertEquals(computeCapHit(contract, 2024), 1_000_000);
+});
+
+// ---------- computeDeadCap ----------
+
+Deno.test("computeDeadCap: accelerates remaining proration slices", () => {
+  const contract = makeContract({
+    years: [
+      {
+        leagueYear: 2024,
+        base: 5_000_000,
+        rosterBonus: 0,
+        workoutBonus: 0,
+        perGameRosterBonus: 0,
+        guaranteeType: "none",
+        isVoid: false,
+      },
+      {
+        leagueYear: 2025,
+        base: 5_000_000,
+        rosterBonus: 0,
+        workoutBonus: 0,
+        perGameRosterBonus: 0,
+        guaranteeType: "none",
+        isVoid: false,
+      },
+    ],
+    bonusProrations: [
+      { amount: 10_000_000, firstYear: 2024, years: 5, source: "signing" },
+    ],
+  });
+  // Cut in 2025: remaining years = 2025,2026,2027,2028 = 4 years
+  // perYear = floor(10M/5) = 2_000_000
+  // accelerated = 2_000_000 * 4 = 8_000_000
+  // No guaranteed base/roster bonus => dead cap = 8_000_000
+  assertEquals(computeDeadCap(contract, 2025), 8_000_000);
+});
+
+Deno.test("computeDeadCap: includes fully guaranteed base and roster bonus from cutYear onward", () => {
+  const contract = makeContract({
+    years: [
+      {
+        leagueYear: 2024,
+        base: 5_000_000,
+        rosterBonus: 1_000_000,
+        workoutBonus: 500_000,
+        perGameRosterBonus: 200_000,
+        guaranteeType: "full",
+        isVoid: false,
+      },
+      {
+        leagueYear: 2025,
+        base: 3_000_000,
+        rosterBonus: 500_000,
+        workoutBonus: 0,
+        perGameRosterBonus: 100_000,
+        guaranteeType: "full",
+        isVoid: false,
+      },
+      {
+        leagueYear: 2026,
+        base: 2_000_000,
+        rosterBonus: 0,
+        workoutBonus: 0,
+        perGameRosterBonus: 0,
+        guaranteeType: "none",
+        isVoid: false,
+      },
+    ],
+  });
+  // Cut in 2025: guaranteed base+roster from 2025 onward
+  // 2025: 3M + 500K = 3_500_000 (full guarantee)
+  // 2026: none guarantee, excluded
+  assertEquals(computeDeadCap(contract, 2025), 3_500_000);
+});
+
+Deno.test("computeDeadCap: PGRB is excluded (not guaranteed)", () => {
+  const contract = makeContract({
+    years: [
+      {
+        leagueYear: 2024,
+        base: 1_000_000,
+        rosterBonus: 0,
+        workoutBonus: 0,
+        perGameRosterBonus: 2_000_000,
+        guaranteeType: "full",
+        isVoid: false,
+      },
+    ],
+  });
+  // PGRB excluded; only base is guaranteed
+  assertEquals(computeDeadCap(contract, 2024), 1_000_000);
+});
+
+Deno.test("computeDeadCap: combines accelerated proration with guaranteed salary", () => {
+  const contract = makeContract({
+    years: [
+      {
+        leagueYear: 2024,
+        base: 5_000_000,
+        rosterBonus: 1_000_000,
+        workoutBonus: 0,
+        perGameRosterBonus: 0,
+        guaranteeType: "full",
+        isVoid: false,
+      },
+      {
+        leagueYear: 2025,
+        base: 10_000_000,
+        rosterBonus: 2_000_000,
+        workoutBonus: 0,
+        perGameRosterBonus: 0,
+        guaranteeType: "full",
+        isVoid: false,
+      },
+    ],
+    bonusProrations: [
+      { amount: 20_000_000, firstYear: 2024, years: 5, source: "signing" },
+    ],
+  });
+  // Cut in 2025:
+  // Accelerated proration: remaining = 4 years, perYear = floor(20M/5) = 4M => 16M
+  // Guaranteed from 2025: base 10M + roster 2M = 12M
+  // Total: 16M + 12M = 28M
+  assertEquals(computeDeadCap(contract, 2025), 28_000_000);
+});
+
+Deno.test("computeDeadCap: rounding residue lands on final proration year in acceleration", () => {
+  const contract = makeContract({
+    years: [
+      {
+        leagueYear: 2024,
+        base: 0,
+        rosterBonus: 0,
+        workoutBonus: 0,
+        perGameRosterBonus: 0,
+        guaranteeType: "none",
+        isVoid: false,
+      },
+    ],
+    bonusProrations: [
+      { amount: 10_000_000, firstYear: 2024, years: 3, source: "signing" },
+    ],
+  });
+  // Cut in 2024: accelerate all 3 years
+  // With residue handling: total must equal 10_000_000
+  assertEquals(computeDeadCap(contract, 2024), 10_000_000);
+});
+
+Deno.test("computeDeadCap: unexercised option bonuses contribute nothing", () => {
+  const contract = makeContract({
+    years: [
+      {
+        leagueYear: 2024,
+        base: 1_000_000,
+        rosterBonus: 0,
+        workoutBonus: 0,
+        perGameRosterBonus: 0,
+        guaranteeType: "full",
+        isVoid: false,
+      },
+    ],
+    optionBonuses: [
+      {
+        amount: 50_000_000,
+        exerciseYear: 2025,
+        prorationYears: 5,
+        exercisedAt: null,
+      },
+    ],
+  });
+  assertEquals(computeDeadCap(contract, 2024), 1_000_000);
+});
+
+Deno.test("computeDeadCap: injury-only guarantees are excluded", () => {
+  const contract = makeContract({
+    years: [
+      {
+        leagueYear: 2024,
+        base: 5_000_000,
+        rosterBonus: 1_000_000,
+        workoutBonus: 0,
+        perGameRosterBonus: 0,
+        guaranteeType: "injury",
+        isVoid: false,
+      },
+    ],
+  });
+  assertEquals(computeDeadCap(contract, 2024), 0);
+});
+
+// ---------- computeHeadlineValue ----------
+
+Deno.test("computeHeadlineValue: sums all yearly dollars", () => {
+  const contract = makeContract({
+    years: [
+      {
+        leagueYear: 2024,
+        base: 5_000_000,
+        rosterBonus: 1_000_000,
+        workoutBonus: 500_000,
+        perGameRosterBonus: 850_000,
+        guaranteeType: "full",
+        isVoid: false,
+      },
+      {
+        leagueYear: 2025,
+        base: 6_000_000,
+        rosterBonus: 1_000_000,
+        workoutBonus: 500_000,
+        perGameRosterBonus: 850_000,
+        guaranteeType: "none",
+        isVoid: false,
+      },
+    ],
+  });
+  // (5M+1M+500K+850K) + (6M+1M+500K+850K) = 7_350_000 + 8_350_000 = 15_700_000
+  assertEquals(computeHeadlineValue(contract), 15_700_000);
+});
+
+Deno.test("computeHeadlineValue: includes materialized bonus proration face amounts", () => {
+  const contract = makeContract({
+    years: [
+      {
+        leagueYear: 2024,
+        base: 1_000_000,
+        rosterBonus: 0,
+        workoutBonus: 0,
+        perGameRosterBonus: 0,
+        guaranteeType: "none",
+        isVoid: false,
+      },
+    ],
+    bonusProrations: [
+      { amount: 20_000_000, firstYear: 2024, years: 5, source: "signing" },
+      { amount: 5_000_000, firstYear: 2025, years: 3, source: "restructure" },
+    ],
+  });
+  // yearTotals: 1M
+  // materialized: 20M + 5M = 25M
+  // total: 26M
+  assertEquals(computeHeadlineValue(contract), 26_000_000);
+});
+
+Deno.test("computeHeadlineValue: includes unexercised option bonus face amounts", () => {
+  const contract = makeContract({
+    years: [
+      {
+        leagueYear: 2024,
+        base: 1_000_000,
+        rosterBonus: 0,
+        workoutBonus: 0,
+        perGameRosterBonus: 0,
+        guaranteeType: "none",
+        isVoid: false,
+      },
+    ],
+    optionBonuses: [
+      {
+        amount: 50_000_000,
+        exerciseYear: 2025,
+        prorationYears: 5,
+        exercisedAt: null,
+      },
+      {
+        amount: 30_000_000,
+        exerciseYear: 2026,
+        prorationYears: 4,
+        exercisedAt: null,
+      },
+    ],
+  });
+  // yearTotals: 1M
+  // unexercised options: 50M + 30M = 80M
+  // total: 81M
+  assertEquals(computeHeadlineValue(contract), 81_000_000);
+});
+
+Deno.test("computeHeadlineValue: void years contribute their dollars to headline", () => {
+  const contract = makeContract({
+    years: [
+      {
+        leagueYear: 2024,
+        base: 5_000_000,
+        rosterBonus: 0,
+        workoutBonus: 0,
+        perGameRosterBonus: 0,
+        guaranteeType: "full",
+        isVoid: false,
+      },
+      {
+        leagueYear: 2025,
+        base: 0,
+        rosterBonus: 0,
+        workoutBonus: 0,
+        perGameRosterBonus: 0,
+        guaranteeType: "none",
+        isVoid: true,
+      },
+    ],
+  });
+  assertEquals(computeHeadlineValue(contract), 5_000_000);
+});
+
+// ---------- Taysom Hill case study ----------
+
+Deno.test("Taysom Hill: computeCapHit 2021 ≈ $10.075M", () => {
+  const contract = makeTaysomHillContract();
+  assertEquals(computeCapHit(contract, 2021), 10_075_000);
+});
+
+Deno.test("Taysom Hill: computeCapHit on void years returns 0 (no proration)", () => {
+  const contract = makeTaysomHillContract();
+  assertEquals(computeCapHit(contract, 2022), 0);
+  assertEquals(computeCapHit(contract, 2023), 0);
+  assertEquals(computeCapHit(contract, 2024), 0);
+});
+
+Deno.test("Taysom Hill: computeHeadlineValue ≈ $105.075M (real + options)", () => {
+  const contract = makeTaysomHillContract();
+  // Year totals: 2021 = 1.075M + 7.5M + 0 + 1.5M = 10.075M
+  // Void years all zero
+  // No materialized prorations (no signing bonus)
+  // Unexercised option: $95M
+  // Total: 10.075M + 95M = 105.075M
+  assertEquals(computeHeadlineValue(contract), 105_075_000);
+});
+
+Deno.test("Taysom Hill: computeDeadCap 2022 = 0 (no proration, no remaining guarantees)", () => {
+  const contract = makeTaysomHillContract();
+  // Cut after 2021: no signing bonus proration, no guaranteed years remaining
+  assertEquals(computeDeadCap(contract, 2022), 0);
+});
+
+function makeTaysomHillContract(): CapContractInput {
+  return {
+    years: [
+      {
+        leagueYear: 2021,
+        base: 1_075_000,
+        rosterBonus: 7_500_000,
+        workoutBonus: 0,
+        perGameRosterBonus: 1_500_000,
+        guaranteeType: "full",
+        isVoid: false,
+      },
+      {
+        leagueYear: 2022,
+        base: 0,
+        rosterBonus: 0,
+        workoutBonus: 0,
+        perGameRosterBonus: 0,
+        guaranteeType: "none",
+        isVoid: true,
+      },
+      {
+        leagueYear: 2023,
+        base: 0,
+        rosterBonus: 0,
+        workoutBonus: 0,
+        perGameRosterBonus: 0,
+        guaranteeType: "none",
+        isVoid: true,
+      },
+      {
+        leagueYear: 2024,
+        base: 0,
+        rosterBonus: 0,
+        workoutBonus: 0,
+        perGameRosterBonus: 0,
+        guaranteeType: "none",
+        isVoid: true,
+      },
+    ],
+    bonusProrations: [],
+    optionBonuses: [
+      {
+        amount: 95_000_000,
+        exerciseYear: 2022,
+        prorationYears: 5,
+        exercisedAt: null,
+      },
+    ],
+  };
+}

--- a/packages/shared/contracts/cap-engine.ts
+++ b/packages/shared/contracts/cap-engine.ts
@@ -1,0 +1,120 @@
+import type {
+  ContractBonusSource,
+  ContractGuaranteeType,
+} from "../types/player.ts";
+
+export interface CapContractYear {
+  leagueYear: number;
+  base: number;
+  rosterBonus: number;
+  workoutBonus: number;
+  perGameRosterBonus: number;
+  guaranteeType: ContractGuaranteeType;
+  isVoid: boolean;
+}
+
+export interface CapBonusProration {
+  amount: number;
+  firstYear: number;
+  years: number;
+  source: ContractBonusSource;
+}
+
+export interface CapOptionBonus {
+  amount: number;
+  exerciseYear: number;
+  prorationYears: number;
+  exercisedAt: Date | null;
+}
+
+export interface CapContractInput {
+  years: CapContractYear[];
+  bonusProrations: CapBonusProration[];
+  optionBonuses: CapOptionBonus[];
+}
+
+function prorationForYear(
+  proration: CapBonusProration,
+  year: number,
+): number {
+  if (
+    year < proration.firstYear || year >= proration.firstYear + proration.years
+  ) {
+    return 0;
+  }
+  const perYear = Math.floor(proration.amount / proration.years);
+  const isLastYear = year === proration.firstYear + proration.years - 1;
+  if (isLastYear) {
+    return proration.amount - perYear * (proration.years - 1);
+  }
+  return perYear;
+}
+
+export function computeCapHit(
+  contract: CapContractInput,
+  year: number,
+): number {
+  const yearRow = contract.years.find((y) => y.leagueYear === year);
+  if (!yearRow) return 0;
+
+  const proratedPortion = contract.bonusProrations
+    .map((p) => prorationForYear(p, year))
+    .reduce((sum, v) => sum + v, 0);
+
+  if (yearRow.isVoid) return proratedPortion;
+
+  return (
+    yearRow.base +
+    yearRow.rosterBonus +
+    yearRow.workoutBonus +
+    yearRow.perGameRosterBonus +
+    proratedPortion
+  );
+}
+
+export function computeDeadCap(
+  contract: CapContractInput,
+  cutYear: number,
+): number {
+  const acceleratedBonus = contract.bonusProrations
+    .map((p) => {
+      const endYear = p.firstYear + p.years;
+      const yearsRemaining = Math.max(0, endYear - cutYear);
+      if (yearsRemaining === 0) return 0;
+      let total = 0;
+      for (let y = cutYear; y < endYear; y++) {
+        total += prorationForYear(p, y);
+      }
+      return total;
+    })
+    .reduce((sum, v) => sum + v, 0);
+
+  const remainingGuaranteedBase = contract.years
+    .filter((y) => y.leagueYear >= cutYear && y.guaranteeType === "full")
+    .reduce((sum, y) => sum + y.base + y.rosterBonus, 0);
+
+  return acceleratedBonus + remainingGuaranteedBase;
+}
+
+export function computeHeadlineValue(contract: CapContractInput): number {
+  const yearTotals = contract.years.reduce(
+    (sum, y) =>
+      sum +
+      y.base +
+      y.rosterBonus +
+      y.workoutBonus +
+      y.perGameRosterBonus,
+    0,
+  );
+
+  const materializedBonuses = contract.bonusProrations.reduce(
+    (sum, p) => sum + p.amount,
+    0,
+  );
+
+  const unexercisedOptionFace = contract.optionBonuses
+    .filter((o) => o.exercisedAt === null)
+    .reduce((sum, o) => sum + o.amount, 0);
+
+  return yearTotals + materializedBonuses + unexercisedOptionFace;
+}

--- a/packages/shared/mod.ts
+++ b/packages/shared/mod.ts
@@ -95,6 +95,17 @@ export {
   CONTRACT_TYPES,
 } from "./contracts/contract-ledger.ts";
 export type {
+  CapBonusProration,
+  CapContractInput,
+  CapContractYear,
+  CapOptionBonus,
+} from "./contracts/cap-engine.ts";
+export {
+  computeCapHit,
+  computeDeadCap,
+  computeHeadlineValue,
+} from "./contracts/cap-engine.ts";
+export type {
   Contract,
   ContractBonusSource,
   ContractGuaranteeType,


### PR DESCRIPTION
## Summary

Closes #290

- Adds three pure cap-engine functions (`computeCapHit`, `computeDeadCap`, `computeHeadlineValue`) as defined in ADR 0016, operating on contract data with no mutations or DB calls
- Implements integer-only proration with rounding residue on the final year so sums reconcile exactly
- Includes the Taysom Hill case study from the ADR as a test fixture (~$10M cap hit 2021, ~$105M headline)
- Exports new types (`CapContractInput`, `CapContractYear`, `CapBonusProration`, `CapOptionBonus`) and functions from `@zone-blitz/shared`

🤖 Generated with [Claude Code](https://claude.com/claude-code)