### PR TITLE
test(hooks): add tests for use-league-clock and use-mobile

### DIFF
--- a/client/src/hooks/use-league-clock.test.ts
+++ b/client/src/hooks/use-league-clock.test.ts
@@ -1,0 +1,149 @@
+import { renderHook, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { describe, expect, it, vi } from "vitest";
+import { useAdvanceLeagueClock, useLeagueClock } from "./use-league-clock.ts";
+import { createElement } from "react";
+
+const mockGet = vi.fn();
+const mockPost = vi.fn();
+
+vi.mock("../api.ts", () => ({
+  api: {
+    api: {
+      "league-clock": {
+        ":leagueId": {
+          $get: (...args: unknown[]) => mockGet(...args),
+          advance: {
+            $post: (...args: unknown[]) => mockPost(...args),
+          },
+        },
+      },
+    },
+  },
+}));
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  return ({ children }: { children: React.ReactNode }) =>
+    createElement(QueryClientProvider, { client: queryClient }, children);
+}
+
+describe("useLeagueClock", () => {
+  it("fetches the league clock by leagueId", async () => {
+    const clock = { phase: "regular-season", week: 3 };
+    mockGet.mockResolvedValue({ json: () => Promise.resolve(clock) });
+
+    const { result } = renderHook(() => useLeagueClock("league-1"), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+
+    expect(result.current.data).toEqual(clock);
+    expect(mockGet).toHaveBeenCalledWith({ param: { leagueId: "league-1" } });
+  });
+
+  it("is disabled when leagueId is empty", () => {
+    const { result } = renderHook(() => useLeagueClock(""), {
+      wrapper: createWrapper(),
+    });
+
+    expect(result.current.fetchStatus).toBe("idle");
+  });
+});
+
+describe("useAdvanceLeagueClock", () => {
+  const advanceArgs = {
+    leagueId: "league-1",
+    isCommissioner: true,
+    gateState: {
+      teams: [
+        {
+          teamId: "t-1",
+          isNpc: false,
+          autoPilot: false,
+          capCompliant: true,
+          activeRosterCount: 53,
+          rosterLimit: 53,
+        },
+      ],
+      draftOrderResolved: true,
+      superBowlPlayed: false,
+      priorPhaseComplete: true,
+    },
+  };
+
+  it("advances the league clock on success", async () => {
+    const response = { phase: "playoffs", week: 1 };
+    mockPost.mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: () => Promise.resolve(response),
+    });
+
+    const { result } = renderHook(() => useAdvanceLeagueClock(), {
+      wrapper: createWrapper(),
+    });
+
+    result.current.mutate(advanceArgs);
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+
+    expect(result.current.data).toEqual(response);
+    expect(mockPost).toHaveBeenCalledWith({
+      param: { leagueId: "league-1" },
+      json: {
+        isCommissioner: true,
+        overrideReason: undefined,
+        gateState: advanceArgs.gateState,
+      },
+    });
+  });
+
+  it("throws with server message when advance fails", async () => {
+    mockPost.mockResolvedValue({
+      ok: false,
+      status: 422,
+      json: () => Promise.resolve({ message: "Gate not satisfied" }),
+    });
+
+    const { result } = renderHook(() => useAdvanceLeagueClock(), {
+      wrapper: createWrapper(),
+    });
+
+    result.current.mutate(advanceArgs);
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true);
+    });
+
+    expect(result.current.error).toBeInstanceOf(Error);
+    expect(result.current.error?.message).toBe("Gate not satisfied");
+  });
+
+  it("throws with fallback message when server has no message", async () => {
+    mockPost.mockResolvedValue({
+      ok: false,
+      status: 500,
+      json: () => Promise.resolve({}),
+    });
+
+    const { result } = renderHook(() => useAdvanceLeagueClock(), {
+      wrapper: createWrapper(),
+    });
+
+    result.current.mutate(advanceArgs);
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true);
+    });
+
+    expect(result.current.error?.message).toBe("Advance failed (500)");
+  });
+});

--- a/client/src/hooks/use-mobile.test.ts
+++ b/client/src/hooks/use-mobile.test.ts
@@ -1,0 +1,65 @@
+import { act, renderHook } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { useIsMobile } from "./use-mobile.ts";
+
+function setupMatchMedia(matches: boolean) {
+  const listeners: Array<() => void> = [];
+  const mql = {
+    matches,
+    addEventListener: (_event: string, cb: () => void) => {
+      listeners.push(cb);
+    },
+    removeEventListener: vi.fn(),
+  };
+  vi.stubGlobal("matchMedia", vi.fn().mockReturnValue(mql));
+  return { mql, listeners };
+}
+
+describe("useIsMobile", () => {
+  it("returns true when viewport is below mobile breakpoint", () => {
+    vi.stubGlobal("innerWidth", 500);
+    setupMatchMedia(true);
+
+    const { result } = renderHook(() => useIsMobile());
+
+    expect(result.current).toBe(true);
+  });
+
+  it("returns false when viewport is at or above mobile breakpoint", () => {
+    vi.stubGlobal("innerWidth", 1024);
+    setupMatchMedia(false);
+
+    const { result } = renderHook(() => useIsMobile());
+
+    expect(result.current).toBe(false);
+  });
+
+  it("updates when the media query change fires", () => {
+    vi.stubGlobal("innerWidth", 1024);
+    const { listeners } = setupMatchMedia(false);
+
+    const { result } = renderHook(() => useIsMobile());
+
+    expect(result.current).toBe(false);
+
+    vi.stubGlobal("innerWidth", 500);
+    act(() => {
+      listeners.forEach((cb) => cb());
+    });
+
+    expect(result.current).toBe(true);
+  });
+
+  it("removes the listener on unmount", () => {
+    vi.stubGlobal("innerWidth", 1024);
+    const { mql } = setupMatchMedia(false);
+
+    const { unmount } = renderHook(() => useIsMobile());
+    unmount();
+
+    expect(mql.removeEventListener).toHaveBeenCalledWith(
+      "change",
+      expect.any(Function),
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- Adds tests for `useLeagueClock`, `useAdvanceLeagueClock`, and `useIsMobile` hooks which were missing test coverage
- Fixes client branch coverage falling below the 95% threshold (was 94.92%) by covering all branches: disabled query path, error message fallback, media query change events, and listener cleanup