### PR TITLE
feat(league-clock): expand hiring phase step catalog to 8-step timeline

### DIFF
--- a/client/src/features/league/league-clock-display.test.tsx
+++ b/client/src/features/league/league-clock-display.test.tsx
@@ -331,7 +331,7 @@ describe("LeagueClockDisplay", () => {
           seasonYear: 2026,
           phase: "genesis_staff_hiring",
           stepIndex: 0,
-          slug: "hire_initial_staff",
+          slug: "hiring_market_survey",
           kind: "event",
           flavorDate: null,
           advancedAt: "2026-01-01T00:00:00Z",

--- a/server/features/league-clock/default-phase-steps.test.ts
+++ b/server/features/league-clock/default-phase-steps.test.ts
@@ -34,9 +34,20 @@ Deno.test("every phase has at least one step", () => {
   }
 });
 
-Deno.test("all slugs are unique", () => {
-  const slugs = DEFAULT_PHASE_STEPS.map((s) => s.slug);
-  assertEquals(new Set(slugs).size, slugs.length);
+Deno.test("slugs are unique within each phase", () => {
+  const slugsByPhase = new Map<string, string[]>();
+  for (const step of DEFAULT_PHASE_STEPS) {
+    const list = slugsByPhase.get(step.phase) ?? [];
+    list.push(step.slug);
+    slugsByPhase.set(step.phase, list);
+  }
+  for (const [phase, slugs] of slugsByPhase) {
+    assertEquals(
+      new Set(slugs).size,
+      slugs.length,
+      `Phase "${phase}" has duplicate slugs`,
+    );
+  }
 });
 
 Deno.test("stepIndex values are sequential within each phase starting at 0", () => {
@@ -197,4 +208,81 @@ Deno.test("genesis steps appear before recurring steps in the catalog", () => {
     (s) => s.phase === "offseason_review",
   );
   assertEquals(firstGenesisIdx < firstRecurringIdx, true);
+});
+
+const HIRING_STEP_SLUGS = [
+  "hiring_market_survey",
+  "hiring_interview_1",
+  "hiring_interview_2",
+  "hiring_offers",
+  "hiring_decisions",
+  "hiring_second_wave_interview",
+  "hiring_second_wave_decisions",
+  "hiring_finalization",
+] as const;
+
+Deno.test("genesis_staff_hiring has 8 hiring steps in the ADR 0032 order", () => {
+  const steps = DEFAULT_PHASE_STEPS.filter(
+    (s) => s.phase === "genesis_staff_hiring",
+  ).sort((a, b) => a.stepIndex - b.stepIndex);
+  assertEquals(steps.length, 8);
+  for (let i = 0; i < HIRING_STEP_SLUGS.length; i++) {
+    assertEquals(steps[i].stepIndex, i);
+    assertEquals(steps[i].slug, HIRING_STEP_SLUGS[i]);
+    assertEquals(steps[i].kind, "event");
+  }
+});
+
+Deno.test("coaching_carousel has 9 steps: coaching_firings + 8 hiring steps", () => {
+  const steps = DEFAULT_PHASE_STEPS.filter(
+    (s) => s.phase === "coaching_carousel",
+  ).sort((a, b) => a.stepIndex - b.stepIndex);
+  assertEquals(steps.length, 9);
+
+  assertEquals(steps[0].stepIndex, 0);
+  assertEquals(steps[0].slug, "coaching_firings");
+  assertEquals(steps[0].kind, "event");
+  assertEquals(steps[0].flavorDate, "Feb 12");
+
+  for (let i = 0; i < HIRING_STEP_SLUGS.length; i++) {
+    const step = steps[i + 1];
+    assertEquals(step.stepIndex, i + 1);
+    assertEquals(step.slug, HIRING_STEP_SLUGS[i]);
+    assertEquals(step.kind, "event");
+    assertEquals(
+      typeof step.flavorDate === "string" && step.flavorDate.length > 0,
+      true,
+      `coaching_carousel step "${step.slug}" is missing a flavor date`,
+    );
+  }
+});
+
+Deno.test("coaching_carousel hiring step flavor dates are monotonically ordered", () => {
+  const steps = DEFAULT_PHASE_STEPS.filter(
+    (s) => s.phase === "coaching_carousel",
+  ).sort((a, b) => a.stepIndex - b.stepIndex);
+
+  const monthOrder: Record<string, number> = { Feb: 2, Mar: 3 };
+  const toOrdinal = (label: string): number => {
+    const [month, day] = label.split(" ");
+    return monthOrder[month] * 100 + Number(day);
+  };
+
+  for (let i = 1; i < steps.length; i++) {
+    const prev = toOrdinal(steps[i - 1].flavorDate!);
+    const curr = toOrdinal(steps[i].flavorDate!);
+    assertEquals(
+      curr >= prev,
+      true,
+      `step ${steps[i].slug} flavorDate ${steps[i].flavorDate} precedes ${
+        steps[i - 1].flavorDate
+      }`,
+    );
+  }
+});
+
+Deno.test("legacy single-step hiring slugs are removed from the catalog", () => {
+  const slugs = new Set(DEFAULT_PHASE_STEPS.map((s) => s.slug));
+  assertEquals(slugs.has("hire_initial_staff"), false);
+  assertEquals(slugs.has("coaching_hires"), false);
 });

--- a/server/features/league-clock/default-phase-steps.ts
+++ b/server/features/league-clock/default-phase-steps.ts
@@ -6,14 +6,60 @@ export interface DefaultPhaseStep {
   flavorDate?: string;
 }
 
-export const DEFAULT_PHASE_STEPS: DefaultPhaseStep[] = [
-  // genesis_staff_hiring
-  {
+const HIRING_STEP_SLUGS = [
+  "hiring_market_survey",
+  "hiring_interview_1",
+  "hiring_interview_2",
+  "hiring_offers",
+  "hiring_decisions",
+  "hiring_second_wave_interview",
+  "hiring_second_wave_decisions",
+  "hiring_finalization",
+] as const;
+
+const COACHING_CAROUSEL_HIRING_FLAVOR_DATES: Record<
+  (typeof HIRING_STEP_SLUGS)[number],
+  string
+> = {
+  hiring_market_survey: "Feb 12",
+  hiring_interview_1: "Feb 14",
+  hiring_interview_2: "Feb 17",
+  hiring_offers: "Feb 20",
+  hiring_decisions: "Feb 24",
+  hiring_second_wave_interview: "Feb 28",
+  hiring_second_wave_decisions: "Mar 2",
+  hiring_finalization: "Mar 3",
+};
+
+const GENESIS_STAFF_HIRING_STEPS: DefaultPhaseStep[] = HIRING_STEP_SLUGS.map(
+  (slug, index) => ({
     phase: "genesis_staff_hiring",
-    stepIndex: 0,
-    slug: "hire_initial_staff",
+    stepIndex: index,
+    slug,
     kind: "event",
+  }),
+);
+
+const COACHING_CAROUSEL_STEPS: DefaultPhaseStep[] = [
+  {
+    phase: "coaching_carousel",
+    stepIndex: 0,
+    slug: "coaching_firings",
+    kind: "event",
+    flavorDate: "Feb 12",
   },
+  ...HIRING_STEP_SLUGS.map((slug, index): DefaultPhaseStep => ({
+    phase: "coaching_carousel",
+    stepIndex: index + 1,
+    slug,
+    kind: "event",
+    flavorDate: COACHING_CAROUSEL_HIRING_FLAVOR_DATES[slug],
+  })),
+];
+
+export const DEFAULT_PHASE_STEPS: DefaultPhaseStep[] = [
+  // genesis_staff_hiring (8-step hiring timeline — ADR 0032)
+  ...GENESIS_STAFF_HIRING_STEPS,
 
   // genesis_founding_pool
   {
@@ -63,21 +109,8 @@ export const DEFAULT_PHASE_STEPS: DefaultPhaseStep[] = [
     flavorDate: "Feb 10",
   },
 
-  // coaching_carousel
-  {
-    phase: "coaching_carousel",
-    stepIndex: 0,
-    slug: "coaching_firings",
-    kind: "event",
-    flavorDate: "Feb 12",
-  },
-  {
-    phase: "coaching_carousel",
-    stepIndex: 1,
-    slug: "coaching_hires",
-    kind: "event",
-    flavorDate: "Feb 18",
-  },
+  // coaching_carousel (firings + 8-step hiring timeline — ADR 0032)
+  ...COACHING_CAROUSEL_STEPS,
 
   // tag_window
   {

--- a/server/features/league-clock/gates.test.ts
+++ b/server/features/league-clock/gates.test.ts
@@ -298,5 +298,53 @@ Deno.test("gates", async (t) => {
       );
       assertEquals(next, { phase: "offseason_rollover", stepIndex: 0 });
     });
+
+    await t.step(
+      "walks through all 8 genesis_staff_hiring steps before advancing",
+      () => {
+        for (let i = 0; i < 7; i++) {
+          const next = computeNextStep(
+            { phase: "genesis_staff_hiring", stepIndex: i },
+            DEFAULT_PHASE_STEPS,
+            phases,
+          );
+          assertEquals(next, {
+            phase: "genesis_staff_hiring",
+            stepIndex: i + 1,
+          });
+        }
+
+        const afterFinalization = computeNextStep(
+          { phase: "genesis_staff_hiring", stepIndex: 7 },
+          DEFAULT_PHASE_STEPS,
+          phases,
+        );
+        assertEquals(afterFinalization, {
+          phase: "genesis_founding_pool",
+          stepIndex: 0,
+        });
+      },
+    );
+
+    await t.step(
+      "walks through all 9 coaching_carousel steps before advancing",
+      () => {
+        for (let i = 0; i < 8; i++) {
+          const next = computeNextStep(
+            { phase: "coaching_carousel", stepIndex: i },
+            DEFAULT_PHASE_STEPS,
+            phases,
+          );
+          assertEquals(next, { phase: "coaching_carousel", stepIndex: i + 1 });
+        }
+
+        const afterFinalization = computeNextStep(
+          { phase: "coaching_carousel", stepIndex: 8 },
+          DEFAULT_PHASE_STEPS,
+          phases,
+        );
+        assertEquals(afterFinalization, { phase: "tag_window", stepIndex: 0 });
+      },
+    );
   });
 });

--- a/server/features/league-clock/league-clock.service.test.ts
+++ b/server/features/league-clock/league-clock.service.test.ts
@@ -592,7 +592,7 @@ Deno.test("league-clock.service", async (t) => {
               Promise.resolve(
                 createMockClock({
                   phase: "coaching_carousel",
-                  stepIndex: 1,
+                  stepIndex: 8,
                 }),
               ),
           },
@@ -776,7 +776,7 @@ Deno.test("league-clock.service", async (t) => {
     );
 
     await t.step(
-      "Year 1 league advances through genesis phases normally",
+      "Year 1 league advances within genesis_staff_hiring steps",
       async () => {
         const service = createService({
           leagueClockRepo: {
@@ -785,6 +785,32 @@ Deno.test("league-clock.service", async (t) => {
                 createMockClock({
                   phase: "genesis_staff_hiring",
                   stepIndex: 0,
+                  hasCompletedGenesis: false,
+                }),
+              ),
+          },
+        });
+
+        const result = await service.advance(
+          "league-1",
+          createActor(),
+          createGateState(),
+        );
+        assertEquals(result.phase, "genesis_staff_hiring");
+        assertEquals(result.stepIndex, 1);
+      },
+    );
+
+    await t.step(
+      "Year 1 league transitions from the final genesis_staff_hiring step to genesis_founding_pool",
+      async () => {
+        const service = createService({
+          leagueClockRepo: {
+            getByLeagueId: () =>
+              Promise.resolve(
+                createMockClock({
+                  phase: "genesis_staff_hiring",
+                  stepIndex: 7,
                   hasCompletedGenesis: false,
                 }),
               ),


### PR DESCRIPTION
## Summary

Implements ADR 0032's 8-step hiring timeline in both the genesis
`genesis_staff_hiring` phase and the recurring `coaching_carousel`
phase. Genesis hiring now walks through 8 event steps (market survey,
two interview weeks, offers, decisions, second-wave interview, second-
wave decisions, finalization), and `coaching_carousel` keeps
`coaching_firings` as step 0 then walks through the same 8 hiring
slugs with flavor dates spanning Feb 12 through early March.

Closes #432