### PR TITLE
fix(ui): show toast feedback when advancing the league clock

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -21,9 +21,11 @@
         "clsx": "^2.1.1",
         "hono": "^4",
         "lucide-react": "^1.8.0",
+        "next-themes": "^0.4.6",
         "react": "^19",
         "react-dom": "^19",
         "shadcn": "^4.2.0",
+        "sonner": "^2.0.7",
         "tailwind-merge": "^3.5.0",
         "tw-animate-css": "^1.4.0"
       },
@@ -5867,6 +5869,16 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/next-themes": {
+      "version": "0.4.6",
+      "resolved": "https://registry.npmjs.org/next-themes/-/next-themes-0.4.6.tgz",
+      "integrity": "sha512-pZvgD5L0IEvX5/9GWyHMf3m8BKiVQwsCMHfoFosXtXBMnaS0ZnIJ9ST4b4NqLVKDEm8QBxoNNGNaBv2JNF6XNA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc"
+      }
+    },
     "node_modules/node-domexception": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
@@ -6902,6 +6914,16 @@
       "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
       "integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==",
       "license": "MIT"
+    },
+    "node_modules/sonner": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/sonner/-/sonner-2.0.7.tgz",
+      "integrity": "sha512-W6ZN4p58k8aDKA4XPcx2hpIQXBRAgyiWVkYhT7CvK6D3iAu7xjvVyhQHg2/iaKJZ1XVJ4r7XuwGL+WGEK37i9w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^18.0.0 || ^19.0.0 || ^19.0.0-rc",
+        "react-dom": "^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      }
     },
     "node_modules/source-map": {
       "version": "0.6.1",

--- a/client/package.json
+++ b/client/package.json
@@ -18,9 +18,11 @@
     "clsx": "^2.1.1",
     "hono": "^4",
     "lucide-react": "^1.8.0",
+    "next-themes": "^0.4.6",
     "react": "^19",
     "react-dom": "^19",
     "shadcn": "^4.2.0",
+    "sonner": "^2.0.7",
     "tailwind-merge": "^3.5.0",
     "tw-animate-css": "^1.4.0"
   },

--- a/client/src/components/ui/sonner.tsx
+++ b/client/src/components/ui/sonner.tsx
@@ -1,0 +1,37 @@
+import { Toaster as Sonner, type ToasterProps } from "sonner";
+import {
+  CircleCheckIcon,
+  InfoIcon,
+  Loader2Icon,
+  OctagonXIcon,
+  TriangleAlertIcon,
+} from "lucide-react";
+
+const Toaster = ({ ...props }: ToasterProps) => {
+  return (
+    <Sonner
+      className="toaster group"
+      icons={{
+        success: <CircleCheckIcon className="size-4" />,
+        info: <InfoIcon className="size-4" />,
+        warning: <TriangleAlertIcon className="size-4" />,
+        error: <OctagonXIcon className="size-4" />,
+        loading: <Loader2Icon className="size-4 animate-spin" />,
+      }}
+      style={{
+        "--normal-bg": "var(--popover)",
+        "--normal-text": "var(--popover-foreground)",
+        "--normal-border": "var(--border)",
+        "--border-radius": "var(--radius)",
+      } as React.CSSProperties}
+      toastOptions={{
+        classNames: {
+          toast: "cn-toast",
+        },
+      }}
+      {...props}
+    />
+  );
+};
+
+export { Toaster };

--- a/client/src/features/league/league-clock-display.test.tsx
+++ b/client/src/features/league/league-clock-display.test.tsx
@@ -7,6 +7,7 @@ import {
 } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { Toaster } from "@/components/ui/sonner";
 import { LeagueClockDisplay } from "./league-clock-display.tsx";
 
 const mockGetClock = vi.fn();
