### PR TITLE
feat(ui-league): hide sidebar items by phase and collapse empty groups

### DIFF
--- a/client/src/features/league/layout.test.tsx
+++ b/client/src/features/league/layout.test.tsx
@@ -295,9 +295,66 @@ describe("LeagueLayout", () => {
     });
 
     expect(screen.getByRole("link", { name: "Owner" })).toBeDefined();
+    expect(screen.getByRole("link", { name: "Charter" })).toBeDefined();
     expect(screen.queryByRole("link", { name: "Roster" })).toBeNull();
     expect(screen.queryByRole("link", { name: "Draft" })).toBeNull();
     expect(screen.queryByRole("link", { name: "Standings" })).toBeNull();
+  });
+
+  it("shows genesis-only items only in their respective phases", async () => {
+    mockPhase = "genesis_staff_hiring";
+    renderWithProviders();
+
+    await waitFor(() => {
+      expect(screen.getByRole("link", { name: "Staff Hiring" })).toBeDefined();
+    });
+
+    expect(screen.queryByRole("link", { name: "Charter" })).toBeNull();
+    expect(screen.queryByRole("link", { name: "Founding Pool" })).toBeNull();
+    expect(screen.queryByRole("link", { name: "Allocation Draft" })).toBeNull();
+  });
+
+  it("shows Founding Pool only during genesis_founding_pool", async () => {
+    mockPhase = "genesis_founding_pool";
+    renderWithProviders();
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("link", { name: "Founding Pool" }),
+      ).toBeDefined();
+    });
+
+    expect(screen.queryByRole("link", { name: "Charter" })).toBeNull();
+    expect(screen.queryByRole("link", { name: "Staff Hiring" })).toBeNull();
+  });
+
+  it("shows Allocation Draft only during genesis_allocation_draft", async () => {
+    mockPhase = "genesis_allocation_draft";
+    renderWithProviders();
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("link", { name: "Allocation Draft" }),
+      ).toBeDefined();
+    });
+
+    expect(screen.queryByRole("link", { name: "Charter" })).toBeNull();
+    expect(screen.queryByRole("link", { name: "Staff Hiring" })).toBeNull();
+    expect(screen.queryByRole("link", { name: "Founding Pool" })).toBeNull();
+  });
+
+  it("hides all genesis-only items in regular_season", async () => {
+    mockPhase = "regular_season";
+    renderWithProviders();
+
+    await waitFor(() => {
+      expect(screen.getByRole("link", { name: "Roster" })).toBeDefined();
+    });
+
+    expect(screen.queryByRole("link", { name: "Charter" })).toBeNull();
+    expect(screen.queryByRole("link", { name: "Staff Hiring" })).toBeNull();
+    expect(screen.queryByRole("link", { name: "Founding Pool" })).toBeNull();
+    expect(screen.queryByRole("link", { name: "Allocation Draft" })).toBeNull();
   });
 
   it("shows all nav items when phase is loading", () => {

--- a/client/src/features/league/nav-config.test.ts
+++ b/client/src/features/league/nav-config.test.ts
@@ -112,6 +112,43 @@ describe("navGroups", () => {
     expect(visibleLabels("regular_season")).toContain("Opponents");
   });
 
+  it("shows Charter only in genesis_charter", () => {
+    expect(visibleLabels("genesis_charter")).toContain("Charter");
+    expect(visibleLabels("genesis_franchise_establishment")).not.toContain(
+      "Charter",
+    );
+    expect(visibleLabels("regular_season")).not.toContain("Charter");
+  });
+
+  it("shows Staff Hiring only in genesis_staff_hiring", () => {
+    expect(visibleLabels("genesis_staff_hiring")).toContain("Staff Hiring");
+    expect(visibleLabels("genesis_charter")).not.toContain("Staff Hiring");
+    expect(visibleLabels("genesis_founding_pool")).not.toContain(
+      "Staff Hiring",
+    );
+    expect(visibleLabels("regular_season")).not.toContain("Staff Hiring");
+  });
+
+  it("shows Founding Pool only in genesis_founding_pool", () => {
+    expect(visibleLabels("genesis_founding_pool")).toContain("Founding Pool");
+    expect(visibleLabels("genesis_charter")).not.toContain("Founding Pool");
+    expect(visibleLabels("genesis_allocation_draft")).not.toContain(
+      "Founding Pool",
+    );
+    expect(visibleLabels("regular_season")).not.toContain("Founding Pool");
+  });
+
+  it("shows Allocation Draft only in genesis_allocation_draft", () => {
+    expect(visibleLabels("genesis_allocation_draft")).toContain(
+      "Allocation Draft",
+    );
+    expect(visibleLabels("genesis_charter")).not.toContain("Allocation Draft");
+    expect(visibleLabels("genesis_free_agency")).not.toContain(
+      "Allocation Draft",
+    );
+    expect(visibleLabels("regular_season")).not.toContain("Allocation Draft");
+  });
+
   it("every item is visible in at least one phase", () => {
     for (const group of navGroups) {
       for (const item of group.items) {

--- a/client/src/features/league/nav-config.ts
+++ b/client/src/features/league/nav-config.ts
@@ -1,12 +1,16 @@
 import {
   ArrowLeftRightIcon,
+  BriefcaseIcon,
   CalendarIcon,
   ClipboardListIcon,
   CrownIcon,
   DollarSignIcon,
+  GavelIcon,
   HomeIcon,
+  LayersIcon,
   ListOrderedIcon,
   NewspaperIcon,
+  ScrollTextIcon,
   SearchIcon,
   TrophyIcon,
   UserPlusIcon,
@@ -68,6 +72,11 @@ const freeAgencyPhases = inPhases(
   "regular_season",
 );
 
+const genesisCharter = inPhases("genesis_charter");
+const genesisStaffHiring = inPhases("genesis_staff_hiring");
+const genesisFoundingPool = inPhases("genesis_founding_pool");
+const genesisAllocationDraft = inPhases("genesis_allocation_draft");
+
 export const navGroups: NavGroup[] = [
   {
     label: "Team",
@@ -91,6 +100,12 @@ export const navGroups: NavGroup[] = [
         Icon: SearchIcon,
         visibleInPhases: fromStaffHiring,
       },
+      {
+        label: "Staff Hiring",
+        path: "staff-hiring",
+        Icon: BriefcaseIcon,
+        visibleInPhases: genesisStaffHiring,
+      },
     ],
   },
   {
@@ -101,6 +116,18 @@ export const navGroups: NavGroup[] = [
         path: "draft",
         Icon: ListOrderedIcon,
         visibleInPhases: draftPhases,
+      },
+      {
+        label: "Allocation Draft",
+        path: "allocation-draft",
+        Icon: GavelIcon,
+        visibleInPhases: genesisAllocationDraft,
+      },
+      {
+        label: "Founding Pool",
+        path: "founding-pool",
+        Icon: LayersIcon,
+        visibleInPhases: genesisFoundingPool,
       },
       {
         label: "Trades",
@@ -125,6 +152,12 @@ export const navGroups: NavGroup[] = [
   {
     label: "League",
     items: [
+      {
+        label: "Charter",
+        path: "charter",
+        Icon: ScrollTextIcon,
+        visibleInPhases: genesisCharter,
+      },
       {
         label: "Standings",
         path: "standings",


### PR DESCRIPTION
## Summary

Closes #295

- Adds four genesis-only nav entries (Charter, Staff Hiring, Founding Pool, Allocation Draft) to the sidebar config, each gated to its single genesis phase via `inPhases`.
- Together with the `filterNavGroups` logic and `visibleInPhases` predicate from #302, the sidebar now fully satisfies ADR 0020: items are hidden (not disabled) outside their phase, groups collapse when all children are hidden, always-on items (Home, Owner, Settings, All Leagues, Profile) always render, and the phase→visibility mapping lives declaratively in the nav config with no `if (phase === ...)` branching in the layout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)