### PR TITLE
fix(scouts): align salary bands with ADR 0032 NFL ranges

### DIFF
--- a/server/features/scouts/scouts-generator.test.ts
+++ b/server/features/scouts/scouts-generator.test.ts
@@ -159,22 +159,37 @@ Deno.test("hiredAt dates spread across multiple years", () => {
   assertEquals(years.size > 1, true);
 });
 
-Deno.test("contract salaries fall within sane per-role bounds", () => {
+Deno.test("contract salaries fall within ADR 0032 per-role bounds", () => {
   const result = makeGenerator().generate(INPUT);
   for (const s of result) {
     assertEquals(s.contractSalary > 0, true);
     assertEquals(s.contractBuyout >= 0, true);
     if (s.role === "DIRECTOR") {
-      assertEquals(s.contractSalary >= 800_000, true);
-      assertEquals(s.contractSalary <= 2_500_000, true);
+      assertEquals(s.contractSalary >= 250_000, true);
+      assertEquals(s.contractSalary <= 800_000, true);
     }
     if (s.role === "NATIONAL_CROSS_CHECKER") {
-      assertEquals(s.contractSalary >= 400_000, true);
-      assertEquals(s.contractSalary <= 1_200_000, true);
+      assertEquals(s.contractSalary >= 150_000, true);
+      assertEquals(s.contractSalary <= 400_000, true);
     }
     if (s.role === "AREA_SCOUT") {
-      assertEquals(s.contractSalary >= 120_000, true);
-      assertEquals(s.contractSalary <= 400_000, true);
+      assertEquals(s.contractSalary >= 80_000, true);
+      assertEquals(s.contractSalary <= 200_000, true);
+    }
+  }
+});
+
+Deno.test("contract years fall within ADR 0032 per-role bounds", () => {
+  const result = makeGenerator().generate(INPUT);
+  for (const s of result) {
+    if (s.role === "DIRECTOR") {
+      assertEquals(s.contractYears >= 3 && s.contractYears <= 5, true);
+    }
+    if (s.role === "NATIONAL_CROSS_CHECKER") {
+      assertEquals(s.contractYears >= 2 && s.contractYears <= 4, true);
+    }
+    if (s.role === "AREA_SCOUT") {
+      assertEquals(s.contractYears >= 1 && s.contractYears <= 3, true);
     }
   }
 });

--- a/server/features/scouts/scouts-generator.ts
+++ b/server/features/scouts/scouts-generator.ts
@@ -101,8 +101,8 @@ const ROLE_BANDS: Record<ScoutRole, RoleBand> = {
   DIRECTOR: {
     ageMin: 50,
     ageMax: 65,
-    salaryMin: 800_000,
-    salaryMax: 2_500_000,
+    salaryMin: 250_000,
+    salaryMax: 800_000,
     yearsMin: 3,
     yearsMax: 5,
     buyoutYearsMin: 1,
@@ -115,8 +115,8 @@ const ROLE_BANDS: Record<ScoutRole, RoleBand> = {
   NATIONAL_CROSS_CHECKER: {
     ageMin: 42,
     ageMax: 58,
-    salaryMin: 400_000,
-    salaryMax: 1_200_000,
+    salaryMin: 150_000,
+    salaryMax: 400_000,
     yearsMin: 2,
     yearsMax: 4,
     buyoutYearsMin: 0,
@@ -129,8 +129,8 @@ const ROLE_BANDS: Record<ScoutRole, RoleBand> = {
   AREA_SCOUT: {
     ageMin: 30,
     ageMax: 50,
-    salaryMin: 120_000,
-    salaryMax: 400_000,
+    salaryMin: 80_000,
+    salaryMax: 200_000,
     yearsMin: 1,
     yearsMax: 3,
     buyoutYearsMin: 0,
@@ -190,14 +190,14 @@ export function createScoutsGenerator(
             band.yearsMin,
             band.yearsMax,
           );
-          // 25k step so output reads as plausible salary numbers rather
-          // than arbitrary 6-digit values.
+          // 10k step so the tightened ADR 0032 bands (e.g. area scout
+          // $80K–$200K) can reach their ceiling with meaningful variance.
           const salarySteps = Math.max(
             1,
-            Math.floor((band.salaryMax - band.salaryMin) / 25_000),
+            Math.floor((band.salaryMax - band.salaryMin) / 10_000),
           );
           const contractSalary = band.salaryMin +
-            intInRange(random, 0, salarySteps) * 25_000;
+            intInRange(random, 0, salarySteps) * 10_000;
           const buyoutYears = intInRange(
             random,
             band.buyoutYearsMin,
@@ -261,10 +261,10 @@ export function createScoutsGenerator(
           );
           const salarySteps = Math.max(
             1,
-            Math.floor((band.salaryMax - band.salaryMin) / 25_000),
+            Math.floor((band.salaryMax - band.salaryMin) / 10_000),
           );
           const contractSalary = band.salaryMin +
-            intInRange(random, 0, salarySteps) * 25_000;
+            intInRange(random, 0, salarySteps) * 10_000;
           const buyoutYears = intInRange(
             random,
             band.buyoutYearsMin,


### PR DESCRIPTION
## Summary

- Rebase the scouts generator salary bands on ADR 0032: Director $250K–$800K, National Cross-Checker $150K–$400K, Area Scout $80K–$200K (down from 2–3x inflated values).
- Tighten the salary step from $25K to $10K so the narrower area-scout band can reach its ceiling with varied output.
- Update the generator tests to the new bounds and add a contract-years assertion matching the ADR (Director 3–5, CC 2–4, Area 1–3) so drift fails loudly.

Closes #436