### PR TITLE
feat(sim): add structured logging to the simulation engine

### DIFF
--- a/server/features/simulation/mod.ts
+++ b/server/features/simulation/mod.ts
@@ -108,6 +108,9 @@ export type {
 export { simulateSeason } from "./simulate-season.ts";
 export type { SeasonInput, SeasonResult } from "./simulate-season.ts";
 
+export { noopLogger } from "./simulation-logger.ts";
+export type { SimLogger } from "./simulation-logger.ts";
+
 export { computeSeasonAggregates } from "./season-aggregates.ts";
 export type { SeasonAggregates } from "./season-aggregates.ts";
 

--- a/server/features/simulation/simulate-game.test.ts
+++ b/server/features/simulation/simulate-game.test.ts
@@ -19,6 +19,7 @@ import {
   makePlayer,
   makeStarters,
 } from "./test-helpers.ts";
+import { createSpyLogger } from "./simulation-logger.test.ts";
 
 function makeBench(prefix: string): PlayerRuntime[] {
   return [
@@ -1671,6 +1672,229 @@ Deno.test("simulateGame", async (t) => {
       );
     },
   );
+
+  await t.step(
+    "logging: accepts optional logger without changing results",
+    () => {
+      const { logger } = createSpyLogger();
+      const home = makeTeam("home");
+      const away = makeTeam("away");
+
+      const withoutLog = simulateGame({ home, away, seed: 42 });
+      const withLog = simulateGame({ home, away, seed: 42, log: logger });
+
+      assertEquals(withLog.finalScore, withoutLog.finalScore);
+      assertEquals(withLog.events.length, withoutLog.events.length);
+    },
+  );
+
+  await t.step("logging: emits game start and game end info logs", () => {
+    const { logger, calls } = createSpyLogger();
+    simulateGame({
+      home: makeTeam("home"),
+      away: makeTeam("away"),
+      seed: 42,
+      log: logger,
+    });
+
+    const startLogs = calls.filter((c) => c.msg === "game started");
+    const endLogs = calls.filter((c) => c.msg === "game ended");
+    assertEquals(startLogs.length, 1);
+    assertEquals(startLogs[0].level, "info");
+    assertEquals(endLogs.length, 1);
+    assertEquals(endLogs[0].level, "info");
+    assertExists(endLogs[0].obj.homeScore);
+    assertExists(endLogs[0].obj.awayScore);
+  });
+
+  await t.step("logging: emits quarter transition info logs", () => {
+    const { logger, calls } = createSpyLogger();
+    simulateGame({
+      home: makeTeam("home"),
+      away: makeTeam("away"),
+      seed: 42,
+      log: logger,
+    });
+
+    const quarterLogs = calls.filter((c) => c.msg === "quarter started");
+    assertGreaterOrEqual(quarterLogs.length, 4);
+    assertEquals(quarterLogs[0].level, "info");
+  });
+
+  await t.step("logging: emits drive start debug logs", () => {
+    const { logger, calls } = createSpyLogger();
+    simulateGame({
+      home: makeTeam("home"),
+      away: makeTeam("away"),
+      seed: 42,
+      log: logger,
+    });
+
+    const driveLogs = calls.filter((c) => c.msg === "drive started");
+    assertGreater(driveLogs.length, 0);
+    assertEquals(driveLogs[0].level, "debug");
+    assertExists(driveLogs[0].obj.driveIndex);
+  });
+
+  await t.step("logging: emits play resolved debug logs", () => {
+    const { logger, calls } = createSpyLogger();
+    simulateGame({
+      home: makeTeam("home"),
+      away: makeTeam("away"),
+      seed: 42,
+      log: logger,
+    });
+
+    const playLogs = calls.filter((c) => c.msg === "play resolved");
+    assertGreater(playLogs.length, 0);
+    assertEquals(playLogs[0].level, "debug");
+    assertExists(playLogs[0].obj.outcome);
+  });
+
+  await t.step("logging: emits scoring event info logs", () => {
+    const { logger, calls } = createSpyLogger();
+    simulateGame({
+      home: makeTeam("home"),
+      away: makeTeam("away"),
+      seed: 42,
+      log: logger,
+    });
+
+    const scoringLogs = calls.filter(
+      (c) =>
+        c.msg === "touchdown scored" ||
+        c.msg === "field goal made" ||
+        c.msg === "safety scored",
+    );
+    assertGreater(scoringLogs.length, 0);
+    assertEquals(scoringLogs[0].level, "info");
+  });
+
+  await t.step("logging: emits kickoff debug logs", () => {
+    const { logger, calls } = createSpyLogger();
+    simulateGame({
+      home: makeTeam("home"),
+      away: makeTeam("away"),
+      seed: 42,
+      log: logger,
+    });
+
+    const kickoffLogs = calls.filter((c) => c.msg === "kickoff");
+    assertGreater(kickoffLogs.length, 0);
+    assertEquals(kickoffLogs[0].level, "debug");
+  });
+
+  await t.step("logging: emits fourth down decision debug logs", () => {
+    const { logger, calls } = createSpyLogger();
+    // Run multiple seeds to find fourth-down decisions
+    for (let seed = 1; seed <= 20; seed++) {
+      simulateGame({
+        home: makeTeam("home"),
+        away: makeTeam("away"),
+        seed,
+        log: logger,
+      });
+    }
+
+    const fourthDownLogs = calls.filter(
+      (c) => c.msg === "fourth down decision",
+    );
+    assertGreater(fourthDownLogs.length, 0);
+    assertEquals(fourthDownLogs[0].level, "debug");
+    assertExists(fourthDownLogs[0].obj.decision);
+  });
+
+  await t.step("logging: emits penalty debug logs", () => {
+    const { logger, calls } = createSpyLogger();
+    for (let seed = 1; seed <= 20; seed++) {
+      simulateGame({
+        home: makeTeam("home"),
+        away: makeTeam("away"),
+        seed,
+        log: logger,
+      });
+    }
+
+    const penaltyLogs = calls.filter((c) => c.msg === "penalty");
+    assertGreater(penaltyLogs.length, 0);
+    assertEquals(penaltyLogs[0].level, "debug");
+    assertExists(penaltyLogs[0].obj.type);
+    assertExists(penaltyLogs[0].obj.accepted);
+  });
+
+  await t.step("logging: emits turnover debug logs", () => {
+    const { logger, calls } = createSpyLogger();
+    for (let seed = 1; seed <= 20; seed++) {
+      simulateGame({
+        home: makeTeam("home"),
+        away: makeTeam("away"),
+        seed,
+        log: logger,
+      });
+    }
+
+    const turnoverLogs = calls.filter((c) => c.msg === "turnover");
+    assertGreater(turnoverLogs.length, 0);
+    assertEquals(turnoverLogs[0].level, "debug");
+  });
+
+  await t.step("logging: emits overtime info log when game goes to OT", () => {
+    const { logger, calls } = createSpyLogger();
+    let otFound = false;
+    for (let seed = 1; seed <= 5000 && !otFound; seed++) {
+      calls.length = 0;
+      const result = simulateGame({
+        home: makeTeam("home"),
+        away: makeTeam("away"),
+        seed,
+        log: logger,
+      });
+      if (result.events.some((e) => e.quarter === "OT")) {
+        otFound = true;
+        const otLogs = calls.filter((c) => c.msg === "overtime started");
+        assertEquals(otLogs.length, 1);
+        assertEquals(otLogs[0].level, "info");
+      }
+    }
+    assertEquals(otFound, true);
+  });
+
+  await t.step("logging: emits conversion debug logs after touchdowns", () => {
+    const { logger, calls } = createSpyLogger();
+    simulateGame({
+      home: makeTeam("home"),
+      away: makeTeam("away"),
+      seed: 42,
+      log: logger,
+    });
+
+    const conversionLogs = calls.filter(
+      (c) => c.msg === "conversion attempt",
+    );
+    assertGreater(conversionLogs.length, 0);
+    assertEquals(conversionLogs[0].level, "debug");
+  });
+
+  await t.step("logging: emits timeout debug logs when timeouts occur", () => {
+    const { logger, calls } = createSpyLogger();
+    let foundTimeout = false;
+    for (let seed = 1; seed <= 500 && !foundTimeout; seed++) {
+      calls.length = 0;
+      const result = simulateGame({
+        home: makeTeam("home"),
+        away: makeTeam("away"),
+        seed,
+        log: logger,
+      });
+      if (result.events.some((e) => e.tags.includes("timeout"))) {
+        foundTimeout = true;
+        const timeoutLogs = calls.filter((c) => c.msg === "timeout called");
+        assertGreater(timeoutLogs.length, 0);
+        assertEquals(timeoutLogs[0].level, "debug");
+      }
+    }
+    assertEquals(foundTimeout, true);
+  });
 
   await t.step(
     "two-minute defense shifts to prevent-adjacent coverage",

--- a/server/features/simulation/simulate-game.ts
+++ b/server/features/simulation/simulate-game.ts
@@ -1,3 +1,5 @@
+import type { SimLogger } from "./simulation-logger.ts";
+import { noopLogger } from "./simulation-logger.ts";
 import type { SeededRng } from "./rng.ts";
 import { createSeededRng } from "./rng.ts";
 import type {
@@ -85,6 +87,7 @@ export interface SimulationInput {
   seed: number;
   gameId?: string;
   isPlayoff?: boolean;
+  log?: SimLogger;
 }
 
 export interface ActiveRosters {
@@ -151,8 +154,19 @@ function promoteNextManUp(
 }
 
 export function simulateGame(input: SimulationInput): GameResult {
+  const log = (input.log ?? noopLogger).child({ module: "simulate-game" });
   const rng = createSeededRng(input.seed);
   const gameId = input.gameId ?? `game-${input.seed}`;
+
+  log.info(
+    {
+      gameId,
+      homeTeamId: input.home.teamId,
+      awayTeamId: input.away.teamId,
+      seed: input.seed,
+    },
+    "game started",
+  );
 
   const events: PlayEvent[] = [];
 
@@ -254,7 +268,29 @@ export function simulateGame(input: SimulationInput): GameResult {
     events.push(result.event);
     incrementGlobalPlayIndex(state);
 
+    log.debug(
+      {
+        gameId,
+        quarter: state.quarter,
+        kickingTeamId,
+        receivingTeamId,
+        startingYardLine: result.startingYardLine,
+        isReturnTd: result.isReturnTouchdown,
+        isOnsideRecovery: result.isOnsideRecovery,
+      },
+      "kickoff",
+    );
+
     if (result.isReturnTouchdown) {
+      log.info(
+        {
+          gameId,
+          quarter: state.quarter,
+          teamId: receivingTeamId,
+          type: "kickoff_return_td",
+        },
+        "touchdown scored",
+      );
       addScore(state, receivingSide, 6);
 
       doConversion(receivingTeamId);
@@ -267,11 +303,30 @@ export function simulateGame(input: SimulationInput): GameResult {
     if (result.isOnsideRecovery) {
       setPossession(state, kickingSide);
       startNewDrive(state, result.startingYardLine);
+      log.debug(
+        {
+          gameId,
+          driveIndex: state.driveIndex,
+          teamId: kickingTeamId,
+          yardLine: result.startingYardLine,
+          onsideRecovery: true,
+        },
+        "drive started",
+      );
       return;
     }
 
     setPossession(state, receivingSide);
     startNewDrive(state, result.startingYardLine);
+    log.debug(
+      {
+        gameId,
+        driveIndex: state.driveIndex,
+        teamId: receivingTeamId,
+        yardLine: result.startingYardLine,
+      },
+      "drive started",
+    );
   }
 
   function buildGameState(): GameState {
@@ -351,6 +406,16 @@ export function simulateGame(input: SimulationInput): GameResult {
     };
     const conversionEvents = resolveConversion(ctx, rng);
     events.push(...conversionEvents);
+
+    log.debug(
+      {
+        gameId,
+        quarter: state.quarter,
+        scoringTeamId,
+        type: conversionEvents[0]?.outcome ?? "unknown",
+      },
+      "conversion attempt",
+    );
   }
 
   function handleScoring(event: PlayEvent): boolean {
@@ -360,11 +425,33 @@ export function simulateGame(input: SimulationInput): GameResult {
     addScore(state, result.scoringTeamSide!, result.points!);
 
     if (result.type === "safety") {
+      log.info(
+        {
+          gameId,
+          quarter: state.quarter,
+          teamId: result.scoringTeamId,
+          homeScore: state.homeScore,
+          awayScore: state.awayScore,
+        },
+        "safety scored",
+      );
       performKickoff(result.kickoffSide!, { isSafetyKick: result.safetyKick });
       return true;
     }
 
     // TD or return TD
+    const tdType = result.type === "return_td" ? "return_td" : "touchdown";
+    log.info(
+      {
+        gameId,
+        quarter: state.quarter,
+        teamId: result.scoringTeamId,
+        type: tdType,
+        homeScore: state.homeScore,
+        awayScore: state.awayScore,
+      },
+      "touchdown scored",
+    );
     doConversion(result.scoringTeamId!);
     performKickoff(result.kickoffSide!);
     return true;
@@ -427,8 +514,29 @@ export function simulateGame(input: SimulationInput): GameResult {
       const kickingSide: "home" | "away" =
         currentOffenseTeamId() === input.home.teamId ? "home" : "away";
       addScore(state, kickingSide, 3);
+      log.info(
+        {
+          gameId,
+          quarter: state.quarter,
+          teamId: currentOffenseTeamId(),
+          yardLine: state.yardLine,
+          homeScore: state.homeScore,
+          awayScore: state.awayScore,
+        },
+        "field goal made",
+      );
       performKickoff(kickingSide);
     } else {
+      log.debug(
+        {
+          gameId,
+          quarter: state.quarter,
+          teamId: currentOffenseTeamId(),
+          yardLine: state.yardLine,
+          blocked: fgResult.blocked,
+        },
+        "field goal missed",
+      );
       switchPossession(state);
       startNewDrive(state, fgResult.defenseYardLine);
     }
@@ -542,6 +650,19 @@ export function simulateGame(input: SimulationInput): GameResult {
       aggressiveness: offenseTeam.coachingMods.aggressiveness,
     }, rng);
 
+    log.debug(
+      {
+        gameId,
+        quarter: state.quarter,
+        decision,
+        yardsToEndzone,
+        distance: state.distance,
+        scoreDifferential: offenseScore - defenseScore,
+        teamId: currentOffenseTeamId(),
+      },
+      "fourth down decision",
+    );
+
     if (decision === "go") {
       return false;
     }
@@ -624,11 +745,50 @@ export function simulateGame(input: SimulationInput): GameResult {
       if (timeoutSide) {
         useTimeout(state, timeoutSide);
         event.tags.push("timeout");
+        log.debug(
+          {
+            gameId,
+            quarter: state.quarter,
+            side: timeoutSide,
+            clock: formatClock(state.clock),
+          },
+          "timeout called",
+        );
       }
     }
 
     processInjury(event);
     events.push(event);
+
+    log.debug(
+      {
+        gameId,
+        quarter: state.quarter,
+        clock: formatClock(state.clock),
+        down: state.down,
+        distance: state.distance,
+        yardLine: state.yardLine,
+        outcome: event.outcome,
+        yardage: event.yardage,
+        offenseTeamId: event.offenseTeamId,
+        concept: event.call.concept,
+      },
+      "play resolved",
+    );
+
+    if (event.penalty) {
+      log.debug(
+        {
+          gameId,
+          quarter: state.quarter,
+          type: event.penalty.type,
+          yardage: event.penalty.yardage,
+          accepted: event.penalty.accepted,
+          againstTeamId: event.penalty.againstTeamId,
+        },
+        "penalty",
+      );
+    }
 
     recordPlay(state);
 
@@ -644,7 +804,20 @@ export function simulateGame(input: SimulationInput): GameResult {
     }
 
     if (handleScoring(event)) return true;
-    if (handleTurnover(state, event)) return true;
+
+    if (handleTurnover(state, event)) {
+      log.debug(
+        {
+          gameId,
+          quarter: state.quarter,
+          outcome: event.outcome,
+          offenseTeamId: event.offenseTeamId,
+          yardLine: state.yardLine,
+        },
+        "turnover",
+      );
+      return true;
+    }
 
     advanceDowns(state, event.yardage);
 
@@ -652,6 +825,15 @@ export function simulateGame(input: SimulationInput): GameResult {
     // Cast needed: advanceDowns mutates down through the state-manager,
     // but TypeScript narrows state.down to 4 inside the isFourthDownAttempt guard.
     if (isFourthDownAttempt && (state.down as number) !== 1) {
+      log.debug(
+        {
+          gameId,
+          quarter: state.quarter,
+          offenseTeamId: event.offenseTeamId,
+          yardLine: state.yardLine,
+        },
+        "turnover on downs",
+      );
       const turnoverYardLine = Math.max(
         1,
         Math.min(99, state.yardLine),
@@ -672,6 +854,15 @@ export function simulateGame(input: SimulationInput): GameResult {
     q = (q + 1) as 1 | 2 | 3 | 4
   ) {
     setQuarter(state, q, QUARTER_SECONDS);
+    log.info(
+      {
+        gameId,
+        quarter: q,
+        homeScore: state.homeScore,
+        awayScore: state.awayScore,
+      },
+      "quarter started",
+    );
 
     if (q === 3) {
       resetHalfTimeouts(state);
@@ -690,6 +881,15 @@ export function simulateGame(input: SimulationInput): GameResult {
   if (state.homeScore === state.awayScore) {
     const isPlayoff = input.isPlayoff ?? false;
     setQuarter(state, "OT", OT_SECONDS);
+    log.info(
+      {
+        gameId,
+        homeScore: state.homeScore,
+        awayScore: state.awayScore,
+        isPlayoff,
+      },
+      "overtime started",
+    );
 
     const otCoinFlip: "home" | "away" = rng.next() < 0.5 ? "home" : "away";
     setPossession(state, otCoinFlip);
@@ -739,6 +939,16 @@ export function simulateGame(input: SimulationInput): GameResult {
       }
     }
   }
+
+  log.info(
+    {
+      gameId,
+      homeScore: state.homeScore,
+      awayScore: state.awayScore,
+      totalPlays: events.length,
+    },
+    "game ended",
+  );
 
   return {
     gameId,

--- a/server/features/simulation/simulate-season.test.ts
+++ b/server/features/simulation/simulate-season.test.ts
@@ -1,6 +1,12 @@
-import { assertEquals, assertGreater, assertLessOrEqual } from "@std/assert";
+import {
+  assertEquals,
+  assertExists,
+  assertGreater,
+  assertLessOrEqual,
+} from "@std/assert";
 import { simulateSeason } from "./simulate-season.ts";
 import { computeSeasonAggregates } from "./season-aggregates.ts";
+import { createSpyLogger } from "./simulation-logger.test.ts";
 
 // NFL target bands from game-simulation north-star.
 // Current engine does not hit all targets; these serve as the tuning yardstick.
@@ -144,6 +150,78 @@ Deno.test("simulateSeason aggregates land inside regression bands", () => {
     REGRESSION_BANDS.turnoversPerTeamPerGame,
     "TO/team/game",
   );
+});
+
+Deno.test("simulateSeason logging: accepts optional logger without changing results", () => {
+  const { logger } = createSpyLogger();
+  const without = simulateSeason({
+    leagueSeed: 42,
+    teamCount: 4,
+    gamesPerTeam: 3,
+  });
+  const withLog = simulateSeason({
+    leagueSeed: 42,
+    teamCount: 4,
+    gamesPerTeam: 3,
+    log: logger,
+  });
+
+  assertEquals(withLog.results.length, without.results.length);
+  for (let i = 0; i < without.results.length; i++) {
+    assertEquals(withLog.results[i].finalScore, without.results[i].finalScore);
+  }
+});
+
+Deno.test("simulateSeason logging: emits season start and end info logs", () => {
+  const { logger, calls } = createSpyLogger();
+  simulateSeason({
+    leagueSeed: 42,
+    teamCount: 4,
+    gamesPerTeam: 3,
+    log: logger,
+  });
+
+  const startLogs = calls.filter((c) => c.msg === "season simulation started");
+  const endLogs = calls.filter((c) => c.msg === "season simulation ended");
+  assertEquals(startLogs.length, 1);
+  assertEquals(startLogs[0].level, "info");
+  assertExists(startLogs[0].obj.teamCount);
+  assertEquals(endLogs.length, 1);
+  assertEquals(endLogs[0].level, "info");
+  assertExists(endLogs[0].obj.elapsedMs);
+  assertExists(endLogs[0].obj.totalGames);
+});
+
+Deno.test("simulateSeason logging: emits week progress debug logs", () => {
+  const { logger, calls } = createSpyLogger();
+  simulateSeason({
+    leagueSeed: 42,
+    teamCount: 4,
+    gamesPerTeam: 3,
+    log: logger,
+  });
+
+  const weekLogs = calls.filter((c) => c.msg === "week simulated");
+  assertGreater(weekLogs.length, 0);
+  assertEquals(weekLogs[0].level, "debug");
+  assertExists(weekLogs[0].obj.week);
+  assertExists(weekLogs[0].obj.gamesInWeek);
+});
+
+Deno.test("simulateSeason logging: passes logger to individual games", () => {
+  const { logger, calls } = createSpyLogger();
+  simulateSeason({
+    leagueSeed: 42,
+    teamCount: 4,
+    gamesPerTeam: 3,
+    log: logger,
+  });
+
+  // Each game should emit "game started" and "game ended"
+  const gameStartLogs = calls.filter((c) => c.msg === "game started");
+  const gameEndLogs = calls.filter((c) => c.msg === "game ended");
+  assertGreater(gameStartLogs.length, 0);
+  assertEquals(gameStartLogs.length, gameEndLogs.length);
 });
 
 Deno.test("PERF: NFL-band calibration report measures distance to NFL targets", () => {

--- a/server/features/simulation/simulate-season.ts
+++ b/server/features/simulation/simulate-season.ts
@@ -8,11 +8,14 @@ import type { CoachingMods, PlayerRuntime } from "./resolve-play.ts";
 import { createSeededRng, deriveGameSeed } from "./rng.ts";
 import type { SeededRng } from "./rng.ts";
 import { type SimTeam, simulateGame } from "./simulate-game.ts";
+import type { SimLogger } from "./simulation-logger.ts";
+import { noopLogger } from "./simulation-logger.ts";
 
 export interface SeasonInput {
   leagueSeed: number;
   teamCount?: number;
   gamesPerTeam?: number;
+  log?: SimLogger;
 }
 
 export interface SeasonResult {
@@ -240,6 +243,7 @@ function generateSchedule(
 
 export function simulateSeason(input: SeasonInput): SeasonResult {
   const { leagueSeed, teamCount = 32, gamesPerTeam = 17 } = input;
+  const log = (input.log ?? noopLogger).child({ module: "simulate-season" });
   const setupRng = createSeededRng(leagueSeed);
 
   const teams: SimTeam[] = [];
@@ -248,6 +252,12 @@ export function simulateSeason(input: SeasonInput): SeasonResult {
   }
 
   const schedule = generateSchedule(teamCount, gamesPerTeam);
+  const gamesPerWeek = teamCount / 2;
+
+  log.info(
+    { leagueSeed, teamCount, gamesPerTeam, totalGames: schedule.length },
+    "season simulation started",
+  );
 
   const start = performance.now();
   const results: GameResult[] = [];
@@ -261,11 +271,34 @@ export function simulateSeason(input: SeasonInput): SeasonResult {
       away: teams[away],
       seed: gameSeed,
       gameId,
+      log: input.log,
     });
     results.push(result);
+
+    // Log week completion at the end of each week
+    if ((i + 1) % gamesPerWeek === 0 || i === schedule.length - 1) {
+      const week = Math.floor(i / gamesPerWeek) + 1;
+      const weekGames = Math.min(
+        gamesPerWeek,
+        (i + 1) - (week - 1) * gamesPerWeek,
+      );
+      log.debug(
+        { week, gamesInWeek: weekGames, totalCompleted: i + 1 },
+        "week simulated",
+      );
+    }
   }
 
   const elapsedMs = performance.now() - start;
+
+  log.info(
+    {
+      leagueSeed,
+      totalGames: results.length,
+      elapsedMs: Math.round(elapsedMs),
+    },
+    "season simulation ended",
+  );
 
   return { results, elapsedMs };
 }

--- a/server/features/simulation/simulation-logger.test.ts
+++ b/server/features/simulation/simulation-logger.test.ts
@@ -1,0 +1,78 @@
+import { assertEquals } from "@std/assert";
+import { noopLogger, type SimLogger } from "./simulation-logger.ts";
+
+Deno.test("noopLogger", async (t) => {
+  await t.step("info does not throw", () => {
+    noopLogger.info({ key: "value" }, "test message");
+  });
+
+  await t.step("debug does not throw", () => {
+    noopLogger.debug({ key: "value" }, "test message");
+  });
+
+  await t.step("child returns a logger that also does not throw", () => {
+    const child = noopLogger.child({ module: "test" });
+    child.info({}, "child info");
+    child.debug({}, "child debug");
+  });
+
+  await t.step("child of child returns a logger", () => {
+    const grandchild = noopLogger.child({ a: 1 }).child({ b: 2 });
+    grandchild.info({}, "grandchild info");
+  });
+});
+
+export function createSpyLogger(): {
+  logger: SimLogger;
+  calls: {
+    level: "info" | "debug";
+    obj: Record<string, unknown>;
+    msg: string;
+  }[];
+} {
+  const calls: {
+    level: "info" | "debug";
+    obj: Record<string, unknown>;
+    msg: string;
+  }[] = [];
+
+  function makeLogger(
+    bindings: Record<string, unknown>,
+  ): SimLogger {
+    return {
+      info(obj: Record<string, unknown>, msg: string) {
+        calls.push({ level: "info", obj: { ...bindings, ...obj }, msg });
+      },
+      debug(obj: Record<string, unknown>, msg: string) {
+        calls.push({ level: "debug", obj: { ...bindings, ...obj }, msg });
+      },
+      child(childBindings: Record<string, unknown>) {
+        return makeLogger({ ...bindings, ...childBindings });
+      },
+    };
+  }
+
+  return { logger: makeLogger({}), calls };
+}
+
+Deno.test("createSpyLogger", async (t) => {
+  await t.step("captures info calls with bindings", () => {
+    const { logger, calls } = createSpyLogger();
+    const child = logger.child({ module: "test" });
+    child.info({ gameId: "g1" }, "game started");
+
+    assertEquals(calls.length, 1);
+    assertEquals(calls[0].level, "info");
+    assertEquals(calls[0].msg, "game started");
+    assertEquals(calls[0].obj.module, "test");
+    assertEquals(calls[0].obj.gameId, "g1");
+  });
+
+  await t.step("captures debug calls", () => {
+    const { logger, calls } = createSpyLogger();
+    logger.debug({ yards: 5 }, "play resolved");
+
+    assertEquals(calls.length, 1);
+    assertEquals(calls[0].level, "debug");
+  });
+});

--- a/server/features/simulation/simulation-logger.ts
+++ b/server/features/simulation/simulation-logger.ts
@@ -1,0 +1,24 @@
+/**
+ * Minimal structured logger interface for the simulation engine.
+ *
+ * Compatible with pino.Logger so callers can pass a real pino instance,
+ * but the simulation module itself stays dependency-free.
+ */
+export interface SimLogger {
+  info(obj: Record<string, unknown>, msg: string): void;
+  debug(obj: Record<string, unknown>, msg: string): void;
+  child(bindings: Record<string, unknown>): SimLogger;
+}
+
+function createNoopLogger(): SimLogger {
+  const noop: SimLogger = {
+    info() {},
+    debug() {},
+    child() {
+      return noop;
+    },
+  };
+  return noop;
+}
+
+export const noopLogger: SimLogger = createNoopLogger();


### PR DESCRIPTION
## Summary

- Introduces a `SimLogger` interface and `noopLogger` default so `simulateGame` and `simulateSeason` accept an optional `log` parameter for structured logging at key decision points
- Emits **info**-level logs for game/season lifecycle events (start/end, quarter transitions, overtime, scoring) and **debug**-level logs for high-volume per-play data (kickoffs, play resolution, fourth-down decisions, penalties, turnovers, timeouts, conversions, week progress)
- Fully backward-compatible — existing callers that omit `log` see zero overhead via the noop default; the `SimLogger` interface is pino.Logger-compatible so callers can pass a real pino instance directly

Closes #411

🤖 Generated with [Claude Code](https://claude.com/claude-code)