@@ -37,6 +38,7 @@ function renderWithProviders(props: {
   return render(
     <QueryClientProvider client={queryClient}>
       <LeagueClockDisplay {...props} />
+      <Toaster />
     </QueryClientProvider>,
   );
 }
@@ -159,12 +161,11 @@ describe("LeagueClockDisplay", () => {
     fireEvent.click(screen.getByRole("button", { name: /advance/i }));
 
     await waitFor(() => {
-      expect(screen.getByRole("alert")).toBeDefined();
+      expect(screen.getByText(/not cap-compliant/i)).toBeDefined();
     });
-    expect(screen.getByText(/not cap-compliant/i)).toBeDefined();
   });
 
-  it("advances successfully when Advance button is clicked", async () => {
+  it("shows a success toast when advance succeeds", async () => {
     mockGetClock.mockResolvedValue({
       ok: true,
       json: () =>
@@ -188,6 +189,8 @@ describe("LeagueClockDisplay", () => {
           seasonYear: 2026,
           phase: "offseason_review",
           stepIndex: 1,
+          slug: "end_of_year_recap",
+          flavorDate: "Feb 10",
           advancedAt: "2026-01-01T00:00:00Z",
           overrideReason: null,
           overrideBlockers: null,
@@ -207,7 +210,99 @@ describe("LeagueClockDisplay", () => {
     fireEvent.click(screen.getByRole("button", { name: /advance/i }));
 
     await waitFor(() => {
-      expect(mockAdvance).toHaveBeenCalled();
+      expect(screen.getByText(/Advanced to End Of Year Recap/)).toBeDefined();
+    });
+  });
+
+  it("shows a success toast with flavor date when present", async () => {
+    mockGetClock.mockResolvedValue({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          leagueId: "lg-1",
+          seasonYear: 2026,
+          phase: "regular_season",
+          stepIndex: 0,
+          slug: "week_1",
+          kind: "week",
+          flavorDate: "Sep 7",
+          advancedAt: "2026-01-01T00:00:00Z",
+        }),
+    });
+
+    mockAdvance.mockResolvedValue({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          leagueId: "lg-1",
+          seasonYear: 2026,
+          phase: "regular_season",
+          stepIndex: 1,
+          slug: "week_2",
+          flavorDate: "Sep 14",
+          advancedAt: "2026-01-01T00:00:00Z",
+          overrideReason: null,
+          overrideBlockers: null,
+          autoResolved: [],
+          looped: false,
+        }),
+    });
+
+    renderWithProviders({ leagueId: "lg-1", isCommissioner: true });
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("button", { name: /advance/i }),
+      ).toBeDefined();
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: /advance/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText(/Advanced to Week 2/)).toBeDefined();
+    });
+    expect(screen.getByText(/Sep 14/)).toBeDefined();
+  });
+
+  it("shows an error toast when advance fails", async () => {
+    mockGetClock.mockResolvedValue({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          leagueId: "lg-1",
+          seasonYear: 2026,
+          phase: "preseason",
+          stepIndex: 3,
+          slug: "final_cuts",
+          kind: "event",
+          flavorDate: "Aug 27",
+          advancedAt: "2026-01-01T00:00:00Z",
+        }),
+    });
+
+    mockAdvance.mockResolvedValue({
+      ok: false,
+      status: 400,
+      json: () =>
+        Promise.resolve({
+          error: "GATE_BLOCKED",
+          message:
+            "Cannot advance to regular_season: Team is not cap-compliant",
+        }),
+    });
+
+    renderWithProviders({ leagueId: "lg-1", isCommissioner: true });
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("button", { name: /advance/i }),
+      ).toBeDefined();
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: /advance/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText(/Cannot Advance/)).toBeDefined();
     });
   });
 

--- a/client/src/features/league/league-clock-display.test.tsx
+++ b/client/src/features/league/league-clock-display.test.tsx
@@ -264,6 +264,58 @@ describe("LeagueClockDisplay", () => {
     expect(screen.getByText(/Sep 14/)).toBeDefined();
   });
 
