### PR TITLE
feat(sim): drive starting field position derived from prior possession outcome

### DIFF
--- a/server/features/simulation/resolve-field-goal.test.ts
+++ b/server/features/simulation/resolve-field-goal.test.ts
@@ -257,6 +257,29 @@ Deno.test("resolveFieldGoal", async (t) => {
     },
   );
 
+  await t.step(
+    "missed FG from inside the 20 gives defense ball at the 20 per NFL rules",
+    () => {
+      let foundMiss = false;
+      for (let seed = 1; seed <= 2000 && !foundMiss; seed++) {
+        const result = resolveFieldGoal({
+          kicker: makeKicker({ kickingAccuracy: 20, kickingPower: 20 }),
+          yardLine: 90,
+          rng: createSeededRng(seed),
+        });
+        if (result.outcome === "missed" || result.outcome === "blocked") {
+          foundMiss = true;
+          assertEquals(
+            result.defenseYardLine >= 20,
+            true,
+            `defenseYardLine should be at least 20, got ${result.defenseYardLine}`,
+          );
+        }
+      }
+      assertEquals(foundMiss, true);
+    },
+  );
+
   await t.step("very long FGs have low success rate", () => {
     const trials = 500;
     let made = 0;

--- a/server/features/simulation/resolve-field-goal.ts
+++ b/server/features/simulation/resolve-field-goal.ts
@@ -46,7 +46,7 @@ function getSuccessProbability(
 export function resolveFieldGoal(input: FieldGoalInput): FieldGoalResult {
   const { kicker, yardLine, weatherPenalty = 0, rng } = input;
   const distance = 100 - yardLine + 17;
-  const defenseYardLine = 100 - yardLine;
+  const defenseYardLine = Math.max(20, 100 - yardLine);
 
   const kickingAccuracy =
     (kicker.attributes as unknown as Record<string, number>).kickingAccuracy ??

--- a/server/features/simulation/resolve-kickoff.test.ts
+++ b/server/features/simulation/resolve-kickoff.test.ts
@@ -329,4 +329,48 @@ Deno.test("resolveKickoff", async (t) => {
     assertEquals(result.event.situation.distance, 10);
     assertEquals(result.event.situation.yardLine, 35);
   });
+
+  await t.step("safety kick situation reflects yard line 20", () => {
+    const rng = createSeededRng(42);
+    const ctx = makeKickoffContext({ isSafetyKick: true });
+    const result = resolveKickoff(ctx, rng);
+
+    assertEquals(result.event.situation.yardLine, 20);
+  });
+
+  await t.step(
+    "safety kick never elects onside even when trailing late",
+    () => {
+      let onsideFound = false;
+      for (let seed = 1; seed <= 500; seed++) {
+        const rng = createSeededRng(seed);
+        const ctx = makeKickoffContext({
+          isSafetyKick: true,
+          scoreDifferential: -10,
+          quarter: 4,
+          clock: "2:00",
+        });
+        const result = resolveKickoff(ctx, rng);
+        if (result.event.tags.includes("onside")) {
+          onsideFound = true;
+        }
+      }
+      assertEquals(onsideFound, false);
+    },
+  );
+
+  await t.step(
+    "safety kick starting yard line is between 1 and 99",
+    () => {
+      for (let seed = 1; seed <= 100; seed++) {
+        const rng = createSeededRng(seed);
+        const ctx = makeKickoffContext({ isSafetyKick: true });
+        const result = resolveKickoff(ctx, rng);
+        if (!result.isReturnTouchdown) {
+          assertGreater(result.startingYardLine, 0);
+          assertEquals(result.startingYardLine <= 99, true);
+        }
+      }
+    },
+  );
 });

--- a/server/features/simulation/resolve-kickoff.ts
+++ b/server/features/simulation/resolve-kickoff.ts
@@ -14,6 +14,7 @@ export interface KickoffContext {
   returner: PlayerRuntime | undefined;
   coverageUnit: PlayerRuntime[];
   scoreDifferential: number;
+  isSafetyKick?: boolean;
 }
 
 export interface KickoffResult {
@@ -24,6 +25,7 @@ export interface KickoffResult {
 }
 
 const KICKOFF_YARD_LINE = 35;
+const SAFETY_KICK_YARD_LINE = 20;
 const TOUCHBACK_YARD_LINE = 25;
 const OOB_YARD_LINE = 40;
 const OOB_RATE = 0.03;
@@ -88,7 +90,11 @@ export function resolveKickoff(
     { role: "kicker", playerId: ctx.kicker.playerId, tags: [] as string[] },
   ];
 
-  const isOnside = shouldElectOnside(
+  const kickYardLine = ctx.isSafetyKick
+    ? SAFETY_KICK_YARD_LINE
+    : KICKOFF_YARD_LINE;
+
+  const isOnside = !ctx.isSafetyKick && shouldElectOnside(
     ctx.scoreDifferential,
     ctx.quarter,
     ctx.clock,
@@ -98,9 +104,9 @@ export function resolveKickoff(
     tags.push("onside" as PlayTag);
 
     const recovered = rng.next() < ONSIDE_RECOVERY_RATE;
-    const yardLine = KICKOFF_YARD_LINE + rng.int(8, 15);
+    const yardLine = kickYardLine + rng.int(8, 15);
 
-    const event = buildEvent(ctx, tags, participants, 0);
+    const event = buildEvent(ctx, tags, participants, 0, kickYardLine);
 
     return {
       event,
@@ -114,7 +120,7 @@ export function resolveKickoff(
   const touchbackRate = computeTouchbackRate(kickingPower);
 
   if (rng.next() < OOB_RATE) {
-    const event = buildEvent(ctx, tags, participants, 0);
+    const event = buildEvent(ctx, tags, participants, 0, kickYardLine);
     return {
       event,
       startingYardLine: OOB_YARD_LINE,
@@ -133,7 +139,7 @@ export function resolveKickoff(
       });
     }
     const startYard = Math.min(99, Math.max(1, 30 + returnDist));
-    const event = buildEvent(ctx, tags, participants, returnDist);
+    const event = buildEvent(ctx, tags, participants, returnDist, kickYardLine);
     return {
       event,
       startingYardLine: startYard,
@@ -143,7 +149,7 @@ export function resolveKickoff(
   }
 
   if (rng.next() < touchbackRate) {
-    const event = buildEvent(ctx, tags, participants, 0);
+    const event = buildEvent(ctx, tags, participants, 0, kickYardLine);
     return {
       event,
       startingYardLine: TOUCHBACK_YARD_LINE,
@@ -153,7 +159,7 @@ export function resolveKickoff(
   }
 
   if (!ctx.returner) {
-    const event = buildEvent(ctx, tags, participants, 0);
+    const event = buildEvent(ctx, tags, participants, 0, kickYardLine);
     return {
       event,
       startingYardLine: TOUCHBACK_YARD_LINE,
@@ -187,7 +193,13 @@ export function resolveKickoff(
 
   if (rng.next() < returnTDChance) {
     tags.push("touchdown");
-    const event = buildEvent(ctx, tags, participants, 100 - catchYard);
+    const event = buildEvent(
+      ctx,
+      tags,
+      participants,
+      100 - catchYard,
+      kickYardLine,
+    );
     return {
       event,
       startingYardLine: 0,
@@ -196,7 +208,7 @@ export function resolveKickoff(
     };
   }
 
-  const event = buildEvent(ctx, tags, participants, returnDist);
+  const event = buildEvent(ctx, tags, participants, returnDist, kickYardLine);
   return {
     event,
     startingYardLine: startYard,
@@ -210,6 +222,7 @@ function buildEvent(
   tags: PlayTag[],
   participants: { role: string; playerId: string; tags: string[] }[],
   yardage: number,
+  kickYardLine: number,
 ): PlayEvent {
   return {
     gameId: ctx.gameId,
@@ -220,7 +233,7 @@ function buildEvent(
     situation: {
       down: 1,
       distance: 10,
-      yardLine: KICKOFF_YARD_LINE,
+      yardLine: kickYardLine,
     },
     offenseTeamId: ctx.kickingTeamId,
     defenseTeamId: ctx.receivingTeamId,

--- a/server/features/simulation/season-aggregates.test.ts
+++ b/server/features/simulation/season-aggregates.test.ts
@@ -99,3 +99,37 @@ Deno.test("computeSeasonAggregates handles zero games", () => {
   assertEquals(agg.passPercentage, 0);
   assertEquals(agg.totalGames, 0);
 });
+
+Deno.test("computeSeasonAggregates computes averageDriveStartYardLine from drive log", () => {
+  const events = [
+    makeEvent({
+      driveIndex: 0,
+      situation: { down: 1, distance: 10, yardLine: 25 },
+    }),
+    makeEvent({
+      driveIndex: 1,
+      situation: { down: 1, distance: 10, yardLine: 35 },
+    }),
+  ];
+  const result = makeGameResult(events);
+  result.driveLog = [
+    {
+      driveIndex: 0,
+      offenseTeamId: "home",
+      startYardLine: 25,
+      plays: 1,
+      yards: 5,
+      result: "punt",
+    },
+    {
+      driveIndex: 1,
+      offenseTeamId: "away",
+      startYardLine: 35,
+      plays: 1,
+      yards: 5,
+      result: "punt",
+    },
+  ];
+  const agg = computeSeasonAggregates([result]);
+  assertEquals(agg.averageDriveStartYardLine, 30);
+});

--- a/server/features/simulation/season-aggregates.ts
+++ b/server/features/simulation/season-aggregates.ts
@@ -10,6 +10,7 @@ export interface SeasonAggregates {
   sacksPerTeamPerGame: number;
   turnoversPerTeamPerGame: number;
   fourthDownGoRate: number;
+  averageDriveStartYardLine: number;
   totalGames: number;
 }
 
@@ -27,6 +28,7 @@ export function computeSeasonAggregates(
       sacksPerTeamPerGame: 0,
       turnoversPerTeamPerGame: 0,
       fourthDownGoRate: 0,
+      averageDriveStartYardLine: 0,
       totalGames: 0,
     };
   }
@@ -114,6 +116,15 @@ export function computeSeasonAggregates(
     }
   }
 
+  let totalDriveStarts = 0;
+  let driveStartYardLineSum = 0;
+  for (const result of results) {
+    for (const drive of result.driveLog) {
+      totalDriveStarts++;
+      driveStartYardLineSum += drive.startYardLine;
+    }
+  }
+
   const totalCategorized = rushPlays + passAttempts;
   const games = results.length;
 
@@ -134,6 +145,9 @@ export function computeSeasonAggregates(
     turnoversPerTeamPerGame: turnovers / (games * 2),
     fourthDownGoRate: fourthDownAttempts > 0
       ? (fourthDownGo / fourthDownAttempts) * 100
+      : 0,
+    averageDriveStartYardLine: totalDriveStarts > 0
+      ? driveStartYardLineSum / totalDriveStarts
       : 0,
     totalGames: games,
   };

--- a/server/features/simulation/seed-sweep.test.ts
+++ b/server/features/simulation/seed-sweep.test.ts
@@ -35,3 +35,10 @@ Deno.test("seedSweep band means are in plausible ranges", () => {
   assertGreater(result.completionPercentage.mean, 30);
   assertLessOrEqual(result.completionPercentage.mean, 95);
 });
+
+Deno.test("seedSweep average drive start sits inside NFL bands", () => {
+  const result = seedSweep([100, 200], { teamCount: 8, gamesPerTeam: 7 });
+
+  assertGreater(result.averageDriveStartYardLine.mean, 20);
+  assertLessOrEqual(result.averageDriveStartYardLine.mean, 35);
+});

--- a/server/features/simulation/seed-sweep.ts
+++ b/server/features/simulation/seed-sweep.ts
@@ -22,6 +22,7 @@ export interface SweepResult {
   sacksPerTeamPerGame: BandStats;
   turnoversPerTeamPerGame: BandStats;
   fourthDownGoRate: BandStats;
+  averageDriveStartYardLine: BandStats;
   averageElapsedMs: number;
 }
 
@@ -73,6 +74,9 @@ export function seedSweep(
     ),
     fourthDownGoRate: computeBandStats(
       aggregates.map((a) => a.fourthDownGoRate),
+    ),
+    averageDriveStartYardLine: computeBandStats(
+      aggregates.map((a) => a.averageDriveStartYardLine),
     ),
     averageElapsedMs: elapsed.reduce((a, b) => a + b, 0) / elapsed.length,
   };

--- a/server/features/simulation/simulate-game.ts
+++ b/server/features/simulation/simulate-game.ts
@@ -262,7 +262,10 @@ export function simulateGame(input: SimulationInput): GameResult {
       .slice(0, 4);
   }
 
-  function performKickoff(kickingSide: "home" | "away"): void {
+  function performKickoff(
+    kickingSide: "home" | "away",
+    options?: { isSafetyKick?: boolean },
+  ): void {
     const receivingSide = kickingSide === "home" ? "away" : "home";
     const kickingTeamId = kickingSide === "home"
       ? input.home.teamId
@@ -290,6 +293,7 @@ export function simulateGame(input: SimulationInput): GameResult {
       returner: findReturner(receivingSide),
       coverageUnit: findCoverageUnit(kickingSide),
       scoreDifferential: receiverScore - kickerScore,
+      isSafetyKick: options?.isSafetyKick,
     };
 
     const result = resolveKickoff(ctx, rng);
@@ -304,7 +308,6 @@ export function simulateGame(input: SimulationInput): GameResult {
       resolveConversion(receivingTeamId);
 
       state.possession = kickingSide;
-      startNewDrive(25);
       performKickoff(receivingSide);
       return;
     }
@@ -499,7 +502,7 @@ export function simulateGame(input: SimulationInput): GameResult {
       else state.homeScore += 2;
 
       const concedingSide: "home" | "away" = isHome ? "home" : "away";
-      performKickoff(concedingSide);
+      performKickoff(concedingSide, { isSafetyKick: true });
       return true;
     }
 


### PR DESCRIPTION
## Summary

Closes #300

- Safety kickoffs now use the free-kick path (yard line 20) instead of the regular kickoff line (35), with onside kicks correctly disabled during safety kicks per NFL rules.
- Missed field goals from inside the 20-yard line give the defense the ball at the 20 per NFL rules, not the raw line of scrimmage.
- Removed dead `startNewDrive(25)` call after kickoff return TDs (immediately overwritten by `performKickoff`).
- Added `averageDriveStartYardLine` metric to season aggregates and seed sweep, with a band check confirming the distribution sits inside NFL bands (20–35).

🤖 Generated with [Claude Code](https://claude.com/claude-code)