### PR TITLE
fix(ui): float league Advance button to the right of the heading

### DIFF
--- a/client/src/features/league/league-clock-display.tsx
+++ b/client/src/features/league/league-clock-display.tsx
@@ -67,7 +67,7 @@ export function LeagueClockDisplay({
   };
 
   return (
-    <div className="flex flex-col gap-2">
+    <div className="flex flex-1 flex-col gap-2">
       <div className="flex items-center gap-3">
         <div className="flex items-center gap-2">
           <CalendarIcon className="size-4 text-muted-foreground" />
@@ -90,6 +90,7 @@ export function LeagueClockDisplay({
           <Button
             size="sm"
             variant="outline"
+            className="ml-auto"
             onClick={handleAdvance}
             disabled={advanceMutation.isPending}
           >


### PR DESCRIPTION
## Summary

- Adds `flex-1` to the `LeagueClockDisplay` root so it fills available header width
- Adds `ml-auto` to the Advance button so it floats to the right side of the league header bar

Closes #408