### PR TITLE
refactor(sim): extract buildPlayEvent factory

### DIFF
--- a/server/features/simulation/play-event.test.ts
+++ b/server/features/simulation/play-event.test.ts
@@ -1,0 +1,221 @@
+import { assertEquals } from "@std/assert";
+import { buildPlayEvent } from "./play-event.ts";
+import type { PlayEvent } from "./events.ts";
+
+Deno.test("buildPlayEvent", async (t) => {
+  const baseArgs = {
+    gameId: "game-1",
+    driveIndex: 2,
+    playIndex: 5,
+    quarter: 3 as const,
+    clock: "8:30",
+    situation: { down: 1 as const, distance: 10, yardLine: 25 },
+    offenseTeamId: "team-a",
+    defenseTeamId: "team-b",
+    call: {
+      concept: "inside_zone",
+      personnel: "11",
+      formation: "shotgun",
+      motion: "none",
+    },
+    coverage: { front: "4-3", coverage: "cover_3", pressure: "base" },
+    outcome: "rush" as const,
+    yardage: 5,
+    tags: ["first_down" as const],
+    participants: [{
+      role: "ballcarrier",
+      playerId: "p1",
+      tags: ["rush_attempt"],
+    }],
+  };
+
+  await t.step("builds a PlayEvent with all required fields", () => {
+    const event: PlayEvent = buildPlayEvent(baseArgs);
+
+    assertEquals(event.gameId, "game-1");
+    assertEquals(event.driveIndex, 2);
+    assertEquals(event.playIndex, 5);
+    assertEquals(event.quarter, 3);
+    assertEquals(event.clock, "8:30");
+    assertEquals(event.situation, { down: 1, distance: 10, yardLine: 25 });
+    assertEquals(event.offenseTeamId, "team-a");
+    assertEquals(event.defenseTeamId, "team-b");
+    assertEquals(event.call.concept, "inside_zone");
+    assertEquals(event.coverage.front, "4-3");
+    assertEquals(event.outcome, "rush");
+    assertEquals(event.yardage, 5);
+    assertEquals(event.tags, ["first_down"]);
+    assertEquals(event.participants.length, 1);
+    assertEquals(event.participants[0].role, "ballcarrier");
+  });
+
+  await t.step("defaults participants to empty array when omitted", () => {
+    const { participants: _, ...argsWithoutParticipants } = baseArgs;
+    const event = buildPlayEvent(argsWithoutParticipants);
+    assertEquals(event.participants, []);
+  });
+
+  await t.step("defaults tags to empty array when omitted", () => {
+    const { tags: _, ...argsWithoutTags } = baseArgs;
+    const event = buildPlayEvent(argsWithoutTags);
+    assertEquals(event.tags, []);
+  });
+
+  await t.step("builds a field goal event", () => {
+    const event = buildPlayEvent({
+      gameId: "game-fg",
+      driveIndex: 1,
+      playIndex: 3,
+      quarter: 2,
+      clock: "0:05",
+      situation: { down: 4, distance: 3, yardLine: 70 },
+      offenseTeamId: "team-a",
+      defenseTeamId: "team-b",
+      call: {
+        concept: "field_goal",
+        personnel: "special_teams",
+        formation: "field_goal",
+        motion: "none",
+      },
+      coverage: {
+        front: "field_goal_block",
+        coverage: "none",
+        pressure: "none",
+      },
+      outcome: "field_goal",
+      yardage: 0,
+      participants: [{ role: "kicker", playerId: "k1", tags: [] }],
+    });
+
+    assertEquals(event.outcome, "field_goal");
+    assertEquals(event.call.concept, "field_goal");
+    assertEquals(event.tags, []);
+  });
+
+  await t.step("builds a kneel event", () => {
+    const event = buildPlayEvent({
+      gameId: "game-kneel",
+      driveIndex: 4,
+      playIndex: 10,
+      quarter: 4,
+      clock: "0:40",
+      situation: { down: 1, distance: 10, yardLine: 30 },
+      offenseTeamId: "team-a",
+      defenseTeamId: "team-b",
+      call: {
+        concept: "kneel",
+        personnel: "victory",
+        formation: "under_center",
+        motion: "none",
+      },
+      coverage: {
+        front: "victory",
+        coverage: "none",
+        pressure: "none",
+      },
+      outcome: "kneel",
+      yardage: -1,
+      tags: ["victory_formation"],
+    });
+
+    assertEquals(event.outcome, "kneel");
+    assertEquals(event.yardage, -1);
+    assertEquals(event.tags, ["victory_formation"]);
+  });
+
+  await t.step("builds a kickoff event", () => {
+    const event = buildPlayEvent({
+      gameId: "game-ko",
+      driveIndex: 0,
+      playIndex: 0,
+      quarter: 1,
+      clock: "15:00",
+      situation: { down: 1, distance: 10, yardLine: 35 },
+      offenseTeamId: "team-a",
+      defenseTeamId: "team-b",
+      call: {
+        concept: "kickoff",
+        personnel: "special_teams",
+        formation: "kickoff",
+        motion: "none",
+      },
+      coverage: {
+        front: "kick_return",
+        coverage: "none",
+        pressure: "none",
+      },
+      outcome: "kickoff",
+      yardage: 60,
+      participants: [{ role: "kicker", playerId: "k1", tags: [] }],
+    });
+
+    assertEquals(event.outcome, "kickoff");
+    assertEquals(event.yardage, 60);
+  });
+
+  await t.step("builds a punt event", () => {
+    const event = buildPlayEvent({
+      gameId: "game-punt",
+      driveIndex: 3,
+      playIndex: 7,
+      quarter: 3,
+      clock: "5:00",
+      situation: { down: 4, distance: 8, yardLine: 30 },
+      offenseTeamId: "team-a",
+      defenseTeamId: "team-b",
+      call: {
+        concept: "punt",
+        personnel: "special_teams",
+        formation: "punt",
+        motion: "none",
+      },
+      coverage: {
+        front: "punt_return",
+        coverage: "none",
+        pressure: "none",
+      },
+      outcome: "punt",
+      yardage: 45,
+      tags: ["muff"],
+      participants: [
+        { role: "punter", playerId: "p1", tags: [] },
+        { role: "returner", playerId: "r1", tags: [] },
+      ],
+    });
+
+    assertEquals(event.outcome, "punt");
+    assertEquals(event.yardage, 45);
+    assertEquals(event.tags, ["muff"]);
+    assertEquals(event.participants.length, 2);
+  });
+
+  await t.step("builds an extra point event", () => {
+    const event = buildPlayEvent({
+      gameId: "game-xp",
+      driveIndex: 2,
+      playIndex: 4,
+      quarter: 2,
+      clock: "7:30",
+      situation: { down: 1, distance: 0, yardLine: 85 },
+      offenseTeamId: "team-a",
+      defenseTeamId: "team-b",
+      call: {
+        concept: "extra_point",
+        personnel: "special_teams",
+        formation: "field_goal",
+        motion: "none",
+      },
+      coverage: {
+        front: "field_goal_block",
+        coverage: "none",
+        pressure: "none",
+      },
+      outcome: "xp",
+      yardage: 0,
+      participants: [{ role: "kicker", playerId: "k1", tags: ["xp_made"] }],
+    });
+
+    assertEquals(event.outcome, "xp");
+    assertEquals(event.participants[0].tags, ["xp_made"]);
+  });
+});

