### PR TITLE
fix(ui): remove duplicate sidebar toggle button

### DIFF
--- a/client/src/features/league/layout.test.tsx
+++ b/client/src/features/league/layout.test.tsx
@@ -175,12 +175,12 @@ describe("LeagueLayout", () => {
     expect(settingsLink.getAttribute("href")).toBe("/leagues/1/settings");
   });
 
-  it("renders toggle buttons for the sidebar", () => {
+  it("renders exactly one toggle button for the sidebar", () => {
     renderWithProviders();
     const toggleButtons = screen.getAllByRole("button", {
       name: /toggle sidebar/i,
     });
-    expect(toggleButtons.length).toBeGreaterThanOrEqual(1);
+    expect(toggleButtons.length).toBe(1);
   });
 
   it("collapses the sidebar when toggle is clicked", () => {

--- a/client/src/features/league/layout.tsx
+++ b/client/src/features/league/layout.tsx
@@ -149,24 +149,15 @@ function LeagueSidebarHeader({ name }: { name?: string }) {
   const isCollapsed = state === "collapsed";
 
   if (isCollapsed) {
-    return (
-      <SidebarHeader>
-        <SidebarMenu>
-          <SidebarMenuItem>
-            <SidebarTrigger className="w-full" />
-          </SidebarMenuItem>
-        </SidebarMenu>
-      </SidebarHeader>
-    );
+    return null;
   }
 
   return (
     <SidebarHeader>
-      <div className="flex items-center justify-between gap-2 px-2 py-1">
+      <div className="flex items-center gap-2 px-2 py-1">
         <span className="truncate text-sm font-semibold">
           {name ?? "League"}
         </span>
-        <SidebarTrigger />
       </div>
     </SidebarHeader>
   );


### PR DESCRIPTION
## Summary

- Removed the duplicate `SidebarTrigger` from the `LeagueSidebarHeader` component, keeping only the one in the `SidebarInset` content header — the standard shadcn sidebar pattern.
- Updated the test to assert exactly one toggle button renders instead of `>= 1`.

Closes #395