### PR TITLE
refactor(sim): collapse roster/player lookup helpers into parameterized finder

### DIFF
--- a/server/features/simulation/find-eligible-player.test.ts
+++ b/server/features/simulation/find-eligible-player.test.ts
@@ -1,0 +1,181 @@
+import { assertEquals } from "@std/assert";
+import { PLAYER_ATTRIBUTE_KEYS } from "@zone-blitz/shared";
+import type { PlayerAttributes } from "@zone-blitz/shared";
+import type { PlayerRuntime } from "./resolve-play.ts";
+import {
+  COVERAGE_UNIT_POSITIONS,
+  findEligiblePlayer,
+  findEligiblePlayers,
+  KICKER_POSITIONS,
+  RETURNER_POSITIONS,
+} from "./find-eligible-player.ts";
+
+function makeAttributes(): PlayerAttributes {
+  const base: Partial<PlayerAttributes> = {};
+  for (const key of PLAYER_ATTRIBUTE_KEYS) {
+    (base as Record<string, number>)[key] = 50;
+    (base as Record<string, number>)[`${key}Potential`] = 50;
+  }
+  return base as PlayerAttributes;
+}
+
+function makePlayer(
+  id: string,
+  bucket: PlayerRuntime["neutralBucket"],
+): PlayerRuntime {
+  return {
+    playerId: id,
+    neutralBucket: bucket,
+    attributes: makeAttributes(),
+  };
+}
+
+Deno.test("findEligiblePlayer returns first player matching a single position", () => {
+  const roster = [
+    makePlayer("qb1", "QB"),
+    makePlayer("k1", "K"),
+    makePlayer("wr1", "WR"),
+  ];
+  const result = findEligiblePlayer(roster, {
+    positions: ["K"],
+    injuredIds: new Set(),
+  });
+  assertEquals(result?.playerId, "k1");
+});
+
+Deno.test("findEligiblePlayer skips injured players", () => {
+  const roster = [
+    makePlayer("k1", "K"),
+    makePlayer("k2", "K"),
+  ];
+  const result = findEligiblePlayer(roster, {
+    positions: ["K"],
+    injuredIds: new Set(["k1"]),
+  });
+  assertEquals(result?.playerId, "k2");
+});
+
+Deno.test("findEligiblePlayer returns undefined when no match and no fallback", () => {
+  const roster = [makePlayer("qb1", "QB")];
+  const result = findEligiblePlayer(roster, {
+    positions: ["K"],
+    injuredIds: new Set(),
+  });
+  assertEquals(result, undefined);
+});
+
+Deno.test("findEligiblePlayer returns fallback when no eligible match", () => {
+  const fallback = makePlayer("k-fallback", "K");
+  const roster = [makePlayer("qb1", "QB")];
+  const result = findEligiblePlayer(roster, {
+    positions: ["K"],
+    injuredIds: new Set(),
+    fallback,
+  });
+  assertEquals(result?.playerId, "k-fallback");
+});
+
+Deno.test("findEligiblePlayer prioritizes positions in order", () => {
+  const roster = [
+    makePlayer("rb1", "RB"),
+    makePlayer("wr1", "WR"),
+  ];
+  const result = findEligiblePlayer(roster, {
+    positions: ["WR", "RB"],
+    injuredIds: new Set(),
+  });
+  assertEquals(result?.playerId, "wr1");
+});
+
+Deno.test("findEligiblePlayer falls through to second position when first has no match", () => {
+  const roster = [
+    makePlayer("rb1", "RB"),
+    makePlayer("qb1", "QB"),
+  ];
+  const result = findEligiblePlayer(roster, {
+    positions: ["WR", "RB"],
+    injuredIds: new Set(),
+  });
+  assertEquals(result?.playerId, "rb1");
+});
+
+Deno.test("findEligiblePlayer returns fallback when all matching players are injured", () => {
+  const fallback = makePlayer("k-fallback", "K");
+  const roster = [makePlayer("k1", "K")];
+  const result = findEligiblePlayer(roster, {
+    positions: ["K"],
+    injuredIds: new Set(["k1"]),
+    fallback,
+  });
+  assertEquals(result?.playerId, "k-fallback");
+});
+
+Deno.test("findEligiblePlayers returns all matching players", () => {
+  const roster = [
+    makePlayer("lb1", "LB"),
+    makePlayer("s1", "S"),
+    makePlayer("cb1", "CB"),
+    makePlayer("qb1", "QB"),
+    makePlayer("lb2", "LB"),
+    makePlayer("cb2", "CB"),
+  ];
+  const result = findEligiblePlayers(roster, {
+    positions: ["LB", "S", "CB"],
+    injuredIds: new Set(),
+  });
+  assertEquals(result.length, 5);
+});
+
+Deno.test("findEligiblePlayers respects limit", () => {
+  const roster = [
+    makePlayer("lb1", "LB"),
+    makePlayer("s1", "S"),
+    makePlayer("cb1", "CB"),
+    makePlayer("lb2", "LB"),
+    makePlayer("cb2", "CB"),
+  ];
+  const result = findEligiblePlayers(roster, {
+    positions: ["LB", "S", "CB"],
+    injuredIds: new Set(),
+    limit: 4,
+  });
+  assertEquals(result.length, 4);
+});
+
+Deno.test("findEligiblePlayers skips injured players", () => {
+  const roster = [
+    makePlayer("lb1", "LB"),
+    makePlayer("s1", "S"),
+    makePlayer("cb1", "CB"),
+  ];
+  const result = findEligiblePlayers(roster, {
+    positions: ["LB", "S", "CB"],
+    injuredIds: new Set(["s1"]),
+  });
+  assertEquals(result.length, 2);
+  assertEquals(
+    result.map((p: PlayerRuntime) => p.playerId),
+    ["lb1", "cb1"],
+  );
+});
+
+Deno.test("findEligiblePlayers returns empty array when no matches", () => {
+  const roster = [makePlayer("qb1", "QB")];
+  const result = findEligiblePlayers(roster, {
+    positions: ["LB", "S", "CB"],
+    injuredIds: new Set(),
+  });
+  assertEquals(result.length, 0);
+});
+
+Deno.test("KICKER_POSITIONS contains K", () => {
+  assertEquals(KICKER_POSITIONS, ["K"]);
+});
+
+Deno.test("RETURNER_POSITIONS contains WR and RB in priority order", () => {
+  assertEquals(RETURNER_POSITIONS, ["WR", "RB"]);
+});
+
+Deno.test("COVERAGE_UNIT_POSITIONS contains LB, S, and CB", () => {
+  assertEquals(COVERAGE_UNIT_POSITIONS, ["LB", "S", "CB"]);
+});

