### PR TITLE
fix(league-clock): gate founding pool phase on staff hiring

### DIFF
--- a/client/src/features/league/league-clock-display.tsx
+++ b/client/src/features/league/league-clock-display.tsx
@@ -56,6 +56,7 @@ export function LeagueClockDisplay({
           draftOrderResolved: true,
           superBowlPlayed: true,
           priorPhaseComplete: true,
+          allTeamsHaveStaff: false,
         },
       },
       {

--- a/client/src/hooks/use-league-clock.test.ts
+++ b/client/src/hooks/use-league-clock.test.ts
@@ -84,6 +84,7 @@ describe("useAdvanceLeagueClock", () => {
       draftOrderResolved: true,
       superBowlPlayed: false,
       priorPhaseComplete: true,
+      allTeamsHaveStaff: false,
     },
   };
 

--- a/client/src/hooks/use-league-clock.ts
+++ b/client/src/hooks/use-league-clock.ts
@@ -43,6 +43,7 @@ export function useAdvanceLeagueClock() {
         draftOrderResolved: boolean;
         superBowlPlayed: boolean;
         priorPhaseComplete: boolean;
+        allTeamsHaveStaff: boolean;
       };
     }) => {
       const res = await api.api["league-clock"][":leagueId"].advance.$post({

--- a/server/features/league-clock/gates.test.ts
+++ b/server/features/league-clock/gates.test.ts
@@ -29,6 +29,7 @@ function createState(
     draftOrderResolved: true,
     superBowlPlayed: true,
     priorPhaseComplete: true,
+    allTeamsHaveStaff: true,
     ...overrides,
   };
 }
@@ -180,6 +181,28 @@ Deno.test("gates", async (t) => {
           result.blockers[0].reason,
           "Super Bowl has not been played",
         );
+      }
+    });
+  });
+
+  await t.step("enterGenesisFoundingPool", async (t) => {
+    const gate = getGateForPhase("genesis_founding_pool")!;
+
+    await t.step("passes when all teams have staff", () => {
+      const result = gate(createState({ allTeamsHaveStaff: true }));
+      assertEquals(result, { ok: true });
+    });
+
+    await t.step("blocks when not all teams have staff", () => {
+      const result = gate(createState({ allTeamsHaveStaff: false }));
+      assertEquals(result.ok, false);
+      if (!result.ok) {
+        assertEquals(result.blockers.length, 1);
+        assertEquals(
+          result.blockers[0].reason,
+          "All teams must hire staff before generating the founding player pool",
+        );
+        assertEquals(result.blockers[0].autoResolvable, false);
       }
     });
   });

--- a/server/features/league-clock/gates.ts
+++ b/server/features/league-clock/gates.ts
@@ -24,6 +24,7 @@ export interface LeagueGateState {
   draftOrderResolved: boolean;
   superBowlPlayed: boolean;
   priorPhaseComplete: boolean;
+  allTeamsHaveStaff: boolean;
 }
 
 export type GateFn = (state: LeagueGateState) => GateResult;
@@ -71,6 +72,21 @@ function enterDraft(state: LeagueGateState): GateResult {
   return blockers.length > 0 ? { ok: false, blockers } : GATE_OK;
 }
 
