### PR TITLE
refactor(sim): extract pass/run/sack/INT magic numbers into named constants

### DIFF
--- a/server/features/simulation/resolve-field-goal.ts
+++ b/server/features/simulation/resolve-field-goal.ts
@@ -18,6 +18,29 @@ export interface FieldGoalInput {
   rng: SeededRng;
 }
 
+// ── Field-goal calibration knobs ──────────────────────────────────────
+const FG_SNAP_DISTANCE = 17;
+const FG_TOUCHBACK_YARD_LINE = 20;
+const FG_RETURN_TO_SPOT_THRESHOLD = 50;
+
+const FG_BLOCK = {
+  floor: 0.005,
+  base: 0.04,
+  accuracyScale: 0.02,
+  powerScale: 0.01,
+} as const;
+
+const FG_SUCCESS_BANDS = [
+  { maxDistance: 27, base: 0.90, accuracyBonus: 0.08, powerBonus: 0 },
+  { maxDistance: 37, base: 0.80, accuracyBonus: 0.12, powerBonus: 0 },
+  { maxDistance: 47, base: 0.65, accuracyBonus: 0.15, powerBonus: 0.05 },
+  { maxDistance: 52, base: 0.45, accuracyBonus: 0.2, powerBonus: 0.1 },
+  { maxDistance: Infinity, base: 0.30, accuracyBonus: 0.15, powerBonus: 0.15 },
+] as const;
+
+const FG_SUCCESS_FLOOR = 0.01;
+const FG_SUCCESS_CEILING = 0.99;
+
 function getSuccessProbability(
   distance: number,
   kickingAccuracy: number,
@@ -27,26 +50,20 @@ function getSuccessProbability(
   const accuracyFactor = kickingAccuracy / 100;
   const powerFactor = kickingPower / 100;
 
-  let baseProb: number;
-  if (distance <= 27) {
-    baseProb = 0.90 + accuracyFactor * 0.08;
-  } else if (distance <= 37) {
-    baseProb = 0.80 + accuracyFactor * 0.12;
-  } else if (distance <= 47) {
-    baseProb = 0.65 + accuracyFactor * 0.15 + powerFactor * 0.05;
-  } else if (distance <= 52) {
-    baseProb = 0.45 + accuracyFactor * 0.2 + powerFactor * 0.1;
-  } else {
-    baseProb = 0.30 + accuracyFactor * 0.15 + powerFactor * 0.15;
-  }
+  const band = FG_SUCCESS_BANDS.find((b) => distance <= b.maxDistance)!;
+  const baseProb = band.base + accuracyFactor * band.accuracyBonus +
+    powerFactor * band.powerBonus;
 
-  return Math.max(0.01, Math.min(0.99, baseProb - weatherPenalty));
+  return Math.max(
+    FG_SUCCESS_FLOOR,
+    Math.min(FG_SUCCESS_CEILING, baseProb - weatherPenalty),
+  );
 }
 
 export function resolveFieldGoal(input: FieldGoalInput): FieldGoalResult {
   const { kicker, yardLine, weatherPenalty = 0, rng } = input;
-  const distance = 100 - yardLine + 17;
-  const defenseYardLine = Math.max(20, 100 - yardLine);
+  const distance = 100 - yardLine + FG_SNAP_DISTANCE;
+  const defenseYardLine = Math.max(FG_TOUCHBACK_YARD_LINE, 100 - yardLine);
 
   const kickingAccuracy =
     (kicker.attributes as unknown as Record<string, number>).kickingAccuracy ??
@@ -55,8 +72,9 @@ export function resolveFieldGoal(input: FieldGoalInput): FieldGoalResult {
     (kicker.attributes as unknown as Record<string, number>).kickingPower ?? 50;
 
   const blockChance = Math.max(
-    0.005,
-    0.04 - (kickingAccuracy / 100) * 0.02 - (kickingPower / 100) * 0.01,
+    FG_BLOCK.floor,
+    FG_BLOCK.base - (kickingAccuracy / 100) * FG_BLOCK.accuracyScale -
+      (kickingPower / 100) * FG_BLOCK.powerScale,
   );
   if (rng.next() < blockChance) {
     return {
@@ -85,7 +103,7 @@ export function resolveFieldGoal(input: FieldGoalInput): FieldGoalResult {
     };
   }
 
-  const returnToSpotOfKick = distance >= 50;
+  const returnToSpotOfKick = distance >= FG_RETURN_TO_SPOT_THRESHOLD;
   return {
     outcome: "missed",
     distance,

--- a/server/features/simulation/resolve-fourth-down.ts
+++ b/server/features/simulation/resolve-fourth-down.ts
@@ -53,8 +53,20 @@ function getDistanceBucket(distance: number): DistanceBucket {
   return "long_6_plus";
 }
 
+const FIELD_GOAL_SNAP_DISTANCE = 17;
+const FIELD_GOAL_MAX_RANGE = 55;
+
+const FOURTH_DOWN = {
+  aggrBase: 0.5,
+  aggrScale: 100,
+  urgencyDeficitCap: 21,
+  urgencyTimeCap: 1800,
+  urgencyBoost: 0.3,
+  quarterSeconds: 900,
+} as const;
+
 function isInFieldGoalRange(yardsToEndzone: number): boolean {
-  return yardsToEndzone + 17 <= 55;
+  return yardsToEndzone + FIELD_GOAL_SNAP_DISTANCE <= FIELD_GOAL_MAX_RANGE;
 }
 
 export function resolveFourthDown(
@@ -65,7 +77,8 @@ export function resolveFourthDown(
   const bucket = getDistanceBucket(input.distance);
   let goRate = BASE_GO_RATES[zone][bucket];
 
-  const aggrMultiplier = 0.5 + input.aggressiveness / 100;
+  const aggrMultiplier = FOURTH_DOWN.aggrBase +
+    input.aggressiveness / FOURTH_DOWN.aggrScale;
   goRate *= aggrMultiplier;
 
   const isLateGame = input.quarter === "OT" || input.quarter >= 3;
@@ -73,10 +86,10 @@ export function resolveFourthDown(
     const deficit = Math.abs(input.scoreDifferential);
     const timeLeft = input.quarter === 4 || input.quarter === "OT"
       ? input.clockSeconds
-      : input.clockSeconds + 900;
-    const urgency = Math.min(deficit / 21, 1) *
-      Math.max(0, 1 - timeLeft / 1800);
-    goRate += urgency * 0.3;
+      : input.clockSeconds + FOURTH_DOWN.quarterSeconds;
+    const urgency = Math.min(deficit / FOURTH_DOWN.urgencyDeficitCap, 1) *
+      Math.max(0, 1 - timeLeft / FOURTH_DOWN.urgencyTimeCap);
+    goRate += urgency * FOURTH_DOWN.urgencyBoost;
   }
 
   goRate = Math.max(0, Math.min(1, goRate));

--- a/server/features/simulation/resolve-play.ts
+++ b/server/features/simulation/resolve-play.ts
@@ -110,6 +110,69 @@ const PASS_CONCEPTS = new Set([
   "deep_shot",
 ]);
 
+// ── Play-call tuning knobs ────────────────────────────────────────────
+const PLAY_CALL = {
+  runBias: 0.07,
+  shortYardageRunBoost: 0.15,
+  longYardageRunPenalty: 0.08,
+  twoMinuteRunPenalty: 0.2,
+  runProbFloor: 0.15,
+  runProbCeiling: 0.85,
+  rpoIntegrationThreshold: 60,
+  passingDepthThreshold: 50,
+  personnelWeightThreshold: 60,
+  formationShotgunThreshold: 60,
+  formationUnderCenterThreshold: 40,
+  blitzPassSituationBoost: 0.15,
+  blitzTwoMinutePenalty: 0.2,
+  blitzFloor: 0.05,
+  blitzCeiling: 0.8,
+} as const;
+
+// ── Pass-resolution calibration knobs ─────────────────────────────────
+const PASS_RESOLUTION = {
+  completion: {
+    base: 0.655,
+    coverageModifier: 0.010,
+    floor: 0.18,
+    ceiling: 0.92,
+  },
+  interception: { base: 0.022, coverageModifier: 0.002, floor: 0.004 },
+  sack: { base: 0.086, protectionModifier: 0.005, floor: 0.01 },
+  bigPlay: {
+    base: 0.20,
+    coverageModifier: 0.008,
+    floor: 0.05,
+    ceiling: 0.45,
+    yards: { min: 13, max: 35 },
+  },
+  completionYards: { min: 3, max: 14 },
+  fumbleOnSack: 0.08,
+} as const;
+
+// ── Run-resolution calibration knobs ──────────────────────────────────
+const RUN_RESOLUTION = {
+  stuffThreshold: -20,
+  stuffYards: { min: -3, max: 0 },
+  shortGainThreshold: -5,
+  shortGainYards: { min: 1, max: 5 },
+  bigPlayThreshold: 15,
+  bigPlayYards: { min: 9, max: 26 },
+  normalYards: { min: 2, max: 8 },
+  fumbleRate: 0.009,
+} as const;
+
+// ── Miscellaneous play-outcome knobs ──────────────────────────────────
+const INJURY_ON_PLAY = 0.005;
+const RETURN_TD = {
+  base: 0.02,
+  attrScale: 0.06 / 60,
+  attrBaseline: 30,
+  floor: 0.01,
+  ceiling: 0.10,
+} as const;
+const SACK_YARDAGE = { min: -10, max: -3 } as const;
+
 const FIT_MODIFIER: Record<SchemeFitLabel, number> = {
   ideal: 10,
   fits: 5,
@@ -169,37 +232,45 @@ export function drawOffensiveCall(
   const isShortYardage = situation.down >= 3 && situation.distance <= 3;
   const isLongYardage = situation.distance >= 7;
 
-  let runProbability = (100 - runPassLean) / 100 + 0.07;
-  if (isShortYardage) runProbability += 0.15;
-  if (isLongYardage) runProbability -= 0.08;
-  if (options?.twoMinute) runProbability -= 0.2;
-  runProbability = Math.max(0.15, Math.min(0.85, runProbability));
+  let runProbability = (100 - runPassLean) / 100 + PLAY_CALL.runBias;
+  if (isShortYardage) runProbability += PLAY_CALL.shortYardageRunBoost;
+  if (isLongYardage) runProbability -= PLAY_CALL.longYardageRunPenalty;
+  if (options?.twoMinute) runProbability -= PLAY_CALL.twoMinuteRunPenalty;
+  runProbability = Math.max(
+    PLAY_CALL.runProbFloor,
+    Math.min(PLAY_CALL.runProbCeiling, runProbability),
+  );
 
   const isRun = rng.next() < runProbability;
 
   let concept: string;
   if (isRun) {
     const runConcepts = [...RUN_CONCEPTS];
-    if ((offense?.rpoIntegration ?? 50) > 60) runConcepts.push("rpo");
+    if ((offense?.rpoIntegration ?? 50) > PLAY_CALL.rpoIntegrationThreshold) {
+      runConcepts.push("rpo");
+    }
     concept = rng.pick(runConcepts);
   } else {
     const passConcepts = [...PASS_CONCEPTS];
-    if (isLongYardage && (offense?.passingDepth ?? 50) > 50) {
+    if (
+      isLongYardage &&
+      (offense?.passingDepth ?? 50) > PLAY_CALL.passingDepthThreshold
+    ) {
       passConcepts.push("deep_shot");
     }
     concept = rng.pick(passConcepts);
   }
 
   const personnelWeight = offense?.personnelWeight ?? 50;
-  const heavyPersonnel = personnelWeight > 60;
+  const heavyPersonnel = personnelWeight > PLAY_CALL.personnelWeightThreshold;
   const personnel = heavyPersonnel
     ? rng.pick(["12", "21", "22"] as const)
     : rng.pick(["11", "10"] as const);
 
   const formationLean = offense?.formationUnderCenterShotgun ?? 50;
-  const formation = formationLean > 60
+  const formation = formationLean > PLAY_CALL.formationShotgunThreshold
     ? rng.pick(["shotgun", "pistol"] as const)
-    : formationLean < 40
+    : formationLean < PLAY_CALL.formationUnderCenterThreshold
     ? rng.pick(["under_center", "singleback", "i_form"] as const)
     : rng.pick(FORMATIONS);
 
@@ -254,9 +325,12 @@ export function drawDefensiveCall(
   const pressureRate = defense?.pressureRate ?? 50;
   const isPassSituation = situation.down >= 3 && situation.distance >= 5;
   let blitzProb = pressureRate / 100;
-  if (isPassSituation) blitzProb += 0.15;
-  if (options?.twoMinute) blitzProb -= 0.2;
-  blitzProb = Math.max(0.05, Math.min(0.8, blitzProb));
+  if (isPassSituation) blitzProb += PLAY_CALL.blitzPassSituationBoost;
+  if (options?.twoMinute) blitzProb -= PLAY_CALL.blitzTwoMinutePenalty;
+  blitzProb = Math.max(
+    PLAY_CALL.blitzFloor,
+    Math.min(PLAY_CALL.blitzCeiling, blitzProb),
+  );
 
   let pressure: string;
   if (rng.next() < blitzProb) {
@@ -386,18 +460,30 @@ export function synthesizeOutcome(
         blockingContribs.length
       : avgScore;
 
-    if (blockScore < -20) {
-      yardage = rng.int(-3, 0);
-    } else if (blockScore < -5) {
-      yardage = rng.int(1, 5);
-    } else if (blockScore > 15) {
-      yardage = rng.int(9, 26);
+    if (blockScore < RUN_RESOLUTION.stuffThreshold) {
+      yardage = rng.int(
+        RUN_RESOLUTION.stuffYards.min,
+        RUN_RESOLUTION.stuffYards.max,
+      );
+    } else if (blockScore < RUN_RESOLUTION.shortGainThreshold) {
+      yardage = rng.int(
+        RUN_RESOLUTION.shortGainYards.min,
+        RUN_RESOLUTION.shortGainYards.max,
+      );
+    } else if (blockScore > RUN_RESOLUTION.bigPlayThreshold) {
+      yardage = rng.int(
+        RUN_RESOLUTION.bigPlayYards.min,
+        RUN_RESOLUTION.bigPlayYards.max,
+      );
       tags.push("big_play");
     } else {
-      yardage = rng.int(2, 8);
+      yardage = rng.int(
+        RUN_RESOLUTION.normalYards.min,
+        RUN_RESOLUTION.normalYards.max,
+      );
     }
 
-    if (rng.next() < 0.009) {
+    if (rng.next() < RUN_RESOLUTION.fumbleRate) {
       outcome = "fumble";
       tags.push("fumble", "turnover");
     } else {
@@ -428,10 +514,14 @@ export function synthesizeOutcome(
         protectionContribs.length
       : avgScore;
 
-    const sackProb = Math.max(0.01, 0.086 - protectionScore * 0.005);
+    const sackProb = Math.max(
+      PASS_RESOLUTION.sack.floor,
+      PASS_RESOLUTION.sack.base -
+        protectionScore * PASS_RESOLUTION.sack.protectionModifier,
+    );
     if (rng.next() < sackProb) {
       outcome = "sack";
-      yardage = rng.int(-10, -3);
+      yardage = rng.int(SACK_YARDAGE.min, SACK_YARDAGE.max);
       tags.push("sack", "pressure");
 
       const rusher = contributions.find((c) =>
@@ -454,7 +544,7 @@ export function synthesizeOutcome(
         }
       }
 
-      if (rng.next() < 0.08) {
+      if (rng.next() < PASS_RESOLUTION.fumbleOnSack) {
         outcome = "fumble";
         tags.push("fumble", "turnover");
       }
@@ -471,14 +561,26 @@ export function synthesizeOutcome(
           routeContribs.length
         : avgScore;
 
-      const intProb = Math.max(0.004, 0.022 - coverageScore * 0.002);
+      const intProb = Math.max(
+        PASS_RESOLUTION.interception.floor,
+        PASS_RESOLUTION.interception.base -
+          coverageScore * PASS_RESOLUTION.interception.coverageModifier,
+      );
       const completionProb = Math.max(
-        0.18,
-        Math.min(0.92, 0.655 + coverageScore * 0.010),
+        PASS_RESOLUTION.completion.floor,
+        Math.min(
+          PASS_RESOLUTION.completion.ceiling,
+          PASS_RESOLUTION.completion.base +
+            coverageScore * PASS_RESOLUTION.completion.coverageModifier,
+        ),
       );
       const bigPlayProb = Math.max(
-        0.05,
-        Math.min(0.45, 0.20 + coverageScore * 0.008),
+        PASS_RESOLUTION.bigPlay.floor,
+        Math.min(
+          PASS_RESOLUTION.bigPlay.ceiling,
+          PASS_RESOLUTION.bigPlay.base +
+            coverageScore * PASS_RESOLUTION.bigPlay.coverageModifier,
+        ),
       );
 
       const roll = rng.next();
@@ -507,10 +609,16 @@ export function synthesizeOutcome(
         outcome = "pass_complete";
         const isBigPlay = rng.next() < bigPlayProb;
         if (isBigPlay) {
-          yardage = rng.int(13, 35);
+          yardage = rng.int(
+            PASS_RESOLUTION.bigPlay.yards.min,
+            PASS_RESOLUTION.bigPlay.yards.max,
+          );
           tags.push("big_play");
         } else {
-          yardage = rng.int(3, 14);
+          yardage = rng.int(
+            PASS_RESOLUTION.completionYards.min,
+            PASS_RESOLUTION.completionYards.max,
+          );
         }
         const target = routeContribs.find((c) => c.score > 0) ??
           routeContribs[0];
@@ -533,7 +641,7 @@ export function synthesizeOutcome(
     }
   }
 
-  if (rng.next() < 0.005) {
+  if (rng.next() < INJURY_ON_PLAY) {
     tags.push("injury");
   }
 
@@ -566,8 +674,12 @@ export function synthesizeOutcome(
     const speed = defender?.attributes.speed ?? 50;
     const acceleration = defender?.attributes.acceleration ?? 50;
     const avgAttr = (speed + acceleration) / 2;
-    const returnTdProb = 0.02 + (avgAttr - 30) * (0.06 / 60);
-    if (rng.next() < Math.max(0.01, Math.min(0.10, returnTdProb))) {
+    const returnTdProb = RETURN_TD.base +
+      (avgAttr - RETURN_TD.attrBaseline) * RETURN_TD.attrScale;
+    if (
+      rng.next() <
+        Math.max(RETURN_TD.floor, Math.min(RETURN_TD.ceiling, returnTdProb))
+    ) {
       tags.push("return_td", "touchdown");
       if (defender) {
         const existingIdx = participants.findIndex(

--- a/server/features/simulation/resolve-punt.ts
+++ b/server/features/simulation/resolve-punt.ts
@@ -24,6 +24,32 @@ export interface PuntInput {
   rng: SeededRng;
 }
 
+// ── Punt calibration knobs ────────────────────────────────────────────
+const PUNT_DISTANCE = {
+  baseMean: 35,
+  powerScale: 20,
+  baseStddev: 8,
+  accuracyScale: 4,
+  floor: 20,
+  ceiling: 65,
+} as const;
+
+const PUNT_OUTCOME = {
+  block: { floor: 0.005, base: 0.03, accuracyScale: 0.025 },
+  muff: { base: 0.02, agilityScale: 0.03 },
+  downedInside10: { base: 0.3, accuracyScale: 0.3, zoneThreshold: 90 },
+  fairCatch: { base: 0.3, coverageScale: 0.3, floor: 0.1, ceiling: 0.7 },
+  return: {
+    baseMean: 5,
+    ratingScale: 15,
+    coveragePenaltyScale: 8,
+    meanFloor: 2,
+    stddev: 5,
+    floor: 1,
+    ceiling: 40,
+  },
+} as const;
+
 function averageAttribute(
   players: PlayerRuntime[],
   attr: string,
@@ -41,9 +67,16 @@ function computePuntDistance(punter: PlayerRuntime, rng: SeededRng): number {
     .puntingPower ?? 50;
   const accuracy = (punter.attributes as unknown as Record<string, number>)
     .puntingAccuracy ?? 50;
-  const baseMean = 35 + (power / 100) * 20;
-  const baseStddev = 8 - (accuracy / 100) * 4;
-  return rng.gaussian(baseMean, baseStddev, 20, 65);
+  const baseMean = PUNT_DISTANCE.baseMean +
+    (power / 100) * PUNT_DISTANCE.powerScale;
+  const baseStddev = PUNT_DISTANCE.baseStddev -
+    (accuracy / 100) * PUNT_DISTANCE.accuracyScale;
+  return rng.gaussian(
+    baseMean,
+    baseStddev,
+    PUNT_DISTANCE.floor,
+    PUNT_DISTANCE.ceiling,
+  );
 }
 
 function selectOutcome(
@@ -62,28 +95,36 @@ function selectOutcome(
   const returnerAgility =
     (returner.attributes as unknown as Record<string, number>).agility ?? 50;
 
-  const blockChance = Math.max(0.005, 0.03 - (punterAccuracy / 100) * 0.025);
+  const blockChance = Math.max(
+    PUNT_OUTCOME.block.floor,
+    PUNT_OUTCOME.block.base -
+      (punterAccuracy / 100) * PUNT_OUTCOME.block.accuracyScale,
+  );
   const roll = rng.next();
 
   if (roll < blockChance) return "blocked_punt";
 
-  const muffBase = 0.02;
-  const muffChance = muffBase + (1 - returnerAgility / 100) * 0.03;
+  const muffChance = PUNT_OUTCOME.muff.base +
+    (1 - returnerAgility / 100) * PUNT_OUTCOME.muff.agilityScale;
   if (roll < blockChance + muffChance) return "muffed_punt";
 
   if (rawLanding >= 100) return "touchback";
 
-  if (rawLanding >= 90) {
-    const downedChance = 0.3 + (punterAccuracy / 100) * 0.3;
+  if (rawLanding >= PUNT_OUTCOME.downedInside10.zoneThreshold) {
+    const downedChance = PUNT_OUTCOME.downedInside10.base +
+      (punterAccuracy / 100) * PUNT_OUTCOME.downedInside10.accuracyScale;
     if (rng.next() < downedChance) return "downed_inside_10";
     return "touchback";
   }
 
-  const fairCatchBase = 0.3;
-  const coverageBonus = (coverageRating - 50) / 100 * 0.3;
+  const coverageBonus = (coverageRating - 50) / 100 *
+    PUNT_OUTCOME.fairCatch.coverageScale;
   const fairCatchChance = Math.max(
-    0.1,
-    Math.min(0.7, fairCatchBase + coverageBonus),
+    PUNT_OUTCOME.fairCatch.floor,
+    Math.min(
+      PUNT_OUTCOME.fairCatch.ceiling,
+      PUNT_OUTCOME.fairCatch.base + coverageBonus,
+    ),
   );
   if (rng.next() < fairCatchChance) return "fair_catch";
 
@@ -152,11 +193,21 @@ export function resolvePunt(input: PuntInput): PuntResult {
       const returnerRating = (returnerSpeed + returnerAccel) / 2;
       const coverageSpeed = averageAttribute(coverageUnit, "speed");
 
-      const returnBase = 5 + (returnerRating / 100) * 15;
-      const coveragePenalty = (coverageSpeed / 100) * 8;
-      const returnMean = Math.max(2, returnBase - coveragePenalty);
+      const returnBase = PUNT_OUTCOME.return.baseMean +
+        (returnerRating / 100) * PUNT_OUTCOME.return.ratingScale;
+      const coveragePenalty = (coverageSpeed / 100) *
+        PUNT_OUTCOME.return.coveragePenaltyScale;
+      const returnMean = Math.max(
+        PUNT_OUTCOME.return.meanFloor,
+        returnBase - coveragePenalty,
+      );
 
-      const returnYards = rng.gaussian(returnMean, 5, 1, 40);
+      const returnYards = rng.gaussian(
+        returnMean,
+        PUNT_OUTCOME.return.stddev,
+        PUNT_OUTCOME.return.floor,
+        PUNT_OUTCOME.return.ceiling,
+      );
       const netLanding = Math.max(1, landing - returnYards);
       const netYards = netLanding - yardLine;
 

--- a/server/features/simulation/simulate-game.ts
+++ b/server/features/simulation/simulate-game.ts
@@ -63,6 +63,12 @@ const INJURY_WEIGHTS = [0.35, 0.25, 0.15, 0.10, 0.08, 0.05, 0.02];
 const OT_SECONDS = 600;
 const TIMEOUTS_PER_HALF = 3;
 const KNEEL_CLOCK_BURN = 40;
+const CLOCK_STOP_RUNOFF = { min: 5, max: 15 } as const;
+const TIMEOUT_USAGE = {
+  offenseTrailingProb: 0.4,
+  defenseLeadingProb: 0.3,
+} as const;
+const KICKOFF_STARTING_YARD_LINE = 35;
 
 interface MutableGameState {
   quarter: 1 | 2 | 3 | 4 | "OT";
@@ -178,13 +184,13 @@ export function simulateGame(input: SimulationInput): GameResult {
     homeScore: 0,
     awayScore: 0,
     possession: "home",
-    yardLine: 35,
+    yardLine: KICKOFF_STARTING_YARD_LINE,
     down: 1,
     distance: 10,
     driveIndex: 0,
     playIndex: 0,
     globalPlayIndex: 0,
-    driveStartYardLine: 35,
+    driveStartYardLine: KICKOFF_STARTING_YARD_LINE,
     drivePlays: 0,
     driveYards: 0,
     homeTimeouts: TIMEOUTS_PER_HALF,
@@ -851,13 +857,19 @@ export function simulateGame(input: SimulationInput): GameResult {
     const offenseTrailing = offenseScore < defenseScore;
     const defenseLeading = defenseScore > offenseScore;
 
-    if (offenseTrailing && offenseTimeouts > 0 && rng.next() < 0.4) {
+    if (
+      offenseTrailing && offenseTimeouts > 0 &&
+      rng.next() < TIMEOUT_USAGE.offenseTrailingProb
+    ) {
       if (state.possession === "home") state.homeTimeouts--;
       else state.awayTimeouts--;
       return true;
     }
 
-    if (defenseLeading && defenseTimeouts > 0 && rng.next() < 0.3) {
+    if (
+      defenseLeading && defenseTimeouts > 0 &&
+      rng.next() < TIMEOUT_USAGE.defenseLeadingProb
+    ) {
       if (state.possession === "home") state.awayTimeouts--;
       else state.homeTimeouts--;
       return true;
@@ -911,7 +923,7 @@ export function simulateGame(input: SimulationInput): GameResult {
     if (!shouldClockStop(event)) {
       state.clock -= SECONDS_PER_PLAY;
     } else {
-      state.clock -= rng.int(5, 15);
+      state.clock -= rng.int(CLOCK_STOP_RUNOFF.min, CLOCK_STOP_RUNOFF.max);
     }
 
     if (event.penalty?.accepted && !event.tags.includes("return_td")) {


### PR DESCRIPTION
## Summary

- Hoists inline magic numbers (probability floats, yardage ranges, thresholds) from `resolve-play.ts`, `resolve-fourth-down.ts`, `resolve-punt.ts`, `resolve-field-goal.ts`, and `simulate-game.ts` into self-documenting named `const` declarations at the top of each file.
- Groups related calibration knobs into object literals (`PASS_RESOLUTION`, `RUN_RESOLUTION`, `PLAY_CALL`, `PUNT_OUTCOME`, `FG_SUCCESS_BANDS`, etc.) so future tuning is a single-stanza diff instead of scattered grep-and-replace on bare floats.
- No behavior change — all 137 simulation tests pass with identical output and the same calibration report.

Closes #371