### PR TITLE
feat(generate): add ADR-0030 narrative milestones and retry control

### DIFF
--- a/client/src/features/generate/index.test.tsx
+++ b/client/src/features/generate/index.test.tsx
@@ -1,7 +1,13 @@
-import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import {
+  act,
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+} from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { afterEach, describe, expect, it, vi } from "vitest";
-import { Generate } from "./index.tsx";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { Generate, MILESTONE_COPY } from "./index.tsx";
 
 const mockFoundPost = vi.fn();
 const mockNavigate = vi.fn();
@@ -36,16 +42,37 @@ function renderWithProviders() {
   );
 }
 
+beforeEach(() => {
+  vi.useFakeTimers();
+});
+
 afterEach(() => {
+  vi.useRealTimers();
   cleanup();
   vi.clearAllMocks();
 });
 
 describe("Generate", () => {
-  it("shows loading state with founding message", () => {
+  it("shows the first ADR-0030 milestone copy on mount", () => {
     mockFoundPost.mockReturnValue(new Promise(() => {}));
     renderWithProviders();
-    expect(screen.getByText("Founding your league")).toBeDefined();
+    expect(
+      screen.getByText("Creating coaches and league foundation…"),
+    ).toBeDefined();
+  });
+
+  it("cycles through narrative milestones while generation is pending", () => {
+    mockFoundPost.mockReturnValue(new Promise(() => {}));
+    renderWithProviders();
+
+    expect(screen.getByText(MILESTONE_COPY[0])).toBeDefined();
+
+    for (let i = 1; i < MILESTONE_COPY.length; i++) {
+      act(() => {
+        vi.advanceTimersByTime(2500);
+      });
+      expect(screen.getByText(MILESTONE_COPY[i])).toBeDefined();
+    }
   });
 
   it("calls the found endpoint and navigates to dashboard on success", async () => {
@@ -64,12 +91,12 @@ describe("Generate", () => {
     );
     renderWithProviders();
 
-    await waitFor(() => {
+    await vi.waitFor(() => {
       expect(mockFoundPost).toHaveBeenCalledWith({
         param: { id: "league-1" },
       });
     });
-    await waitFor(() => {
+    await vi.waitFor(() => {
       expect(mockNavigate).toHaveBeenCalledWith({
         to: "/leagues/$leagueId",
         params: { leagueId: "league-1" },
@@ -77,15 +104,65 @@ describe("Generate", () => {
     });
   });
 
-  it("shows error alert when founding fails", async () => {
+  it("only calls the found endpoint once across re-renders", async () => {
+    mockFoundPost.mockReturnValue(new Promise(() => {}));
+    const { rerender } = renderWithProviders();
+
+    await vi.waitFor(() => {
+      expect(mockFoundPost).toHaveBeenCalledTimes(1);
+    });
+
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    rerender(
+      <QueryClientProvider client={queryClient}>
+        <Generate />
+      </QueryClientProvider>,
+    );
+
+    expect(mockFoundPost).toHaveBeenCalledTimes(1);
+  });
+
+  it("shows error alert with retry control when founding fails", async () => {
     mockFoundPost.mockReturnValue(
       Promise.resolve({ ok: false, status: 500 }),
     );
     renderWithProviders();
 
-    await waitFor(() => {
+    await vi.waitFor(() => {
       expect(screen.getByText("Generation failed")).toBeDefined();
     });
     expect(mockNavigate).not.toHaveBeenCalled();
+    expect(screen.getByRole("button", { name: /try again/i })).toBeDefined();
+  });
+
+  it("retries the found call when the user clicks Try again", async () => {
+    mockFoundPost.mockReturnValueOnce(
+      Promise.resolve({ ok: false, status: 500 }),
+    );
+    renderWithProviders();
+
+    await vi.waitFor(() => {
+      expect(screen.getByText("Generation failed")).toBeDefined();
+    });
+
+    mockFoundPost.mockReturnValueOnce(
+      Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve({ leagueId: "league-1" }),
+      }),
+    );
+    fireEvent.click(screen.getByRole("button", { name: /try again/i }));
+
+    await vi.waitFor(() => {
+      expect(mockFoundPost).toHaveBeenCalledTimes(2);
+    });
+    await vi.waitFor(() => {
+      expect(mockNavigate).toHaveBeenCalledWith({
+        to: "/leagues/$leagueId",
+        params: { leagueId: "league-1" },
+      });
+    });
   });
 });

--- a/client/src/features/generate/index.tsx
+++ b/client/src/features/generate/index.tsx
@@ -1,13 +1,23 @@
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 import { useNavigate, useParams } from "@tanstack/react-router";
 import { Loader2Icon } from "lucide-react";
 import { useFoundLeague } from "../../hooks/use-leagues.ts";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import { Button } from "@/components/ui/button";
+
+export const MILESTONE_COPY = [
+  "Creating coaches and league foundation…",
+  "Assembling the founding player pool…",
+  "Founding the league…",
+] as const;
+
+const MILESTONE_INTERVAL_MS = 2500;
 
 export function Generate() {
   const { leagueId } = useParams({ strict: false });
   const foundLeague = useFoundLeague();
   const navigate = useNavigate();
+  const [milestoneIndex, setMilestoneIndex] = useState(0);
 
   useEffect(() => {
     if (
@@ -24,15 +34,43 @@ export function Generate() {
     });
   }, [leagueId]);
 
+  useEffect(() => {
+    const interval = setInterval(() => {
+      setMilestoneIndex((index) =>
+        Math.min(index + 1, MILESTONE_COPY.length - 1)
+      );
+    }, MILESTONE_INTERVAL_MS);
+    return () => clearInterval(interval);
+  }, []);
+
+  const handleRetry = () => {
+    if (!leagueId) return;
+    setMilestoneIndex(0);
+    foundLeague.reset();
+    foundLeague.mutate(leagueId, {
+      onSuccess: () => {
+        navigate({
+          to: "/leagues/$leagueId",
+          params: { leagueId },
+        });
+      },
+    });
+  };
+
   if (foundLeague.isError) {
     return (
-      <div className="min-h-screen bg-background text-foreground flex items-center justify-center">
-        <Alert variant="destructive" className="max-w-md">
-          <AlertTitle>Generation failed</AlertTitle>
-          <AlertDescription>
-            {foundLeague.error?.message ?? "Something went wrong."}
-          </AlertDescription>
-        </Alert>
+      <div className="min-h-screen bg-background text-foreground flex items-center justify-center p-8">
+        <div className="max-w-md w-full space-y-4">
+          <Alert variant="destructive">
+            <AlertTitle>Generation failed</AlertTitle>
+            <AlertDescription>
+              {foundLeague.error?.message ?? "Something went wrong."}
+            </AlertDescription>
+          </Alert>
+          <Button onClick={handleRetry} className="w-full">
+            Try again
+          </Button>
+        </div>
       </div>
     );
   }
@@ -42,8 +80,8 @@ export function Generate() {
       <Loader2Icon className="size-12 animate-spin text-primary" />
       <div className="text-center space-y-2">
         <p className="text-2xl font-semibold">Founding your league</p>
-        <p className="text-muted-foreground">
-          Generating coaches, players, and a full season schedule...
+        <p className="text-muted-foreground" aria-live="polite">
+          {MILESTONE_COPY[milestoneIndex]}
         </p>
       </div>
     </div>


### PR DESCRIPTION
## Summary

- Cycle the generation step through the three ADR-0030 narrative milestones ("Creating coaches and league foundation…", "Assembling the founding player pool…", "Founding the league…") on a fixed 2.5s cadence — copy is narrative only, not server-driven, per ADR 0030.
- Replace the dead-end error alert with a recoverable state: surface a Try again button that re-issues the found call and resets the milestone copy, so the founder can recover without restarting the wizard.

Closes #315