### PR TITLE
fix(sim): tune pass-resolution knobs to land 15/15 calibration metrics

### DIFF
--- a/server/features/simulation/resolve-play.ts
+++ b/server/features/simulation/resolve-play.ts
@@ -471,10 +471,10 @@ export function synthesizeOutcome(
           routeContribs.length
         : avgScore;
 
-      const intProb = Math.max(0.003, 0.020 - coverageScore * 0.002);
+      const intProb = Math.max(0.004, 0.022 - coverageScore * 0.002);
       const completionProb = Math.max(
         0.18,
-        Math.min(0.92, 0.67 + coverageScore * 0.010),
+        Math.min(0.92, 0.655 + coverageScore * 0.010),
       );
       const bigPlayProb = Math.max(
         0.05,
@@ -507,7 +507,7 @@ export function synthesizeOutcome(
         outcome = "pass_complete";
         const isBigPlay = rng.next() < bigPlayProb;
         if (isBigPlay) {
-          yardage = rng.int(13, 37);
+          yardage = rng.int(13, 35);
           tags.push("big_play");
         } else {
           yardage = rng.int(3, 14);

--- a/server/features/simulation/simulate-game.ts
+++ b/server/features/simulation/simulate-game.ts
@@ -48,7 +48,7 @@ export interface SimulationInput {
 }
 
 const QUARTER_SECONDS = 900;
-const SECONDS_PER_PLAY = 34.5;
+const SECONDS_PER_PLAY = 34.8;
 const INJURY_SEVERITIES: InjurySeverity[] = [
   "shake_off",
   "miss_drive",


### PR DESCRIPTION
## Summary

- Closes #369. The five remaining mean-gate failures after #368 (`completion_pct`, `yards_per_attempt`, `pass_yards`, `interceptions`, `turnovers`) are all governed by the same probabilistic pass branch in `resolve-play` from #366.
- `resolve-play`: bump base `completionProb` 0.67 → 0.655 and base `intProb` 0.020 → 0.022. Lower completion drags YPA and pass_yards into band as a side-effect; higher INT lifts both interceptions and turnovers.
- `simulate-game`: `SECONDS_PER_PLAY` 34.5 → 34.8 to compensate for the extra incompletions/INTs (which stop the clock) and keep `plays/game` inside its band.
- Calibration result: **10/15 → 15/15** metrics passing.