### PR TITLE
fix(schedule): add founding-league schedule generator with conference support

### DIFF
--- a/server/db/seed.ts
+++ b/server/db/seed.ts
@@ -90,14 +90,16 @@ await db
       primaryColor: f.primaryColor,
       secondaryColor: f.secondaryColor,
       accentColor: f.accentColor,
-      conference: "Founding",
-      division: "Founding",
+      conference: f.conference,
+      division: f.division,
     })),
   )
   .onConflictDoUpdate({
     target: franchises.abbreviation,
     set: {
       cityId: sql`excluded.city_id`,
+      conference: sql`excluded.conference`,
+      division: sql`excluded.division`,
       updatedAt: new Date(),
     },
   });

--- a/server/features/franchise/founding-franchises.test.ts
+++ b/server/features/franchise/founding-franchises.test.ts
@@ -96,3 +96,21 @@ Deno.test("FOUNDING_FRANCHISES all have non-empty required fields", () => {
     );
   }
 });
+
+Deno.test("FOUNDING_FRANCHISES split evenly into Mountain and Pacific conferences", () => {
+  const conferences = FOUNDING_FRANCHISES.map((f) => f.conference);
+  const mountain = conferences.filter((c) => c === "Mountain");
+  const pacific = conferences.filter((c) => c === "Pacific");
+  assertEquals(mountain.length, 4);
+  assertEquals(pacific.length, 4);
+});
+
+Deno.test("FOUNDING_FRANCHISES conference matches division name", () => {
+  for (const franchise of FOUNDING_FRANCHISES) {
+    assertEquals(
+      franchise.conference,
+      franchise.division,
+      `${franchise.name} conference/division mismatch`,
+    );
+  }
+});