+  it("shows a success toast without flavor date when absent", async () => {
+    mockGetClock.mockResolvedValue({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          leagueId: "lg-1",
+          seasonYear: 2026,
+          phase: "genesis_charter",
+          stepIndex: 0,
+          slug: "ratify_league_charter",
+          kind: "event",
+          flavorDate: null,
+          advancedAt: "2026-01-01T00:00:00Z",
+          hasCompletedGenesis: false,
+        }),
+    });
+
+    mockAdvance.mockResolvedValue({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          leagueId: "lg-1",
+          seasonYear: 2026,
+          phase: "genesis_franchise_establishment",
+          stepIndex: 0,
+          slug: "establish_franchises",
+          flavorDate: null,
+          advancedAt: "2026-01-01T00:00:00Z",
+          overrideReason: null,
+          overrideBlockers: null,
+          autoResolved: [],
+          looped: false,
+        }),
+    });
+
+    renderWithProviders({ leagueId: "lg-1", isCommissioner: true });
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("button", { name: /advance/i }),
+      ).toBeDefined();
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: /advance/i }));
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(/Advanced to Establish Franchises/),
+      ).toBeDefined();
+    });
+  });
+
   it("shows an error toast when advance fails", async () => {
     mockGetClock.mockResolvedValue({
       ok: true,

--- a/client/src/features/league/league-clock-display.tsx
+++ b/client/src/features/league/league-clock-display.tsx
@@ -1,12 +1,6 @@
-import { useState } from "react";
-import {
-  AlertTriangleIcon,
-  CalendarIcon,
-  ChevronRightIcon,
-  InfoIcon,
-} from "lucide-react";
+import { CalendarIcon, ChevronRightIcon, InfoIcon } from "lucide-react";
+import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
-import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { Badge } from "@/components/ui/badge";
 import {
   useAdvanceLeagueClock,
@@ -38,7 +32,6 @@ export function LeagueClockDisplay({
 }: LeagueClockDisplayProps) {
   const { data: clock } = useLeagueClock(leagueId);
   const advanceMutation = useAdvanceLeagueClock();
-  const [error, setError] = useState<string | null>(null);
 
   if (!clock) return null;
 
@@ -46,7 +39,6 @@ export function LeagueClockDisplay({
   const showInauguralYearNote = clock.isInauguralSeason && !isSetupPhase;
 
   const handleAdvance = () => {
-    setError(null);
     advanceMutation.mutate(
       {
         leagueId,
@@ -59,8 +51,15 @@ export function LeagueClockDisplay({
         },
       },
       {
+        onSuccess: (data) => {
+          const stepName = formatSlug(data.slug);
+          const description = data.flavorDate
+            ? `${formatPhase(data.phase)} — ${data.flavorDate}`
+            : formatPhase(data.phase);
+          toast.success(`Advanced to ${stepName}`, { description });
+        },
         onError: (err) => {
-          setError(err.message);
+          toast.error("Cannot Advance", { description: err.message });
         },
       },
     );
@@ -103,13 +102,6 @@ export function LeagueClockDisplay({
           <InfoIcon className="size-3" />
           <span>No preseason (inaugural year)</span>
         </div>
-      )}
-      {error && (
-        <Alert variant="destructive">
-          <AlertTriangleIcon />
-          <AlertTitle>Cannot Advance</AlertTitle>
-          <AlertDescription>{error}</AlertDescription>
-        </Alert>
       )}
     </div>
   );

--- a/client/src/hooks/use-league-clock.ts
+++ b/client/src/hooks/use-league-clock.ts
@@ -19,6 +19,20 @@ export function useLeagueClock(leagueId: string) {
   });
 }
 
+interface AdvanceResult {
+  leagueId: string;
+  seasonYear: number;
+  phase: string;
+  stepIndex: number;
+  slug: string;
+  flavorDate: string | null;
+  advancedAt: string;
+  overrideReason: string | null;
+  overrideBlockers: unknown;
+  autoResolved: unknown[];
+  looped: boolean;
+}
+
 export function useAdvanceLeagueClock() {
   const queryClient = useQueryClient();
   return useMutation({
@@ -44,7 +58,7 @@ export function useAdvanceLeagueClock() {
         superBowlPlayed: boolean;
         priorPhaseComplete: boolean;
       };
-    }) => {
+    }): Promise<AdvanceResult> => {
       const res = await api.api["league-clock"][":leagueId"].advance.$post({
         param: { leagueId },
         json: { isCommissioner, overrideReason, gateState },
@@ -56,7 +70,7 @@ export function useAdvanceLeagueClock() {
             `Advance failed (${res.status})`,
         );
       }
-      return res.json();
+      return res.json() as Promise<AdvanceResult>;
     },
     onSuccess: (_data, variables) => {
       queryClient.invalidateQueries({

--- a/client/src/main.tsx
+++ b/client/src/main.tsx
@@ -1,6 +1,7 @@
 import { createRoot } from "react-dom/client";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { RouterProvider } from "@tanstack/react-router";
+import { Toaster } from "@/components/ui/sonner";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import { createAppRouter } from "./router.tsx";
 import "./index.css";
@@ -12,6 +13,7 @@ createRoot(document.getElementById("root")!).render(
   <QueryClientProvider client={queryClient}>
     <TooltipProvider delay={700}>
       <RouterProvider router={router} />
+      <Toaster />
     </TooltipProvider>
   </QueryClientProvider>,
 );

--- a/deno.lock
+++ b/deno.lock
@@ -33,12 +33,14 @@
     "npm:happy-dom@18": "18.0.1",
     "npm:hono@4": "4.12.12",
     "npm:lucide-react@^1.8.0": "1.8.0_react@19.2.4",
+    "npm:next-themes@~0.4.6": "0.4.6_react@19.2.4_react-dom@19.2.4__react@19.2.4",
     "npm:pino-pretty@13": "13.1.3",
     "npm:pino@9": "9.14.0",
     "npm:postgres@3": "3.4.9",
     "npm:react-dom@19": "19.2.4_react@19.2.4",
     "npm:react@19": "19.2.4",
     "npm:shadcn@^4.2.0": "4.2.0_typescript@5.9.3",
+    "npm:sonner@^2.0.7": "2.0.7_react@19.2.4_react-dom@19.2.4__react@19.2.4",
     "npm:tailwind-merge@^3.5.0": "3.5.0",
     "npm:tailwindcss@4": "4.2.2",
     "npm:tsc@*": "2.0.4",
@@ -2911,6 +2913,13 @@
     "negotiator@1.0.0": {
       "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg=="
     },
+    "next-themes@0.4.6_react@19.2.4_react-dom@19.2.4__react@19.2.4": {
+      "integrity": "sha512-pZvgD5L0IEvX5/9GWyHMf3m8BKiVQwsCMHfoFosXtXBMnaS0ZnIJ9ST4b4NqLVKDEm8QBxoNNGNaBv2JNF6XNA==",
+      "dependencies": [
+        "react",
+        "react-dom"
+      ]
+    },
     "node-domexception@1.0.0": {
       "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
       "deprecated": true
@@ -3501,6 +3510,13 @@
         "atomic-sleep"
       ]
     },
+    "sonner@2.0.7_react@19.2.4_react-dom@19.2.4__react@19.2.4": {
+      "integrity": "sha512-W6ZN4p58k8aDKA4XPcx2hpIQXBRAgyiWVkYhT7CvK6D3iAu7xjvVyhQHg2/iaKJZ1XVJ4r7XuwGL+WGEK37i9w==",
+      "dependencies": [
+        "react",
+        "react-dom"
+      ]
+    },
     "source-map-js@1.2.1": {
       "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA=="
     },
@@ -3974,9 +3990,11 @@
             "npm:happy-dom@18",
             "npm:hono@4",
             "npm:lucide-react@^1.8.0",
+            "npm:next-themes@~0.4.6",
             "npm:react-dom@19",
             "npm:react@19",
             "npm:shadcn@^4.2.0",
+            "npm:sonner@^2.0.7",
             "npm:tailwind-merge@^3.5.0",
             "npm:tailwindcss@4",
             "npm:tw-animate-css@^1.4.0",

--- a/server/features/league-clock/league-clock.router.test.ts
+++ b/server/features/league-clock/league-clock.router.test.ts
@@ -32,6 +32,8 @@ function createMockAdvanceResult(
     seasonYear: 2026,
     phase: "offseason_review",
     stepIndex: 1,
+    slug: "end_of_year_recap",
+    flavorDate: "Feb 10",
     advancedAt: new Date("2026-01-01T00:00:00Z"),
     overrideReason: null,
     overrideBlockers: null,

--- a/server/features/league-clock/league-clock.service.test.ts
+++ b/server/features/league-clock/league-clock.service.test.ts
@@ -167,6 +167,31 @@ Deno.test("league-clock.service", async (t) => {
       assertEquals(result.looped, false);
     });
 
+    await t.step(
+      "returns slug and flavorDate of the target step",
+      async () => {
+        const service = createService({
+          leagueClockRepo: {
+            getByLeagueId: () =>
+              Promise.resolve(
+                createMockClock({
+                  phase: "regular_season",
+                  stepIndex: 0,
+                }),
+              ),
+          },
+        });
+
+        const result = await service.advance(
+          "league-1",
+          createActor(),
+          createGateState(),
+        );
+        assertEquals(result.slug, "week_2");
+        assertEquals(result.flavorDate, "Sep 14");
+      },
+    );
+
     await t.step("advances to next phase when at last step", async () => {
       const service = createService({
         leagueClockRepo: {

--- a/server/features/league-clock/league-clock.service.ts
+++ b/server/features/league-clock/league-clock.service.ts
@@ -24,6 +24,8 @@ export interface AdvanceResult {
   seasonYear: number;
   phase: string;
   stepIndex: number;
+  slug: string;
+  flavorDate: string | null;
   advancedAt: Date;
   overrideReason: string | null;
   overrideBlockers: unknown;
@@ -232,6 +234,10 @@ export function createLeagueClockService(deps: {
         }
       }
 
+      const targetStep = DEFAULT_PHASE_STEPS.find(
+        (s) => s.phase === targetPhase && s.stepIndex === targetStepIndex,
+      );
+
       return await deps.txRunner.run(async (tx) => {
         const row = await deps.leagueClockRepo.upsert(
           {
@@ -252,6 +258,8 @@ export function createLeagueClockService(deps: {
           seasonYear: row.seasonYear,
           phase: row.phase,
           stepIndex: row.stepIndex,
+          slug: targetStep?.slug ?? "",
+          flavorDate: targetStep?.flavorDate ?? null,
           advancedAt: row.advancedAt,
           overrideReason: row.overrideReason,
           overrideBlockers: row.overrideBlockers,


### PR DESCRIPTION
## Summary

- Installed sonner (via shadcn) and mounted `<Toaster />` in the app root to enable toast notifications.
- On advance success, a toast shows the target step name and flavor date (e.g. "Advanced to Week 2 — Sep 14").
- On advance error, a toast shows the error message instead of the previous inline alert.
- Server's advance endpoint now returns `slug` and `flavorDate` of the target step so the client can build a human-readable message.

Closes #399