### PR TITLE
feat(create-league): add readonly league-settings preview to step 1

### DIFF
--- a/client/src/features/create-league/index.test.tsx
+++ b/client/src/features/create-league/index.test.tsx
@@ -10,6 +10,7 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { CreateLeague } from "./index.tsx";
 import { CREATION_STAGES, STAGE_INTERVAL_MS } from "./stages.ts";
+import { LEAGUE_SETTINGS_DEFAULTS } from "./league-settings-defaults.ts";
 
 const mockPost = vi.fn();
 const mockNavigate = vi.fn();
@@ -126,6 +127,78 @@ describe("CreateLeague", () => {
 
     await waitFor(() => {
       expect(screen.getByText("Failed to create league")).toBeDefined();
+    });
+  });
+
+  describe("league settings preview", () => {
+    it("renders disabled inputs prefilled with MVP defaults", () => {
+      renderWithProviders();
+      const seasonLength = screen.getByLabelText(
+        "Regular season games",
+      ) as HTMLInputElement;
+      expect(seasonLength.disabled).toBe(true);
+      expect(seasonLength.value).toBe(
+        String(LEAGUE_SETTINGS_DEFAULTS.seasonLength),
+      );
+
+      const conferences = screen.getByLabelText(
+        "Conferences",
+      ) as HTMLInputElement;
+      expect(conferences.disabled).toBe(true);
+      expect(conferences.value).toBe(
+        String(LEAGUE_SETTINGS_DEFAULTS.conferences),
+      );
+
+      const divisions = screen.getByLabelText(
+        "Divisions per conference",
+      ) as HTMLInputElement;
+      expect(divisions.disabled).toBe(true);
+      expect(divisions.value).toBe(
+        String(LEAGUE_SETTINGS_DEFAULTS.divisionsPerConference),
+      );
+
+      const rosterSize = screen.getByLabelText(
+        "Roster size",
+      ) as HTMLInputElement;
+      expect(rosterSize.disabled).toBe(true);
+      expect(rosterSize.value).toBe(
+        String(LEAGUE_SETTINGS_DEFAULTS.rosterSize),
+      );
+
+      const salaryCap = screen.getByLabelText(
+        "Salary cap",
+      ) as HTMLInputElement;
+      expect(salaryCap.disabled).toBe(true);
+      expect(salaryCap.value).toBe("$255,000,000");
+
+      const salaryFloor = screen.getByLabelText(
+        "Salary floor",
+      ) as HTMLInputElement;
+      expect(salaryFloor.disabled).toBe(true);
+      expect(salaryFloor.value).toBe("$226,950,000");
+
+      const draftRounds = screen.getByLabelText(
+        "Draft rounds",
+      ) as HTMLInputElement;
+      expect(draftRounds.disabled).toBe(true);
+      expect(draftRounds.value).toBe(
+        String(LEAGUE_SETTINGS_DEFAULTS.draftRounds),
+      );
+    });
+
+    it("does not render a founding franchise count input", () => {
+      renderWithProviders();
+      expect(screen.queryByLabelText(/franchise count/i)).toBeNull();
+      expect(screen.queryByLabelText(/number of teams/i)).toBeNull();
+      expect(screen.queryByLabelText(/founding franchises/i)).toBeNull();
+    });
+
+    it("renders the league name input as editable above the settings", () => {
+      renderWithProviders();
+      const nameInput = screen.getByLabelText(
+        "League name",
+      ) as HTMLInputElement;
+      expect(nameInput.disabled).toBe(false);
     });
   });
 

