### PR TITLE
fix(ui): show full date context in league clock display

### DIFF
--- a/client/src/features/league/league-clock-display.test.tsx
+++ b/client/src/features/league/league-clock-display.test.tsx
@@ -47,7 +47,7 @@ afterEach(() => {
 });
 
 describe("LeagueClockDisplay", () => {
-  it("renders the phase and step name with flavor date", async () => {
+  it("renders the full temporal context: phase, slug, year, and flavor date", async () => {
     mockGetClock.mockResolvedValue({
       ok: true,
       json: () =>
@@ -66,10 +66,11 @@ describe("LeagueClockDisplay", () => {
     renderWithProviders({ leagueId: "lg-1", isCommissioner: true });
 
     await waitFor(() => {
-      expect(screen.getByText("Week 4")).toBeDefined();
+      expect(
+        screen.getByText("Regular Season — Week 4, Year 2026"),
+      ).toBeDefined();
     });
     expect(screen.getByText("Sep 28")).toBeDefined();
-    expect(screen.getByText(/Regular Season/)).toBeDefined();
   });
 
   it("renders Advance button for commissioner", async () => {
@@ -116,7 +117,9 @@ describe("LeagueClockDisplay", () => {
     renderWithProviders({ leagueId: "lg-1", isCommissioner: false });
 
     await waitFor(() => {
-      expect(screen.getByText("Awards Ceremony")).toBeDefined();
+      expect(
+        screen.getByText("Offseason Review — Awards Ceremony, Year 2026"),
+      ).toBeDefined();
     });
     expect(screen.queryByRole("button", { name: /advance/i })).toBeNull();
   });
@@ -211,7 +214,7 @@ describe("LeagueClockDisplay", () => {
     });
   });
 
-  it("renders the season year", async () => {
+  it("renders year as part of the full temporal context string", async () => {
     mockGetClock.mockResolvedValue({
       ok: true,
       json: () =>
@@ -231,7 +234,9 @@ describe("LeagueClockDisplay", () => {
     renderWithProviders({ leagueId: "lg-1", isCommissioner: true });
 
     await waitFor(() => {
-      expect(screen.getByText("2026")).toBeDefined();
+      expect(
+        screen.getByText("Draft — Round 1, Year 2026"),
+      ).toBeDefined();
     });
   });
 
@@ -255,7 +260,9 @@ describe("LeagueClockDisplay", () => {
     renderWithProviders({ leagueId: "lg-1", isCommissioner: false });
 
     await waitFor(() => {
-      expect(screen.getByText("Week 1")).toBeDefined();
+      expect(
+        screen.getByText("Regular Season — Week 1, Year 1"),
+      ).toBeDefined();
     });
     expect(
       screen.getByText("No preseason (inaugural year)"),
@@ -282,7 +289,9 @@ describe("LeagueClockDisplay", () => {
     renderWithProviders({ leagueId: "lg-1", isCommissioner: false });
 
     await waitFor(() => {
-      expect(screen.getByText("Preseason Week 1")).toBeDefined();
+      expect(
+        screen.getByText("Preseason — Preseason Week 1, Year 2"),
+      ).toBeDefined();
     });
     expect(
       screen.queryByText("No preseason (inaugural year)"),
@@ -309,7 +318,9 @@ describe("LeagueClockDisplay", () => {
     renderWithProviders({ leagueId: "lg-1", isCommissioner: false });
 
     await waitFor(() => {
-      expect(screen.getByText("Kickoff")).toBeDefined();
+      expect(
+        screen.getByText("Genesis Kickoff — Kickoff, Year 1"),
+      ).toBeDefined();
     });
     expect(
       screen.queryByText("No preseason (inaugural year)"),

--- a/client/src/features/league/league-clock-display.tsx
+++ b/client/src/features/league/league-clock-display.tsx
@@ -1,13 +1,7 @@
 import { useState } from "react";
-import {
-  AlertTriangleIcon,
-  CalendarIcon,
-  ChevronRightIcon,
-  InfoIcon,
-} from "lucide-react";
+import { AlertTriangleIcon, ChevronRightIcon, InfoIcon } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
-import { Badge } from "@/components/ui/badge";
 import {
   useAdvanceLeagueClock,
   useLeagueClock,
@@ -25,6 +19,14 @@ function formatPhase(phase: string): string {
     .split("_")
     .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
     .join(" ");
+}
+
+function formatClockHeading(
+  phase: string,
+  slug: string,
+  seasonYear: number,
+): string {
+  return `${formatPhase(phase)} — ${formatSlug(slug)}, Year ${seasonYear}`;
 }
 
 interface LeagueClockDisplayProps {
@@ -70,15 +72,8 @@ export function LeagueClockDisplay({
     <div className="flex flex-col gap-2">
       <div className="flex items-center gap-3">
         <div className="flex items-center gap-2">
-          <CalendarIcon className="size-4 text-muted-foreground" />
-          <span className="text-sm font-medium text-muted-foreground">
-            {clock.seasonYear}
-          </span>
-          <Badge variant="outline">{formatPhase(clock.phase)}</Badge>
-        </div>
-        <div className="flex items-center gap-2">
           <span className="text-sm font-semibold">
-            {formatSlug(clock.slug)}
+            {formatClockHeading(clock.phase, clock.slug, clock.seasonYear)}
           </span>
           {clock.flavorDate && (
             <span className="text-xs text-muted-foreground">


### PR DESCRIPTION
## Summary

- Replaces the confusing calendar icon + bare season year number with a single human-readable heading: `Phase — Slug, Year N` (e.g., "Regular Season — Week 4, Year 2026")
- Removes the `CalendarIcon` and phase `Badge` in favour of the consolidated heading string, giving users immediate temporal context at a glance

Closes #403