### PR TITLE
fix(ui): remove broken Staff Hiring nav link and skip completed genesis phase

### DIFF
--- a/client/src/features/league/index.test.tsx
+++ b/client/src/features/league/index.test.tsx
@@ -56,15 +56,14 @@ afterEach(() => {
 });
 
 describe("LeagueHome", () => {
-  it("renders the staff-hiring view when phase is genesis_staff_hiring", async () => {
+  it("renders the dashboard view when phase is genesis_staff_hiring", async () => {
     mockPhase = "genesis_staff_hiring";
     renderWithProviders();
     await waitFor(() => {
       expect(
-        screen.getByRole("heading", { name: "Staff Hiring" }),
+        screen.getByRole("heading", { name: "League Home" }),
       ).toBeDefined();
     });
-    expect(screen.getByText(/hire the head coaches/i)).toBeDefined();
   });
 
   it("renders the founding-pool view when phase is genesis_founding_pool", async () => {

--- a/client/src/features/league/index.tsx
+++ b/client/src/features/league/index.tsx
@@ -16,11 +16,6 @@ const PHASE_VIEWS: Partial<Record<LeaguePhase, PhaseView>> = {
     description:
       "The eight founding franchises take the field. Claim yours and meet your rivals.",
   },
-  genesis_staff_hiring: {
-    title: "Staff Hiring",
-    description:
-      "Hire the head coaches and scouts who will shape your franchise's first season.",
-  },
   genesis_founding_pool: {
     title: "Founding Pool",
     description:

--- a/client/src/features/league/layout.test.tsx
+++ b/client/src/features/league/layout.test.tsx
@@ -303,9 +303,10 @@ describe("LeagueLayout", () => {
     renderWithProviders();
 
     await waitFor(() => {
-      expect(screen.getByRole("link", { name: "Staff Hiring" })).toBeDefined();
+      expect(screen.getByRole("link", { name: "Coaches" })).toBeDefined();
     });
 
+    expect(screen.queryByRole("link", { name: "Staff Hiring" })).toBeNull();
     expect(screen.queryByRole("link", { name: "Charter" })).toBeNull();
     expect(screen.queryByRole("link", { name: "Founding Pool" })).toBeNull();
     expect(screen.queryByRole("link", { name: "Allocation Draft" })).toBeNull();

--- a/client/src/features/league/nav-config.test.ts
+++ b/client/src/features/league/nav-config.test.ts
@@ -119,13 +119,10 @@ describe("navGroups", () => {
     expect(visibleLabels("regular_season")).not.toContain("Charter");
   });
 
-  it("shows Staff Hiring only in genesis_staff_hiring", () => {
-    expect(visibleLabels("genesis_staff_hiring")).toContain("Staff Hiring");
-    expect(visibleLabels("genesis_charter")).not.toContain("Staff Hiring");
-    expect(visibleLabels("genesis_founding_pool")).not.toContain(
-      "Staff Hiring",
-    );
-    expect(visibleLabels("regular_season")).not.toContain("Staff Hiring");
+  it("does not include a Staff Hiring nav item", () => {
+    for (const phase of LEAGUE_PHASES) {
+      expect(visibleLabels(phase)).not.toContain("Staff Hiring");
+    }
   });
 
   it("shows Founding Pool only in genesis_founding_pool", () => {
@@ -162,7 +159,7 @@ describe("navGroups", () => {
       ["genesis_charter", ["Home", "Charter"]],
       [
         "genesis_staff_hiring",
-        ["Home", "Coaches", "Scouts", "Staff Hiring", "Media"],
+        ["Home", "Coaches", "Scouts", "Media"],
       ],
       [
         "genesis_allocation_draft",

--- a/client/src/features/league/nav-config.ts
+++ b/client/src/features/league/nav-config.ts
@@ -1,6 +1,5 @@
 import {
   ArrowLeftRightIcon,
-  BriefcaseIcon,
   CalendarIcon,
   ClipboardListIcon,
   DollarSignIcon,
@@ -72,7 +71,6 @@ const freeAgencyPhases = inPhases(
 );
 
 const genesisCharter = inPhases("genesis_charter");
-const genesisStaffHiring = inPhases("genesis_staff_hiring");
 const genesisFoundingPool = inPhases("genesis_founding_pool");
 const genesisAllocationDraft = inPhases("genesis_allocation_draft");
 
@@ -98,12 +96,6 @@ export const navGroups: NavGroup[] = [
         path: "scouts",
         Icon: SearchIcon,
         visibleInPhases: fromStaffHiring,
-      },
-      {
-        label: "Staff Hiring",
-        path: "staff-hiring",
-        Icon: BriefcaseIcon,
-        visibleInPhases: genesisStaffHiring,
       },
     ],
   },

--- a/server/features/league/league.service.test.ts
+++ b/server/features/league/league.service.test.ts
@@ -634,7 +634,7 @@ Deno.test("league.service", async (t) => {
           upsert: (row) => {
             clockUpserted = true;
             assertEquals(row.leagueId, leagueId);
-            assertEquals(row.phase, "genesis_staff_hiring");
+            assertEquals(row.phase, "genesis_founding_pool");
             assertEquals(row.seasonYear, 1);
             assertEquals(row.stepIndex, 0);
             return Promise.resolve({

--- a/server/features/league/league.service.ts
+++ b/server/features/league/league.service.ts
@@ -11,7 +11,7 @@ import type { ScheduleService } from "../schedule/schedule.service.interface.ts"
 import type { LeagueClockRepository } from "../league-clock/league-clock.repository.ts";
 
 const FOUNDING_TEAM_COUNT = 8;
-const FIRST_INCOMPLETE_GENESIS_PHASE = "genesis_staff_hiring";
+const FIRST_INCOMPLETE_GENESIS_PHASE = "genesis_founding_pool";
 
 export function createLeagueService(deps: {
   txRunner: TransactionRunner;


### PR DESCRIPTION
## Summary

- Removed the broken "Staff Hiring" navigation link that pointed to a non-existent route (`/leagues/$leagueId/staff-hiring`).
- Changed `FIRST_INCOMPLETE_GENESIS_PHASE` from `genesis_staff_hiring` to `genesis_founding_pool` so users land on a meaningful phase after league creation (staff is already hired during the founding process).
- Removed the `genesis_staff_hiring` entry from `PHASE_VIEWS` since that phase is now auto-completed during founding.

Closes #397