--- a/server/features/simulation/play-event.ts
+++ b/server/features/simulation/play-event.ts
@@ -1,0 +1,44 @@
+import type {
+  DefensiveCall,
+  OffensiveCall,
+  PlayEvent,
+  PlayOutcome,
+  PlayParticipant,
+  PlayTag,
+} from "./events.ts";
+
+export type BuildPlayEventArgs = {
+  gameId: string;
+  driveIndex: number;
+  playIndex: number;
+  quarter: 1 | 2 | 3 | 4 | "OT";
+  clock: string;
+  situation: { down: 1 | 2 | 3 | 4; distance: number; yardLine: number };
+  offenseTeamId: string;
+  defenseTeamId: string;
+  call: OffensiveCall;
+  coverage: DefensiveCall;
+  outcome: PlayOutcome;
+  yardage: number;
+  tags?: PlayTag[];
+  participants?: PlayParticipant[];
+};
+
+export function buildPlayEvent(args: BuildPlayEventArgs): PlayEvent {
+  return {
+    gameId: args.gameId,
+    driveIndex: args.driveIndex,
+    playIndex: args.playIndex,
+    quarter: args.quarter,
+    clock: args.clock,
+    situation: args.situation,
+    offenseTeamId: args.offenseTeamId,
+    defenseTeamId: args.defenseTeamId,
+    call: args.call,
+    coverage: args.coverage,
+    outcome: args.outcome,
+    yardage: args.yardage,
+    tags: args.tags ?? [],
+    participants: args.participants ?? [],
+  };
+}

