### PR TITLE
refactor(sim): split synthesizeOutcome into run/pass handlers

### DIFF
--- a/server/features/simulation/resolve-play.ts
+++ b/server/features/simulation/resolve-play.ts
@@ -9,8 +9,6 @@ import type {
   OffensiveCall,
   PenaltyInfo,
   PlayEvent,
-  PlayOutcome,
-  PlayTag,
 } from "./events.ts";
 import type { SeededRng } from "./rng.ts";
 import { computeSchemeFit } from "../schemes/fit.ts";
@@ -21,6 +19,8 @@ import {
   shouldPenaltyOccur,
 } from "./resolve-penalty.ts";
 import { resolveMatchups } from "./resolve-matchups.ts";
+import { synthesizeRunOutcome } from "./synthesize-run-outcome.ts";
+import { synthesizePassOutcome } from "./synthesize-pass-outcome.ts";
 
 export interface Situation {
   down: 1 | 2 | 3 | 4;
@@ -130,7 +130,7 @@ const PLAY_CALL = {
 } as const;
 
 // ── Pass-resolution calibration knobs ─────────────────────────────────
-const PASS_RESOLUTION = {
+export const PASS_RESOLUTION = {
   completion: {
     base: 0.655,
     coverageModifier: 0.010,
@@ -151,7 +151,7 @@ const PASS_RESOLUTION = {
 } as const;
 
 // ── Run-resolution calibration knobs ──────────────────────────────────
-const RUN_RESOLUTION = {
+export const RUN_RESOLUTION = {
   stuffThreshold: -20,
   stuffYards: { min: -3, max: 0 },
   shortGainThreshold: -5,
@@ -171,7 +171,7 @@ const RETURN_TD = {
   floor: 0.01,
   ceiling: 0.10,
 } as const;
-const SACK_YARDAGE = { min: -10, max: -3 } as const;
+export const SACK_YARDAGE = { min: -10, max: -3 } as const;
 
 const FIT_MODIFIER: Record<SchemeFitLabel, number> = {
   ideal: 10,
@@ -437,209 +437,14 @@ export function synthesizeOutcome(
   defensePlayerIds?: string[],
 ): PlayEvent {
   const isRunPlay = RUN_CONCEPTS.has(call.concept);
-  const avgScore = contributions.length > 0
-    ? contributions.reduce((sum, c) => sum + c.score, 0) / contributions.length
-    : 0;
 
-  const participants = contributions.map((c) => ({
-    role: c.matchup.type,
-    playerId: c.matchup.attacker.playerId,
-    tags: [] as string[],
-  }));
+  const result = isRunPlay
+    ? synthesizeRunOutcome(contributions, state.situation, rng)
+    : synthesizePassOutcome(contributions, state.situation, rng);
 
-  const tags: PlayTag[] = [];
-  let outcome: PlayOutcome;
-  let yardage: number;
-
-  if (isRunPlay) {
-    const blockingContribs = contributions.filter(
-      (c) => c.matchup.type === "run_block" || c.matchup.type === "run_defense",
-    );
-    const blockScore = blockingContribs.length > 0
-      ? blockingContribs.reduce((s, c) => s + c.score, 0) /
-        blockingContribs.length
-      : avgScore;
-
-    if (blockScore < RUN_RESOLUTION.stuffThreshold) {
-      yardage = rng.int(
-        RUN_RESOLUTION.stuffYards.min,
-        RUN_RESOLUTION.stuffYards.max,
-      );
-    } else if (blockScore < RUN_RESOLUTION.shortGainThreshold) {
-      yardage = rng.int(
-        RUN_RESOLUTION.shortGainYards.min,
-        RUN_RESOLUTION.shortGainYards.max,
-      );
-    } else if (blockScore > RUN_RESOLUTION.bigPlayThreshold) {
-      yardage = rng.int(
-        RUN_RESOLUTION.bigPlayYards.min,
-        RUN_RESOLUTION.bigPlayYards.max,
-      );
-      tags.push("big_play");
-    } else {
-      yardage = rng.int(
-        RUN_RESOLUTION.normalYards.min,
-        RUN_RESOLUTION.normalYards.max,
-      );
-    }
-
-    if (rng.next() < RUN_RESOLUTION.fumbleRate) {
-      outcome = "fumble";
-      tags.push("fumble", "turnover");
-    } else {
-      outcome = "rush";
-    }
-
-    if (yardage >= state.situation.distance) {
-      tags.push("first_down");
-    }
-
-    const rb = contributions.find(
-      (c) => c.matchup.attacker.neutralBucket === "RB",
-    );
-    if (rb) {
-      const idx = participants.findIndex(
-        (p) => p.playerId === rb.matchup.attacker.playerId,
-      );
-      if (idx >= 0) participants[idx].tags.push("ball_carrier");
-    }
-  } else {
-    const protectionContribs = contributions.filter(
-      (c) =>
-        c.matchup.type === "pass_protection" ||
-        c.matchup.type === "pass_rush",
-    );
-    const protectionScore = protectionContribs.length > 0
-      ? protectionContribs.reduce((s, c) => s + c.score, 0) /
-        protectionContribs.length
-      : avgScore;
-
-    const sackProb = Math.max(
-      PASS_RESOLUTION.sack.floor,
-      PASS_RESOLUTION.sack.base -
-        protectionScore * PASS_RESOLUTION.sack.protectionModifier,
-    );
-    if (rng.next() < sackProb) {
-      outcome = "sack";
-      yardage = rng.int(SACK_YARDAGE.min, SACK_YARDAGE.max);
-      tags.push("sack", "pressure");
-
-      const rusher = contributions.find((c) =>
-        c.matchup.type === "pass_rush" ||
-        (c.matchup.type === "pass_protection" &&
-          c.score < 0)
-      );
-      if (rusher) {
-        const idx = participants.findIndex(
-          (p) => p.playerId === rusher.matchup.defender.playerId,
-        );
-        if (idx >= 0) {
-          participants[idx].tags.push("sack");
-        } else {
-          participants.push({
-            role: "pass_rush",
-            playerId: rusher.matchup.defender.playerId,
-            tags: ["sack"],
-          });
-        }
-      }
-
-      if (rng.next() < PASS_RESOLUTION.fumbleOnSack) {
-        outcome = "fumble";
-        tags.push("fumble", "turnover");
-      }
-    } else {
-      if (protectionScore < -5) {
-        tags.push("pressure");
-      }
-
-      const routeContribs = contributions.filter(
-        (c) => c.matchup.type === "route_coverage",
-      );
-      const coverageScore = routeContribs.length > 0
-        ? routeContribs.reduce((s, c) => s + c.score, 0) /
-          routeContribs.length
-        : avgScore;
-
-      const intProb = Math.max(
-        PASS_RESOLUTION.interception.floor,
-        PASS_RESOLUTION.interception.base -
-          coverageScore * PASS_RESOLUTION.interception.coverageModifier,
-      );
-      const completionProb = Math.max(
-        PASS_RESOLUTION.completion.floor,
-        Math.min(
-          PASS_RESOLUTION.completion.ceiling,
-          PASS_RESOLUTION.completion.base +
-            coverageScore * PASS_RESOLUTION.completion.coverageModifier,
-        ),
-      );
-      const bigPlayProb = Math.max(
-        PASS_RESOLUTION.bigPlay.floor,
-        Math.min(
-          PASS_RESOLUTION.bigPlay.ceiling,
-          PASS_RESOLUTION.bigPlay.base +
-            coverageScore * PASS_RESOLUTION.bigPlay.coverageModifier,
-        ),
-      );
-
-      const roll = rng.next();
-      if (roll < intProb) {
-        outcome = "interception";
-        yardage = 0;
-        tags.push("interception", "turnover");
-
-        const interceptor = routeContribs.find((c) => c.score < -5) ??
-          routeContribs[0];
-        if (interceptor) {
-          const idx = participants.findIndex(
-            (p) => p.playerId === interceptor.matchup.defender.playerId,
-          );
-          if (idx >= 0) {
-            participants[idx].tags.push("interception");
-          } else {
-            participants.push({
-              role: "route_coverage",
-              playerId: interceptor.matchup.defender.playerId,
-              tags: ["interception"],
-            });
-          }
-        }
-      } else if (roll < intProb + completionProb) {
-        outcome = "pass_complete";
-        const isBigPlay = rng.next() < bigPlayProb;
-        if (isBigPlay) {
-          yardage = rng.int(
-            PASS_RESOLUTION.bigPlay.yards.min,
-            PASS_RESOLUTION.bigPlay.yards.max,
-          );
-          tags.push("big_play");
-        } else {
-          yardage = rng.int(
-            PASS_RESOLUTION.completionYards.min,
-            PASS_RESOLUTION.completionYards.max,
-          );
-        }
-        const target = routeContribs.find((c) => c.score > 0) ??
-          routeContribs[0];
-        if (target) {
-          const idx = participants.findIndex(
-            (p) => p.playerId === target.matchup.attacker.playerId,
-          );
-          if (idx >= 0) participants[idx].tags.push("target", "reception");
-        }
-      } else {
-        outcome = "pass_incomplete";
-        yardage = 0;
-      }
-
-      if (
-        outcome === "pass_complete" && yardage >= state.situation.distance
-      ) {
-        tags.push("first_down");
-      }
-    }
-  }
+  let { outcome } = result;
+  let { yardage } = result;
+  const { tags, participants } = result;
 
   if (rng.next() < INJURY_ON_PLAY) {
     tags.push("injury");
@@ -760,8 +565,8 @@ export function synthesizeOutcome(
     call,
     coverage,
     participants,
-    outcome: outcome!,
-    yardage: yardage!,
+    outcome,
+    yardage,
     tags,
     penalty,
   };

--- a/server/features/simulation/synthesize-pass-outcome.test.ts
+++ b/server/features/simulation/synthesize-pass-outcome.test.ts
@@ -1,0 +1,377 @@
+import { assertEquals, assertExists } from "@std/assert";
+import {
+  PLAYER_ATTRIBUTE_KEYS,
+  type PlayerAttributes,
+} from "@zone-blitz/shared";
+import { createRng, mulberry32 } from "./rng.ts";
+import type { SeededRng } from "./rng.ts";
+import type {
+  MatchupContribution,
+  PlayerRuntime,
+  Situation,
+} from "./resolve-play.ts";
+import { synthesizePassOutcome } from "./synthesize-pass-outcome.ts";
+
+function makeAttributes(
+  overrides: Partial<PlayerAttributes> = {},
+): PlayerAttributes {
+  const base: Partial<PlayerAttributes> = {};
+  for (const key of PLAYER_ATTRIBUTE_KEYS) {
+    (base as Record<string, number>)[key] = 50;
+    (base as Record<string, number>)[`${key}Potential`] = 50;
+  }
+  return { ...base, ...overrides } as PlayerAttributes;
+}
+
+function makePlayer(
+  id: string,
+  bucket: PlayerRuntime["neutralBucket"],
+  overrides: Partial<PlayerAttributes> = {},
+): PlayerRuntime {
+  return {
+    playerId: id,
+    neutralBucket: bucket,
+    attributes: makeAttributes(overrides),
+  };
+}
+
+function makeSituation(overrides: Partial<Situation> = {}): Situation {
+  return { down: 1, distance: 10, yardLine: 30, ...overrides };
+}
+
+function makeRng(seed = 42): SeededRng {
+  return createRng(mulberry32(seed));
+}
+
+Deno.test("synthesizePassOutcome", async (t) => {
+  await t.step("produces sack on terrible protection", () => {
+    let sackCount = 0;
+    const trials = 30;
+    for (let i = 0; i < trials; i++) {
+      const rng = makeRng(i);
+      const contribs: MatchupContribution[] = [
+        {
+          matchup: {
+            type: "pass_protection",
+            attacker: makePlayer("ot1", "OT"),
+            defender: makePlayer("edge1", "EDGE"),
+          },
+          attackerFit: "neutral",
+          defenderFit: "neutral",
+          score: -20,
+        },
+      ];
+      const result = synthesizePassOutcome(contribs, makeSituation(), rng);
+      if (result.outcome === "sack" || result.outcome === "fumble") {
+        sackCount++;
+      }
+    }
+    assertEquals(sackCount / trials > 0.10, true);
+  });
+
+  await t.step("tags sack and pressure on sack outcome", () => {
+    let sackFound = false;
+    for (let seed = 0; seed < 500; seed++) {
+      const rng = makeRng(seed);
+      const contribs: MatchupContribution[] = [
+        {
+          matchup: {
+            type: "pass_protection",
+            attacker: makePlayer("ot1", "OT"),
+            defender: makePlayer("edge1", "EDGE"),
+          },
+          attackerFit: "neutral",
+          defenderFit: "neutral",
+          score: -20,
+        },
+      ];
+      const result = synthesizePassOutcome(contribs, makeSituation(), rng);
+      if (result.outcome === "sack") {
+        assertEquals(result.tags.includes("sack"), true);
+        assertEquals(result.tags.includes("pressure"), true);
+        sackFound = true;
+        break;
+      }
+    }
+    assertEquals(sackFound, true);
+  });
+
+  await t.step("tags pass rusher with sack participant tag", () => {
+    let sackWithRusherFound = false;
+    for (let seed = 0; seed < 500; seed++) {
+      const rng = makeRng(seed);
+      const contribs: MatchupContribution[] = [
+        {
+          matchup: {
+            type: "pass_protection",
+            attacker: makePlayer("ot1", "OT"),
+            defender: makePlayer("edge1", "EDGE"),
+          },
+          attackerFit: "neutral",
+          defenderFit: "neutral",
+          score: -20,
+        },
+      ];
+      const result = synthesizePassOutcome(contribs, makeSituation(), rng);
+      if (result.outcome === "sack") {
+        const rusher = result.participants.find((p) => p.tags.includes("sack"));
+        assertExists(rusher);
+        sackWithRusherFound = true;
+        break;
+      }
+    }
+    assertEquals(sackWithRusherFound, true);
+  });
+
+  await t.step("can produce sack-fumble", () => {
+    let fumbleFound = false;
+    for (let seed = 0; seed < 5000; seed++) {
+      const rng = makeRng(seed);
+      const contribs: MatchupContribution[] = [
+        {
+          matchup: {
+            type: "pass_protection",
+            attacker: makePlayer("ot1", "OT"),
+            defender: makePlayer("edge1", "EDGE"),
+          },
+          attackerFit: "neutral",
+          defenderFit: "neutral",
+          score: -20,
+        },
+      ];
+      const result = synthesizePassOutcome(contribs, makeSituation(), rng);
+      if (result.outcome === "fumble" && result.tags.includes("sack")) {
+        assertEquals(result.tags.includes("turnover"), true);
+        fumbleFound = true;
+        break;
+      }
+    }
+    assertEquals(fumbleFound, true);
+  });
+
+  await t.step("produces interception on terrible coverage", () => {
+    let intFound = false;
+    for (let seed = 0; seed < 2000; seed++) {
+      const rng = makeRng(seed);
+      const contribs: MatchupContribution[] = [
+        {
+          matchup: {
+            type: "pass_protection",
+            attacker: makePlayer("ot1", "OT"),
+            defender: makePlayer("edge1", "EDGE"),
+          },
+          attackerFit: "neutral",
+          defenderFit: "neutral",
+          score: 10,
+        },
+        {
+          matchup: {
+            type: "route_coverage",
+            attacker: makePlayer("wr1", "WR"),
+            defender: makePlayer("cb1", "CB"),
+          },
+          attackerFit: "neutral",
+          defenderFit: "neutral",
+          score: -20,
+        },
+      ];
+      const result = synthesizePassOutcome(contribs, makeSituation(), rng);
+      if (result.outcome === "interception") {
+        assertEquals(result.tags.includes("interception"), true);
+        assertEquals(result.tags.includes("turnover"), true);
+        intFound = true;
+        break;
+      }
+    }
+    assertEquals(intFound, true);
+  });
+
+  await t.step("tags interceptor participant", () => {
+    for (let seed = 0; seed < 2000; seed++) {
+      const rng = makeRng(seed);
+      const contribs: MatchupContribution[] = [
+        {
+          matchup: {
+            type: "pass_protection",
+            attacker: makePlayer("ot1", "OT"),
+            defender: makePlayer("edge1", "EDGE"),
+          },
+          attackerFit: "neutral",
+          defenderFit: "neutral",
+          score: 10,
+        },
+        {
+          matchup: {
+            type: "route_coverage",
+            attacker: makePlayer("wr1", "WR"),
+            defender: makePlayer("cb1", "CB"),
+          },
+          attackerFit: "neutral",
+          defenderFit: "neutral",
+          score: -20,
+        },
+      ];
+      const result = synthesizePassOutcome(contribs, makeSituation(), rng);
+      if (result.outcome === "interception") {
+        const interceptor = result.participants.find((p) =>
+          p.tags.includes("interception")
+        );
+        assertExists(interceptor);
+        break;
+      }
+    }
+  });
+
+  await t.step("produces completions with target/reception tags", () => {
+    let completionFound = false;
+    for (let seed = 0; seed < 100; seed++) {
+      const rng = makeRng(seed);
+      const contribs: MatchupContribution[] = [
+        {
+          matchup: {
+            type: "route_coverage",
+            attacker: makePlayer("wr1", "WR"),
+            defender: makePlayer("cb1", "CB"),
+          },
+          attackerFit: "neutral",
+          defenderFit: "neutral",
+          score: 15,
+        },
+      ];
+      const result = synthesizePassOutcome(contribs, makeSituation(), rng);
+      if (result.outcome === "pass_complete") {
+        const target = result.participants.find((p) =>
+          p.tags.includes("target")
+        );
+        if (target) {
+          assertEquals(target.tags.includes("reception"), true);
+          completionFound = true;
+          break;
+        }
+      }
+    }
+    assertEquals(completionFound, true);
+  });
+
+  await t.step("produces big_play completions", () => {
+    let bigPlayFound = false;
+    for (let seed = 0; seed < 200; seed++) {
+      const rng = makeRng(seed);
+      const contribs: MatchupContribution[] = [
+        {
+          matchup: {
+            type: "route_coverage",
+            attacker: makePlayer("wr1", "WR"),
+            defender: makePlayer("cb1", "CB"),
+          },
+          attackerFit: "neutral",
+          defenderFit: "neutral",
+          score: 15,
+        },
+      ];
+      const result = synthesizePassOutcome(contribs, makeSituation(), rng);
+      if (result.tags.includes("big_play")) {
+        bigPlayFound = true;
+        break;
+      }
+    }
+    assertEquals(bigPlayFound, true);
+  });
+
+  await t.step("produces pass_incomplete outcome", () => {
+    let incompleteFound = false;
+    for (let seed = 0; seed < 100; seed++) {
+      const rng = makeRng(seed);
+      const contribs: MatchupContribution[] = [
+        {
+          matchup: {
+            type: "route_coverage",
+            attacker: makePlayer("wr1", "WR"),
+            defender: makePlayer("cb1", "CB"),
+          },
+          attackerFit: "neutral",
+          defenderFit: "neutral",
+          score: 0,
+        },
+      ];
+      const result = synthesizePassOutcome(contribs, makeSituation(), rng);
+      if (result.outcome === "pass_incomplete") {
+        assertEquals(result.yardage, 0);
+        incompleteFound = true;
+        break;
+      }
+    }
+    assertEquals(incompleteFound, true);
+  });
+
+  await t.step("tags first_down on pass completion meeting distance", () => {
+    let firstDownFound = false;
+    for (let seed = 0; seed < 100; seed++) {
+      const rng = makeRng(seed);
+      const contribs: MatchupContribution[] = [
+        {
+          matchup: {
+            type: "route_coverage",
+            attacker: makePlayer("wr1", "WR"),
+            defender: makePlayer("cb1", "CB"),
+          },
+          attackerFit: "neutral",
+          defenderFit: "neutral",
+          score: 15,
+        },
+      ];
+      const result = synthesizePassOutcome(
+        contribs,
+        makeSituation({ down: 1, distance: 5 }),
+        rng,
+      );
+      if (
+        result.outcome === "pass_complete" &&
+        result.yardage >= 5 &&
+        result.tags.includes("first_down")
+      ) {
+        firstDownFound = true;
+        break;
+      }
+    }
+    assertEquals(firstDownFound, true);
+  });
+
+  await t.step(
+    "tags pressure without sack on negative protection score",
+    () => {
+      const rng = makeRng(42);
+      const contribs: MatchupContribution[] = [
+        {
+          matchup: {
+            type: "pass_protection",
+            attacker: makePlayer("ot1", "OT"),
+            defender: makePlayer("edge1", "EDGE"),
+          },
+          attackerFit: "neutral",
+          defenderFit: "neutral",
+          score: -10,
+        },
+        {
+          matchup: {
+            type: "route_coverage",
+            attacker: makePlayer("wr1", "WR"),
+            defender: makePlayer("cb1", "CB"),
+          },
+          attackerFit: "neutral",
+          defenderFit: "neutral",
+          score: 0,
+        },
+      ];
+      const result = synthesizePassOutcome(contribs, makeSituation(), rng);
+      assertEquals(result.tags.includes("pressure"), true);
+    },
+  );
+
+  await t.step("handles empty contributions gracefully", () => {
+    const rng = makeRng(42);
+    const result = synthesizePassOutcome([], makeSituation(), rng);
+    assertEquals(typeof result.outcome, "string");
+    assertEquals(typeof result.yardage, "number");
+  });
+});

--- a/server/features/simulation/synthesize-pass-outcome.ts
+++ b/server/features/simulation/synthesize-pass-outcome.ts
@@ -1,0 +1,163 @@
+import type { PlayOutcome, PlayTag } from "./events.ts";
+import type { MatchupContribution, Situation } from "./resolve-play.ts";
+import { PASS_RESOLUTION, SACK_YARDAGE } from "./resolve-play.ts";
+import type { SeededRng } from "./rng.ts";
+import type { OutcomeResult } from "./synthesize-run-outcome.ts";
+
+export function synthesizePassOutcome(
+  contributions: MatchupContribution[],
+  situation: Situation,
+  rng: SeededRng,
+): OutcomeResult {
+  const avgScore = contributions.length > 0
+    ? contributions.reduce((sum, c) => sum + c.score, 0) / contributions.length
+    : 0;
+
+  const participants = contributions.map((c) => ({
+    role: c.matchup.type,
+    playerId: c.matchup.attacker.playerId,
+    tags: [] as string[],
+  }));
+
+  const tags: PlayTag[] = [];
+  let outcome: PlayOutcome;
+  let yardage: number;
+
+  const protectionContribs = contributions.filter(
+    (c) =>
+      c.matchup.type === "pass_protection" ||
+      c.matchup.type === "pass_rush",
+  );
+  const protectionScore = protectionContribs.length > 0
+    ? protectionContribs.reduce((s, c) => s + c.score, 0) /
+      protectionContribs.length
+    : avgScore;
+
+  const sackProb = Math.max(
+    PASS_RESOLUTION.sack.floor,
+    PASS_RESOLUTION.sack.base -
+      protectionScore * PASS_RESOLUTION.sack.protectionModifier,
+  );
+  if (rng.next() < sackProb) {
+    outcome = "sack";
+    yardage = rng.int(SACK_YARDAGE.min, SACK_YARDAGE.max);
+    tags.push("sack", "pressure");
+
+    const rusher = contributions.find((c) =>
+      c.matchup.type === "pass_rush" ||
+      (c.matchup.type === "pass_protection" &&
+        c.score < 0)
+    );
+    if (rusher) {
+      const idx = participants.findIndex(
+        (p) => p.playerId === rusher.matchup.defender.playerId,
+      );
+      if (idx >= 0) {
+        participants[idx].tags.push("sack");
+      } else {
+        participants.push({
+          role: "pass_rush",
+          playerId: rusher.matchup.defender.playerId,
+          tags: ["sack"],
+        });
+      }
+    }
+
+    if (rng.next() < PASS_RESOLUTION.fumbleOnSack) {
+      outcome = "fumble";
+      tags.push("fumble", "turnover");
+    }
+  } else {
+    if (protectionScore < -5) {
+      tags.push("pressure");
+    }
+
+    const routeContribs = contributions.filter(
+      (c) => c.matchup.type === "route_coverage",
+    );
+    const coverageScore = routeContribs.length > 0
+      ? routeContribs.reduce((s, c) => s + c.score, 0) /
+        routeContribs.length
+      : avgScore;
+
+    const intProb = Math.max(
+      PASS_RESOLUTION.interception.floor,
+      PASS_RESOLUTION.interception.base -
+        coverageScore * PASS_RESOLUTION.interception.coverageModifier,
+    );
+    const completionProb = Math.max(
+      PASS_RESOLUTION.completion.floor,
+      Math.min(
+        PASS_RESOLUTION.completion.ceiling,
+        PASS_RESOLUTION.completion.base +
+          coverageScore * PASS_RESOLUTION.completion.coverageModifier,
+      ),
+    );
+    const bigPlayProb = Math.max(
+      PASS_RESOLUTION.bigPlay.floor,
+      Math.min(
+        PASS_RESOLUTION.bigPlay.ceiling,
+        PASS_RESOLUTION.bigPlay.base +
+          coverageScore * PASS_RESOLUTION.bigPlay.coverageModifier,
+      ),
+    );
+
+    const roll = rng.next();
+    if (roll < intProb) {
+      outcome = "interception";
+      yardage = 0;
+      tags.push("interception", "turnover");
+
+      const interceptor = routeContribs.find((c) => c.score < -5) ??
+        routeContribs[0];
+      if (interceptor) {
+        const idx = participants.findIndex(
+          (p) => p.playerId === interceptor.matchup.defender.playerId,
+        );
+        if (idx >= 0) {
+          participants[idx].tags.push("interception");
+        } else {
+          participants.push({
+            role: "route_coverage",
+            playerId: interceptor.matchup.defender.playerId,
+            tags: ["interception"],
+          });
+        }
+      }
+    } else if (roll < intProb + completionProb) {
+      outcome = "pass_complete";
+      const isBigPlay = rng.next() < bigPlayProb;
+      if (isBigPlay) {
+        yardage = rng.int(
+          PASS_RESOLUTION.bigPlay.yards.min,
+          PASS_RESOLUTION.bigPlay.yards.max,
+        );
+        tags.push("big_play");
+      } else {
+        yardage = rng.int(
+          PASS_RESOLUTION.completionYards.min,
+          PASS_RESOLUTION.completionYards.max,
+        );
+      }
+      const target = routeContribs.find((c) => c.score > 0) ??
+        routeContribs[0];
+      if (target) {
+        const idx = participants.findIndex(
+          (p) => p.playerId === target.matchup.attacker.playerId,
+        );
+        if (idx >= 0) participants[idx].tags.push("target", "reception");
+      }
+    } else {
+      outcome = "pass_incomplete";
+      yardage = 0;
+    }
+
+    if (
+      outcome === "pass_complete" && yardage >= situation.distance
+    ) {
+      tags.push("first_down");
+    }
+  }
+
+  return { outcome: outcome!, yardage: yardage!, tags, participants };
+}

--- a/server/features/simulation/synthesize-run-outcome.test.ts
+++ b/server/features/simulation/synthesize-run-outcome.test.ts
@@ -1,0 +1,244 @@
+import { assertEquals } from "@std/assert";
+import {
+  PLAYER_ATTRIBUTE_KEYS,
+  type PlayerAttributes,
+} from "@zone-blitz/shared";
+import { createRng, mulberry32 } from "./rng.ts";
+import type { SeededRng } from "./rng.ts";
+import type {
+  MatchupContribution,
+  PlayerRuntime,
+  Situation,
+} from "./resolve-play.ts";
+import { synthesizeRunOutcome } from "./synthesize-run-outcome.ts";
+
+function makeAttributes(
+  overrides: Partial<PlayerAttributes> = {},
+): PlayerAttributes {
+  const base: Partial<PlayerAttributes> = {};
+  for (const key of PLAYER_ATTRIBUTE_KEYS) {
+    (base as Record<string, number>)[key] = 50;
+    (base as Record<string, number>)[`${key}Potential`] = 50;
+  }
+  return { ...base, ...overrides } as PlayerAttributes;
+}
+
+function makePlayer(
+  id: string,
+  bucket: PlayerRuntime["neutralBucket"],
+  overrides: Partial<PlayerAttributes> = {},
+): PlayerRuntime {
+  return {
+    playerId: id,
+    neutralBucket: bucket,
+    attributes: makeAttributes(overrides),
+  };
+}
+
+function makeSituation(overrides: Partial<Situation> = {}): Situation {
+  return { down: 1, distance: 10, yardLine: 30, ...overrides };
+}
+
+function makeRng(seed = 42): SeededRng {
+  return createRng(mulberry32(seed));
+}
+
+Deno.test("synthesizeRunOutcome", async (t) => {
+  await t.step(
+    "returns rush outcome with yardage for dominant blocking",
+    () => {
+      let positiveCount = 0;
+      const trials = 30;
+      for (let i = 0; i < trials; i++) {
+        const rng = makeRng(i);
+        const contribs: MatchupContribution[] = [
+          {
+            matchup: {
+              type: "run_block",
+              attacker: makePlayer("ot1", "OT"),
+              defender: makePlayer("idl1", "IDL"),
+            },
+            attackerFit: "neutral",
+            defenderFit: "neutral",
+            score: 20,
+          },
+        ];
+        const result = synthesizeRunOutcome(contribs, makeSituation(), rng);
+        if (result.yardage > 0) positiveCount++;
+      }
+      assertEquals(positiveCount / trials > 0.9, true);
+    },
+  );
+
+  await t.step("returns negative yardage for terrible blocking", () => {
+    const rng = makeRng(42);
+    const contribs: MatchupContribution[] = [
+      {
+        matchup: {
+          type: "run_block",
+          attacker: makePlayer("ot1", "OT"),
+          defender: makePlayer("idl1", "IDL"),
+        },
+        attackerFit: "neutral",
+        defenderFit: "neutral",
+        score: -25,
+      },
+    ];
+    const result = synthesizeRunOutcome(contribs, makeSituation(), rng);
+    assertEquals(result.yardage <= 0, true);
+  });
+
+  await t.step(
+    "returns moderate yardage for slightly negative blocking",
+    () => {
+      const rng = makeRng(42);
+      const contribs: MatchupContribution[] = [
+        {
+          matchup: {
+            type: "run_block",
+            attacker: makePlayer("ot1", "OT"),
+            defender: makePlayer("idl1", "IDL"),
+          },
+          attackerFit: "neutral",
+          defenderFit: "neutral",
+          score: -10,
+        },
+      ];
+      const result = synthesizeRunOutcome(contribs, makeSituation(), rng);
+      assertEquals(result.yardage >= 1 && result.yardage <= 5, true);
+    },
+  );
+
+  await t.step("tags big_play for great blocking", () => {
+    let bigPlayFound = false;
+    for (let seed = 0; seed < 100; seed++) {
+      const rng = makeRng(seed);
+      const contribs: MatchupContribution[] = [
+        {
+          matchup: {
+            type: "run_block",
+            attacker: makePlayer("ot1", "OT"),
+            defender: makePlayer("idl1", "IDL"),
+          },
+          attackerFit: "neutral",
+          defenderFit: "neutral",
+          score: 20,
+        },
+      ];
+      const result = synthesizeRunOutcome(contribs, makeSituation(), rng);
+      if (result.tags.includes("big_play")) {
+        bigPlayFound = true;
+        break;
+      }
+    }
+    assertEquals(bigPlayFound, true);
+  });
+
+  await t.step("can produce fumble outcome", () => {
+    let fumbleFound = false;
+    for (let seed = 0; seed < 5000; seed++) {
+      const rng = makeRng(seed);
+      const contribs: MatchupContribution[] = [
+        {
+          matchup: {
+            type: "run_block",
+            attacker: makePlayer("rb1", "RB"),
+            defender: makePlayer("lb1", "LB"),
+          },
+          attackerFit: "neutral",
+          defenderFit: "neutral",
+          score: 5,
+        },
+      ];
+      const result = synthesizeRunOutcome(contribs, makeSituation(), rng);
+      if (result.outcome === "fumble") {
+        assertEquals(result.tags.includes("fumble"), true);
+        assertEquals(result.tags.includes("turnover"), true);
+        fumbleFound = true;
+        break;
+      }
+    }
+    assertEquals(fumbleFound, true);
+  });
+
+  await t.step("tags first_down when yardage meets distance", () => {
+    const rng = makeRng(5);
+    const contribs: MatchupContribution[] = [
+      {
+        matchup: {
+          type: "run_block",
+          attacker: makePlayer("ot1", "OT"),
+          defender: makePlayer("idl1", "IDL"),
+        },
+        attackerFit: "neutral",
+        defenderFit: "neutral",
+        score: 10,
+      },
+    ];
+    const result = synthesizeRunOutcome(
+      contribs,
+      makeSituation({ down: 1, distance: 3 }),
+      rng,
+    );
+    if (result.yardage >= 3) {
+      assertEquals(result.tags.includes("first_down"), true);
+    }
+  });
+
+  await t.step("tags RB as ball_carrier", () => {
+    const rng = makeRng(42);
+    const contribs: MatchupContribution[] = [
+      {
+        matchup: {
+          type: "run_block",
+          attacker: makePlayer("rb1", "RB"),
+          defender: makePlayer("lb1", "LB"),
+        },
+        attackerFit: "neutral",
+        defenderFit: "neutral",
+        score: 5,
+      },
+    ];
+    const result = synthesizeRunOutcome(contribs, makeSituation(), rng);
+    const rb = result.participants.find((p) => p.playerId === "rb1");
+    assertEquals(rb?.tags.includes("ball_carrier"), true);
+  });
+
+  await t.step("handles empty contributions gracefully", () => {
+    const rng = makeRng(42);
+    const result = synthesizeRunOutcome([], makeSituation(), rng);
+    assertEquals(typeof result.outcome, "string");
+    assertEquals(typeof result.yardage, "number");
+  });
+
+  await t.step(
+    "uses run_block and run_defense contributions for blocking score",
+    () => {
+      const rng = makeRng(42);
+      const contribs: MatchupContribution[] = [
+        {
+          matchup: {
+            type: "run_block",
+            attacker: makePlayer("ot1", "OT"),
+            defender: makePlayer("idl1", "IDL"),
+          },
+          attackerFit: "neutral",
+          defenderFit: "neutral",
+          score: 20,
+        },
+        {
+          matchup: {
+            type: "run_defense",
+            attacker: makePlayer("lb1", "LB"),
+            defender: makePlayer("rb1", "RB"),
+          },
+          attackerFit: "neutral",
+          defenderFit: "neutral",
+          score: 20,
+        },
+      ];
+      const result = synthesizeRunOutcome(contribs, makeSituation(), rng);
+      assertEquals(typeof result.yardage, "number");
+    },
+  );
+});

--- a/server/features/simulation/synthesize-run-outcome.ts
+++ b/server/features/simulation/synthesize-run-outcome.ts
@@ -1,0 +1,85 @@
+import type { PlayOutcome, PlayTag } from "./events.ts";
+import type { MatchupContribution, Situation } from "./resolve-play.ts";
+import { RUN_RESOLUTION } from "./resolve-play.ts";
+import type { SeededRng } from "./rng.ts";
+
+export interface OutcomeResult {
+  outcome: PlayOutcome;
+  yardage: number;
+  tags: PlayTag[];
+  participants: { role: string; playerId: string; tags: string[] }[];
+}
+
+export function synthesizeRunOutcome(
+  contributions: MatchupContribution[],
+  situation: Situation,
+  rng: SeededRng,
+): OutcomeResult {
+  const avgScore = contributions.length > 0
+    ? contributions.reduce((sum, c) => sum + c.score, 0) / contributions.length
+    : 0;
+
+  const participants = contributions.map((c) => ({
+    role: c.matchup.type,
+    playerId: c.matchup.attacker.playerId,
+    tags: [] as string[],
+  }));
+
+  const tags: PlayTag[] = [];
+
+  const blockingContribs = contributions.filter(
+    (c) => c.matchup.type === "run_block" || c.matchup.type === "run_defense",
+  );
+  const blockScore = blockingContribs.length > 0
+    ? blockingContribs.reduce((s, c) => s + c.score, 0) /
+      blockingContribs.length
+    : avgScore;
+
+  let yardage: number;
+  if (blockScore < RUN_RESOLUTION.stuffThreshold) {
+    yardage = rng.int(
+      RUN_RESOLUTION.stuffYards.min,
+      RUN_RESOLUTION.stuffYards.max,
+    );
+  } else if (blockScore < RUN_RESOLUTION.shortGainThreshold) {
+    yardage = rng.int(
+      RUN_RESOLUTION.shortGainYards.min,
+      RUN_RESOLUTION.shortGainYards.max,
+    );
+  } else if (blockScore > RUN_RESOLUTION.bigPlayThreshold) {
+    yardage = rng.int(
+      RUN_RESOLUTION.bigPlayYards.min,
+      RUN_RESOLUTION.bigPlayYards.max,
+    );
+    tags.push("big_play");
+  } else {
+    yardage = rng.int(
+      RUN_RESOLUTION.normalYards.min,
+      RUN_RESOLUTION.normalYards.max,
+    );
+  }
+
+  let outcome: PlayOutcome;
+  if (rng.next() < RUN_RESOLUTION.fumbleRate) {
+    outcome = "fumble";
+    tags.push("fumble", "turnover");
+  } else {
+    outcome = "rush";
+  }
+
+  if (yardage >= situation.distance) {
+    tags.push("first_down");
+  }
+
+  const rb = contributions.find(
+    (c) => c.matchup.attacker.neutralBucket === "RB",
+  );
+  if (rb) {
+    const idx = participants.findIndex(
+      (p) => p.playerId === rb.matchup.attacker.playerId,
+    );
+    if (idx >= 0) participants[idx].tags.push("ball_carrier");
+  }
+
+  return { outcome, yardage, tags, participants };
+}


### PR DESCRIPTION
## Summary

- Extracts `synthesizeRunOutcome` and `synthesizePassOutcome` from the ~280-line `synthesizeOutcome` function into dedicated files (`synthesize-run-outcome.ts`, `synthesize-pass-outcome.ts`)
- Keeps shared post-processing (injury roll, safety check, end-zone clamp, return-TD on turnovers, penalty insertion) in the `synthesizeOutcome` wrapper in `resolve-play.ts`
- Adds focused test files for each handler; all 139 simulation tests pass with determinism preserved

Closes #372

🤖 Generated with [Claude Code](https://claude.com/claude-code)