--- a/client/src/features/create-league/index.tsx
+++ b/client/src/features/create-league/index.tsx
@@ -6,6 +6,7 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { CREATION_STAGES, STAGE_INTERVAL_MS } from "./stages.ts";
+import { LEAGUE_SETTINGS_DEFAULTS } from "./league-settings-defaults.ts";
 
 export function CreateLeague() {
   const createLeague = useCreateLeague();
@@ -87,6 +88,136 @@ export function CreateLeague() {
                     placeholder="e.g. The Gridiron Classic"
                     autoFocus
                   />
+                </div>
+
+                <hr className="border-border" />
+
+                <div className="space-y-4">
+                  <p className="text-sm font-medium text-muted-foreground">
+                    League settings — 8 founding franchises
+                  </p>
+
+                  <div className="grid grid-cols-2 gap-4">
+                    <div className="space-y-2">
+                      <label
+                        htmlFor="season-length"
+                        className="text-sm font-medium"
+                      >
+                        Regular season games
+                      </label>
+                      <Input
+                        id="season-length"
+                        type="number"
+                        value={LEAGUE_SETTINGS_DEFAULTS.seasonLength}
+                        disabled
+                        readOnly
+                      />
+                    </div>
+
+                    <div className="space-y-2">
+                      <label
+                        htmlFor="conferences"
+                        className="text-sm font-medium"
+                      >
+                        Conferences
+                      </label>
+                      <Input
+                        id="conferences"
+                        type="number"
+                        value={LEAGUE_SETTINGS_DEFAULTS.conferences}
+                        disabled
+                        readOnly
+                      />
+                    </div>
+
+                    <div className="space-y-2">
+                      <label
+                        htmlFor="divisions-per-conference"
+                        className="text-sm font-medium"
+                      >
+                        Divisions per conference
+                      </label>
+                      <Input
+                        id="divisions-per-conference"
+                        type="number"
+                        value={LEAGUE_SETTINGS_DEFAULTS.divisionsPerConference}
+                        disabled
+                        readOnly
+                      />
+                    </div>
+
+                    <div className="space-y-2">
+                      <label
+                        htmlFor="roster-size"
+                        className="text-sm font-medium"
+                      >
+                        Roster size
+                      </label>
+                      <Input
+                        id="roster-size"
+                        type="number"
+                        value={LEAGUE_SETTINGS_DEFAULTS.rosterSize}
+                        disabled
+                        readOnly
+                      />
+                    </div>
+
+                    <div className="space-y-2">
+                      <label
+                        htmlFor="salary-cap"
+                        className="text-sm font-medium"
+                      >
+                        Salary cap
+                      </label>
+                      <Input
+                        id="salary-cap"
+                        type="text"
+                        value={`$${
+                          LEAGUE_SETTINGS_DEFAULTS.salaryCap.toLocaleString(
+                            "en-US",
+                          )
+                        }`}
+                        disabled
+                        readOnly
+                      />
+                    </div>
+
+                    <div className="space-y-2">
+                      <label
+                        htmlFor="salary-floor"
+                        className="text-sm font-medium"
+                      >
+                        Salary floor
+                      </label>
+                      <Input
+                        id="salary-floor"
+                        type="text"
+                        value={`$${
+                          LEAGUE_SETTINGS_DEFAULTS.salaryFloor.toLocaleString(
+                            "en-US",
+                          )
+                        }`}
+                        disabled
+                        readOnly
+                      />
+                    </div>
+
+                    <div className="space-y-2">
+                      <label
+                        htmlFor="draft-rounds"
+                        className="text-sm font-medium"
+                      >
+                        Draft rounds
+                      </label>
+                      <Input
+                        id="draft-rounds"
+                        type="number"
+                        value={LEAGUE_SETTINGS_DEFAULTS.draftRounds}
+                        disabled
+                        readOnly
+                      />
+                    </div>
+                  </div>
                 </div>
 
                 {createLeague.isError && (

--- a/client/src/features/create-league/league-settings-defaults.ts
+++ b/client/src/features/create-league/league-settings-defaults.ts
@@ -1,0 +1,13 @@
+import { deriveDefaultSeasonLength } from "@zone-blitz/shared";
+
+const MVP_FRANCHISE_COUNT = 8;
+
+export const LEAGUE_SETTINGS_DEFAULTS = {
+  seasonLength: deriveDefaultSeasonLength(MVP_FRANCHISE_COUNT),
+  conferences: 1,
+  divisionsPerConference: 2,
+  rosterSize: 53,
+  salaryCap: 255_000_000,
+  salaryFloor: Math.round(255_000_000 * 0.89),
+  draftRounds: 7,
+} as const;


### PR DESCRIPTION
## Summary

- Adds a block of disabled form inputs below the league-name field on the create-league wizard's first page, showing MVP defaults: regular season games (10), conferences (1), divisions per conference (2), roster size (53), salary cap ($255M), salary floor ($226.95M), and draft rounds (7).
- Founding franchise count is mentioned only in static copy ("8 founding franchises") per ADR 0029 — no form input.
- All settings use shadcn `Input` in its `disabled` state so future editability is a `disabled` flag flip per ADR 0028.
- Extracts league settings defaults into a dedicated constants module sourcing values from the shared `deriveDefaultSeasonLength` function and server schema defaults.

Closes #313

🤖 Generated with [Claude Code](https://claude.com/claude-code)