--- a/server/features/simulation/resolve-kickoff.ts
+++ b/server/features/simulation/resolve-kickoff.ts
@@ -1,4 +1,5 @@
 import type { PlayEvent, PlayTag } from "./events.ts";
+import { buildPlayEvent } from "./play-event.ts";
 import type { PlayerRuntime } from "./resolve-play.ts";
 import type { SeededRng } from "./rng.ts";
 
@@ -106,7 +107,7 @@ export function resolveKickoff(
     const recovered = rng.next() < ONSIDE_RECOVERY_RATE;
     const yardLine = kickYardLine + rng.int(8, 15);
 
-    const event = buildEvent(ctx, tags, participants, 0, kickYardLine);
+    const event = buildKickoffEvent(ctx, tags, participants, 0, kickYardLine);
 
     return {
       event,
@@ -120,7 +121,7 @@ export function resolveKickoff(
   const touchbackRate = computeTouchbackRate(kickingPower);
 
   if (rng.next() < OOB_RATE) {
-    const event = buildEvent(ctx, tags, participants, 0, kickYardLine);
+    const event = buildKickoffEvent(ctx, tags, participants, 0, kickYardLine);
     return {
       event,
       startingYardLine: OOB_YARD_LINE,
@@ -139,7 +140,13 @@ export function resolveKickoff(
       });
     }
     const startYard = Math.min(99, Math.max(1, 30 + returnDist));
-    const event = buildEvent(ctx, tags, participants, returnDist, kickYardLine);
+    const event = buildKickoffEvent(
+      ctx,
+      tags,
+      participants,
+      returnDist,
+      kickYardLine,
+    );
     return {
       event,
       startingYardLine: startYard,
@@ -149,7 +156,7 @@ export function resolveKickoff(
   }
 
   if (rng.next() < touchbackRate) {
-    const event = buildEvent(ctx, tags, participants, 0, kickYardLine);
+    const event = buildKickoffEvent(ctx, tags, participants, 0, kickYardLine);
     return {
       event,
       startingYardLine: TOUCHBACK_YARD_LINE,
@@ -159,7 +166,7 @@ export function resolveKickoff(
   }
 
   if (!ctx.returner) {
-    const event = buildEvent(ctx, tags, participants, 0, kickYardLine);
+    const event = buildKickoffEvent(ctx, tags, participants, 0, kickYardLine);
     return {
       event,
       startingYardLine: TOUCHBACK_YARD_LINE,
@@ -193,7 +200,7 @@ export function resolveKickoff(
 
   if (rng.next() < returnTDChance) {
     tags.push("touchdown");
-    const event = buildEvent(
+    const event = buildKickoffEvent(
       ctx,
       tags,
       participants,
@@ -208,7 +215,13 @@ export function resolveKickoff(
     };
   }
 
-  const event = buildEvent(ctx, tags, participants, returnDist, kickYardLine);
+  const event = buildKickoffEvent(
+    ctx,
+    tags,
+    participants,
+    returnDist,
+    kickYardLine,
+  );
   return {
     event,
     startingYardLine: startYard,
@@ -217,14 +230,14 @@ export function resolveKickoff(
   };
 }
 
-function buildEvent(
+function buildKickoffEvent(
   ctx: KickoffContext,
   tags: PlayTag[],
   participants: { role: string; playerId: string; tags: string[] }[],
   yardage: number,
   kickYardLine: number,
-): PlayEvent {
-  return {
+) {
+  return buildPlayEvent({
     gameId: ctx.gameId,
     driveIndex: ctx.driveIndex,
     playIndex: ctx.playIndex,
@@ -252,5 +265,5 @@ function buildEvent(
     outcome: "kickoff",
     yardage,
     tags,
-  };
+  });
 }

--- a/server/features/simulation/simulate-game.ts
+++ b/server/features/simulation/simulate-game.ts
@@ -4,7 +4,6 @@ import type {
   GameResult,
   InjurySeverity,
   PlayEvent,
-  PlayOutcome,
   PlayTag,
 } from "./events.ts";
 import type {
@@ -30,6 +29,7 @@ import {
 import { resolvePunt } from "./resolve-punt.ts";
 import { resolveFieldGoal } from "./resolve-field-goal.ts";
 import { resolveFourthDown } from "./resolve-fourth-down.ts";
+import { buildPlayEvent } from "./play-event.ts";
 
 export interface SimTeam {
   teamId: string;
@@ -406,7 +406,7 @@ export function simulateGame(input: SimulationInput): GameResult {
     if (choice === "xp") {
       const kicker = findKicker(isHome ? "home" : "away");
       const made = resolveExtraPoint(kicker, rng);
-      const xpEvent: PlayEvent = {
+      const xpEvent = buildPlayEvent({
         gameId,
         driveIndex: state.driveIndex,
         playIndex: state.playIndex,
@@ -433,10 +433,10 @@ export function simulateGame(input: SimulationInput): GameResult {
           playerId: kicker.playerId,
           tags: made ? ["xp_made"] : ["xp_missed"],
         }],
-        outcome: "xp" as PlayOutcome,
+        outcome: "xp",
         yardage: 0,
         tags: made ? [] : ["xp_missed" as PlayTag],
-      };
+      });
       events.push(xpEvent);
       state.playIndex++;
       state.globalPlayIndex++;
@@ -536,7 +536,7 @@ export function simulateGame(input: SimulationInput): GameResult {
       tags: [],
     }];
 
-    const fgEvent: PlayEvent = {
+    const fgEvent = buildPlayEvent({
       gameId,
       driveIndex: state.driveIndex,
       playIndex: state.playIndex,
@@ -563,8 +563,7 @@ export function simulateGame(input: SimulationInput): GameResult {
       participants,
       outcome: fgResult.outcome === "made" ? "field_goal" : "missed_field_goal",
       yardage: 0,
-      tags: [],
-    };
+    });
 
     if (fgResult.blocked) {
       fgEvent.tags.push("blocked_kick");
@@ -632,7 +631,7 @@ export function simulateGame(input: SimulationInput): GameResult {
     if (puntResult.outcome === "muffed_punt") puntTags.push("muff");
     if (puntResult.outcome === "blocked_punt") puntTags.push("blocked_kick");
 
-    const puntEvent: PlayEvent = {
+    const puntEvent = buildPlayEvent({
       gameId,
       driveIndex: state.driveIndex,
       playIndex: state.playIndex,
@@ -660,7 +659,7 @@ export function simulateGame(input: SimulationInput): GameResult {
       outcome: "punt",
       yardage: puntResult.netYards,
       tags: puntTags,
-    };
+    });
 
     events.push(puntEvent);
     state.drivePlays++;
@@ -789,7 +788,7 @@ export function simulateGame(input: SimulationInput): GameResult {
   }
 
   function emitKneel(): void {
-    const kneelEvent: PlayEvent = {
+    const kneelEvent = buildPlayEvent({
       gameId,
       driveIndex: state.driveIndex,
       playIndex: state.playIndex,
@@ -813,11 +812,10 @@ export function simulateGame(input: SimulationInput): GameResult {
         coverage: "none",
         pressure: "none",
       },
-      participants: [],
       outcome: "kneel",
       yardage: -1,
       tags: ["victory_formation"],
-    };
+    });
 
     events.push(kneelEvent);
     state.drivePlays++;


### PR DESCRIPTION
## Summary

- Adds a `buildPlayEvent` factory in `server/features/simulation/play-event.ts` that centralises `PlayEvent` object construction with sensible defaults for `tags` and `participants`.
- Converts all five hand-rolled `PlayEvent` literal sites (field goal, punt, extra point, kneel, kickoff) to use the factory, eliminating duplicated field assignments.
- Adding a new field to `PlayEvent` now requires a single edit in the factory instead of touching five scattered call-sites.

Closes #374

🤖 Generated with [Claude Code](https://claude.com/claude-code)