### PR TITLE
docs(staff): add ADR 0032 — multi-week staff hiring process

### DIFF
--- a/docs/product/decisions/0032-multi-week-staff-hiring.md
+++ b/docs/product/decisions/0032-multi-week-staff-hiring.md
@@ -1,0 +1,194 @@
+# 0032 — Multi-week staff hiring process
+
+- **Date:** 2026-04-16
+- **Status:** Proposed
+- **Area:** [Coaches](../north-star/coaches.md),
+  [Scouting](../north-star/scouting.md),
+  [League Genesis](../north-star/league-genesis.md),
+  [0014 — Season calendar and phase state machine](./0014-season-calendar-phase-state-machine.md),
+  [0023 — Contested staff hiring market](./0023-contested-staff-hiring-market.md)
+
+## Context
+
+ADR 0023 describes _how_ the contested staff market resolves (candidate
+preferences, parallel bidding, iterative rounds) but treats timing as implicit —
+hiring is a single atomic phase with no notion of simulated weeks. The
+north-star coaching doc envisions interviews, negotiations, and candidate
+decision-making as a lived experience, not an instant transaction. ADR 0014's
+phase state machine provides multi-step granularity inside every phase, but no
+ADR formalizes the step catalog for hiring.
+
+An instant hiring phase misses the gameplay that makes staff decisions
+interesting: scouting a candidate before committing, losing a target because you
+hesitated, poaching a coordinator mid-interview cycle, or scrambling to fill a
+vacancy after your top choice signs elsewhere. The hiring timeline should feel
+like a compressed version of a real coaching search — measured in weeks, not
+clicks.
+
+## Decision
+
+Staff hiring — during both the genesis `GENESIS_STAFF_HIRING` phase and the
+recurring `coaching_carousel` phase — proceeds across **multiple simulated
+weeks**, each modeled as a step in ADR 0014's phase-step catalog. Each week
+represents a distinct stage of the hiring process where candidates and
+franchises interact.
+
+### Hiring timeline (steps within the phase)
+
+1. **Openings & market survey (Week 1).** Fired coaches and vacated positions
+   become public. The full candidate pool is revealed. For each candidate,
+   franchises see resume, reputation, scheme preference, and personality
+   impressions — the same opaque signals described in the coaches north-star
+   doc. Franchises may designate **interest** in up to N candidates (a soft cap
+   that forces prioritization). No binding offers yet.
+
+2. **Interview window (Weeks 2–3).** Franchises request interviews with
+   candidates they expressed interest in. Each franchise can conduct a limited
+   number of interviews per week (representing bandwidth — you can't interview
+   everyone). Interviews surface additional signal: coaching philosophy details,
+   staff-fit impressions, and scheme-specific depth. Candidates may decline
+   interview requests from franchises that don't meet a minimum preference
+   threshold (per ADR 0023's "candidates can refuse" rule).
+
+3. **Offer window (Week 4).** Franchises submit binding contract offers to
+   interviewed candidates. Each franchise may extend offers to multiple
+   candidates but must honor every offer if accepted — cap and budget
+   implications are real. Offer terms include salary, length, and incentive
+   structure (per the coaches north-star's contract section).
+
+4. **Candidate decision (Week 5).** Candidates evaluate all offers using their
+   hidden preference function (ADR 0023: market tier, philosophy fit, existing-
+   staff fit, compensation). Candidates who received multiple offers choose the
+   best match. Candidates who received no offer above their minimum threshold
+   remain unsigned. Results are revealed to all franchises simultaneously.
+
+5. **Second wave (Weeks 6–7, optional).** Franchises with unfilled mandatory
+   positions and unsigned candidates re-enter a compressed interview + offer
+   cycle. This second wave is two steps: one for interviews and one for offers
+   and decisions. The compressed timeline reflects real-world urgency — you're
+   hiring from the leftovers and both sides know it.
+
+6. **Finalization (Week 8).** Any franchise still missing a mandatory staff
+   position is auto-assigned the best available unsigned candidate (NPC teams)
+   or shown a "must hire" gate blocker (human teams) that prevents phase advance
+   until filled. The phase cannot complete with unfilled mandatory slots.
+
+### Genesis vs. recurring-season differences
+
+- **Genesis (`GENESIS_STAFF_HIRING`):** Every franchise starts with a completely
+  empty staff. The candidate pool is larger (enough candidates for all
+  franchises to fill every mandatory role). The full 8-step timeline runs.
+  Genesis hiring is the first significant decision point after franchise
+  establishment.
+
+- **Recurring season (`coaching_carousel`):** Only franchises with vacancies
+  participate. The candidate pool is the union of fired coaches, retiring
+  coaches re-entering, coordinators seeking promotion, and newly generated
+  candidates. If no franchise has a vacancy, the phase auto-advances in a single
+  step.
+
+### User decisions at each stage
+
+| Stage            | User action                                               |
+| ---------------- | --------------------------------------------------------- |
+| Market survey    | Browse candidates, designate interest list                |
+| Interview window | Select which candidates to interview (limited slots)      |
+| Offer window     | Set contract terms, choose which candidates to offer      |
+| Decision reveal  | Review results — who signed, who was lost to a competitor |
+| Second wave      | Repeat interview/offer for unfilled positions             |
+| Finalization     | Fill any remaining mandatory slots                        |
+
+### Interaction with league advancement
+
+Each hiring week is a **step** in the phase-step catalog (ADR 0014). The
+controlling GM (or commissioner in multiplayer) advances through steps using the
+same mechanism as every other phase. In multiplayer with ready-check enabled,
+all human GMs must be ready before advancing past each hiring step — ensuring no
+one is rushed through their interview decisions.
+
+Between hiring steps, NPC franchises execute their hiring AI: expressing
+interest, requesting interviews, and submitting offers according to their
+personality and philosophy (per ADR 0023's NPC behavior rules).
+
+### Season vs. offseason constraints
+
+- **Offseason coaching carousel:** The full multi-week hiring timeline runs.
+  This is the primary hiring window.
+- **Mid-season vacancies (fired mid-season):** A franchise that fires a coach
+  during the regular season may only hire an **interim** from their existing
+  staff or from the unsigned candidate pool. Interim hires skip the full
+  timeline — they are a single-step emergency appointment. The permanent
+  replacement search happens in the next offseason's coaching carousel.
+- **Position coach vacancies during the season** (poaching, resignation): Filled
+  immediately from internal staff or unsigned candidates. No multi-week process
+  — these are operational hires, not marquee searches.
+
+## Alternatives considered
+
+- **Instant atomic hiring (status quo).** All hiring resolves in a single
+  advance action with no intermediate steps. Simpler to implement but eliminates
+  the strategic depth of timing, interview limits, and competing offers. The
+  user never experiences the tension of losing a candidate to a rival. Rejected
+  because it reduces the most consequential offseason decision to a menu
+  selection.
+
+- **Real-time countdown timers per hiring step.** Each step lasts N real-world
+  minutes, forcing urgency. Appealing for multiplayer drama but hostile to
+  single-player pacing and async multiplayer. Rejected for v1; compatible as a
+  future layer on top of the step-based model (the step catalog doesn't care
+  whether advance is user-initiated or timer-driven).
+
+- **Unlimited interviews and offers (no bandwidth cap).** Franchises can
+  interview and offer every candidate simultaneously. Eliminates the
+  prioritization decision — you never have to choose who to pursue first.
+  Rejected because scarcity of attention is what creates interesting tradeoffs
+  (do you chase the elite HC or lock down coordinators first?).
+
+- **Single-round hiring with no second wave.** If you miss your top choice, you
+  wait until next offseason. Punishing for new players who misjudge the market.
+  Rejected because the second wave is a safety valve that prevents a bad hiring
+  round from crippling a franchise for an entire season.
+
+## Consequences
+
+- **Hiring becomes a multi-step strategic minigame.** The user's interview
+  choices, offer timing, and fallback plans matter. This is aligned with the
+  coaches north-star's vision of hiring as a consequential, uncertain process.
+
+- **The phase-step catalog for `coaching_carousel` and `GENESIS_STAFF_HIRING`
+  must be seeded.** Each hiring week becomes a row in `league_phase_step` with
+  slugs like `hiring_market_survey`, `hiring_interview_1`, `hiring_interview_2`,
+  `hiring_offers`, `hiring_decisions`, `hiring_second_wave_interview`,
+  `hiring_second_wave_decisions`, `hiring_finalization`.
+
+- **NPC hiring AI must operate per-step, not per-phase.** The AI described in
+  ADR 0023 must be decomposed into per-step behaviors: express interest, request
+  interviews, submit offers. This is more complex but produces more realistic
+  and readable NPC behavior.
+
+- **Interview and offer limits become tunable league settings.** Different
+  leagues may want tighter or looser hiring constraints. The step catalog is
+  fixed but the bandwidth caps (interviews per week, concurrent offers) can be
+  league parameters.
+
+- **Mid-season coaching changes are intentionally limited.** The interim-only
+  rule for mid-season firings creates a real cost to firing a coach during the
+  season — you're stuck with a stopgap until the offseason carousel. This
+  mirrors real NFL dynamics and makes the firing decision weightier.
+
+- **Follow-up work:**
+  - Seed the `league_phase_step` rows for both `coaching_carousel` and
+    `GENESIS_STAFF_HIRING` phases.
+  - Implement per-step NPC hiring AI (interest → interview → offer decisions).
+  - Design the hiring UI: candidate browsing, interview request, offer builder,
+    decision-reveal screen.
+  - Define the interview bandwidth and offer caps as league settings with
+    sensible defaults.
+  - Wire the `hiring_finalization` step's gate function to enforce mandatory
+    staff requirements before phase advance.
+
+## Related decisions
+
+- [0014 — Season calendar and phase state machine](./0014-season-calendar-phase-state-machine.md)
+- [0023 — Contested staff hiring market](./0023-contested-staff-hiring-market.md)
+- [0018 — Genesis phase state machine](./0018-genesis-phase-state-machine.md)

--- a/docs/product/north-star/coaches.md
+++ b/docs/product/north-star/coaches.md
@@ -870,3 +870,4 @@ calls you make when it stops working.
 ## Related decisions
 
 - [0023 — Contested staff hiring market](../decisions/0023-contested-staff-hiring-market.md)
+- [0032 — Multi-week staff hiring process](../decisions/0032-multi-week-staff-hiring.md)


### PR DESCRIPTION
## Summary

- Adds ADR 0032 formalizing staff hiring as a multi-week process (~8 simulated weeks) rather than an instant transaction, covering market survey, interviews, offers, candidate decisions, and a second wave for unfilled positions.
- Each hiring week maps to a step in ADR 0014's phase-step catalog, reusing the existing league-clock advance mechanics for both genesis and recurring coaching-carousel phases.
- Defines mid-season constraints (interim-only hires), user decisions at each stage, and interaction with multiplayer ready-check advancement.

Closes #401