### PR TITLE
refactor(client): replace Genesis references with user-friendly language

### DIFF
--- a/client/src/features/league/league-clock-display.test.tsx
+++ b/client/src/features/league/league-clock-display.test.tsx
@@ -235,7 +235,7 @@ describe("LeagueClockDisplay", () => {
     });
   });
 
-  it("renders 'No preseason (inaugural year)' note in Year 1", async () => {
+  it("renders 'No preseason (inaugural year)' note in inaugural season", async () => {
     mockGetClock.mockResolvedValue({
       ok: true,
       json: () =>
@@ -262,7 +262,7 @@ describe("LeagueClockDisplay", () => {
     ).toBeDefined();
   });
 
-  it("does not render inaugural year note when hasCompletedGenesis is true", async () => {
+  it("does not render inaugural year note after inaugural season", async () => {
     mockGetClock.mockResolvedValue({
       ok: true,
       json: () =>
@@ -289,7 +289,7 @@ describe("LeagueClockDisplay", () => {
     ).toBeNull();
   });
 
-  it("does not render inaugural year note during genesis phases", async () => {
+  it("does not render inaugural year note during setup phases", async () => {
     mockGetClock.mockResolvedValue({
       ok: true,
       json: () =>

--- a/client/src/features/league/league-clock-display.tsx
+++ b/client/src/features/league/league-clock-display.tsx
@@ -42,8 +42,8 @@ export function LeagueClockDisplay({
 
   if (!clock) return null;
 
-  const showInauguralYearNote = !clock.hasCompletedGenesis &&
-    !clock.phase.startsWith("genesis_");
+  const isSetupPhase = clock.phase.startsWith("genesis_");
+  const showInauguralYearNote = clock.isInauguralSeason && !isSetupPhase;
 
   const handleAdvance = () => {
     setError(null);

--- a/client/src/hooks/use-league-clock.test.ts
+++ b/client/src/hooks/use-league-clock.test.ts
@@ -32,8 +32,14 @@ function createWrapper() {
 
 describe("useLeagueClock", () => {
   it("fetches the league clock by leagueId", async () => {
-    const clock = { phase: "regular-season", week: 3 };
-    mockGet.mockResolvedValue({ json: () => Promise.resolve(clock) });
+    const apiResponse = {
+      phase: "regular-season",
+      week: 3,
+      hasCompletedGenesis: true,
+    };
+    mockGet.mockResolvedValue({
+      json: () => Promise.resolve(apiResponse),
+    });
 
     const { result } = renderHook(() => useLeagueClock("league-1"), {
       wrapper: createWrapper(),
@@ -43,7 +49,11 @@ describe("useLeagueClock", () => {
       expect(result.current.isSuccess).toBe(true);
     });
 
-    expect(result.current.data).toEqual(clock);
+    expect(result.current.data).toEqual({
+      phase: "regular-season",
+      week: 3,
+      isInauguralSeason: false,
+    });
     expect(mockGet).toHaveBeenCalledWith({ param: { leagueId: "league-1" } });
   });
 

--- a/client/src/hooks/use-league-clock.ts
+++ b/client/src/hooks/use-league-clock.ts
@@ -8,7 +8,12 @@ export function useLeagueClock(leagueId: string) {
       const res = await api.api["league-clock"][":leagueId"].$get({
         param: { leagueId },
       });
-      return res.json();
+      const data = await res.json();
+      const { hasCompletedGenesis, ...rest } = data;
+      return {
+        ...rest,
+        isInauguralSeason: !hasCompletedGenesis,
+      };
     },
     enabled: !!leagueId,
   });


### PR DESCRIPTION
## Summary

- Maps the API's `hasCompletedGenesis` field to `isInauguralSeason` in the `useLeagueClock` hook, removing the internal "Genesis" terminology from the UI layer
- Renames the component's local variable to `isSetupPhase` instead of checking `genesis_` prefixes directly
- Updates test descriptions to use "inaugural season" and "setup phases" wording

Closes #391