### PR TITLE
refactor(sim): unify mutable game-state updates behind a state-manager API

### DIFF
--- a/server/features/simulation/game-clock.test.ts
+++ b/server/features/simulation/game-clock.test.ts
@@ -1,6 +1,5 @@
 import { assertEquals } from "@std/assert";
 import type { PlayEvent, PlayTag } from "./events.ts";
-import type { MutableGameState } from "./game-clock.ts";
 import {
   formatClock,
   KNEEL_CLOCK_BURN,
@@ -12,29 +11,18 @@ import {
   TIMEOUTS_PER_HALF,
   trySpendTimeout,
 } from "./game-clock.ts";
+import {
+  createInitialState,
+  type SimulationState,
+} from "./game-state-manager.ts";
 
 function makeState(
-  overrides: Partial<MutableGameState> = {},
-): MutableGameState {
-  return {
-    quarter: 1,
-    clock: QUARTER_SECONDS,
-    homeScore: 0,
-    awayScore: 0,
-    possession: "home",
-    yardLine: 35,
-    down: 1,
-    distance: 10,
-    driveIndex: 0,
-    playIndex: 0,
-    globalPlayIndex: 0,
-    driveStartYardLine: 35,
-    drivePlays: 0,
-    driveYards: 0,
-    homeTimeouts: TIMEOUTS_PER_HALF,
-    awayTimeouts: TIMEOUTS_PER_HALF,
+  overrides: Partial<SimulationState> = {},
+): SimulationState {
+  return createInitialState({
+    kickoffYardLine: 35,
     ...overrides,
-  };
+  });
 }
 
 function makeEvent(
@@ -338,7 +326,7 @@ Deno.test("game-clock", async (t) => {
   });
 
   await t.step("trySpendTimeout", async (t) => {
-    await t.step("returns false outside two-minute drill", () => {
+    await t.step("returns null outside two-minute drill", () => {
       const state = makeState({
         quarter: 2,
         clock: 300,
@@ -356,12 +344,12 @@ Deno.test("game-clock", async (t) => {
         pick: <T>(arr: readonly T[]): T => arr[0],
         gaussian: () => 0,
       };
-      assertEquals(trySpendTimeout(state, rng), false);
+      assertEquals(trySpendTimeout(state, rng), null);
       assertEquals(callCount, 0);
     });
 
     await t.step(
-      "can spend offense timeout when trailing in two-minute drill",
+      "returns offense side when trailing in two-minute drill",
       () => {
         const state = makeState({
           quarter: 2,
@@ -377,13 +365,12 @@ Deno.test("game-clock", async (t) => {
           pick: <T>(arr: readonly T[]): T => arr[0],
           gaussian: () => 0,
         };
-        assertEquals(trySpendTimeout(state, rng), true);
-        assertEquals(state.homeTimeouts, 2);
+        assertEquals(trySpendTimeout(state, rng), "home");
       },
     );
 
     await t.step(
-      "does not spend timeout when rng roll is high",
+      "returns null when rng roll is high",
       () => {
         const state = makeState({
           quarter: 4,
@@ -400,14 +387,12 @@ Deno.test("game-clock", async (t) => {
           pick: <T>(arr: readonly T[]): T => arr[0],
           gaussian: () => 0,
         };
-        assertEquals(trySpendTimeout(state, rng), false);
-        assertEquals(state.homeTimeouts, 3);
-        assertEquals(state.awayTimeouts, 3);
+        assertEquals(trySpendTimeout(state, rng), null);
       },
     );
 
     await t.step(
-      "can spend defense timeout when leading in two-minute drill",
+      "returns offense side when trailing in two-minute drill (away possession)",
       () => {
         const state = makeState({
           quarter: 4,
@@ -418,25 +403,22 @@ Deno.test("game-clock", async (t) => {
           homeTimeouts: 3,
           awayTimeouts: 3,
         });
-        // First call (offense trailing check) returns > 0.4 to skip offense
-        // Second call (defense leading check) returns < 0.3 to trigger defense timeout
         let callIdx = 0;
         const rng = {
           next: () => {
             callIdx++;
-            return callIdx === 1 ? 0.1 : 0.1; // offense trailing + has timeouts
+            return callIdx === 1 ? 0.1 : 0.1;
           },
           int: () => 0,
           pick: <T>(arr: readonly T[]): T => arr[0],
           gaussian: () => 0,
         };
-        // Away is trailing (7 < 14), so offense timeout is spent first
-        assertEquals(trySpendTimeout(state, rng), true);
-        assertEquals(state.awayTimeouts, 2);
+        // Away is trailing (7 < 14), so offense timeout side is returned
+        assertEquals(trySpendTimeout(state, rng), "away");
       },
     );
 
-    await t.step("does not spend timeout with 0 timeouts remaining", () => {
+    await t.step("returns null with 0 timeouts remaining", () => {
       const state = makeState({
         quarter: 4,
         clock: 90,
@@ -452,7 +434,7 @@ Deno.test("game-clock", async (t) => {
         pick: <T>(arr: readonly T[]): T => arr[0],
         gaussian: () => 0,
       };
-      assertEquals(trySpendTimeout(state, rng), false);
+      assertEquals(trySpendTimeout(state, rng), null);
     });
   });
 });

--- a/server/features/simulation/game-clock.ts
+++ b/server/features/simulation/game-clock.ts
@@ -51,7 +51,7 @@ export function shouldClockStop(event: PlayEvent): boolean {
   );
 }
 
-export function shouldKneel(state: MutableGameState): boolean {
+export function shouldKneel(state: Readonly<MutableGameState>): boolean {
   if (state.quarter !== 2 && state.quarter !== 4) return false;
 
   const offenseScore = state.possession === "home"
@@ -67,12 +67,17 @@ export function shouldKneel(state: MutableGameState): boolean {
   return state.clock <= clockNeeded && state.clock > 0;
 }
 
+/**
+ * Determines whether a timeout should be spent and by which side.
+ * Returns the side that used a timeout, or null if none was used.
+ * The caller is responsible for applying the timeout via the state-manager.
+ */
 export function trySpendTimeout(
-  state: MutableGameState,
+  state: Readonly<MutableGameState>,
   rng: SeededRng,
-): boolean {
+): "home" | "away" | null {
   const twoMinute = isTwoMinuteDrill(state.quarter, formatClock(state.clock));
-  if (!twoMinute) return false;
+  if (!twoMinute) return null;
 
   const offenseTimeouts = state.possession === "home"
     ? state.homeTimeouts
@@ -92,16 +97,12 @@ export function trySpendTimeout(
   const defenseLeading = defenseScore > offenseScore;
 
   if (offenseTrailing && offenseTimeouts > 0 && rng.next() < 0.4) {
-    if (state.possession === "home") state.homeTimeouts--;
-    else state.awayTimeouts--;
-    return true;
+    return state.possession;
   }
 
   if (defenseLeading && defenseTimeouts > 0 && rng.next() < 0.3) {
-    if (state.possession === "home") state.awayTimeouts--;
-    else state.homeTimeouts--;
-    return true;
+    return state.possession === "home" ? "away" : "home";
   }
 
-  return false;
+  return null;
 }

--- a/server/features/simulation/game-state-manager.test.ts
+++ b/server/features/simulation/game-state-manager.test.ts
@@ -1,0 +1,317 @@
+import { assertEquals } from "@std/assert";
+import {
+  addScore,
+  advanceDowns,
+  applyKneel,
+  applyPenaltyYardage,
+  createInitialState,
+  flipPossession,
+  incrementGlobalPlayIndex,
+  incrementPlayIndex,
+  recordPlay,
+  resetHalfTimeouts,
+  setClock,
+  setPossession,
+  setQuarter,
+  type SimulationState,
+  startNewDrive,
+  tickClock,
+  useTimeout,
+} from "./game-state-manager.ts";
+
+function makeState(overrides: Partial<SimulationState> = {}): SimulationState {
+  return createInitialState({
+    kickoffYardLine: 35,
+    ...overrides,
+  });
+}
+
+Deno.test("createInitialState sets default values", () => {
+  const state = createInitialState({ kickoffYardLine: 35 });
+  assertEquals(state.quarter, 1);
+  assertEquals(state.clock, 900);
+  assertEquals(state.homeScore, 0);
+  assertEquals(state.awayScore, 0);
+  assertEquals(state.possession, "home");
+  assertEquals(state.yardLine, 35);
+  assertEquals(state.down, 1);
+  assertEquals(state.distance, 10);
+  assertEquals(state.driveIndex, 0);
+  assertEquals(state.playIndex, 0);
+  assertEquals(state.globalPlayIndex, 0);
+  assertEquals(state.driveStartYardLine, 35);
+  assertEquals(state.drivePlays, 0);
+  assertEquals(state.driveYards, 0);
+  assertEquals(state.homeTimeouts, 3);
+  assertEquals(state.awayTimeouts, 3);
+});
+
+Deno.test("startNewDrive resets drive state and increments driveIndex", () => {
+  const state = makeState({ driveIndex: 2, playIndex: 5, drivePlays: 8 });
+  startNewDrive(state, 25);
+  assertEquals(state.driveIndex, 3);
+  assertEquals(state.playIndex, 0);
+  assertEquals(state.yardLine, 25);
+  assertEquals(state.down, 1);
+  assertEquals(state.distance, 10);
+  assertEquals(state.driveStartYardLine, 25);
+  assertEquals(state.drivePlays, 0);
+  assertEquals(state.driveYards, 0);
+});
+
+Deno.test("flipPossession toggles home to away", () => {
+  const state = makeState({ possession: "home" });
+  flipPossession(state);
+  assertEquals(state.possession, "away");
+});
+
+Deno.test("flipPossession toggles away to home", () => {
+  const state = makeState({ possession: "away" });
+  flipPossession(state);
+  assertEquals(state.possession, "home");
+});
+
+Deno.test("setPossession sets possession directly", () => {
+  const state = makeState({ possession: "home" });
+  setPossession(state, "away");
+  assertEquals(state.possession, "away");
+});
+
+Deno.test("advanceDowns grants first down when yardage meets distance", () => {
+  const state = makeState({ yardLine: 50, down: 2, distance: 8 });
+  advanceDowns(state, 8);
+  assertEquals(state.yardLine, 58);
+  assertEquals(state.down, 1);
+  assertEquals(state.distance, 10);
+});
+
+Deno.test("advanceDowns grants first down when yardage exceeds distance", () => {
+  const state = makeState({ yardLine: 50, down: 1, distance: 10 });
+  advanceDowns(state, 15);
+  assertEquals(state.yardLine, 65);
+  assertEquals(state.down, 1);
+  assertEquals(state.distance, 10);
+});
+
+Deno.test("advanceDowns increments down when yardage is short", () => {
+  const state = makeState({ yardLine: 50, down: 1, distance: 10 });
+  advanceDowns(state, 3);
+  assertEquals(state.yardLine, 53);
+  assertEquals(state.down, 2);
+  assertEquals(state.distance, 7);
+});
+
+Deno.test("advanceDowns clamps yardLine to minimum 1", () => {
+  const state = makeState({ yardLine: 2, down: 1, distance: 10 });
+  advanceDowns(state, -5);
+  assertEquals(state.yardLine, 1);
+});
+
+Deno.test("advanceDowns caps distance at yards to endzone", () => {
+  const state = makeState({ yardLine: 95, down: 2, distance: 3 });
+  advanceDowns(state, 3);
+  assertEquals(state.yardLine, 98);
+  assertEquals(state.down, 1);
+  assertEquals(state.distance, 2);
+});
+
+Deno.test("advanceDowns grants first down when remaining distance becomes zero or less", () => {
+  const state = makeState({ yardLine: 50, down: 2, distance: 3 });
+  advanceDowns(state, 2);
+  assertEquals(state.down, 3);
+  assertEquals(state.distance, 1);
+});
+
+Deno.test("advanceDowns caps down at 4", () => {
+  const state = makeState({ yardLine: 50, down: 4, distance: 10 });
+  advanceDowns(state, 3);
+  assertEquals(state.down, 4);
+  assertEquals(state.distance, 7);
+});
+
+Deno.test("advanceDowns accumulates driveYards", () => {
+  const state = makeState({
+    yardLine: 50,
+    down: 1,
+    distance: 10,
+    driveYards: 20,
+  });
+  advanceDowns(state, 7);
+  assertEquals(state.driveYards, 27);
+});
+
+Deno.test("addScore adds points to home", () => {
+  const state = makeState({ homeScore: 7 });
+  addScore(state, "home", 6);
+  assertEquals(state.homeScore, 13);
+});
+
+Deno.test("addScore adds points to away", () => {
+  const state = makeState({ awayScore: 3 });
+  addScore(state, "away", 7);
+  assertEquals(state.awayScore, 10);
+});
+
+Deno.test("recordPlay increments play counters", () => {
+  const state = makeState({ drivePlays: 2, globalPlayIndex: 10, playIndex: 3 });
+  recordPlay(state);
+  assertEquals(state.drivePlays, 3);
+  assertEquals(state.globalPlayIndex, 11);
+  assertEquals(state.playIndex, 4);
+});
+
+Deno.test("incrementGlobalPlayIndex increments only globalPlayIndex", () => {
+  const state = makeState({ globalPlayIndex: 5, playIndex: 2, drivePlays: 3 });
+  incrementGlobalPlayIndex(state);
+  assertEquals(state.globalPlayIndex, 6);
+  assertEquals(state.playIndex, 2);
+  assertEquals(state.drivePlays, 3);
+});
+
+Deno.test("incrementPlayIndex increments only playIndex", () => {
+  const state = makeState({ playIndex: 4, globalPlayIndex: 10, drivePlays: 2 });
+  incrementPlayIndex(state);
+  assertEquals(state.playIndex, 5);
+  assertEquals(state.globalPlayIndex, 10);
+  assertEquals(state.drivePlays, 2);
+});
+
+Deno.test("tickClock subtracts seconds from clock", () => {
+  const state = makeState({ clock: 900 });
+  tickClock(state, 35);
+  assertEquals(state.clock, 865);
+});
+
+Deno.test("setClock sets clock directly", () => {
+  const state = makeState({ clock: 100 });
+  setClock(state, 600);
+  assertEquals(state.clock, 600);
+});
+
+Deno.test("setQuarter sets quarter and clock", () => {
+  const state = makeState();
+  setQuarter(state, 2, 900);
+  assertEquals(state.quarter, 2);
+  assertEquals(state.clock, 900);
+});
+
+Deno.test("setQuarter sets OT quarter", () => {
+  const state = makeState();
+  setQuarter(state, "OT", 600);
+  assertEquals(state.quarter, "OT");
+  assertEquals(state.clock, 600);
+});
+
+Deno.test("useTimeout decrements home timeouts", () => {
+  const state = makeState({ homeTimeouts: 3 });
+  useTimeout(state, "home");
+  assertEquals(state.homeTimeouts, 2);
+});
+
+Deno.test("useTimeout decrements away timeouts", () => {
+  const state = makeState({ awayTimeouts: 2 });
+  useTimeout(state, "away");
+  assertEquals(state.awayTimeouts, 1);
+});
+
+Deno.test("resetHalfTimeouts resets both sides to 3", () => {
+  const state = makeState({ homeTimeouts: 1, awayTimeouts: 0 });
+  resetHalfTimeouts(state);
+  assertEquals(state.homeTimeouts, 3);
+  assertEquals(state.awayTimeouts, 3);
+});
+
+Deno.test("applyKneel adjusts down, distance, and yardLine", () => {
+  const state = makeState({ down: 1, distance: 10, yardLine: 30 });
+  applyKneel(state);
+  assertEquals(state.down, 2);
+  assertEquals(state.distance, 11);
+  assertEquals(state.yardLine, 29);
+});
+
+Deno.test("applyKneel caps down at 4", () => {
+  const state = makeState({ down: 4, distance: 10, yardLine: 30 });
+  applyKneel(state);
+  assertEquals(state.down, 4);
+  assertEquals(state.distance, 11);
+  assertEquals(state.yardLine, 29);
+});
+
+Deno.test("applyKneel clamps yardLine to minimum 1", () => {
+  const state = makeState({ down: 1, distance: 10, yardLine: 1 });
+  applyKneel(state);
+  assertEquals(state.yardLine, 1);
+});
+
+Deno.test("applyPenaltyYardage against offense moves yard line back", () => {
+  const state = makeState({ yardLine: 50, down: 1, distance: 10 });
+  applyPenaltyYardage(state, {
+    isAgainstOffense: true,
+    penaltyYardage: 10,
+    phase: "pre_snap",
+    automaticFirstDown: false,
+  });
+  assertEquals(state.yardLine, 40);
+  assertEquals(state.distance, 20);
+  assertEquals(state.driveYards, -10);
+});
+
+Deno.test("applyPenaltyYardage against offense post-snap increments down", () => {
+  const state = makeState({ yardLine: 50, down: 1, distance: 10 });
+  applyPenaltyYardage(state, {
+    isAgainstOffense: true,
+    penaltyYardage: 5,
+    phase: "post_snap",
+    automaticFirstDown: false,
+  });
+  assertEquals(state.yardLine, 45);
+  assertEquals(state.down, 2);
+  assertEquals(state.distance, 15);
+});
+
+Deno.test("applyPenaltyYardage against offense clamps at own 1", () => {
+  const state = makeState({ yardLine: 3, down: 1, distance: 10 });
+  applyPenaltyYardage(state, {
+    isAgainstOffense: true,
+    penaltyYardage: 10,
+    phase: "pre_snap",
+    automaticFirstDown: false,
+  });
+  assertEquals(state.yardLine, 1);
+});
+
+Deno.test("applyPenaltyYardage against defense moves yard line forward", () => {
+  const state = makeState({ yardLine: 50, down: 2, distance: 8 });
+  applyPenaltyYardage(state, {
+    isAgainstOffense: false,
+    penaltyYardage: 10,
+    phase: "post_snap",
+    automaticFirstDown: false,
+  });
+  assertEquals(state.yardLine, 60);
+  assertEquals(state.down, 1);
+});
+
+Deno.test("applyPenaltyYardage against defense with automatic first down", () => {
+  const state = makeState({ yardLine: 50, down: 3, distance: 15 });
+  applyPenaltyYardage(state, {
+    isAgainstOffense: false,
+    penaltyYardage: 5,
+    phase: "post_snap",
+    automaticFirstDown: true,
+  });
+  assertEquals(state.yardLine, 55);
+  assertEquals(state.down, 1);
+  assertEquals(state.distance, 10);
+});
+
+Deno.test("applyPenaltyYardage against defense clamps at endzone", () => {
+  const state = makeState({ yardLine: 97, down: 1, distance: 3 });
+  applyPenaltyYardage(state, {
+    isAgainstOffense: false,
+    penaltyYardage: 10,
+    phase: "post_snap",
+    automaticFirstDown: false,
+  });
+  assertEquals(state.yardLine, 100);
+});

--- a/server/features/simulation/game-state-manager.ts
+++ b/server/features/simulation/game-state-manager.ts
@@ -1,0 +1,253 @@
+/**
+ * Centralized state-manager for MutableGameState.
+ *
+ * All field mutations go through these functions. The public type
+ * `SimulationState` is `Readonly<MutableGameState>`, so direct
+ * `state.down = ...` outside this module is a TypeScript error.
+ */
+
+import type { MutableGameState } from "./game-clock.ts";
+import { TIMEOUTS_PER_HALF } from "./game-clock.ts";
+
+export type SimulationState = Readonly<MutableGameState>;
+
+function asMutable(state: SimulationState): MutableGameState {
+  return state as MutableGameState;
+}
+
+// -- Drive management --
+
+export function startNewDrive(
+  state: SimulationState,
+  yardLine: number,
+): void {
+  const s = asMutable(state);
+  s.driveIndex++;
+  s.playIndex = 0;
+  s.yardLine = yardLine;
+  s.down = 1;
+  s.distance = 10;
+  s.driveStartYardLine = yardLine;
+  s.drivePlays = 0;
+  s.driveYards = 0;
+}
+
+export function flipPossession(state: SimulationState): void {
+  const s = asMutable(state);
+  s.possession = s.possession === "home" ? "away" : "home";
+}
+
+export function setPossession(
+  state: SimulationState,
+  side: "home" | "away",
+): void {
+  asMutable(state).possession = side;
+}
+
+// -- Down / distance / yardline --
+
+export function advanceDowns(
+  state: SimulationState,
+  yardage: number,
+): void {
+  const s = asMutable(state);
+  s.yardLine += yardage;
+  s.driveYards += yardage;
+
+  if (s.yardLine <= 0) {
+    s.yardLine = 1;
+  }
+
+  if (yardage >= s.distance) {
+    s.down = 1;
+    s.distance = Math.min(10, 100 - s.yardLine);
+  } else {
+    s.distance -= yardage;
+    if (s.distance <= 0) {
+      s.down = 1;
+      s.distance = Math.min(10, 100 - s.yardLine);
+    } else {
+      s.down = Math.min(s.down + 1, 4) as 1 | 2 | 3 | 4;
+    }
+  }
+}
+
+export function applyKneel(state: SimulationState): void {
+  const s = asMutable(state);
+  s.down = Math.min(s.down + 1, 4) as 1 | 2 | 3 | 4;
+  s.distance += 1;
+  s.yardLine -= 1;
+  if (s.yardLine < 1) s.yardLine = 1;
+}
+
+export interface PenaltyParams {
+  isAgainstOffense: boolean;
+  penaltyYardage: number;
+  phase: "pre_snap" | "post_snap";
+  automaticFirstDown: boolean;
+}
+
+export function applyPenaltyYardage(
+  state: SimulationState,
+  penalty: PenaltyParams,
+): void {
+  const s = asMutable(state);
+
+  if (penalty.isAgainstOffense) {
+    const penaltyYards = -Math.min(penalty.penaltyYardage, s.yardLine - 1);
+    s.yardLine += penaltyYards;
+    s.driveYards += penaltyYards;
+    if (penalty.phase === "pre_snap") {
+      s.distance = Math.min(
+        s.distance + penalty.penaltyYardage,
+        100 - s.yardLine,
+      );
+    } else {
+      s.down = Math.min(s.down + 1, 4) as 1 | 2 | 3 | 4;
+      s.distance = Math.min(
+        s.distance + penalty.penaltyYardage,
+        100 - s.yardLine,
+      );
+    }
+  } else {
+    const penaltyYards = Math.min(penalty.penaltyYardage, 100 - s.yardLine);
+    s.yardLine += penaltyYards;
+    s.driveYards += penaltyYards;
+    if (penalty.automaticFirstDown) {
+      s.down = 1;
+      s.distance = Math.min(10, 100 - s.yardLine);
+    } else {
+      s.down = 1;
+      s.distance = Math.max(1, s.distance - penalty.penaltyYardage);
+      if (s.distance <= 0 || penalty.penaltyYardage >= s.distance) {
+        s.distance = Math.min(10, 100 - s.yardLine);
+      }
+    }
+  }
+}
+
+// -- Scoring --
+
+export function addScore(
+  state: SimulationState,
+  side: "home" | "away",
+  points: number,
+): void {
+  const s = asMutable(state);
+  if (side === "home") {
+    s.homeScore += points;
+  } else {
+    s.awayScore += points;
+  }
+}
+
+// -- Play tracking --
+
+export function recordPlay(state: SimulationState): void {
+  const s = asMutable(state);
+  s.drivePlays++;
+  s.globalPlayIndex++;
+  s.playIndex++;
+}
+
+export function incrementGlobalPlayIndex(state: SimulationState): void {
+  asMutable(state).globalPlayIndex++;
+}
+
+export function incrementPlayIndex(state: SimulationState): void {
+  asMutable(state).playIndex++;
+}
+
+// -- Clock --
+
+export function tickClock(
+  state: SimulationState,
+  seconds: number,
+): void {
+  asMutable(state).clock -= seconds;
+}
+
+export function setClock(
+  state: SimulationState,
+  seconds: number,
+): void {
+  asMutable(state).clock = seconds;
+}
+
+export function setQuarter(
+  state: SimulationState,
+  quarter: 1 | 2 | 3 | 4 | "OT",
+  clockSeconds: number,
+): void {
+  const s = asMutable(state);
+  s.quarter = quarter;
+  s.clock = clockSeconds;
+}
+
+// -- Timeouts --
+
+export function useTimeout(
+  state: SimulationState,
+  side: "home" | "away",
+): void {
+  const s = asMutable(state);
+  if (side === "home") {
+    s.homeTimeouts--;
+  } else {
+    s.awayTimeouts--;
+  }
+}
+
+export function resetHalfTimeouts(state: SimulationState): void {
+  const s = asMutable(state);
+  s.homeTimeouts = TIMEOUTS_PER_HALF;
+  s.awayTimeouts = TIMEOUTS_PER_HALF;
+}
+
+// -- Factory --
+
+export interface CreateInitialStateOptions {
+  kickoffYardLine: number;
+  quarter?: 1 | 2 | 3 | 4 | "OT";
+  clock?: number;
+  homeScore?: number;
+  awayScore?: number;
+  possession?: "home" | "away";
+  yardLine?: number;
+  down?: 1 | 2 | 3 | 4;
+  distance?: number;
+  driveIndex?: number;
+  playIndex?: number;
+  globalPlayIndex?: number;
+  driveStartYardLine?: number;
+  drivePlays?: number;
+  driveYards?: number;
+  homeTimeouts?: number;
+  awayTimeouts?: number;
+}
+
+const QUARTER_SECONDS = 900;
+
+export function createInitialState(
+  options: CreateInitialStateOptions,
+): SimulationState {
+  const state: MutableGameState = {
+    quarter: options.quarter ?? 1,
+    clock: options.clock ?? QUARTER_SECONDS,
+    homeScore: options.homeScore ?? 0,
+    awayScore: options.awayScore ?? 0,
+    possession: options.possession ?? "home",
+    yardLine: options.yardLine ?? options.kickoffYardLine,
+    down: options.down ?? 1,
+    distance: options.distance ?? 10,
+    driveIndex: options.driveIndex ?? 0,
+    playIndex: options.playIndex ?? 0,
+    globalPlayIndex: options.globalPlayIndex ?? 0,
+    driveStartYardLine: options.driveStartYardLine ?? options.kickoffYardLine,
+    drivePlays: options.drivePlays ?? 0,
+    driveYards: options.driveYards ?? 0,
+    homeTimeouts: options.homeTimeouts ?? TIMEOUTS_PER_HALF,
+    awayTimeouts: options.awayTimeouts ?? TIMEOUTS_PER_HALF,
+  };
+  return state;
+}

--- a/server/features/simulation/possession.test.ts
+++ b/server/features/simulation/possession.test.ts
@@ -1,7 +1,9 @@
 import { assertEquals } from "@std/assert";
 import type { PlayEvent, PlayTag } from "./events.ts";
-import type { MutableGameState } from "./game-clock.ts";
-import { QUARTER_SECONDS, TIMEOUTS_PER_HALF } from "./game-clock.ts";
+import {
+  createInitialState,
+  type SimulationState,
+} from "./game-state-manager.ts";
 import {
   advanceDowns,
   applyAcceptedPenalty,
@@ -11,27 +13,12 @@ import {
 } from "./possession.ts";
 
 function makeState(
-  overrides: Partial<MutableGameState> = {},
-): MutableGameState {
-  return {
-    quarter: 1,
-    clock: QUARTER_SECONDS,
-    homeScore: 0,
-    awayScore: 0,
-    possession: "home",
-    yardLine: 35,
-    down: 1,
-    distance: 10,
-    driveIndex: 0,
-    playIndex: 0,
-    globalPlayIndex: 0,
-    driveStartYardLine: 35,
-    drivePlays: 0,
-    driveYards: 0,
-    homeTimeouts: TIMEOUTS_PER_HALF,
-    awayTimeouts: TIMEOUTS_PER_HALF,
+  overrides: Partial<SimulationState> = {},
+): SimulationState {
+  return createInitialState({
+    kickoffYardLine: 35,
     ...overrides,
-  };
+  });
 }
 
 function makeEvent(

--- a/server/features/simulation/possession.ts
+++ b/server/features/simulation/possession.ts
@@ -1,48 +1,32 @@
 import type { PlayEvent } from "./events.ts";
-import type { MutableGameState } from "./game-clock.ts";
+import type { SimulationState } from "./game-state-manager.ts";
+import {
+  advanceDowns as advanceDownsImpl,
+  applyPenaltyYardage,
+  flipPossession,
+  startNewDrive as startNewDriveImpl,
+} from "./game-state-manager.ts";
 
-export function startNewDrive(state: MutableGameState, yardLine: number): void {
-  state.driveIndex++;
-  state.playIndex = 0;
-  state.yardLine = yardLine;
-  state.down = 1;
-  state.distance = 10;
-  state.driveStartYardLine = yardLine;
-  state.drivePlays = 0;
-  state.driveYards = 0;
+export function startNewDrive(
+  state: SimulationState,
+  yardLine: number,
+): void {
+  startNewDriveImpl(state, yardLine);
 }
 
-export function switchPossession(state: MutableGameState): void {
-  state.possession = state.possession === "home" ? "away" : "home";
+export function switchPossession(state: SimulationState): void {
+  flipPossession(state);
 }
 
 export function advanceDowns(
-  state: MutableGameState,
+  state: SimulationState,
   yardage: number,
 ): void {
-  state.yardLine += yardage;
-  state.driveYards += yardage;
-
-  if (state.yardLine <= 0) {
-    state.yardLine = 1;
-  }
-
-  if (yardage >= state.distance) {
-    state.down = 1;
-    state.distance = Math.min(10, 100 - state.yardLine);
-  } else {
-    state.distance -= yardage;
-    if (state.distance <= 0) {
-      state.down = 1;
-      state.distance = Math.min(10, 100 - state.yardLine);
-    } else {
-      state.down = Math.min(state.down + 1, 4) as 1 | 2 | 3 | 4;
-    }
-  }
+  advanceDownsImpl(state, yardage);
 }
 
 export function handleTurnover(
-  state: MutableGameState,
+  state: SimulationState,
   event: PlayEvent,
 ): boolean {
   if (!event.tags.includes("turnover")) return false;
@@ -58,42 +42,15 @@ export function handleTurnover(
 }
 
 export function applyAcceptedPenalty(
-  state: MutableGameState,
+  state: SimulationState,
   event: PlayEvent,
   currentOffenseTeamId: string,
 ): void {
   const penalty = event.penalty!;
-  const isAgainstOffense = penalty.againstTeamId === currentOffenseTeamId;
-
-  if (isAgainstOffense) {
-    const penaltyYards = -Math.min(penalty.yardage, state.yardLine - 1);
-    state.yardLine += penaltyYards;
-    state.driveYards += penaltyYards;
-    if (penalty.phase === "pre_snap") {
-      state.distance = Math.min(
-        state.distance + penalty.yardage,
-        100 - state.yardLine,
-      );
-    } else {
-      state.down = Math.min(state.down + 1, 4) as 1 | 2 | 3 | 4;
-      state.distance = Math.min(
-        state.distance + penalty.yardage,
-        100 - state.yardLine,
-      );
-    }
-  } else {
-    const penaltyYards = Math.min(penalty.yardage, 100 - state.yardLine);
-    state.yardLine += penaltyYards;
-    state.driveYards += penaltyYards;
-    if (penalty.automaticFirstDown) {
-      state.down = 1;
-      state.distance = Math.min(10, 100 - state.yardLine);
-    } else {
-      state.down = 1;
-      state.distance = Math.max(1, state.distance - penalty.yardage);
-      if (state.distance <= 0 || penalty.yardage >= state.distance) {
-        state.distance = Math.min(10, 100 - state.yardLine);
-      }
-    }
-  }
+  applyPenaltyYardage(state, {
+    isAgainstOffense: penalty.againstTeamId === currentOffenseTeamId,
+    penaltyYardage: penalty.yardage,
+    phase: penalty.phase,
+    automaticFirstDown: penalty.automaticFirstDown,
+  });
 }

--- a/server/features/simulation/resolve-scoring.test.ts
+++ b/server/features/simulation/resolve-scoring.test.ts
@@ -5,8 +5,10 @@ import {
   resolveConversion,
 } from "./resolve-scoring.ts";
 import type { ConversionContext } from "./resolve-scoring.ts";
-import type { MutableGameState } from "./game-clock.ts";
-import { QUARTER_SECONDS, TIMEOUTS_PER_HALF } from "./game-clock.ts";
+import {
+  createInitialState,
+  type SimulationState,
+} from "./game-state-manager.ts";
 import type { PlayerRuntime, TeamRuntime } from "./resolve-play.ts";
 import {
   PLAYER_ATTRIBUTE_KEYS,
@@ -45,27 +47,12 @@ function makeEvent(
 }
 
 function makeState(
-  overrides: Partial<MutableGameState> = {},
-): MutableGameState {
-  return {
-    quarter: 1,
-    clock: QUARTER_SECONDS,
-    homeScore: 0,
-    awayScore: 0,
-    possession: "home",
-    yardLine: 35,
-    down: 1,
-    distance: 10,
-    driveIndex: 0,
-    playIndex: 0,
-    globalPlayIndex: 0,
-    driveStartYardLine: 35,
-    drivePlays: 0,
-    driveYards: 0,
-    homeTimeouts: TIMEOUTS_PER_HALF,
-    awayTimeouts: TIMEOUTS_PER_HALF,
+  overrides: Partial<SimulationState> = {},
+): SimulationState {
+  return createInitialState({
+    kickoffYardLine: 35,
     ...overrides,
-  };
+  });
 }
 
 function makeAttributes(

--- a/server/features/simulation/resolve-scoring.ts
+++ b/server/features/simulation/resolve-scoring.ts
@@ -1,7 +1,6 @@
 import type { PlayEvent, PlayTag } from "./events.ts";
 import type { GameState, PlayerRuntime, TeamRuntime } from "./resolve-play.ts";
 import type { SeededRng } from "./rng.ts";
-import type { MutableGameState } from "./game-clock.ts";
 import { formatClock } from "./game-clock.ts";
 import type { SimTeam } from "./simulate-game.ts";
 import type { ActiveRosters } from "./simulate-game.ts";
@@ -11,6 +10,12 @@ import {
   resolveTwoPointConversion,
 } from "./scoring.ts";
 import { buildPlayEvent } from "./play-event.ts";
+import type { SimulationState } from "./game-state-manager.ts";
+import {
+  addScore,
+  incrementGlobalPlayIndex,
+  incrementPlayIndex,
+} from "./game-state-manager.ts";
 
 export interface ScoringResult {
   scored: boolean;
@@ -70,7 +75,7 @@ export function determineScoringOutcome(
 
 export interface ConversionContext {
   gameId: string;
-  state: MutableGameState;
+  state: SimulationState;
   scoringTeamId: string;
   homeTeamId: string;
   home: SimTeam;
@@ -139,11 +144,10 @@ export function resolveConversion(
       tags: made ? [] : ["xp_missed" as PlayTag],
     });
     events.push(xpEvent);
-    state.playIndex++;
-    state.globalPlayIndex++;
+    incrementPlayIndex(state);
+    incrementGlobalPlayIndex(state);
     if (made) {
-      if (isHome) state.homeScore += 1;
-      else state.awayScore += 1;
+      addScore(state, isHome ? "home" : "away", 1);
     }
   } else {
     const offense = ctx.buildTeamRuntime(
@@ -163,11 +167,10 @@ export function resolveConversion(
       rng,
     );
     events.push(conversionEvent);
-    state.playIndex++;
-    state.globalPlayIndex++;
+    incrementPlayIndex(state);
+    incrementGlobalPlayIndex(state);
     if (conversionEvent.tags.includes("two_point_conversion")) {
-      if (isHome) state.homeScore += 2;
-      else state.awayScore += 2;
+      addScore(state, isHome ? "home" : "away", 2);
     }
   }
 

--- a/server/features/simulation/simulate-game.ts
+++ b/server/features/simulation/simulate-game.ts
@@ -33,7 +33,6 @@ import {
   RETURNER_POSITIONS,
 } from "./find-eligible-player.ts";
 
-import type { MutableGameState } from "./game-clock.ts";
 import {
   formatClock,
   KICKOFF_STARTING_YARD_LINE,
@@ -43,7 +42,6 @@ import {
   SECONDS_PER_PLAY,
   shouldClockStop,
   shouldKneel,
-  TIMEOUTS_PER_HALF,
   trySpendTimeout,
 } from "./game-clock.ts";
 import {
@@ -58,6 +56,20 @@ import {
   resolveConversion,
 } from "./resolve-scoring.ts";
 import type { ConversionContext } from "./resolve-scoring.ts";
+import type { SimulationState } from "./game-state-manager.ts";
+import {
+  addScore,
+  applyKneel,
+  createInitialState,
+  incrementGlobalPlayIndex,
+  recordPlay,
+  resetHalfTimeouts,
+  setClock,
+  setPossession,
+  setQuarter,
+  tickClock,
+  useTimeout,
+} from "./game-state-manager.ts";
 
 export interface SimTeam {
   teamId: string;
@@ -152,24 +164,9 @@ export function simulateGame(input: SimulationInput): GameResult {
     injuredPlayerIds: new Set(),
   };
 
-  const state: MutableGameState = {
-    quarter: 1,
-    clock: QUARTER_SECONDS,
-    homeScore: 0,
-    awayScore: 0,
-    possession: "home",
-    yardLine: KICKOFF_STARTING_YARD_LINE,
-    down: 1,
-    distance: 10,
-    driveIndex: 0,
-    playIndex: 0,
-    globalPlayIndex: 0,
-    driveStartYardLine: KICKOFF_STARTING_YARD_LINE,
-    drivePlays: 0,
-    driveYards: 0,
-    homeTimeouts: TIMEOUTS_PER_HALF,
-    awayTimeouts: TIMEOUTS_PER_HALF,
-  };
+  const state: SimulationState = createInitialState({
+    kickoffYardLine: KICKOFF_STARTING_YARD_LINE,
+  });
 
   function findPlayerByBucket(
     side: "home" | "away",
@@ -255,27 +252,25 @@ export function simulateGame(input: SimulationInput): GameResult {
 
     const result = resolveKickoff(ctx, rng);
     events.push(result.event);
-    state.globalPlayIndex++;
+    incrementGlobalPlayIndex(state);
 
     if (result.isReturnTouchdown) {
-      const isReceiverHome = receivingSide === "home";
-      if (isReceiverHome) state.homeScore += 6;
-      else state.awayScore += 6;
+      addScore(state, receivingSide, 6);
 
       doConversion(receivingTeamId);
 
-      state.possession = kickingSide;
+      setPossession(state, kickingSide);
       performKickoff(receivingSide);
       return;
     }
 
     if (result.isOnsideRecovery) {
-      state.possession = kickingSide;
+      setPossession(state, kickingSide);
       startNewDrive(state, result.startingYardLine);
       return;
     }
 
-    state.possession = receivingSide;
+    setPossession(state, receivingSide);
     startNewDrive(state, result.startingYardLine);
   }
 
@@ -362,18 +357,14 @@ export function simulateGame(input: SimulationInput): GameResult {
     const result = determineScoringOutcome(event, input.home.teamId);
     if (!result.scored) return false;
 
-    if (result.type === "safety") {
-      if (result.scoringTeamSide === "home") state.homeScore += result.points!;
-      else state.awayScore += result.points!;
+    addScore(state, result.scoringTeamSide!, result.points!);
 
+    if (result.type === "safety") {
       performKickoff(result.kickoffSide!, { isSafetyKick: result.safetyKick });
       return true;
     }
 
     // TD or return TD
-    if (result.scoringTeamSide === "home") state.homeScore += result.points!;
-    else state.awayScore += result.points!;
-
     doConversion(result.scoringTeamId!);
     performKickoff(result.kickoffSide!);
     return true;
@@ -430,15 +421,12 @@ export function simulateGame(input: SimulationInput): GameResult {
     }
 
     events.push(fgEvent);
-    state.drivePlays++;
-    state.globalPlayIndex++;
-    state.playIndex++;
+    recordPlay(state);
 
     if (fgResult.outcome === "made") {
-      const isHome = currentOffenseTeamId() === input.home.teamId;
-      if (isHome) state.homeScore += 3;
-      else state.awayScore += 3;
-      const kickingSide: "home" | "away" = isHome ? "home" : "away";
+      const kickingSide: "home" | "away" =
+        currentOffenseTeamId() === input.home.teamId ? "home" : "away";
+      addScore(state, kickingSide, 3);
       performKickoff(kickingSide);
     } else {
       switchPossession(state);
@@ -519,9 +507,7 @@ export function simulateGame(input: SimulationInput): GameResult {
     });
 
     events.push(puntEvent);
-    state.drivePlays++;
-    state.globalPlayIndex++;
-    state.playIndex++;
+    recordPlay(state);
 
     if (puntResult.outcome === "blocked_punt") {
       switchPossession(state);
@@ -600,14 +586,9 @@ export function simulateGame(input: SimulationInput): GameResult {
     });
 
     events.push(kneelEvent);
-    state.drivePlays++;
-    state.globalPlayIndex++;
-    state.playIndex++;
-    state.clock -= KNEEL_CLOCK_BURN;
-    state.down = Math.min(state.down + 1, 4) as 1 | 2 | 3 | 4;
-    state.distance += 1;
-    state.yardLine -= 1;
-    if (state.yardLine < 1) state.yardLine = 1;
+    recordPlay(state);
+    tickClock(state, KNEEL_CLOCK_BURN);
+    applyKneel(state);
   }
 
   function runPlay(): boolean {
@@ -639,8 +620,9 @@ export function simulateGame(input: SimulationInput): GameResult {
     }
 
     if (twoMinute) {
-      const usedTimeout = trySpendTimeout(state, rng);
-      if (usedTimeout) {
+      const timeoutSide = trySpendTimeout(state, rng);
+      if (timeoutSide) {
+        useTimeout(state, timeoutSide);
         event.tags.push("timeout");
       }
     }
@@ -648,14 +630,12 @@ export function simulateGame(input: SimulationInput): GameResult {
     processInjury(event);
     events.push(event);
 
-    state.drivePlays++;
-    state.globalPlayIndex++;
-    state.playIndex++;
+    recordPlay(state);
 
     if (!shouldClockStop(event)) {
-      state.clock -= SECONDS_PER_PLAY;
+      tickClock(state, SECONDS_PER_PLAY);
     } else {
-      state.clock -= rng.int(5, 15);
+      tickClock(state, rng.int(5, 15));
     }
 
     if (event.penalty?.accepted && !event.tags.includes("return_td")) {
@@ -669,7 +649,9 @@ export function simulateGame(input: SimulationInput): GameResult {
     advanceDowns(state, event.yardage);
 
     // Turnover on downs: 4th-down go-for-it failed to convert
-    if (isFourthDownAttempt && state.down !== 1) {
+    // Cast needed: advanceDowns mutates down through the state-manager,
+    // but TypeScript narrows state.down to 4 inside the isFourthDownAttempt guard.
+    if (isFourthDownAttempt && (state.down as number) !== 1) {
       const turnoverYardLine = Math.max(
         1,
         Math.min(99, state.yardLine),
@@ -689,12 +671,10 @@ export function simulateGame(input: SimulationInput): GameResult {
     q <= 4;
     q = (q + 1) as 1 | 2 | 3 | 4
   ) {
-    state.quarter = q;
-    state.clock = QUARTER_SECONDS;
+    setQuarter(state, q, QUARTER_SECONDS);
 
     if (q === 3) {
-      state.homeTimeouts = TIMEOUTS_PER_HALF;
-      state.awayTimeouts = TIMEOUTS_PER_HALF;
+      resetHalfTimeouts(state);
       const secondHalfKicker: "home" | "away" = state.possession === "home"
         ? "home"
         : "away";
@@ -709,11 +689,10 @@ export function simulateGame(input: SimulationInput): GameResult {
 
   if (state.homeScore === state.awayScore) {
     const isPlayoff = input.isPlayoff ?? false;
-    state.quarter = "OT";
-    state.clock = OT_SECONDS;
+    setQuarter(state, "OT", OT_SECONDS);
 
     const otCoinFlip: "home" | "away" = rng.next() < 0.5 ? "home" : "away";
-    state.possession = otCoinFlip;
+    setPossession(state, otCoinFlip);
     performKickoff(otCoinFlip === "home" ? "away" : "home");
 
     const scoreBeforeOt = { home: state.homeScore, away: state.awayScore };
@@ -754,7 +733,7 @@ export function simulateGame(input: SimulationInput): GameResult {
         }
       } else {
         if (state.clock <= 0) {
-          state.clock = OT_SECONDS;
+          setClock(state, OT_SECONDS);
           performKickoff(rng.next() < 0.5 ? "home" : "away");
         }
       }


### PR DESCRIPTION
## Summary

- Introduces `game-state-manager.ts` with a `SimulationState` type (`Readonly<MutableGameState>`) and 16 explicit mutation functions (`startNewDrive`, `advanceDowns`, `addScore`, `flipPossession`, `applyPenaltyYardage`, etc.)
- Refactors all 15+ direct field-mutation call-sites in `simulate-game.ts` to route through the state-manager, eliminating inline `state.down = ...` / `state.yardLine += ...` assignments
- Centralizes invariant enforcement (end-zone clamping, down advancement, penalty yardage math) so bugs in field-position logic can be caught in one place

Closes #373

🤖 Generated with [Claude Code](https://claude.com/claude-code)