### PR TITLE
test(ui-league): assert phase→nav-item visibility for representative phases

### DIFF
--- a/client/src/features/league/nav-config.test.ts
+++ b/client/src/features/league/nav-config.test.ts
@@ -10,6 +10,12 @@ function visibleLabels(phase: LeaguePhase): string[] {
     .map((item) => item.label);
 }
 
+function visibleGroupLabels(phase: LeaguePhase): string[] {
+  return navGroups
+    .filter((g) => g.items.some((item) => item.visibleInPhases(phase)))
+    .map((g) => g.label);
+}
+
 describe("navGroups", () => {
   it("every nav item has a visibleInPhases function", () => {
     for (const group of navGroups) {
@@ -156,5 +162,120 @@ describe("navGroups", () => {
         expect(visibleInAny, `${item.label} is never visible`).toBe(true);
       }
     }
+  });
+
+  describe("exact visible set per representative phase", () => {
+    it.each<[LeaguePhase, string[]]>([
+      ["genesis_charter", ["Home", "Charter", "Owner"]],
+      [
+        "genesis_staff_hiring",
+        ["Home", "Coaches", "Scouts", "Staff Hiring", "Media", "Owner"],
+      ],
+      [
+        "genesis_allocation_draft",
+        [
+          "Home",
+          "Roster",
+          "Coaches",
+          "Scouts",
+          "Draft",
+          "Allocation Draft",
+          "Salary Cap",
+          "Media",
+          "Owner",
+        ],
+      ],
+      [
+        "genesis_free_agency",
+        [
+          "Home",
+          "Roster",
+          "Coaches",
+          "Scouts",
+          "Free Agency",
+          "Salary Cap",
+          "Media",
+          "Owner",
+        ],
+      ],
+      [
+        "preseason",
+        [
+          "Home",
+          "Roster",
+          "Coaches",
+          "Scouts",
+          "Trades",
+          "Salary Cap",
+          "Schedule",
+          "Opponents",
+          "Media",
+          "Owner",
+        ],
+      ],
+      [
+        "regular_season",
+        [
+          "Home",
+          "Roster",
+          "Coaches",
+          "Scouts",
+          "Trades",
+          "Free Agency",
+          "Salary Cap",
+          "Standings",
+          "Schedule",
+          "Opponents",
+          "Media",
+          "Owner",
+        ],
+      ],
+      [
+        "offseason_review",
+        [
+          "Home",
+          "Roster",
+          "Coaches",
+          "Scouts",
+          "Salary Cap",
+          "Media",
+          "Owner",
+        ],
+      ],
+    ])(
+      "shows exactly the expected nav items in %s",
+      (phase, expectedLabels) => {
+        expect(visibleLabels(phase)).toEqual(expectedLabels);
+      },
+    );
+  });
+
+  describe("NavGroup visibility per phase", () => {
+    it("hides Team Building group in genesis_charter", () => {
+      expect(visibleGroupLabels("genesis_charter")).toEqual(["Team", "League"]);
+    });
+
+    it("hides Team Building group in genesis_staff_hiring", () => {
+      expect(visibleGroupLabels("genesis_staff_hiring")).toEqual([
+        "Team",
+        "League",
+      ]);
+    });
+
+    it("shows all groups in genesis_allocation_draft", () => {
+      expect(visibleGroupLabels("genesis_allocation_draft")).toEqual([
+        "Team",
+        "Team Building",
+        "League",
+      ]);
+    });
+
+    it("shows all groups in regular_season", () => {
+      expect(visibleGroupLabels("regular_season")).toEqual([
+        "Team",
+        "Team Building",
+        "League",
+      ]);
+    });
   });
 });


### PR DESCRIPTION
## Summary

Closes #296

- Adds exact visible set assertions for all seven representative phases from ADR 0020: `genesis_charter`, `genesis_staff_hiring`, `genesis_allocation_draft`, `genesis_free_agency`, `preseason`, `regular_season`, and `offseason_review`.
- Each test uses `toEqual` against the full expected label array, catching any drift from the authoritative nav-config mapping.
- Adds NavGroup visibility tests asserting that groups with all-hidden children (e.g. Team Building during `genesis_charter`) collapse — matching the `filterNavGroups` behavior in `layout.tsx`.