+function enterGenesisFoundingPool(state: LeagueGateState): GateResult {
+  if (!state.allTeamsHaveStaff) {
+    return {
+      ok: false,
+      blockers: [{
+        teamId: "",
+        reason:
+          "All teams must hire staff before generating the founding player pool",
+        autoResolvable: false,
+      }],
+    };
+  }
+  return GATE_OK;
+}
+
 function enterOffseasonRollover(state: LeagueGateState): GateResult {
   if (!state.superBowlPlayed) {
     return {
@@ -86,6 +102,7 @@ function enterOffseasonRollover(state: LeagueGateState): GateResult {
 }
 
 const PHASE_GATES: Partial<Record<string, GateFn>> = {
+  genesis_founding_pool: enterGenesisFoundingPool,
   regular_season: enterRegularSeason,
   draft: enterDraft,
   offseason_rollover: enterOffseasonRollover,

--- a/server/features/league-clock/league-clock.router.test.ts
+++ b/server/features/league-clock/league-clock.router.test.ts
@@ -1,5 +1,8 @@
 import { assertEquals } from "@std/assert";
-import { createLeagueClockRouter } from "./league-clock.router.ts";
+import {
+  createLeagueClockRouter,
+  type LeagueClockRouterDeps,
+} from "./league-clock.router.ts";
 import type {
   AdvanceResult,
   ClockState,
@@ -65,6 +68,38 @@ function createMockService(
   };
 }
 
+function createMockDeps(
+  overrides: Partial<LeagueClockRouterDeps> = {},
+): LeagueClockRouterDeps {
+  return {
+    teamService: {
+      getByLeagueId: () => Promise.resolve([]),
+      getById: () => {
+        throw new Error("not implemented");
+      },
+      createMany: () => {
+        throw new Error("not implemented");
+      },
+    },
+    coachesService: {
+      generate: () => {
+        throw new Error("not implemented");
+      },
+      generatePool: () => {
+        throw new Error("not implemented");
+      },
+      getStaffTree: () => Promise.resolve([]),
+      getCoachDetail: () => {
+        throw new Error("not implemented");
+      },
+      getFingerprint: () => {
+        throw new Error("not implemented");
+      },
+    },
+    ...overrides,
+  };
+}
+
 Deno.test("league-clock.router", async (t) => {
   await t.step("GET /:leagueId returns current clock state", async () => {
     const state = createMockClockState({
@@ -76,6 +111,7 @@ Deno.test("league-clock.router", async (t) => {
     });
     const router = createLeagueClockRouter(
       createMockService({ getClockState: () => Promise.resolve(state) }),
+      createMockDeps(),
     );
 
     const res = await router.request("/league-1");
@@ -101,6 +137,7 @@ Deno.test("league-clock.router", async (t) => {
             return Promise.resolve(createMockClockState());
           },
         }),
+        createMockDeps(),
       );
 
       await router.request("/my-league-id");
@@ -117,6 +154,7 @@ Deno.test("league-clock.router", async (t) => {
       });
       const router = createLeagueClockRouter(
         createMockService({ advance: () => Promise.resolve(result) }),
+        createMockDeps(),
       );
 
       const res = await router.request("/league-1/advance", {
@@ -151,6 +189,7 @@ Deno.test("league-clock.router", async (t) => {
             return Promise.resolve(createMockAdvanceResult());
           },
         }),
+        createMockDeps(),
       );
 
       await router.request("/league-1/advance", {
@@ -178,6 +217,140 @@ Deno.test("league-clock.router", async (t) => {
   );
 
   await t.step(
+    "POST /:leagueId/advance computes allTeamsHaveStaff server-side",
+    async () => {
+      let receivedGateState: unknown;
+      const router = createLeagueClockRouter(
+        createMockService({
+          advance: (_id, _actor, gateState) => {
+            receivedGateState = gateState;
+            return Promise.resolve(createMockAdvanceResult());
+          },
+        }),
+        createMockDeps({
+          teamService: {
+            getByLeagueId: () =>
+              Promise.resolve([
+                { id: "t-1", leagueId: "league-1", name: "Team 1" },
+                { id: "t-2", leagueId: "league-1", name: "Team 2" },
+              ] as import("@zone-blitz/shared").Team[]),
+            getById: () => {
+              throw new Error("not implemented");
+            },
+            createMany: () => {
+              throw new Error("not implemented");
+            },
+          },
+          coachesService: {
+            generate: () => {
+              throw new Error("not implemented");
+            },
+            generatePool: () => {
+              throw new Error("not implemented");
+            },
+            getStaffTree: (_leagueId: string, teamId: string) =>
+              Promise.resolve(
+                teamId === "t-1"
+                  ? [{ id: "c-1" } as import("@zone-blitz/shared").CoachNode]
+                  : [{ id: "c-2" } as import("@zone-blitz/shared").CoachNode],
+              ),
+            getCoachDetail: () => {
+              throw new Error("not implemented");
+            },
+            getFingerprint: () => {
+              throw new Error("not implemented");
+            },
+          },
+        }),
+      );
+
+      await router.request("/league-1/advance", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          isCommissioner: true,
+          gateState: {
+            teams: [],
+            draftOrderResolved: true,
+            superBowlPlayed: true,
+            priorPhaseComplete: true,
+          },
+        }),
+      });
+
+      const gs = receivedGateState as Record<string, unknown>;
+      assertEquals(gs.allTeamsHaveStaff, true);
+    },
+  );
+
+  await t.step(
+    "POST /:leagueId/advance sets allTeamsHaveStaff to false when a team has no staff",
+    async () => {
+      let receivedGateState: unknown;
+      const router = createLeagueClockRouter(
+        createMockService({
+          advance: (_id, _actor, gateState) => {
+            receivedGateState = gateState;
+            return Promise.resolve(createMockAdvanceResult());
+          },
+        }),
+        createMockDeps({
+          teamService: {
+            getByLeagueId: () =>
+              Promise.resolve([
+                { id: "t-1", leagueId: "league-1", name: "Team 1" },
+                { id: "t-2", leagueId: "league-1", name: "Team 2" },
+              ] as import("@zone-blitz/shared").Team[]),
+            getById: () => {
+              throw new Error("not implemented");
+            },
+            createMany: () => {
+              throw new Error("not implemented");
+            },
+          },
+          coachesService: {
+            generate: () => {
+              throw new Error("not implemented");
+            },
+            generatePool: () => {
+              throw new Error("not implemented");
+            },
+            getStaffTree: (_leagueId: string, teamId: string) =>
+              Promise.resolve(
+                teamId === "t-1"
+                  ? [{ id: "c-1" } as import("@zone-blitz/shared").CoachNode]
+                  : [],
+              ),
+            getCoachDetail: () => {
+              throw new Error("not implemented");
+            },
+            getFingerprint: () => {
+              throw new Error("not implemented");
+            },
+          },
+        }),
+      );
+
+      await router.request("/league-1/advance", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          isCommissioner: true,
+          gateState: {
+            teams: [],
+            draftOrderResolved: true,
+            superBowlPlayed: true,
+            priorPhaseComplete: true,
+          },
+        }),
+      });
+
+      const gs = receivedGateState as Record<string, unknown>;
+      assertEquals(gs.allTeamsHaveStaff, false);
+    },
+  );
+
+  await t.step(
     "POST /:leagueId/votes casts a vote and returns 201",
     async () => {
       const teamId = crypto.randomUUID();
@@ -198,6 +371,7 @@ Deno.test("league-clock.router", async (t) => {
             return Promise.resolve(voteResult);
           },
         }),
+        createMockDeps(),
       );
 
       const res = await router.request(`/${leagueId}/votes`, {
@@ -220,7 +394,10 @@ Deno.test("league-clock.router", async (t) => {
   await t.step(
     "POST /:leagueId/votes returns 400 when teamId is missing",
     async () => {
-      const router = createLeagueClockRouter(createMockService());
+      const router = createLeagueClockRouter(
+        createMockService(),
+        createMockDeps(),
+      );
 
       const res = await router.request("/lg-1/votes", {
         method: "POST",
@@ -235,7 +412,10 @@ Deno.test("league-clock.router", async (t) => {
   await t.step(
     "POST /:leagueId/votes returns 400 when teamId is not a uuid",
     async () => {
-      const router = createLeagueClockRouter(createMockService());
+      const router = createLeagueClockRouter(
+        createMockService(),
+        createMockDeps(),
+      );
 
       const res = await router.request("/lg-1/votes", {
         method: "POST",

--- a/server/features/league-clock/league-clock.router.ts
+++ b/server/features/league-clock/league-clock.router.ts
@@ -3,8 +3,30 @@ import { zValidator } from "@hono/zod-validator";
 import { castAdvanceVoteSchema } from "@zone-blitz/shared";
 import type { LeagueClockService } from "./league-clock.service.ts";
 import type { AppEnv } from "../../env.ts";
+import type { TeamService } from "../team/team.service.interface.ts";
+import type { CoachesService } from "../coaches/coaches.service.interface.ts";
 
-export function createLeagueClockRouter(service: LeagueClockService) {
+export interface LeagueClockRouterDeps {
+  teamService: TeamService;
+  coachesService: CoachesService;
+}
+
+async function resolveAllTeamsHaveStaff(
+  leagueId: string,
+  deps: LeagueClockRouterDeps,
+): Promise<boolean> {
+  const teams = await deps.teamService.getByLeagueId(leagueId);
+  for (const team of teams) {
+    const staff = await deps.coachesService.getStaffTree(leagueId, team.id);
+    if (staff.length === 0) return false;
+  }
+  return true;
+}
+
+export function createLeagueClockRouter(
+  service: LeagueClockService,
+  deps: LeagueClockRouterDeps,
+) {
   return new Hono<AppEnv>()
     .get("/:leagueId", async (c) => {
       const leagueId = c.req.param("leagueId");
@@ -22,10 +44,15 @@ export function createLeagueClockRouter(service: LeagueClockService) {
         overrideReason: body.overrideReason,
       };
 
+      const allTeamsHaveStaff = await resolveAllTeamsHaveStaff(
+        leagueId,
+        deps,
+      );
+
       const result = await service.advance(
         leagueId,
         actor,
-        body.gateState,
+        { ...body.gateState, allTeamsHaveStaff },
       );
 
       return c.json(result);

--- a/server/features/league-clock/league-clock.service.test.ts
+++ b/server/features/league-clock/league-clock.service.test.ts
@@ -116,6 +116,7 @@ function createGateState(
     draftOrderResolved: true,
     superBowlPlayed: true,
     priorPhaseComplete: true,
+    allTeamsHaveStaff: true,
     ...overrides,
   };
 }

--- a/server/features/mod.ts
+++ b/server/features/mod.ts
@@ -172,7 +172,10 @@ export function createFeatureRouters(
     leagueClockRepo,
     log,
   });
-  const leagueClockRouter = createLeagueClockRouter(leagueClockService);
+  const leagueClockRouter = createLeagueClockRouter(leagueClockService, {
+    teamService,
+    coachesService,
+  });
 
   // Routers
   const leagueRouter = createLeagueRouter(leagueService);


### PR DESCRIPTION
## Summary

- Adds a `genesis_founding_pool` entry to the phase gate system that blocks advancement unless all teams have at least one coach on their staff tree
- Computes `allTeamsHaveStaff` server-side in the league-clock router (via team + coaches services) so the gate cannot be bypassed by the client
- Extends `LeagueGateState` with the new `allTeamsHaveStaff` boolean, wired through to both server gate logic and client type definitions

Closes #396

🤖 Generated with [Claude Code](https://claude.com/claude-code)