--- a/server/features/simulation/find-eligible-player.ts
+++ b/server/features/simulation/find-eligible-player.ts
@@ -1,0 +1,47 @@
+import type { NeutralBucket } from "@zone-blitz/shared";
+import type { PlayerRuntime } from "./resolve-play.ts";
+
+export const KICKER_POSITIONS: NeutralBucket[] = ["K"];
+export const RETURNER_POSITIONS: NeutralBucket[] = ["WR", "RB"];
+export const COVERAGE_UNIT_POSITIONS: NeutralBucket[] = ["LB", "S", "CB"];
+
+interface FindOptions {
+  positions: NeutralBucket[];
+  injuredIds: Set<string>;
+  fallback?: PlayerRuntime;
+}
+
+interface FindManyOptions {
+  positions: NeutralBucket[];
+  injuredIds: Set<string>;
+  limit?: number;
+}
+
+export function findEligiblePlayer(
+  roster: PlayerRuntime[],
+  options: FindOptions,
+): PlayerRuntime | undefined {
+  const available = roster.filter(
+    (p) => !options.injuredIds.has(p.playerId),
+  );
+  for (const pos of options.positions) {
+    const player = available.find((p) => p.neutralBucket === pos);
+    if (player) return player;
+  }
+  return options.fallback;
+}
+
+export function findEligiblePlayers(
+  roster: PlayerRuntime[],
+  options: FindManyOptions,
+): PlayerRuntime[] {
+  const available = roster.filter(
+    (p) => !options.injuredIds.has(p.playerId),
+  );
+  const matches = available.filter((p) =>
+    options.positions.includes(p.neutralBucket)
+  );
+  return options.limit !== undefined
+    ? matches.slice(0, options.limit)
+    : matches;
+}