--- a/server/features/franchise/founding-franchises.ts
+++ b/server/features/franchise/founding-franchises.ts
@@ -6,6 +6,8 @@ export interface FoundingFranchise {
   primaryColor: string;
   secondaryColor: string;
   accentColor: string;
+  conference: string;
+  division: string;
 }
 
 export const FOUNDING_FRANCHISES: FoundingFranchise[] = [
@@ -17,6 +19,8 @@ export const FOUNDING_FRANCHISES: FoundingFranchise[] = [
     primaryColor: "#1A1A2E",
     secondaryColor: "#C9A227",
     accentColor: "#E74C3C",
+    conference: "Mountain",
+    division: "Mountain",
   },
   {
     name: "Riveters",
@@ -26,6 +30,8 @@ export const FOUNDING_FRANCHISES: FoundingFranchise[] = [
     primaryColor: "#2D4A3E",
     secondaryColor: "#D4856B",
     accentColor: "#F5F0E1",
+    conference: "Pacific",
+    division: "Pacific",
   },
   {
     name: "Republic",
@@ -35,6 +41,8 @@ export const FOUNDING_FRANCHISES: FoundingFranchise[] = [
     primaryColor: "#8B2331",
     secondaryColor: "#C4A34D",
     accentColor: "#FFFFFF",
+    conference: "Pacific",
+    division: "Pacific",
   },
   {
     name: "Admirals",
@@ -44,6 +52,8 @@ export const FOUNDING_FRANCHISES: FoundingFranchise[] = [
     primaryColor: "#003459",
     secondaryColor: "#D4AF37",
     accentColor: "#FFFFFF",
+    conference: "Pacific",
+    division: "Pacific",
   },
   {
     name: "Pioneers",
@@ -53,6 +63,8 @@ export const FOUNDING_FRANCHISES: FoundingFranchise[] = [
     primaryColor: "#5B3A29",
     secondaryColor: "#E8D5B7",
     accentColor: "#3A7D44",
+    conference: "Mountain",
+    division: "Mountain",
   },
   {
     name: "Spuds",
@@ -62,6 +74,8 @@ export const FOUNDING_FRANCHISES: FoundingFranchise[] = [
     primaryColor: "#6B4226",
     secondaryColor: "#F7DC6F",
     accentColor: "#2ECC71",
+    conference: "Mountain",
+    division: "Mountain",
   },
   {
     name: "Lava",
@@ -71,6 +85,8 @@ export const FOUNDING_FRANCHISES: FoundingFranchise[] = [
     primaryColor: "#B22222",
     secondaryColor: "#FF8C00",
     accentColor: "#1C1C1C",
+    conference: "Pacific",
+    division: "Pacific",
   },
   {
     name: "Roadrunners",
@@ -80,5 +96,7 @@ export const FOUNDING_FRANCHISES: FoundingFranchise[] = [
     primaryColor: "#C75B12",
     secondaryColor: "#40E0D0",
     accentColor: "#F5DEB3",
+    conference: "Mountain",
+    division: "Mountain",
   },
 ];

--- a/server/features/league/league.service.integration.test.ts
+++ b/server/features/league/league.service.integration.test.ts
@@ -108,8 +108,8 @@ async function seedFoundingFranchises(
         primaryColor: f.primaryColor,
         secondaryColor: f.secondaryColor,
         accentColor: f.accentColor,
-        conference: "Founding",
-        division: "Founding",
+        conference: f.conference,
+        division: f.division,
       })
       .returning();
     franchiseIds.push(franchise.id);

--- a/server/features/league/league.service.test.ts
+++ b/server/features/league/league.service.test.ts
@@ -57,8 +57,8 @@ function foundingFranchiseFixtures(): Franchise[] {
     primaryColor: f.primaryColor,
     secondaryColor: f.secondaryColor,
     accentColor: f.accentColor,
-    conference: "Founding",
-    division: "Founding",
+    conference: f.conference,
+    division: f.division,
     createdAt: new Date(),
     updatedAt: new Date(),
   }));
@@ -77,8 +77,8 @@ function foundingTeamFixtures(leagueId: string): Team[] {
     primaryColor: f.primaryColor,
     secondaryColor: f.secondaryColor,
     accentColor: f.accentColor,
-    conference: "Founding",
-    division: "Founding",
+    conference: f.conference,
+    division: f.division,
     createdAt: new Date(),
     updatedAt: new Date(),
   }));

--- a/server/features/mod.ts
+++ b/server/features/mod.ts
@@ -50,8 +50,8 @@ import {
   createFrontOfficeService,
 } from "./front-office/mod.ts";
 import {
+  createScheduleGenerator,
   createScheduleService,
-  createStubScheduleGenerator,
 } from "./schedule/mod.ts";
 import {
   createLeagueClockRepository,
@@ -143,7 +143,7 @@ export function createFeatureRouters(
     log,
   });
   const scheduleService = createScheduleService({
-    generator: createStubScheduleGenerator(),
+    generator: createScheduleGenerator(),
     db,
     log,
   });

--- a/server/features/schedule/mod.ts
+++ b/server/features/schedule/mod.ts
@@ -1,3 +1,4 @@
+export { createScheduleGenerator } from "./schedule-generator.ts";
 export { createStubScheduleGenerator } from "./stub-schedule-generator.ts";
 export { createScheduleService } from "./schedule.service.ts";
 export type { ScheduleService } from "./schedule.service.interface.ts";

--- a/server/features/schedule/schedule-generator.test.ts
+++ b/server/features/schedule/schedule-generator.test.ts
@@ -1,0 +1,156 @@
+import { assertEquals } from "@std/assert";
+import { createScheduleGenerator } from "./schedule-generator.ts";
+import type {
+  GeneratedGame,
+  TeamDivisionInfo,
+} from "./schedule.generator.interface.ts";
+
+// --- 8-team founding league (Mountain / Pacific, 1 division each) ---
+const FOUNDING_TEAMS: TeamDivisionInfo[] = [
+  { teamId: "rno", conference: "Mountain", division: "Mountain" },
+  { teamId: "slc", conference: "Mountain", division: "Mountain" },
+  { teamId: "boi", conference: "Mountain", division: "Mountain" },
+  { teamId: "abq", conference: "Mountain", division: "Mountain" },
+  { teamId: "pdx", conference: "Pacific", division: "Pacific" },
+  { teamId: "sac", conference: "Pacific", division: "Pacific" },
+  { teamId: "sdg", conference: "Pacific", division: "Pacific" },
+  { teamId: "hnl", conference: "Pacific", division: "Pacific" },
+];
+
+const FOUNDING_INPUT = {
+  seasonId: "season-1",
+  seasonLength: 10,
+  teams: FOUNDING_TEAMS,
+};
+
+function generate(
+  overrides: Partial<typeof FOUNDING_INPUT> = {},
+): GeneratedGame[] {
+  const generator = createScheduleGenerator();
+  return generator.generate({ ...FOUNDING_INPUT, ...overrides });
+}
+
+// --- helpers ---
+function countGamesPerTeam(games: GeneratedGame[]): Map<string, number> {
+  const counts = new Map<string, number>();
+  for (const g of games) {
+    counts.set(g.homeTeamId, (counts.get(g.homeTeamId) ?? 0) + 1);
+    counts.set(g.awayTeamId, (counts.get(g.awayTeamId) ?? 0) + 1);
+  }
+  return counts;
+}
+
+function weeksPerTeam(games: GeneratedGame[]): Map<string, Set<number>> {
+  const map = new Map<string, Set<number>>();
+  for (const g of games) {
+    for (const id of [g.homeTeamId, g.awayTeamId]) {
+      if (!map.has(id)) map.set(id, new Set());
+      map.get(id)!.add(g.week);
+    }
+  }
+  return map;
+}
+
+// --- core invariants (8-team founding) ---
+
+Deno.test("each team plays exactly seasonLength games", () => {
+  const games = generate();
+  const counts = countGamesPerTeam(games);
+  for (const team of FOUNDING_TEAMS) {
+    assertEquals(
+      counts.get(team.teamId),
+      10,
+      `${team.teamId} should play 10 games`,
+    );
+  }
+});
+
+Deno.test("total games equals teams * seasonLength / 2", () => {
+  const games = generate();
+  assertEquals(games.length, (8 * 10) / 2);
+});
+
+Deno.test("no team plays more than once per week", () => {
+  const games = generate();
+  const tw = weeksPerTeam(games);
+  // weeksPerTeam uses a Set, so if any week appeared twice it wouldn't
+  // be added — but we also need to verify count matches total games.
+  const counts = countGamesPerTeam(games);
+  for (const team of FOUNDING_TEAMS) {
+    assertEquals(
+      tw.get(team.teamId)!.size,
+      counts.get(team.teamId)!,
+      `${team.teamId} has a duplicate week`,
+    );
+  }
+});
+
+Deno.test("each team has exactly 1 bye week", () => {
+  const games = generate();
+  const tw = weeksPerTeam(games);
+  const totalWeeks = 10 + 1; // seasonLength + 1
+  for (const team of FOUNDING_TEAMS) {
+    const played = tw.get(team.teamId)!.size;
+    assertEquals(
+      played,
+      totalWeeks - 1,
+      `${team.teamId} plays ${played} weeks, expected ${totalWeeks - 1}`,
+    );
+  }
+});
+
+Deno.test("home and away are always different teams", () => {
+  const games = generate();
+  for (const g of games) {
+    assertEquals(
+      g.homeTeamId !== g.awayTeamId,
+      true,
+      `self-play: ${g.homeTeamId}`,
+    );
+  }
+});
+
+Deno.test("all games fall within weeks 1 to seasonLength + 1", () => {
+  const games = generate();
+  for (const g of games) {
+    assertEquals(g.week >= 1 && g.week <= 11, true);
+  }
+});
+
+Deno.test("all games reference the correct seasonId", () => {
+  const games = generate();
+  for (const g of games) {
+    assertEquals(g.seasonId, "season-1");
+  }
+});
+
+Deno.test("no duplicate matchup in the same direction", () => {
+  const games = generate();
+  const seen = new Set<string>();
+  for (const g of games) {
+    const key = `${g.homeTeamId}:${g.awayTeamId}`;
+    assertEquals(seen.has(key), false, `duplicate matchup: ${key}`);
+    seen.add(key);
+  }
+});
+
+// --- conference balance ---
+
+Deno.test("each team plays at least one cross-conference game", () => {
+  const games = generate();
+  const teamConf = new Map(FOUNDING_TEAMS.map((t) => [t.teamId, t.conference]));
+  const crossConf = new Set<string>();
+  for (const g of games) {
+    if (teamConf.get(g.homeTeamId) !== teamConf.get(g.awayTeamId)) {
+      crossConf.add(g.homeTeamId);
+      crossConf.add(g.awayTeamId);
+    }
+  }
+  for (const team of FOUNDING_TEAMS) {
+    assertEquals(
+      crossConf.has(team.teamId),
+      true,
+      `${team.teamId} has no cross-conference game`,
+    );
+  }
+});

--- a/server/features/schedule/schedule-generator.ts
+++ b/server/features/schedule/schedule-generator.ts
@@ -1,0 +1,110 @@
+import type {
+  GeneratedGame,
+  ScheduleGenerator,
+  ScheduleGeneratorInput,
+  TeamDivisionInfo,
+} from "./schedule.generator.interface.ts";
+
+/**
+ * Schedule generator for the founding 8-team league.
+ *
+ * Structure: 2 conferences × 1 division × 4 teams.
+ * Each team plays `seasonLength` games across `seasonLength + 1` weeks
+ * (exactly 1 bye). Division rivals play home-and-away (6 games),
+ * remaining 4 are cross-conference round-robin.
+ */
+export function createScheduleGenerator(): ScheduleGenerator {
+  return {
+    generate(input: ScheduleGeneratorInput): GeneratedGame[] {
+      const { seasonId, seasonLength, teams } = input;
+      const totalWeeks = seasonLength + 1;
+
+      const conferenceMap = new Map<string, TeamDivisionInfo[]>();
+      for (const team of teams) {
+        if (!conferenceMap.has(team.conference)) {
+          conferenceMap.set(team.conference, []);
+        }
+        conferenceMap.get(team.conference)!.push(team);
+      }
+
+      const matchups: { home: string; away: string }[] = [];
+
+      // 1. Division games: home-and-away vs each division rival
+      for (const confTeams of conferenceMap.values()) {
+        for (let i = 0; i < confTeams.length; i++) {
+          for (let j = i + 1; j < confTeams.length; j++) {
+            matchups.push({
+              home: confTeams[i].teamId,
+              away: confTeams[j].teamId,
+            });
+            matchups.push({
+              home: confTeams[j].teamId,
+              away: confTeams[i].teamId,
+            });
+          }
+        }
+      }
+
+      // 2. Cross-conference games: each team plays every team in the other
+      //    conference once. With 4 per conference that gives 4 cross-conf
+      //    games per team (alternating home/away by index for balance).
+      const conferences = [...conferenceMap.keys()];
+      if (conferences.length === 2) {
+        const teamsA = conferenceMap.get(conferences[0])!;
+        const teamsB = conferenceMap.get(conferences[1])!;
+        for (let i = 0; i < teamsA.length; i++) {
+          for (let j = 0; j < teamsB.length; j++) {
+            if ((i + j) % 2 === 0) {
+              matchups.push({ home: teamsA[i].teamId, away: teamsB[j].teamId });
+            } else {
+              matchups.push({ home: teamsB[j].teamId, away: teamsA[i].teamId });
+            }
+          }
+        }
+      }
+
+      // Cap at seasonLength games per team
+      const teamGameCounts = new Map<string, number>();
+      for (const team of teams) {
+        teamGameCounts.set(team.teamId, 0);
+      }
+      const capped: typeof matchups = [];
+      for (const m of matchups) {
+        const hc = teamGameCounts.get(m.home) ?? 0;
+        const ac = teamGameCounts.get(m.away) ?? 0;
+        if (hc < seasonLength && ac < seasonLength) {
+          capped.push(m);
+          teamGameCounts.set(m.home, hc + 1);
+          teamGameCounts.set(m.away, ac + 1);
+        }
+      }
+
+      // 3. Assign matchups to weeks (greedy)
+      const teamWeekUsed = new Map<string, Set<number>>();
+      for (const team of teams) {
+        teamWeekUsed.set(team.teamId, new Set());
+      }
+
+      const games: GeneratedGame[] = [];
+      for (const matchup of capped) {
+        for (let week = 1; week <= totalWeeks; week++) {
+          const homeUsed = teamWeekUsed.get(matchup.home)!;
+          const awayUsed = teamWeekUsed.get(matchup.away)!;
+          if (!homeUsed.has(week) && !awayUsed.has(week)) {
+            games.push({
+              seasonId,
+              week,
+              homeTeamId: matchup.home,
+              awayTeamId: matchup.away,
+            });
+            homeUsed.add(week);
+            awayUsed.add(week);
+            break;
+          }
+        }
+      }
+
+      return games;
+    },
+  };
+}


### PR DESCRIPTION
## Summary

- Adds a new `createScheduleGenerator()` for the 8-team founding league (2 conferences × 4 teams), replacing the stub generator which assumes 32-team NFL structure with 4 divisions per conference.
- Assigns real conference/division values (Mountain/Pacific) to the 8 founding franchises instead of placeholder "Founding" strings.
- Updates seed, test fixtures, and wiring in `server/features/mod.ts` to use the new generator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)