### PR TITLE
feat(ui): display league creation settings on settings page

### DIFF
--- a/client/src/features/league/settings.test.tsx
+++ b/client/src/features/league/settings.test.tsx
@@ -4,13 +4,15 @@ import {
   render,
   screen,
   waitFor,
+  within,
 } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { LeagueSettings } from "./settings.tsx";
 
 const mockDelete = vi.fn();
 const mockNavigate = vi.fn();
+const mockUseLeague = vi.fn();
 
 vi.mock("../../api.ts", () => ({
   api: {
@@ -24,10 +26,28 @@ vi.mock("../../api.ts", () => ({
   },
 }));
 
+const mockUseParams = vi.fn();
+
 vi.mock("@tanstack/react-router", () => ({
-  useParams: () => ({ leagueId: "league-1" }),
+  useParams: (...args: unknown[]) => mockUseParams(...args),
   useNavigate: () => mockNavigate,
 }));
+
+vi.mock("../../hooks/use-league.ts", () => ({
+  useLeague: (...args: unknown[]) => mockUseLeague(...args),
+}));
+
+const baseLeague = {
+  id: "league-1",
+  name: "Test League",
+  numberOfTeams: 8,
+  seasonLength: 17,
+  salaryCap: 255_000_000,
+  capFloorPercent: 89,
+  capGrowthRate: 5,
+  rosterSize: 53,
+  advancePolicy: "commissioner" as const,
+};
 
 function renderWithProviders() {
   const queryClient = new QueryClient({
@@ -43,6 +63,11 @@ function renderWithProviders() {
 afterEach(() => {
   cleanup();
   vi.clearAllMocks();
+});
+
+beforeEach(() => {
+  mockUseParams.mockReturnValue({ leagueId: "league-1" });
+  mockUseLeague.mockReturnValue({ data: baseLeague, isLoading: false });
 });
 
 describe("LeagueSettings", () => {
@@ -130,6 +155,20 @@ describe("LeagueSettings", () => {
     });
   });
 
+  it("does not call delete when leagueId is missing", async () => {
+    mockUseParams.mockReturnValue({ leagueId: undefined });
+    mockUseLeague.mockReturnValue({ data: undefined, isLoading: false });
+    renderWithProviders();
+    fireEvent.click(screen.getByRole("button", { name: "Delete League" }));
+    await waitFor(() => {
+      expect(
+        screen.getByRole("button", { name: "Confirm Delete" }),
+      ).toBeDefined();
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Confirm Delete" }));
+    expect(mockDelete).not.toHaveBeenCalled();
+  });
+
   it("shows Deleting... text while mutation is pending", async () => {
     mockDelete.mockReturnValue(new Promise(() => {}));
     renderWithProviders();
@@ -145,5 +184,101 @@ describe("LeagueSettings", () => {
     await waitFor(() => {
       expect(screen.getByText("Deleting...")).toBeDefined();
     });
+  });
+});
+
+describe("LeagueSettings — league configuration", () => {
+  it("renders the League Configuration heading", () => {
+    renderWithProviders();
+    expect(screen.getByText("League Configuration")).toBeDefined();
+  });
+
+  it("displays the number of teams", () => {
+    renderWithProviders();
+    const section = screen.getByTestId("league-config");
+    expect(within(section).getByText("8")).toBeDefined();
+    expect(within(section).getByText("Teams")).toBeDefined();
+  });
+
+  it("displays the season length", () => {
+    renderWithProviders();
+    const section = screen.getByTestId("league-config");
+    expect(within(section).getByText("17")).toBeDefined();
+    expect(within(section).getByText("Season Games")).toBeDefined();
+  });
+
+  it("displays the roster size", () => {
+    renderWithProviders();
+    const section = screen.getByTestId("league-config");
+    expect(within(section).getByText("53")).toBeDefined();
+    expect(within(section).getByText("Roster Size")).toBeDefined();
+  });
+
+  it("displays the salary cap formatted as currency", () => {
+    renderWithProviders();
+    const section = screen.getByTestId("league-config");
+    expect(within(section).getByText("$255,000,000")).toBeDefined();
+    expect(within(section).getByText("Salary Cap")).toBeDefined();
+  });
+
+  it("displays the salary floor derived from cap and floor percent", () => {
+    renderWithProviders();
+    const section = screen.getByTestId("league-config");
+    expect(within(section).getByText("$226,950,000")).toBeDefined();
+    expect(within(section).getByText("Salary Floor")).toBeDefined();
+  });
+
+  it("displays the cap growth rate as a percentage", () => {
+    renderWithProviders();
+    const section = screen.getByTestId("league-config");
+    expect(within(section).getByText("5%")).toBeDefined();
+    expect(within(section).getByText("Cap Growth Rate")).toBeDefined();
+  });
+
+  it("displays the advance policy", () => {
+    renderWithProviders();
+    const section = screen.getByTestId("league-config");
+    expect(within(section).getByText("Commissioner")).toBeDefined();
+    expect(within(section).getByText("Advance Policy")).toBeDefined();
+  });
+
+  it("displays ready check advance policy when set", () => {
+    mockUseLeague.mockReturnValue({
+      data: { ...baseLeague, advancePolicy: "ready_check" },
+      isLoading: false,
+    });
+    renderWithProviders();
+    const section = screen.getByTestId("league-config");
+    expect(within(section).getByText("Ready Check")).toBeDefined();
+  });
+
+  it("shows a loading state while league data is loading", () => {
+    mockUseLeague.mockReturnValue({ data: undefined, isLoading: true });
+    renderWithProviders();
+    expect(screen.getByTestId("league-config-loading")).toBeDefined();
+  });
+
+  it("does not render the config card when league data is unavailable", () => {
+    mockUseLeague.mockReturnValue({ data: undefined, isLoading: false });
+    renderWithProviders();
+    expect(screen.queryByTestId("league-config")).toBeNull();
+    expect(screen.queryByTestId("league-config-loading")).toBeNull();
+  });
+
+  it("passes empty string to useLeague when leagueId is missing", () => {
+    mockUseParams.mockReturnValue({ leagueId: undefined });
+    mockUseLeague.mockReturnValue({ data: undefined, isLoading: false });
+    renderWithProviders();
+    expect(mockUseLeague).toHaveBeenCalledWith("");
+  });
+
+  it("falls back to raw advance policy value for unknown policies", () => {
+    mockUseLeague.mockReturnValue({
+      data: { ...baseLeague, advancePolicy: "some_unknown" },
+      isLoading: false,
+    });
+    renderWithProviders();
+    const section = screen.getByTestId("league-config");
+    expect(within(section).getByText("some_unknown")).toBeDefined();
   });
 });

--- a/client/src/features/league/settings.tsx
+++ b/client/src/features/league/settings.tsx
@@ -1,5 +1,6 @@
 import { useNavigate, useParams } from "@tanstack/react-router";
 import { useDeleteLeague } from "../../hooks/use-leagues.ts";
+import { useLeague } from "../../hooks/use-league.ts";
 import { Button } from "@/components/ui/button";
 import {
   Card,
@@ -19,11 +20,22 @@ import {
   AlertDialogTitle,
   AlertDialogTrigger,
 } from "@/components/ui/alert-dialog";
+import { Skeleton } from "@/components/ui/skeleton";
+
+const ADVANCE_POLICY_LABELS: Record<string, string> = {
+  commissioner: "Commissioner",
+  ready_check: "Ready Check",
+};
+
+function formatCurrency(value: number): string {
+  return `$${value.toLocaleString("en-US")}`;
+}
 
 export function LeagueSettings() {
   const { leagueId } = useParams({ strict: false });
   const navigate = useNavigate();
   const deleteLeague = useDeleteLeague();
+  const { data: league, isLoading } = useLeague(leagueId ?? "");
 
   const handleDelete = () => {
     if (!leagueId) return;
@@ -40,6 +52,63 @@ export function LeagueSettings() {
       <p className="mt-2 mb-6 max-w-2xl text-muted-foreground">
         Manage your league's configuration and lifecycle.
       </p>
+
+      {isLoading
+        ? (
+          <div data-testid="league-config-loading" className="mb-6 max-w-2xl">
+            <Skeleton className="h-64 w-full" />
+          </div>
+        )
+        : league
+        ? (
+          <Card className="mb-6 max-w-2xl" data-testid="league-config">
+            <CardHeader>
+              <CardTitle>League Configuration</CardTitle>
+              <CardDescription>
+                The settings chosen when this league was created. These are
+                read-only for now.
+              </CardDescription>
+            </CardHeader>
+            <CardContent>
+              <dl className="grid grid-cols-2 gap-x-6 gap-y-4 sm:grid-cols-3">
+                <ConfigItem
+                  label="Teams"
+                  value={String(league.numberOfTeams)}
+                />
+                <ConfigItem
+                  label="Season Games"
+                  value={String(league.seasonLength)}
+                />
+                <ConfigItem
+                  label="Roster Size"
+                  value={String(league.rosterSize)}
+                />
+                <ConfigItem
+                  label="Salary Cap"
+                  value={formatCurrency(league.salaryCap)}
+                />
+                <ConfigItem
+                  label="Salary Floor"
+                  value={formatCurrency(
+                    Math.round(
+                      league.salaryCap * (league.capFloorPercent / 100),
+                    ),
+                  )}
+                />
+                <ConfigItem
+                  label="Cap Growth Rate"
+                  value={`${league.capGrowthRate}%`}
+                />
+                <ConfigItem
+                  label="Advance Policy"
+                  value={ADVANCE_POLICY_LABELS[league.advancePolicy] ??
+                    league.advancePolicy}
+                />
+              </dl>
+            </CardContent>
+          </Card>
+        )
+        : null}
 
       <Card className="max-w-2xl border-destructive/50">
         <CardHeader>
@@ -78,6 +147,15 @@ export function LeagueSettings() {
           </AlertDialog>
         </CardContent>
       </Card>
+    </div>
+  );
+}
+
+function ConfigItem({ label, value }: { label: string; value: string }) {
+  return (
+    <div>
+      <dt className="text-sm text-muted-foreground">{label}</dt>
+      <dd className="text-lg font-semibold">{value}</dd>
     </div>
   );
 }


### PR DESCRIPTION
## Summary

- Adds a read-only "League Configuration" card to the league settings page displaying the settings chosen at league creation: number of teams, season length, roster size, salary cap, salary floor, cap growth rate, and advance policy.
- Uses the existing `useLeague` hook to fetch league data and renders it in a clean definition list layout.
- Includes a loading skeleton while data is fetching and handles missing data gracefully.

Closes #406