### PR TITLE
fix(league): initialize league clock to genesis_charter phase

### DIFF
--- a/server/features/league/league.service.test.ts
+++ b/server/features/league/league.service.test.ts
@@ -634,7 +634,7 @@ Deno.test("league.service", async (t) => {
           upsert: (row) => {
             clockUpserted = true;
             assertEquals(row.leagueId, leagueId);
-            assertEquals(row.phase, "genesis_founding_pool");
+            assertEquals(row.phase, "genesis_charter");
             assertEquals(row.seasonYear, 1);
             assertEquals(row.stepIndex, 0);
             return Promise.resolve({

--- a/server/features/league/league.service.ts
+++ b/server/features/league/league.service.ts
@@ -11,7 +11,7 @@ import type { ScheduleService } from "../schedule/schedule.service.interface.ts"
 import type { LeagueClockRepository } from "../league-clock/league-clock.repository.ts";
 
 const FOUNDING_TEAM_COUNT = 8;
-const FIRST_INCOMPLETE_GENESIS_PHASE = "genesis_founding_pool";
+const FIRST_GENESIS_PHASE = "genesis_charter";
 
 export function createLeagueService(deps: {
   txRunner: TransactionRunner;
@@ -175,7 +175,7 @@ export function createLeagueService(deps: {
           {
             leagueId,
             seasonYear: 1,
-            phase: FIRST_INCOMPLETE_GENESIS_PHASE,
+            phase: FIRST_GENESIS_PHASE,
             stepIndex: 0,
             advancedByUserId: null,
           },


### PR DESCRIPTION
## Summary

- The league clock was initialized to `genesis_founding_pool` (phase 4) during league founding, skipping the first 3 genesis phases (`genesis_charter`, `genesis_franchise_establishment`, `genesis_staff_hiring`).
- Changed the initial phase constant from `genesis_founding_pool` to `genesis_charter` so newly created leagues start at the correct first phase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)