### PR TITLE
chore(sim-calibration): add deno task, daily workflow, and issue-on-drift reporter

### DIFF
--- a/.github/workflows/sim-calibration.yml
+++ b/.github/workflows/sim-calibration.yml
@@ -1,0 +1,114 @@
+name: Sim Calibration
+
+on:
+  schedule:
+    - cron: "0 6 * * *"
+  workflow_dispatch:
+
+permissions:
+  issues: write
+
+jobs:
+  calibrate:
+    name: Run calibration harness
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: denoland/setup-deno@v2
+        with:
+          deno-version: v2.7.11
+
+      - run: deno install
+
+      - name: Run calibration
+        id: calibrate
+        run: |
+          set +e
+          output=$(deno task sim:calibrate 2>&1)
+          exit_code=$?
+          echo "$output"
+          {
+            echo "report<<CALIBRATION_EOF"
+            echo "$output"
+            echo "CALIBRATION_EOF"
+          } >> "$GITHUB_OUTPUT"
+          echo "passed=$( [ $exit_code -eq 0 ] && echo true || echo false )" >> "$GITHUB_OUTPUT"
+          exit 0
+
+      - name: Find last green commit
+        if: steps.calibrate.outputs.passed == 'false'
+        id: last-green
+        run: |
+          last_green=$(git log --format='%H' --since='30 days ago' -- . | head -1)
+          if [ -z "$last_green" ]; then
+            last_green=$(git rev-parse HEAD~10)
+          fi
+          echo "sha=$last_green" >> "$GITHUB_OUTPUT"
+
+      - name: Find existing drift issue
+        id: find-issue
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          issue_number=$(gh issue list \
+            --label "sim-calibration-drift" \
+            --state open \
+            --json number \
+            --jq '.[0].number // empty')
+          echo "number=${issue_number}" >> "$GITHUB_OUTPUT"
+
+      - name: Open or update drift issue
+        if: steps.calibrate.outputs.passed == 'false'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPORT: ${{ steps.calibrate.outputs.report }}
+          ISSUE_NUMBER: ${{ steps.find-issue.outputs.number }}
+          LAST_GREEN: ${{ steps.last-green.outputs.sha }}
+        run: |
+          sha=$(git rev-parse HEAD)
+          sha_short=$(git rev-parse --short HEAD)
+          body=$(cat <<EOF
+          ## Sim calibration drift detected
+
+          **Run:** ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          **HEAD:** ${sha_short} (\`${sha}\`)
+          **SHA range since last green:** \`${LAST_GREEN}..${sha}\`
+
+          ### Report
+
+          \`\`\`
+          ${REPORT}
+          \`\`\`
+
+          See [ADR 0021](docs/product/decisions/0021-sim-calibration-harness.md) for the failure contract.
+          EOF
+          )
+
+          if [ -n "$ISSUE_NUMBER" ]; then
+            gh issue comment "$ISSUE_NUMBER" --body "$body"
+            echo "Commented on existing issue #${ISSUE_NUMBER}"
+          else
+            gh issue create \
+              --title "Sim calibration drift: metrics out of band at ${sha_short}" \
+              --body "$body" \
+              --label "sim-calibration-drift"
+            echo "Created new drift issue"
+          fi
+
+      - name: Close drift issue on green run
+        if: steps.calibrate.outputs.passed == 'true' && steps.find-issue.outputs.number != ''
+        env:
+          GH_TOKEN: ${{ github.token }}
+          ISSUE_NUMBER: ${{ steps.find-issue.outputs.number }}
+        run: |
+          sha_short=$(git rev-parse --short HEAD)
+          gh issue close "$ISSUE_NUMBER" \
+            --comment "Calibration passed at ${sha_short} — closing drift issue."
+
+      - name: Fail step if calibration drifted
+        if: steps.calibrate.outputs.passed == 'false'
+        run: exit 1

--- a/deno.json
+++ b/deno.json
@@ -33,6 +33,7 @@
     "test:client": "cd client && npm exec -- vitest run --coverage",
     "test:coverage": "./bin/check-coverage",
     "test:e2e": "./bin/test-e2e",
+    "sim:calibrate": "deno run --allow-read server/features/simulation/calibration/run-calibration.ts",
     "build": "cd client && deno task build",
     "start": "cd server && deno run --env=../.env --allow-net --allow-env --allow-read --allow-sys main.ts"
   },

--- a/server/features/simulation/calibration/format-report.test.ts
+++ b/server/features/simulation/calibration/format-report.test.ts
@@ -1,0 +1,103 @@
+import { assertEquals } from "@std/assert";
+import { formatReport } from "./format-report.ts";
+import type { CalibrationReport } from "./harness.ts";
+import type { GateResult } from "./three-gate.ts";
+
+function makeGateResult(
+  metric: string,
+  passed: boolean,
+): GateResult {
+  return {
+    metric,
+    passed,
+    meanGate: {
+      passed,
+      simValue: passed ? 50 : 100,
+      bandMean: 50,
+      threshold: 5,
+    },
+    spreadGate: {
+      passed: true,
+      simValue: 10,
+      lowerBound: 7.5,
+      upperBound: 12.5,
+    },
+    tailGate: {
+      passed: true,
+      simP10: 35,
+      simP90: 65,
+      p10Floor: 30,
+      p90Ceiling: 70,
+    },
+  };
+}
+
+Deno.test("formatReport includes pass summary when all pass", () => {
+  const report: CalibrationReport = {
+    totalGames: 1344,
+    totalTeamGames: 2688,
+    results: [
+      makeGateResult("plays", true),
+      makeGateResult("pass_yards", true),
+    ],
+    failures: [],
+    passed: true,
+  };
+
+  const output = formatReport(report);
+  assertEquals(output.includes("PASSED"), true);
+  assertEquals(output.includes("2/2 metrics passed"), true);
+});
+
+Deno.test("formatReport includes failure details when metrics fail", () => {
+  const failedGate = makeGateResult("pass_yards", false);
+  failedGate.meanGate.passed = false;
+
+  const report: CalibrationReport = {
+    totalGames: 1344,
+    totalTeamGames: 2688,
+    results: [makeGateResult("plays", true), failedGate],
+    failures: [failedGate],
+    passed: false,
+  };
+
+  const output = formatReport(report);
+  assertEquals(output.includes("FAILED"), true);
+  assertEquals(output.includes("1/2 metrics passed"), true);
+  assertEquals(output.includes("pass_yards"), true);
+  assertEquals(output.includes("mean"), true);
+});
+
+Deno.test("formatReport shows failing gate names for each failed metric", () => {
+  const failedGate = makeGateResult("yards_per_attempt", false);
+  failedGate.meanGate.passed = false;
+  failedGate.spreadGate.passed = false;
+  failedGate.tailGate.passed = false;
+
+  const report: CalibrationReport = {
+    totalGames: 1344,
+    totalTeamGames: 2688,
+    results: [failedGate],
+    failures: [failedGate],
+    passed: false,
+  };
+
+  const output = formatReport(report);
+  assertEquals(output.includes("mean"), true);
+  assertEquals(output.includes("spread"), true);
+  assertEquals(output.includes("tail"), true);
+});
+
+Deno.test("formatReport includes game count details", () => {
+  const report: CalibrationReport = {
+    totalGames: 1344,
+    totalTeamGames: 2688,
+    results: [makeGateResult("plays", true)],
+    failures: [],
+    passed: true,
+  };
+
+  const output = formatReport(report);
+  assertEquals(output.includes("1344"), true);
+  assertEquals(output.includes("2688"), true);
+});

--- a/server/features/simulation/calibration/format-report.ts
+++ b/server/features/simulation/calibration/format-report.ts
@@ -1,0 +1,56 @@
+import type { CalibrationReport } from "./harness.ts";
+import type { GateResult } from "./three-gate.ts";
+
+function formatFailedGates(result: GateResult): string {
+  const gates: string[] = [];
+
+  if (!result.meanGate.passed) {
+    gates.push(
+      `  - mean: sim=${result.meanGate.simValue.toFixed(2)}, band=${
+        result.meanGate.bandMean.toFixed(2)
+      } ±${result.meanGate.threshold.toFixed(2)}`,
+    );
+  }
+
+  if (!result.spreadGate.passed) {
+    gates.push(
+      `  - spread: sim sd=${result.spreadGate.simValue.toFixed(2)}, expected [${
+        result.spreadGate.lowerBound.toFixed(2)
+      }, ${result.spreadGate.upperBound.toFixed(2)}]`,
+    );
+  }
+
+  if (!result.tailGate.passed) {
+    gates.push(
+      `  - tail: sim p10=${result.tailGate.simP10.toFixed(2)} (floor ${
+        result.tailGate.p10Floor.toFixed(2)
+      }), sim p90=${result.tailGate.simP90.toFixed(2)} (ceiling ${
+        result.tailGate.p90Ceiling.toFixed(2)
+      })`,
+    );
+  }
+
+  return gates.join("\n");
+}
+
+export function formatReport(report: CalibrationReport): string {
+  const passCount = report.results.length - report.failures.length;
+  const total = report.results.length;
+  const status = report.passed ? "PASSED" : "FAILED";
+
+  const lines: string[] = [
+    `Calibration ${status}: ${passCount}/${total} metrics passed`,
+    `Games: ${report.totalGames} | Team-games: ${report.totalTeamGames}`,
+  ];
+
+  if (report.failures.length > 0) {
+    lines.push("");
+    lines.push("Failed metrics:");
+    for (const failure of report.failures) {
+      lines.push(`- ${failure.metric}`);
+      lines.push(formatFailedGates(failure));
+    }
+  }
+
+  return lines.join("\n");
+}

--- a/server/features/simulation/calibration/run-calibration.ts
+++ b/server/features/simulation/calibration/run-calibration.ts
@@ -1,0 +1,30 @@
+import { runCalibration } from "./harness.ts";
+import { formatReport } from "./format-report.ts";
+import { simulateGame } from "../simulate-game.ts";
+import type { CalibrationLeague } from "./generate-calibration-league.ts";
+
+const bandPath = new URL(
+  "../../../../data/bands/team-game.json",
+  import.meta.url,
+);
+const fixturePath = new URL(
+  "./fixtures/calibration-league.json",
+  import.meta.url,
+);
+
+const bandJson = await Deno.readTextFile(bandPath);
+const fixtureJson = await Deno.readTextFile(fixturePath);
+const league: CalibrationLeague = JSON.parse(fixtureJson);
+
+const report = runCalibration({
+  bandJson,
+  league,
+  simulate: simulateGame,
+});
+
+const output = formatReport(report);
+console.log(output);
+
+if (!report.passed) {
+  Deno.exit(1);
+}


### PR DESCRIPTION
## Summary

- Adds `deno task sim:calibrate` to run the calibration harness locally against the committed fixture and band data.
- Adds `sim-calibration.yml` scheduled workflow (daily cron at 06:00 UTC + `workflow_dispatch`) that does **not** block PR merges.
- On failure, the workflow opens a GitHub Issue labeled `sim-calibration-drift` (or comments on an existing open one) with the full failing-metrics report and SHA range since the last green run.
- On a subsequent green run, the workflow closes the open drift issue for traceability.
- Adds `format-report.ts` with tests to format `CalibrationReport` into human-readable text for CLI and issue body.

Closes #298

🤖 Generated with [Claude Code](https://claude.com/claude-code)