### PR TITLE
feat(dashboard): drive league index view from league_clock.phase

### DIFF
--- a/client/src/features/league/index.test.tsx
+++ b/client/src/features/league/index.test.tsx
@@ -1,21 +1,115 @@
-import { cleanup, render, screen } from "@testing-library/react";
-import { afterEach, describe, expect, it } from "vitest";
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { LeagueHome } from "./index.tsx";
+
+let mockPhase: string | undefined = "genesis_staff_hiring";
+const mockClockGet = vi.fn();
+
+vi.mock("@tanstack/react-router", () => ({
+  useParams: () => ({ leagueId: "1" }),
+}));
+
+vi.mock("../../api.ts", () => ({
+  api: {
+    api: {
+      "league-clock": {
+        [":leagueId"]: {
+          $get: (...args: unknown[]) => mockClockGet(...args),
+        },
+      },
+    },
+  },
+}));
+
+function renderWithProviders() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <LeagueHome />
+    </QueryClientProvider>,
+  );
+}
+
+beforeEach(() => {
+  mockClockGet.mockImplementation(() =>
+    Promise.resolve({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          leagueId: "1",
+          seasonYear: 2026,
+          phase: mockPhase,
+          stepIndex: 0,
+          slug: "staff_hiring",
+          kind: "phase",
+        }),
+    })
+  );
+});
 
 afterEach(() => {
   cleanup();
+  vi.clearAllMocks();
 });
 
 describe("LeagueHome", () => {
-  it("renders the League Home heading", () => {
-    render(<LeagueHome />);
+  it("renders the staff-hiring view when phase is genesis_staff_hiring", async () => {
+    mockPhase = "genesis_staff_hiring";
+    renderWithProviders();
+    await waitFor(() => {
+      expect(
+        screen.getByRole("heading", { name: "Staff Hiring" }),
+      ).toBeDefined();
+    });
+    expect(screen.getByText(/hire the head coaches/i)).toBeDefined();
+  });
+
+  it("renders the founding-pool view when phase is genesis_founding_pool", async () => {
+    mockPhase = "genesis_founding_pool";
+    renderWithProviders();
+    await waitFor(() => {
+      expect(
+        screen.getByRole("heading", { name: "Founding Pool" }),
+      ).toBeDefined();
+    });
+  });
+
+  it("renders the allocation-draft view when phase is genesis_allocation_draft", async () => {
+    mockPhase = "genesis_allocation_draft";
+    renderWithProviders();
+    await waitFor(() => {
+      expect(
+        screen.getByRole("heading", { name: "Allocation Draft" }),
+      ).toBeDefined();
+    });
+  });
+
+  it("renders the charter view when phase is genesis_charter", async () => {
+    mockPhase = "genesis_charter";
+    renderWithProviders();
+    await waitFor(() => {
+      expect(screen.getByRole("heading", { name: "Charter" })).toBeDefined();
+    });
+  });
+
+  it("falls back to League Home for non-genesis phases", async () => {
+    mockPhase = "regular_season";
+    renderWithProviders();
+    await waitFor(() => {
+      expect(
+        screen.getByRole("heading", { name: "League Home" }),
+      ).toBeDefined();
+    });
+  });
+
+  it("falls back to League Home before the clock has loaded", () => {
+    mockClockGet.mockImplementation(() => new Promise(() => {}));
+    renderWithProviders();
     expect(
       screen.getByRole("heading", { name: "League Home" }),
     ).toBeDefined();
-  });
-
-  it("renders a coming soon badge", () => {
-    render(<LeagueHome />);
-    expect(screen.getByText(/coming soon/i)).toBeDefined();
   });
 });

--- a/client/src/features/league/index.tsx
+++ b/client/src/features/league/index.tsx
@@ -1,10 +1,58 @@
+import { useParams } from "@tanstack/react-router";
+import { useLeagueClock } from "../../hooks/use-league-clock.ts";
+import type { LeaguePhase } from "../../types/league-phase.ts";
 import { StubPage } from "./stub-page.tsx";
 
+type PhaseView = { title: string; description: string };
+
+const PHASE_VIEWS: Partial<Record<LeaguePhase, PhaseView>> = {
+  genesis_charter: {
+    title: "Charter",
+    description:
+      "Set the league's founding rules — name, scoring, and roster shape.",
+  },
+  genesis_franchise_establishment: {
+    title: "Franchise Establishment",
+    description:
+      "The eight founding franchises take the field. Claim yours and meet your rivals.",
+  },
+  genesis_staff_hiring: {
+    title: "Staff Hiring",
+    description:
+      "Hire the head coaches and scouts who will shape your franchise's first season.",
+  },
+  genesis_founding_pool: {
+    title: "Founding Pool",
+    description:
+      "Review the founding player pool — the talent that will feed the allocation draft.",
+  },
+  genesis_allocation_draft: {
+    title: "Allocation Draft",
+    description:
+      "Build your founding roster, pick by pick, from the founding player pool.",
+  },
+  genesis_free_agency: {
+    title: "Founding Free Agency",
+    description:
+      "Round out your roster from the unsigned founding pool before the league kicks off.",
+  },
+  genesis_kickoff: {
+    title: "Kickoff",
+    description: "Final league checks before the inaugural season begins.",
+  },
+};
+
+const FALLBACK: PhaseView = {
+  title: "League Home",
+  description:
+    "Your league at a glance — standings, news, and what needs your attention.",
+};
+
 export function LeagueHome() {
-  return (
-    <StubPage
-      title="League Home"
-      description="Your league at a glance — standings, news, and what needs your attention."
-    />
-  );
+  const { leagueId } = useParams({ strict: false });
+  const { data: clock } = useLeagueClock(leagueId ?? "");
+  const phase = clock?.phase as LeaguePhase | undefined;
+  const view = (phase && PHASE_VIEWS[phase]) ?? FALLBACK;
+
+  return <StubPage title={view.title} description={view.description} />;
 }


### PR DESCRIPTION
## Summary

Closes #316. Per ADR 0031, the dashboard's index route (`/leagues/$leagueId`) now reads `league_clock.phase` and renders a phase-specific view rather than a static "League Home" stub. Founders land directly in the view for the first incomplete genesis phase (currently `genesis_staff_hiring`, set by the `/leagues/:id/found` endpoint from #312) — no intermediate confirmation screen.

The existing phase-gated sidebar (ADR 0020) already drives off the same clock, so first-render nav is correctly scoped to the active phase.

A single index route handles all phases — no per-phase routes added — so the dashboard view follows the clock if the phase later changes.

Tests cover phase-driven view selection for `genesis_charter`, `genesis_staff_hiring`, `genesis_founding_pool`, and `genesis_allocation_draft`, plus the non-genesis fallback.