### PR TITLE
refactor(sim): extract shared test fixture factories

### DIFF
--- a/server/features/simulation/resolve-matchups.test.ts
+++ b/server/features/simulation/resolve-matchups.test.ts
@@ -1,45 +1,13 @@
 import { assertEquals } from "@std/assert";
-import {
-  PLAYER_ATTRIBUTE_KEYS,
-  type PlayerAttributes,
-} from "@zone-blitz/shared";
-import { createRng, mulberry32 } from "./rng.ts";
-import type { SeededRng } from "./rng.ts";
 import type { DefensiveCall, OffensiveCall } from "./events.ts";
-import type { PlayerRuntime } from "./resolve-play.ts";
 import {
   assignDefense,
   assignOffense,
   rankPlayers,
   resolveMatchups,
 } from "./resolve-matchups.ts";
-
-function makeAttributes(
-  overrides: Partial<PlayerAttributes> = {},
-): PlayerAttributes {
-  const base: Partial<PlayerAttributes> = {};
-  for (const key of PLAYER_ATTRIBUTE_KEYS) {
-    (base as Record<string, number>)[key] = 50;
-    (base as Record<string, number>)[`${key}Potential`] = 50;
-  }
-  return { ...base, ...overrides } as PlayerAttributes;
-}
-
-function makePlayer(
-  id: string,
-  bucket: PlayerRuntime["neutralBucket"],
-  overrides: Partial<PlayerAttributes> = {},
-): PlayerRuntime {
-  return {
-    playerId: id,
-    neutralBucket: bucket,
-    attributes: makeAttributes(overrides),
-  };
-}
-
-function makeRng(seed = 42): SeededRng {
-  return createRng(mulberry32(seed));
-}
+import type { PlayerRuntime } from "./resolve-play.ts";
+import { makePlayer, makeRng } from "./test-helpers.ts";
 
 function makeOffense(): PlayerRuntime[] {
   return [

--- a/server/features/simulation/resolve-play.test.ts
+++ b/server/features/simulation/resolve-play.test.ts
@@ -1,14 +1,6 @@
 import { assertEquals, assertExists, assertNotEquals } from "@std/assert";
-import {
-  PLAYER_ATTRIBUTE_KEYS,
-  type PlayerAttributes,
-  type SchemeFingerprint,
-} from "@zone-blitz/shared";
-import { createRng, mulberry32 } from "./rng.ts";
-import type { SeededRng } from "./rng.ts";
 import type { DefensiveCall, OffensiveCall } from "./events.ts";
 import {
-  type CoachingMods,
   drawDefensiveCall,
   drawOffensiveCall,
   type GameState,
@@ -22,78 +14,14 @@ import {
   type TeamRuntime,
 } from "./resolve-play.ts";
 import { resolveMatchups } from "./resolve-matchups.ts";
-
-function makeAttributes(
-  overrides: Partial<PlayerAttributes> = {},
-): PlayerAttributes {
-  const base: Partial<PlayerAttributes> = {};
-  for (const key of PLAYER_ATTRIBUTE_KEYS) {
-    (base as Record<string, number>)[key] = 50;
-    (base as Record<string, number>)[`${key}Potential`] = 50;
-  }
-  return { ...base, ...overrides } as PlayerAttributes;
-}
-
-function makeFingerprint(
-  overrides: Partial<SchemeFingerprint> = {},
-): SchemeFingerprint {
-  return {
-    offense: {
-      runPassLean: 50,
-      tempo: 50,
-      personnelWeight: 50,
-      formationUnderCenterShotgun: 50,
-      preSnapMotionRate: 50,
-      passingStyle: 50,
-      passingDepth: 50,
-      runGameBlocking: 50,
-      rpoIntegration: 50,
-    },
-    defense: {
-      frontOddEven: 50,
-      gapResponsibility: 50,
-      subPackageLean: 50,
-      coverageManZone: 50,
-      coverageShell: 50,
-      cornerPressOff: 50,
-      pressureRate: 50,
-      disguiseRate: 50,
-    },
-    overrides: {},
-    ...overrides,
-  };
-}
-
-function makeSituation(overrides: Partial<Situation> = {}): Situation {
-  return { down: 1, distance: 10, yardLine: 30, ...overrides };
-}
-
-function makeRng(seed = 42): SeededRng {
-  return createRng(mulberry32(seed));
-}
-
-function makePlayer(
-  id: string,
-  bucket: PlayerRuntime["neutralBucket"],
-  overrides: Partial<PlayerAttributes> = {},
-): PlayerRuntime {
-  return {
-    playerId: id,
-    neutralBucket: bucket,
-    attributes: makeAttributes(overrides),
-  };
-}
-
-function makeCoachingMods(
-  overrides: Partial<CoachingMods> = {},
-): CoachingMods {
-  return {
-    schemeFitBonus: 0,
-    situationalBonus: 0,
-    aggressiveness: 50,
-    ...overrides,
-  };
-}
+import { createRng, mulberry32 } from "./rng.ts";
+import {
+  makeCoachingMods,
+  makeFingerprint,
+  makePlayer,
+  makeRng,
+  makeSituation,
+} from "./test-helpers.ts";
 
 function makeOffense(): PlayerRuntime[] {
   return [

--- a/server/features/simulation/simulate-game.test.ts
+++ b/server/features/simulation/simulate-game.test.ts
@@ -5,103 +5,20 @@ import {
   assertGreater,
   assertGreaterOrEqual,
 } from "@std/assert";
-import {
-  PLAYER_ATTRIBUTE_KEYS,
-  type PlayerAttributes,
-  type SchemeFingerprint,
-} from "@zone-blitz/shared";
-import type { PlayerRuntime } from "./resolve-play.ts";
-import type { CoachingMods } from "./resolve-play.ts";
+import { PLAYER_ATTRIBUTE_KEYS } from "@zone-blitz/shared";
 import type { InjurySeverity, PlayEvent } from "./events.ts";
+import type { PlayerRuntime } from "./resolve-play.ts";
 import {
   type SimTeam,
   simulateGame,
   type SimulationInput,
 } from "./simulate-game.ts";
-
-function makeAttributes(
-  overrides: Partial<PlayerAttributes> = {},
-): PlayerAttributes {
-  const base: Partial<PlayerAttributes> = {};
-  for (const key of PLAYER_ATTRIBUTE_KEYS) {
-    (base as Record<string, number>)[key] = 50;
-    (base as Record<string, number>)[`${key}Potential`] = 50;
-  }
-  return { ...base, ...overrides } as PlayerAttributes;
-}
-
-function makeFingerprint(
-  overrides: Partial<SchemeFingerprint> = {},
-): SchemeFingerprint {
-  return {
-    offense: {
-      runPassLean: 50,
-      tempo: 50,
-      personnelWeight: 50,
-      formationUnderCenterShotgun: 50,
-      preSnapMotionRate: 50,
-      passingStyle: 50,
-      passingDepth: 50,
-      runGameBlocking: 50,
-      rpoIntegration: 50,
-    },
-    defense: {
-      frontOddEven: 50,
-      gapResponsibility: 50,
-      subPackageLean: 50,
-      coverageManZone: 50,
-      coverageShell: 50,
-      cornerPressOff: 50,
-      pressureRate: 50,
-      disguiseRate: 50,
-    },
-    overrides: {},
-    ...overrides,
-  };
-}
-
-function makePlayer(
-  id: string,
-  bucket: PlayerRuntime["neutralBucket"],
-  overrides: Partial<PlayerAttributes> = {},
-): PlayerRuntime {
-  return {
-    playerId: id,
-    neutralBucket: bucket,
-    attributes: makeAttributes(overrides),
-  };
-}
-
-function makeCoachingMods(): CoachingMods {
-  return { schemeFitBonus: 2, situationalBonus: 1, aggressiveness: 50 };
-}
-
-function makeStarters(prefix: string): PlayerRuntime[] {
-  return [
-    makePlayer(`${prefix}-qb`, "QB"),
-    makePlayer(`${prefix}-rb`, "RB"),
-    makePlayer(`${prefix}-wr1`, "WR"),
-    makePlayer(`${prefix}-wr2`, "WR"),
-    makePlayer(`${prefix}-te`, "TE"),
-    makePlayer(`${prefix}-ot1`, "OT"),
-    makePlayer(`${prefix}-ot2`, "OT"),
-    makePlayer(`${prefix}-iol1`, "IOL"),
-    makePlayer(`${prefix}-iol2`, "IOL"),
-    makePlayer(`${prefix}-iol3`, "IOL"),
-    makePlayer(`${prefix}-edge1`, "EDGE"),
-    makePlayer(`${prefix}-edge2`, "EDGE"),
-    makePlayer(`${prefix}-idl1`, "IDL"),
-    makePlayer(`${prefix}-idl2`, "IDL"),
-    makePlayer(`${prefix}-lb1`, "LB"),
-    makePlayer(`${prefix}-lb2`, "LB"),
-    makePlayer(`${prefix}-cb1`, "CB"),
-    makePlayer(`${prefix}-cb2`, "CB"),
-    makePlayer(`${prefix}-s1`, "S"),
-    makePlayer(`${prefix}-s2`, "S"),
-    makePlayer(`${prefix}-k`, "K"),
-    makePlayer(`${prefix}-p`, "P"),
-  ];
-}
+import {
+  makeCoachingMods,
+  makeFingerprint,
+  makePlayer,
+  makeStarters,
+} from "./test-helpers.ts";
 
 function makeBench(prefix: string): PlayerRuntime[] {
   return [
@@ -126,7 +43,7 @@ function makeTeam(prefix: string): SimTeam {
     starters: makeStarters(prefix),
     bench: makeBench(prefix),
     fingerprint: makeFingerprint(),
-    coachingMods: makeCoachingMods(),
+    coachingMods: makeCoachingMods({ schemeFitBonus: 2, situationalBonus: 1 }),
   };
 }
 

--- a/server/features/simulation/test-helpers.ts
+++ b/server/features/simulation/test-helpers.ts
@@ -1,0 +1,109 @@
+import {
+  PLAYER_ATTRIBUTE_KEYS,
+  type PlayerAttributes,
+  type SchemeFingerprint,
+} from "@zone-blitz/shared";
+import type { CoachingMods, PlayerRuntime, Situation } from "./resolve-play.ts";
+import { createRng, mulberry32 } from "./rng.ts";
+import type { SeededRng } from "./rng.ts";
+
+export function makeAttributes(
+  overrides: Partial<PlayerAttributes> = {},
+): PlayerAttributes {
+  const base: Partial<PlayerAttributes> = {};
+  for (const key of PLAYER_ATTRIBUTE_KEYS) {
+    (base as Record<string, number>)[key] = 50;
+    (base as Record<string, number>)[`${key}Potential`] = 50;
+  }
+  return { ...base, ...overrides } as PlayerAttributes;
+}
+
+export function makeFingerprint(
+  overrides: Partial<SchemeFingerprint> = {},
+): SchemeFingerprint {
+  return {
+    offense: {
+      runPassLean: 50,
+      tempo: 50,
+      personnelWeight: 50,
+      formationUnderCenterShotgun: 50,
+      preSnapMotionRate: 50,
+      passingStyle: 50,
+      passingDepth: 50,
+      runGameBlocking: 50,
+      rpoIntegration: 50,
+    },
+    defense: {
+      frontOddEven: 50,
+      gapResponsibility: 50,
+      subPackageLean: 50,
+      coverageManZone: 50,
+      coverageShell: 50,
+      cornerPressOff: 50,
+      pressureRate: 50,
+      disguiseRate: 50,
+    },
+    overrides: {},
+    ...overrides,
+  };
+}
+
+export function makePlayer(
+  id: string,
+  bucket: PlayerRuntime["neutralBucket"],
+  overrides: Partial<PlayerAttributes> = {},
+): PlayerRuntime {
+  return {
+    playerId: id,
+    neutralBucket: bucket,
+    attributes: makeAttributes(overrides),
+  };
+}
+
+export function makeCoachingMods(
+  overrides: Partial<CoachingMods> = {},
+): CoachingMods {
+  return {
+    schemeFitBonus: 0,
+    situationalBonus: 0,
+    aggressiveness: 50,
+    ...overrides,
+  };
+}
+
+export function makeRng(seed = 42): SeededRng {
+  return createRng(mulberry32(seed));
+}
+
+export function makeSituation(
+  overrides: Partial<Situation> = {},
+): Situation {
+  return { down: 1, distance: 10, yardLine: 30, ...overrides };
+}
+
+export function makeStarters(prefix: string): PlayerRuntime[] {
+  return [
+    makePlayer(`${prefix}-qb`, "QB"),
+    makePlayer(`${prefix}-rb`, "RB"),
+    makePlayer(`${prefix}-wr1`, "WR"),
+    makePlayer(`${prefix}-wr2`, "WR"),
+    makePlayer(`${prefix}-te`, "TE"),
+    makePlayer(`${prefix}-ot1`, "OT"),
+    makePlayer(`${prefix}-ot2`, "OT"),
+    makePlayer(`${prefix}-iol1`, "IOL"),
+    makePlayer(`${prefix}-iol2`, "IOL"),
+    makePlayer(`${prefix}-iol3`, "IOL"),
+    makePlayer(`${prefix}-edge1`, "EDGE"),
+    makePlayer(`${prefix}-edge2`, "EDGE"),
+    makePlayer(`${prefix}-idl1`, "IDL"),
+    makePlayer(`${prefix}-idl2`, "IDL"),
+    makePlayer(`${prefix}-lb1`, "LB"),
+    makePlayer(`${prefix}-lb2`, "LB"),
+    makePlayer(`${prefix}-cb1`, "CB"),
+    makePlayer(`${prefix}-cb2`, "CB"),
+    makePlayer(`${prefix}-s1`, "S"),
+    makePlayer(`${prefix}-s2`, "S"),
+    makePlayer(`${prefix}-k`, "K"),
+    makePlayer(`${prefix}-p`, "P"),
+  ];
+}


### PR DESCRIPTION
## Summary

- Hoists duplicated factory functions (`makeAttributes`, `makeFingerprint`, `makePlayer`, `makeCoachingMods`, `makeRng`, `makeSituation`, `makeStarters`) into a shared `server/features/simulation/test-helpers.ts` module
- Updates `simulate-game.test.ts`, `resolve-play.test.ts`, and `resolve-matchups.test.ts` to import from the shared module instead of redefining their own copies
- Eliminates ~80 lines of duplicated test setup code, preventing silent drift between test suites when domain types change

Closes #377