--- a/server/features/simulation/simulate-game.ts
+++ b/server/features/simulation/simulate-game.ts
@@ -30,6 +30,13 @@ import { resolvePunt } from "./resolve-punt.ts";
 import { resolveFieldGoal } from "./resolve-field-goal.ts";
 import { resolveFourthDown } from "./resolve-fourth-down.ts";
 import { buildPlayEvent } from "./play-event.ts";
+import {
+  COVERAGE_UNIT_POSITIONS,
+  findEligiblePlayer,
+  findEligiblePlayers,
+  KICKER_POSITIONS,
+  RETURNER_POSITIONS,
+} from "./find-eligible-player.ts";
 
 export interface SimTeam {
   teamId: string;
@@ -202,10 +209,10 @@ export function simulateGame(input: SimulationInput): GameResult {
     bucket: PlayerRuntime["neutralBucket"],
   ): PlayerRuntime | undefined {
     const active = side === "home" ? rosters.homeActive : rosters.awayActive;
-    return active.find(
-      (p) =>
-        p.neutralBucket === bucket && !rosters.injuredPlayerIds.has(p.playerId),
-    );
+    return findEligiblePlayer(active, {
+      positions: [bucket],
+      injuredIds: rosters.injuredPlayerIds,
+    });
   }
 
   function currentOffenseTeamId(): string {
@@ -234,38 +241,30 @@ export function simulateGame(input: SimulationInput): GameResult {
   function findKicker(side: "home" | "away"): PlayerRuntime {
     const team = side === "home" ? input.home : input.away;
     const active = side === "home" ? rosters.homeActive : rosters.awayActive;
-    const available = active.filter(
-      (p) => !rosters.injuredPlayerIds.has(p.playerId),
-    );
-    return (
-      available.find((p) => p.neutralBucket === "K") ??
-        team.starters.find((p) => p.neutralBucket === "K") ??
-        team.starters[0]
-    );
+    const fallback = team.starters.find((p) => p.neutralBucket === "K") ??
+      team.starters[0];
+    return findEligiblePlayer(active, {
+      positions: KICKER_POSITIONS,
+      injuredIds: rosters.injuredPlayerIds,
+      fallback,
+    })!;
   }
 
   function findReturner(side: "home" | "away"): PlayerRuntime | undefined {
     const active = side === "home" ? rosters.homeActive : rosters.awayActive;
-    const available = active.filter(
-      (p) => !rosters.injuredPlayerIds.has(p.playerId),
-    );
-    return (
-      available.find((p) => p.neutralBucket === "WR") ??
-        available.find((p) => p.neutralBucket === "RB")
-    );
+    return findEligiblePlayer(active, {
+      positions: RETURNER_POSITIONS,
+      injuredIds: rosters.injuredPlayerIds,
+    });
   }
 
   function findCoverageUnit(side: "home" | "away"): PlayerRuntime[] {
     const active = side === "home" ? rosters.homeActive : rosters.awayActive;
-    return active
-      .filter((p) => !rosters.injuredPlayerIds.has(p.playerId))
-      .filter(
-        (p) =>
-          p.neutralBucket === "LB" ||
-          p.neutralBucket === "S" ||
-          p.neutralBucket === "CB",
-      )
-      .slice(0, 4);
+    return findEligiblePlayers(active, {
+      positions: COVERAGE_UNIT_POSITIONS,
+      injuredIds: rosters.injuredPlayerIds,
+      limit: 4,
+    });
   }
 
   function performKickoff(


### PR DESCRIPTION
## Summary

- Extracts `findEligiblePlayer` and `findEligiblePlayers` from four ad-hoc finder functions (`findPlayerByBucket`, `findKicker`, `findReturner`, `findCoverageUnit`) in `simulate-game.ts` into a new `find-eligible-player.ts` module
- Consolidates the shared `filter by position(s) + skip injured + fallback` pattern into a single parameterized helper, preventing subtle inconsistencies in injury/position handling across finders
- Moves position-set constants (`KICKER_POSITIONS`, `RETURNER_POSITIONS`, `COVERAGE_UNIT_POSITIONS`) to a single declaration block

Closes #376