### PR TITLE
feat(staff-hiring): scaffold hiring repository and stubbed service

### DIFF
--- a/server/features/hiring/hiring.repository.test.ts
+++ b/server/features/hiring/hiring.repository.test.ts
@@ -1,0 +1,783 @@
+import { assertEquals, assertExists } from "@std/assert";
+import { drizzle } from "drizzle-orm/postgres-js";
+import { eq, inArray } from "drizzle-orm";
+import postgres from "postgres";
+import pino from "pino";
+import * as schema from "../../db/schema.ts";
+import { coaches } from "../coaches/coach.schema.ts";
+import { scouts } from "../scouts/scout.schema.ts";
+import { leagues } from "../league/league.schema.ts";
+import { teams } from "../team/team.schema.ts";
+import { franchises } from "../franchise/franchise.schema.ts";
+import { cities } from "../cities/city.schema.ts";
+import { states } from "../states/state.schema.ts";
+import {
+  hiringDecisions,
+  hiringInterests,
+  hiringInterviews,
+  hiringOffers,
+} from "./hiring.schema.ts";
+import { createHiringRepository } from "./hiring.repository.ts";
+
+function createTestDb() {
+  const connectionString = Deno.env.get("DATABASE_URL");
+  if (!connectionString) {
+    throw new Error("DATABASE_URL is required for integration tests");
+  }
+  const client = postgres(connectionString);
+  const db = drizzle(client, { schema });
+  return { db, client };
+}
+
+function createTestLogger() {
+  return pino({ level: "silent" });
+}
+
+async function setupFixtures(db: ReturnType<typeof createTestDb>["db"]) {
+  const [league] = await db
+    .insert(leagues)
+    .values({ name: `League ${crypto.randomUUID()}` })
+    .returning();
+  const [state] = await db
+    .insert(states)
+    .values({
+      code: `hr-${crypto.randomUUID().slice(0, 8)}`,
+      name: `TestState-${crypto.randomUUID()}`,
+      region: "West",
+    })
+    .returning();
+  const [city] = await db
+    .insert(cities)
+    .values({
+      name: `TestCity-${crypto.randomUUID()}`,
+      stateId: state.id,
+    })
+    .returning();
+  const [franchise] = await db
+    .insert(franchises)
+    .values({
+      name: "Test Franchise",
+      cityId: city.id,
+      abbreviation: crypto.randomUUID().replace(/-/g, "").slice(0, 8)
+        .toUpperCase(),
+      primaryColor: "#000000",
+      secondaryColor: "#FFFFFF",
+      accentColor: "#FF0000",
+      conference: "AFC",
+      division: "AFC East",
+    })
+    .returning();
+  const [team] = await db
+    .insert(teams)
+    .values({
+      leagueId: league.id,
+      franchiseId: franchise.id,
+      name: "Test Team",
+      cityId: city.id,
+      abbreviation: crypto.randomUUID().replace(/-/g, "").slice(0, 8)
+        .toUpperCase(),
+      primaryColor: "#000000",
+      secondaryColor: "#FFFFFF",
+      accentColor: "#FF0000",
+      conference: "AFC",
+      division: "AFC East",
+    })
+    .returning();
+  return { league, team, state, city, franchise };
+}
+
+interface Ctx {
+  db: ReturnType<typeof createTestDb>["db"];
+  leagueIds: string[];
+  teamIds: string[];
+  franchiseIds: string[];
+  cityIds: string[];
+  stateIds: string[];
+  coachIds: string[];
+  scoutIds: string[];
+  interestIds: string[];
+  interviewIds: string[];
+  offerIds: string[];
+  decisionIds: string[];
+}
+
+function emptyCtx(db: ReturnType<typeof createTestDb>["db"]): Ctx {
+  return {
+    db,
+    leagueIds: [],
+    teamIds: [],
+    franchiseIds: [],
+    cityIds: [],
+    stateIds: [],
+    coachIds: [],
+    scoutIds: [],
+    interestIds: [],
+    interviewIds: [],
+    offerIds: [],
+    decisionIds: [],
+  };
+}
+
+async function cleanup(ctx: Ctx) {
+  if (ctx.decisionIds.length > 0) {
+    await ctx.db.delete(hiringDecisions).where(
+      inArray(hiringDecisions.id, ctx.decisionIds),
+    );
+  }
+  if (ctx.offerIds.length > 0) {
+    await ctx.db.delete(hiringOffers).where(
+      inArray(hiringOffers.id, ctx.offerIds),
+    );
+  }
+  if (ctx.interviewIds.length > 0) {
+    await ctx.db.delete(hiringInterviews).where(
+      inArray(hiringInterviews.id, ctx.interviewIds),
+    );
+  }
+  if (ctx.interestIds.length > 0) {
+    await ctx.db.delete(hiringInterests).where(
+      inArray(hiringInterests.id, ctx.interestIds),
+    );
+  }
+  if (ctx.coachIds.length > 0) {
+    await ctx.db.delete(coaches).where(inArray(coaches.id, ctx.coachIds));
+  }
+  if (ctx.scoutIds.length > 0) {
+    await ctx.db.delete(scouts).where(inArray(scouts.id, ctx.scoutIds));
+  }
+  for (const id of ctx.teamIds) {
+    await ctx.db.delete(teams).where(eq(teams.id, id));
+  }
+  for (const id of ctx.franchiseIds) {
+    await ctx.db.delete(franchises).where(eq(franchises.id, id));
+  }
+  for (const id of ctx.cityIds) {
+    await ctx.db.delete(cities).where(eq(cities.id, id));
+  }
+  for (const id of ctx.stateIds) {
+    await ctx.db.delete(states).where(eq(states.id, id));
+  }
+  for (const id of ctx.leagueIds) {
+    await ctx.db.delete(leagues).where(eq(leagues.id, id));
+  }
+}
+
+Deno.test({
+  name: "hiringRepository.createInterest: inserts row with active status",
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    const { db, client } = createTestDb();
+    const ctx = emptyCtx(db);
+    try {
+      const { league, team } = await setupFixtures(db);
+      ctx.leagueIds.push(league.id);
+      ctx.teamIds.push(team.id);
+
+      const repo = createHiringRepository({ db, log: createTestLogger() });
+      const staffId = crypto.randomUUID();
+      const row = await repo.createInterest({
+        leagueId: league.id,
+        teamId: team.id,
+        staffType: "coach",
+        staffId,
+        stepSlug: "hiring_market_survey",
+      });
+      ctx.interestIds.push(row.id);
+
+      assertEquals(row.leagueId, league.id);
+      assertEquals(row.teamId, team.id);
+      assertEquals(row.staffType, "coach");
+      assertEquals(row.staffId, staffId);
+      assertEquals(row.stepSlug, "hiring_market_survey");
+      assertEquals(row.status, "active");
+    } finally {
+      await cleanup(ctx);
+      await client.end();
+    }
+  },
+});
+
+Deno.test({
+  name: "hiringRepository.updateInterestStatus: flips an interest to withdrawn",
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    const { db, client } = createTestDb();
+    const ctx = emptyCtx(db);
+    try {
+      const { league, team } = await setupFixtures(db);
+      ctx.leagueIds.push(league.id);
+      ctx.teamIds.push(team.id);
+
+      const repo = createHiringRepository({ db, log: createTestLogger() });
+      const created = await repo.createInterest({
+        leagueId: league.id,
+        teamId: team.id,
+        staffType: "scout",
+        staffId: crypto.randomUUID(),
+        stepSlug: "hiring_market_survey",
+      });
+      ctx.interestIds.push(created.id);
+
+      const updated = await repo.updateInterestStatus(created.id, "withdrawn");
+      assertEquals(updated.status, "withdrawn");
+      assertEquals(updated.id, created.id);
+    } finally {
+      await cleanup(ctx);
+      await client.end();
+    }
+  },
+});
+
+Deno.test({
+  name: "hiringRepository.listInterestsByLeague: scopes to a single league",
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    const { db, client } = createTestDb();
+    const ctx = emptyCtx(db);
+    try {
+      const a = await setupFixtures(db);
+      const b = await setupFixtures(db);
+      ctx.leagueIds.push(a.league.id, b.league.id);
+      ctx.teamIds.push(a.team.id, b.team.id);
+      ctx.franchiseIds.push(a.franchise.id, b.franchise.id);
+      ctx.cityIds.push(a.city.id, b.city.id);
+      ctx.stateIds.push(a.state.id, b.state.id);
+
+      const repo = createHiringRepository({ db, log: createTestLogger() });
+      const one = await repo.createInterest({
+        leagueId: a.league.id,
+        teamId: a.team.id,
+        staffType: "coach",
+        staffId: crypto.randomUUID(),
+        stepSlug: "hiring_market_survey",
+      });
+      const two = await repo.createInterest({
+        leagueId: b.league.id,
+        teamId: b.team.id,
+        staffType: "coach",
+        staffId: crypto.randomUUID(),
+        stepSlug: "hiring_market_survey",
+      });
+      ctx.interestIds.push(one.id, two.id);
+
+      const listA = await repo.listInterestsByLeague(a.league.id);
+      assertEquals(listA.length, 1);
+      assertEquals(listA[0].id, one.id);
+    } finally {
+      await cleanup(ctx);
+      await client.end();
+    }
+  },
+});
+
+Deno.test({
+  name: "hiringRepository.createInterview: defaults to requested status",
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    const { db, client } = createTestDb();
+    const ctx = emptyCtx(db);
+    try {
+      const { league, team } = await setupFixtures(db);
+      ctx.leagueIds.push(league.id);
+      ctx.teamIds.push(team.id);
+
+      const repo = createHiringRepository({ db, log: createTestLogger() });
+      const row = await repo.createInterview({
+        leagueId: league.id,
+        teamId: team.id,
+        staffType: "coach",
+        staffId: crypto.randomUUID(),
+        stepSlug: "hiring_interview_1",
+      });
+      ctx.interviewIds.push(row.id);
+
+      assertEquals(row.status, "requested");
+      assertEquals(row.philosophyReveal, null);
+      assertEquals(row.staffFitReveal, null);
+    } finally {
+      await cleanup(ctx);
+      await client.end();
+    }
+  },
+});
+
+Deno.test({
+  name: "hiringRepository.updateInterview: patches status and reveal payloads",
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    const { db, client } = createTestDb();
+    const ctx = emptyCtx(db);
+    try {
+      const { league, team } = await setupFixtures(db);
+      ctx.leagueIds.push(league.id);
+      ctx.teamIds.push(team.id);
+
+      const repo = createHiringRepository({ db, log: createTestLogger() });
+      const created = await repo.createInterview({
+        leagueId: league.id,
+        teamId: team.id,
+        staffType: "scout",
+        staffId: crypto.randomUUID(),
+        stepSlug: "hiring_interview_1",
+      });
+      ctx.interviewIds.push(created.id);
+
+      const updated = await repo.updateInterview(created.id, {
+        status: "completed",
+        philosophyReveal: { schemeFamily: "spread" },
+        staffFitReveal: { hcAlignment: 0.8 },
+      });
+      assertEquals(updated.status, "completed");
+      assertEquals(
+        (updated.philosophyReveal as { schemeFamily: string }).schemeFamily,
+        "spread",
+      );
+      assertEquals(
+        (updated.staffFitReveal as { hcAlignment: number }).hcAlignment,
+        0.8,
+      );
+    } finally {
+      await cleanup(ctx);
+      await client.end();
+    }
+  },
+});
+
+Deno.test({
+  name:
+    "hiringRepository.listInterviewsByLeague: returns only matching league rows",
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    const { db, client } = createTestDb();
+    const ctx = emptyCtx(db);
+    try {
+      const a = await setupFixtures(db);
+      const b = await setupFixtures(db);
+      ctx.leagueIds.push(a.league.id, b.league.id);
+      ctx.teamIds.push(a.team.id, b.team.id);
+      ctx.franchiseIds.push(a.franchise.id, b.franchise.id);
+      ctx.cityIds.push(a.city.id, b.city.id);
+      ctx.stateIds.push(a.state.id, b.state.id);
+
+      const repo = createHiringRepository({ db, log: createTestLogger() });
+      const one = await repo.createInterview({
+        leagueId: a.league.id,
+        teamId: a.team.id,
+        staffType: "coach",
+        staffId: crypto.randomUUID(),
+        stepSlug: "hiring_interview_1",
+      });
+      const two = await repo.createInterview({
+        leagueId: b.league.id,
+        teamId: b.team.id,
+        staffType: "coach",
+        staffId: crypto.randomUUID(),
+        stepSlug: "hiring_interview_1",
+      });
+      ctx.interviewIds.push(one.id, two.id);
+
+      const listB = await repo.listInterviewsByLeague(b.league.id);
+      assertEquals(listB.length, 1);
+      assertEquals(listB[0].id, two.id);
+    } finally {
+      await cleanup(ctx);
+      await client.end();
+    }
+  },
+});
+
+Deno.test({
+  name: "hiringRepository.createOffer: stores numeric buyout multiplier",
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    const { db, client } = createTestDb();
+    const ctx = emptyCtx(db);
+    try {
+      const { league, team } = await setupFixtures(db);
+      ctx.leagueIds.push(league.id);
+      ctx.teamIds.push(team.id);
+
+      const repo = createHiringRepository({ db, log: createTestLogger() });
+      const row = await repo.createOffer({
+        leagueId: league.id,
+        teamId: team.id,
+        staffType: "coach",
+        staffId: crypto.randomUUID(),
+        stepSlug: "hiring_offers",
+        salary: 5_000_000,
+        contractYears: 3,
+        buyoutMultiplier: "0.75",
+        incentives: [{ kind: "playoff_appearance", amount: 500_000 }],
+      });
+      ctx.offerIds.push(row.id);
+
+      assertEquals(row.status, "pending");
+      assertEquals(row.salary, 5_000_000);
+      assertEquals(row.contractYears, 3);
+      assertEquals(row.buyoutMultiplier, "0.75");
+      assertEquals(row.preferenceScore, null);
+    } finally {
+      await cleanup(ctx);
+      await client.end();
+    }
+  },
+});
+
+Deno.test({
+  name:
+    "hiringRepository.updateOffer: patches status and preference score together",
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    const { db, client } = createTestDb();
+    const ctx = emptyCtx(db);
+    try {
+      const { league, team } = await setupFixtures(db);
+      ctx.leagueIds.push(league.id);
+      ctx.teamIds.push(team.id);
+
+      const repo = createHiringRepository({ db, log: createTestLogger() });
+      const created = await repo.createOffer({
+        leagueId: league.id,
+        teamId: team.id,
+        staffType: "coach",
+        staffId: crypto.randomUUID(),
+        stepSlug: "hiring_offers",
+        salary: 3_000_000,
+        contractYears: 2,
+        buyoutMultiplier: "0.50",
+      });
+      ctx.offerIds.push(created.id);
+
+      const updated = await repo.updateOffer(created.id, {
+        status: "accepted",
+        preferenceScore: 87,
+      });
+      assertEquals(updated.status, "accepted");
+      assertEquals(updated.preferenceScore, 87);
+    } finally {
+      await cleanup(ctx);
+      await client.end();
+    }
+  },
+});
+
+Deno.test({
+  name: "hiringRepository.listOffersByLeague: scopes results to a league",
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    const { db, client } = createTestDb();
+    const ctx = emptyCtx(db);
+    try {
+      const a = await setupFixtures(db);
+      const b = await setupFixtures(db);
+      ctx.leagueIds.push(a.league.id, b.league.id);
+      ctx.teamIds.push(a.team.id, b.team.id);
+      ctx.franchiseIds.push(a.franchise.id, b.franchise.id);
+      ctx.cityIds.push(a.city.id, b.city.id);
+      ctx.stateIds.push(a.state.id, b.state.id);
+
+      const repo = createHiringRepository({ db, log: createTestLogger() });
+      const one = await repo.createOffer({
+        leagueId: a.league.id,
+        teamId: a.team.id,
+        staffType: "coach",
+        staffId: crypto.randomUUID(),
+        stepSlug: "hiring_offers",
+        salary: 1_500_000,
+        contractYears: 2,
+        buyoutMultiplier: "0.60",
+      });
+      const two = await repo.createOffer({
+        leagueId: b.league.id,
+        teamId: b.team.id,
+        staffType: "coach",
+        staffId: crypto.randomUUID(),
+        stepSlug: "hiring_offers",
+        salary: 2_500_000,
+        contractYears: 3,
+        buyoutMultiplier: "0.60",
+      });
+      ctx.offerIds.push(one.id, two.id);
+
+      const listA = await repo.listOffersByLeague(a.league.id);
+      assertEquals(listA.length, 1);
+      assertEquals(listA[0].id, one.id);
+    } finally {
+      await cleanup(ctx);
+      await client.end();
+    }
+  },
+});
+
+Deno.test({
+  name:
+    "hiringRepository.createDecision + listDecisionsByLeague: store and fetch",
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    const { db, client } = createTestDb();
+    const ctx = emptyCtx(db);
+    try {
+      const { league, team } = await setupFixtures(db);
+      ctx.leagueIds.push(league.id);
+      ctx.teamIds.push(team.id);
+
+      const repo = createHiringRepository({ db, log: createTestLogger() });
+      const offer = await repo.createOffer({
+        leagueId: league.id,
+        teamId: team.id,
+        staffType: "coach",
+        staffId: crypto.randomUUID(),
+        stepSlug: "hiring_offers",
+        salary: 4_000_000,
+        contractYears: 3,
+        buyoutMultiplier: "0.75",
+      });
+      ctx.offerIds.push(offer.id);
+
+      const decision = await repo.createDecision({
+        leagueId: league.id,
+        staffType: "coach",
+        staffId: offer.staffId,
+        chosenOfferId: offer.id,
+        wave: 1,
+      });
+      ctx.decisionIds.push(decision.id);
+
+      assertEquals(decision.wave, 1);
+      assertEquals(decision.chosenOfferId, offer.id);
+
+      const list = await repo.listDecisionsByLeague(league.id);
+      assertEquals(list.length, 1);
+      assertEquals(list[0].id, decision.id);
+    } finally {
+      await cleanup(ctx);
+      await client.end();
+    }
+  },
+});
+
+Deno.test({
+  name:
+    "hiringRepository.createDecision: accepts null chosen offer for unsigned candidate",
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    const { db, client } = createTestDb();
+    const ctx = emptyCtx(db);
+    try {
+      const { league } = await setupFixtures(db);
+      ctx.leagueIds.push(league.id);
+
+      const repo = createHiringRepository({ db, log: createTestLogger() });
+      const decision = await repo.createDecision({
+        leagueId: league.id,
+        staffType: "scout",
+        staffId: crypto.randomUUID(),
+        chosenOfferId: null,
+        wave: 2,
+      });
+      ctx.decisionIds.push(decision.id);
+
+      assertEquals(decision.chosenOfferId, null);
+      assertEquals(decision.wave, 2);
+    } finally {
+      await cleanup(ctx);
+      await client.end();
+    }
+  },
+});
+
+Deno.test({
+  name:
+    "hiringRepository.listUnassignedCoaches: returns only coaches with teamId null in the league",
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    const { db, client } = createTestDb();
+    const ctx = emptyCtx(db);
+    try {
+      const { league, team } = await setupFixtures(db);
+      ctx.leagueIds.push(league.id);
+      ctx.teamIds.push(team.id);
+
+      const signedId = crypto.randomUUID();
+      const poolId = crypto.randomUUID();
+      await db.insert(coaches).values([
+        {
+          id: signedId,
+          leagueId: league.id,
+          teamId: team.id,
+          firstName: "Signed",
+          lastName: "Coach",
+          role: "HC",
+          age: 50,
+          hiredAt: new Date("2027-01-01T00:00:00Z"),
+          contractYears: 3,
+          contractSalary: 10_000_000,
+          contractBuyout: 20_000_000,
+        },
+        {
+          id: poolId,
+          leagueId: league.id,
+          teamId: null,
+          firstName: "Pool",
+          lastName: "Candidate",
+          role: "OC",
+          age: 42,
+          hiredAt: new Date("2027-01-01T00:00:00Z"),
+          contractYears: 0,
+          contractSalary: 0,
+          contractBuyout: 0,
+          marketTierPref: 70,
+          philosophyFitPref: 60,
+          staffFitPref: 50,
+          compensationPref: 40,
+          minimumThreshold: 35,
+        },
+      ]);
+      ctx.coachIds.push(signedId, poolId);
+
+      const repo = createHiringRepository({ db, log: createTestLogger() });
+      const pool = await repo.listUnassignedCoaches(league.id);
+
+      assertEquals(pool.length, 1);
+      assertEquals(pool[0].id, poolId);
+      assertEquals(pool[0].marketTierPref, 70);
+      assertEquals(pool[0].minimumThreshold, 35);
+    } finally {
+      await cleanup(ctx);
+      await client.end();
+    }
+  },
+});
+
+Deno.test({
+  name:
+    "hiringRepository.listUnassignedScouts: returns only scouts with teamId null in the league",
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    const { db, client } = createTestDb();
+    const ctx = emptyCtx(db);
+    try {
+      const { league, team } = await setupFixtures(db);
+      ctx.leagueIds.push(league.id);
+      ctx.teamIds.push(team.id);
+
+      const signedId = crypto.randomUUID();
+      const poolId = crypto.randomUUID();
+      await db.insert(scouts).values([
+        {
+          id: signedId,
+          leagueId: league.id,
+          teamId: team.id,
+          firstName: "Signed",
+          lastName: "Scout",
+          role: "DIRECTOR",
+        },
+        {
+          id: poolId,
+          leagueId: league.id,
+          teamId: null,
+          firstName: "Pool",
+          lastName: "Scout",
+          role: "AREA_SCOUT",
+          marketTierPref: 40,
+          minimumThreshold: 25,
+        },
+      ]);
+      ctx.scoutIds.push(signedId, poolId);
+
+      const repo = createHiringRepository({ db, log: createTestLogger() });
+      const pool = await repo.listUnassignedScouts(league.id);
+
+      assertEquals(pool.length, 1);
+      assertEquals(pool[0].id, poolId);
+      assertEquals(pool[0].minimumThreshold, 25);
+    } finally {
+      await cleanup(ctx);
+      await client.end();
+    }
+  },
+});
+
+Deno.test({
+  name: "hiringRepository.getInterestById: returns undefined when missing",
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    const { db, client } = createTestDb();
+    try {
+      const repo = createHiringRepository({ db, log: createTestLogger() });
+      const result = await repo.getInterestById(crypto.randomUUID());
+      assertEquals(result, undefined);
+    } finally {
+      await client.end();
+    }
+  },
+});
+
+Deno.test({
+  name: "hiringRepository.getInterestById: returns a stored row",
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    const { db, client } = createTestDb();
+    const ctx = emptyCtx(db);
+    try {
+      const { league, team } = await setupFixtures(db);
+      ctx.leagueIds.push(league.id);
+      ctx.teamIds.push(team.id);
+
+      const repo = createHiringRepository({ db, log: createTestLogger() });
+      const created = await repo.createInterest({
+        leagueId: league.id,
+        teamId: team.id,
+        staffType: "coach",
+        staffId: crypto.randomUUID(),
+        stepSlug: "hiring_market_survey",
+      });
+      ctx.interestIds.push(created.id);
+
+      const fetched = await repo.getInterestById(created.id);
+      assertExists(fetched);
+      assertEquals(fetched?.id, created.id);
+    } finally {
+      await cleanup(ctx);
+      await client.end();
+    }
+  },
+});
+
+Deno.test({
+  name:
+    "hiringRepository.getInterviewById / getOfferById: return undefined when missing",
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    const { db, client } = createTestDb();
+    try {
+      const repo = createHiringRepository({ db, log: createTestLogger() });
+      assertEquals(
+        await repo.getInterviewById(crypto.randomUUID()),
+        undefined,
+      );
+      assertEquals(
+        await repo.getOfferById(crypto.randomUUID()),
+        undefined,
+      );
+    } finally {
+      await client.end();
+    }
+  },
+});

--- a/server/features/hiring/hiring.repository.ts
+++ b/server/features/hiring/hiring.repository.ts
@@ -1,0 +1,425 @@
+import { and, eq, isNull } from "drizzle-orm";
+import type pino from "pino";
+import type { Database, Executor } from "../../db/connection.ts";
+import {
+  hiringDecisions,
+  hiringInterests,
+  hiringInterviews,
+  hiringOffers,
+} from "./hiring.schema.ts";
+import { coaches } from "../coaches/coach.schema.ts";
+import { scouts } from "../scouts/scout.schema.ts";
+
+export type StaffType = "coach" | "scout";
+export type HiringInterestStatus = "active" | "withdrawn";
+export type HiringInterviewStatus =
+  | "requested"
+  | "accepted"
+  | "declined"
+  | "completed";
+export type HiringOfferStatus =
+  | "pending"
+  | "accepted"
+  | "rejected"
+  | "expired";
+
+export interface HiringInterestRow {
+  id: string;
+  leagueId: string;
+  teamId: string;
+  staffType: StaffType;
+  staffId: string;
+  stepSlug: string;
+  status: HiringInterestStatus;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+export interface HiringInterviewRow {
+  id: string;
+  leagueId: string;
+  teamId: string;
+  staffType: StaffType;
+  staffId: string;
+  stepSlug: string;
+  status: HiringInterviewStatus;
+  philosophyReveal: unknown;
+  staffFitReveal: unknown;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+export interface HiringOfferRow {
+  id: string;
+  leagueId: string;
+  teamId: string;
+  staffType: StaffType;
+  staffId: string;
+  stepSlug: string;
+  status: HiringOfferStatus;
+  salary: number;
+  contractYears: number;
+  buyoutMultiplier: string;
+  incentives: unknown;
+  preferenceScore: number | null;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+export interface HiringDecisionRow {
+  id: string;
+  leagueId: string;
+  staffType: StaffType;
+  staffId: string;
+  chosenOfferId: string | null;
+  wave: number;
+  decidedAt: Date;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+export interface UnassignedCandidate {
+  id: string;
+  leagueId: string;
+  firstName: string;
+  lastName: string;
+  role: string;
+  marketTierPref: number | null;
+  philosophyFitPref: number | null;
+  staffFitPref: number | null;
+  compensationPref: number | null;
+  minimumThreshold: number | null;
+}
+
+export interface HiringRepository {
+  createInterest(
+    input: {
+      leagueId: string;
+      teamId: string;
+      staffType: StaffType;
+      staffId: string;
+      stepSlug: string;
+    },
+    tx?: Executor,
+  ): Promise<HiringInterestRow>;
+  getInterestById(
+    id: string,
+    tx?: Executor,
+  ): Promise<HiringInterestRow | undefined>;
+  listInterestsByLeague(
+    leagueId: string,
+    tx?: Executor,
+  ): Promise<HiringInterestRow[]>;
+  updateInterestStatus(
+    id: string,
+    status: HiringInterestStatus,
+    tx?: Executor,
+  ): Promise<HiringInterestRow>;
+
+  createInterview(
+    input: {
+      leagueId: string;
+      teamId: string;
+      staffType: StaffType;
+      staffId: string;
+      stepSlug: string;
+    },
+    tx?: Executor,
+  ): Promise<HiringInterviewRow>;
+  getInterviewById(
+    id: string,
+    tx?: Executor,
+  ): Promise<HiringInterviewRow | undefined>;
+  listInterviewsByLeague(
+    leagueId: string,
+    tx?: Executor,
+  ): Promise<HiringInterviewRow[]>;
+  updateInterview(
+    id: string,
+    patch: {
+      status?: HiringInterviewStatus;
+      philosophyReveal?: unknown;
+      staffFitReveal?: unknown;
+    },
+    tx?: Executor,
+  ): Promise<HiringInterviewRow>;
+
+  createOffer(
+    input: {
+      leagueId: string;
+      teamId: string;
+      staffType: StaffType;
+      staffId: string;
+      stepSlug: string;
+      salary: number;
+      contractYears: number;
+      buyoutMultiplier: string;
+      incentives?: unknown;
+    },
+    tx?: Executor,
+  ): Promise<HiringOfferRow>;
+  getOfferById(
+    id: string,
+    tx?: Executor,
+  ): Promise<HiringOfferRow | undefined>;
+  listOffersByLeague(
+    leagueId: string,
+    tx?: Executor,
+  ): Promise<HiringOfferRow[]>;
+  updateOffer(
+    id: string,
+    patch: {
+      status?: HiringOfferStatus;
+      preferenceScore?: number | null;
+    },
+    tx?: Executor,
+  ): Promise<HiringOfferRow>;
+
+  createDecision(
+    input: {
+      leagueId: string;
+      staffType: StaffType;
+      staffId: string;
+      chosenOfferId: string | null;
+      wave: number;
+    },
+    tx?: Executor,
+  ): Promise<HiringDecisionRow>;
+  listDecisionsByLeague(
+    leagueId: string,
+    tx?: Executor,
+  ): Promise<HiringDecisionRow[]>;
+
+  listUnassignedCoaches(
+    leagueId: string,
+    tx?: Executor,
+  ): Promise<UnassignedCandidate[]>;
+  listUnassignedScouts(
+    leagueId: string,
+    tx?: Executor,
+  ): Promise<UnassignedCandidate[]>;
+}
+
+export function createHiringRepository(deps: {
+  db: Database;
+  log: pino.Logger;
+}): HiringRepository {
+  const log = deps.log.child({ module: "hiring.repository" });
+
+  return {
+    async createInterest(input, tx) {
+      log.debug(
+        { leagueId: input.leagueId, teamId: input.teamId },
+        "creating hiring interest",
+      );
+      const [row] = await (tx ?? deps.db)
+        .insert(hiringInterests)
+        .values({
+          leagueId: input.leagueId,
+          teamId: input.teamId,
+          staffType: input.staffType,
+          staffId: input.staffId,
+          stepSlug: input.stepSlug,
+        })
+        .returning();
+      return row;
+    },
+
+    async getInterestById(id, tx) {
+      const [row] = await (tx ?? deps.db)
+        .select()
+        .from(hiringInterests)
+        .where(eq(hiringInterests.id, id))
+        .limit(1);
+      return row ?? undefined;
+    },
+
+    async listInterestsByLeague(leagueId, tx) {
+      return await (tx ?? deps.db)
+        .select()
+        .from(hiringInterests)
+        .where(eq(hiringInterests.leagueId, leagueId));
+    },
+
+    async updateInterestStatus(id, status, tx) {
+      const [row] = await (tx ?? deps.db)
+        .update(hiringInterests)
+        .set({ status, updatedAt: new Date() })
+        .where(eq(hiringInterests.id, id))
+        .returning();
+      return row;
+    },
+
+    async createInterview(input, tx) {
+      log.debug(
+        { leagueId: input.leagueId, teamId: input.teamId },
+        "creating hiring interview",
+      );
+      const [row] = await (tx ?? deps.db)
+        .insert(hiringInterviews)
+        .values({
+          leagueId: input.leagueId,
+          teamId: input.teamId,
+          staffType: input.staffType,
+          staffId: input.staffId,
+          stepSlug: input.stepSlug,
+        })
+        .returning();
+      return row;
+    },
+
+    async getInterviewById(id, tx) {
+      const [row] = await (tx ?? deps.db)
+        .select()
+        .from(hiringInterviews)
+        .where(eq(hiringInterviews.id, id))
+        .limit(1);
+      return row ?? undefined;
+    },
+
+    async listInterviewsByLeague(leagueId, tx) {
+      return await (tx ?? deps.db)
+        .select()
+        .from(hiringInterviews)
+        .where(eq(hiringInterviews.leagueId, leagueId));
+    },
+
+    async updateInterview(id, patch, tx) {
+      const set: Record<string, unknown> = { updatedAt: new Date() };
+      if (patch.status !== undefined) set.status = patch.status;
+      if (patch.philosophyReveal !== undefined) {
+        set.philosophyReveal = patch.philosophyReveal;
+      }
+      if (patch.staffFitReveal !== undefined) {
+        set.staffFitReveal = patch.staffFitReveal;
+      }
+      const [row] = await (tx ?? deps.db)
+        .update(hiringInterviews)
+        .set(set)
+        .where(eq(hiringInterviews.id, id))
+        .returning();
+      return row;
+    },
+
+    async createOffer(input, tx) {
+      log.debug(
+        { leagueId: input.leagueId, teamId: input.teamId },
+        "creating hiring offer",
+      );
+      const [row] = await (tx ?? deps.db)
+        .insert(hiringOffers)
+        .values({
+          leagueId: input.leagueId,
+          teamId: input.teamId,
+          staffType: input.staffType,
+          staffId: input.staffId,
+          stepSlug: input.stepSlug,
+          salary: input.salary,
+          contractYears: input.contractYears,
+          buyoutMultiplier: input.buyoutMultiplier,
+          ...(input.incentives !== undefined
+            ? { incentives: input.incentives }
+            : {}),
+        })
+        .returning();
+      return row;
+    },
+
+    async getOfferById(id, tx) {
+      const [row] = await (tx ?? deps.db)
+        .select()
+        .from(hiringOffers)
+        .where(eq(hiringOffers.id, id))
+        .limit(1);
+      return row ?? undefined;
+    },
+
+    async listOffersByLeague(leagueId, tx) {
+      return await (tx ?? deps.db)
+        .select()
+        .from(hiringOffers)
+        .where(eq(hiringOffers.leagueId, leagueId));
+    },
+
+    async updateOffer(id, patch, tx) {
+      const set: Record<string, unknown> = { updatedAt: new Date() };
+      if (patch.status !== undefined) set.status = patch.status;
+      if (patch.preferenceScore !== undefined) {
+        set.preferenceScore = patch.preferenceScore;
+      }
+      const [row] = await (tx ?? deps.db)
+        .update(hiringOffers)
+        .set(set)
+        .where(eq(hiringOffers.id, id))
+        .returning();
+      return row;
+    },
+
+    async createDecision(input, tx) {
+      log.debug(
+        { leagueId: input.leagueId, wave: input.wave },
+        "creating hiring decision",
+      );
+      const [row] = await (tx ?? deps.db)
+        .insert(hiringDecisions)
+        .values({
+          leagueId: input.leagueId,
+          staffType: input.staffType,
+          staffId: input.staffId,
+          chosenOfferId: input.chosenOfferId,
+          wave: input.wave,
+        })
+        .returning();
+      return row;
+    },
+
+    async listDecisionsByLeague(leagueId, tx) {
+      return await (tx ?? deps.db)
+        .select()
+        .from(hiringDecisions)
+        .where(eq(hiringDecisions.leagueId, leagueId));
+    },
+
+    async listUnassignedCoaches(leagueId, tx) {
+      const rows = await (tx ?? deps.db)
+        .select({
+          id: coaches.id,
+          leagueId: coaches.leagueId,
+          firstName: coaches.firstName,
+          lastName: coaches.lastName,
+          role: coaches.role,
+          marketTierPref: coaches.marketTierPref,
+          philosophyFitPref: coaches.philosophyFitPref,
+          staffFitPref: coaches.staffFitPref,
+          compensationPref: coaches.compensationPref,
+          minimumThreshold: coaches.minimumThreshold,
+        })
+        .from(coaches)
+        .where(
+          and(eq(coaches.leagueId, leagueId), isNull(coaches.teamId)),
+        );
+      return rows.map((r) => ({ ...r, role: r.role as string }));
+    },
+
+    async listUnassignedScouts(leagueId, tx) {
+      const rows = await (tx ?? deps.db)
+        .select({
+          id: scouts.id,
+          leagueId: scouts.leagueId,
+          firstName: scouts.firstName,
+          lastName: scouts.lastName,
+          role: scouts.role,
+          marketTierPref: scouts.marketTierPref,
+          philosophyFitPref: scouts.philosophyFitPref,
+          staffFitPref: scouts.staffFitPref,
+          compensationPref: scouts.compensationPref,
+          minimumThreshold: scouts.minimumThreshold,
+        })
+        .from(scouts)
+        .where(
+          and(eq(scouts.leagueId, leagueId), isNull(scouts.teamId)),
+        );
+      return rows.map((r) => ({ ...r, role: r.role as string }));
+    },
+  };
+}

--- a/server/features/hiring/hiring.service.test.ts
+++ b/server/features/hiring/hiring.service.test.ts
@@ -1,0 +1,183 @@
+import { assertEquals, assertRejects } from "@std/assert";
+import { DomainError } from "@zone-blitz/shared";
+import pino from "pino";
+import type {
+  HiringDecisionRow,
+  HiringInterestRow,
+  HiringInterviewRow,
+  HiringOfferRow,
+  HiringRepository,
+  UnassignedCandidate,
+} from "./hiring.repository.ts";
+import { createHiringService } from "./hiring.service.ts";
+
+function stubRepo(
+  overrides: Partial<HiringRepository> = {},
+): HiringRepository {
+  const base: HiringRepository = {
+    createInterest: () => Promise.resolve({} as unknown as HiringInterestRow),
+    getInterestById: () => Promise.resolve(undefined),
+    listInterestsByLeague: () => Promise.resolve([]),
+    updateInterestStatus: () =>
+      Promise.resolve({} as unknown as HiringInterestRow),
+    createInterview: () => Promise.resolve({} as unknown as HiringInterviewRow),
+    getInterviewById: () => Promise.resolve(undefined),
+    listInterviewsByLeague: () => Promise.resolve([]),
+    updateInterview: () => Promise.resolve({} as unknown as HiringInterviewRow),
+    createOffer: () => Promise.resolve({} as unknown as HiringOfferRow),
+    getOfferById: () => Promise.resolve(undefined),
+    listOffersByLeague: () => Promise.resolve([]),
+    updateOffer: () => Promise.resolve({} as unknown as HiringOfferRow),
+    createDecision: () => Promise.resolve({} as unknown as HiringDecisionRow),
+    listDecisionsByLeague: () => Promise.resolve([]),
+    listUnassignedCoaches: () => Promise.resolve([] as UnassignedCandidate[]),
+    listUnassignedScouts: () => Promise.resolve([] as UnassignedCandidate[]),
+  };
+  return { ...base, ...overrides };
+}
+
+function silentLog() {
+  return pino({ level: "silent" });
+}
+
+Deno.test("hiringService: step methods throw NOT_IMPLEMENTED until the logic ticket lands", async () => {
+  const service = createHiringService({
+    repo: stubRepo(),
+    log: silentLog(),
+  });
+
+  for (
+    const call of [
+      () => service.openMarket("lg"),
+      () =>
+        service.expressInterest({
+          leagueId: "lg",
+          teamId: "tm",
+          staffType: "coach",
+          staffId: "st",
+          stepSlug: "hiring_market_survey",
+        }),
+      () =>
+        service.requestInterviews({
+          leagueId: "lg",
+          teamId: "tm",
+          stepSlug: "hiring_interview_1",
+          targets: [{ staffType: "coach", staffId: "st" }],
+        }),
+      () => service.resolveInterviewDeclines("lg", "hiring_interview_1"),
+      () =>
+        service.submitOffers({
+          leagueId: "lg",
+          teamId: "tm",
+          stepSlug: "hiring_offers",
+          offers: [],
+        }),
+      () => service.resolveDecisions("lg", 1),
+      () => service.finalize("lg"),
+    ]
+  ) {
+    const err = await assertRejects(call, DomainError);
+    assertEquals((err as DomainError).code, "NOT_IMPLEMENTED");
+  }
+});
+
+Deno.test("hiringService.getHiringState: aggregates league rows from the repository", async () => {
+  const interests: HiringInterestRow[] = [
+    {
+      id: "i-1",
+      leagueId: "lg",
+      teamId: "tm",
+      staffType: "coach",
+      staffId: "s-1",
+      stepSlug: "hiring_market_survey",
+      status: "active",
+      createdAt: new Date(0),
+      updatedAt: new Date(0),
+    },
+  ];
+  const interviews: HiringInterviewRow[] = [
+    {
+      id: "iv-1",
+      leagueId: "lg",
+      teamId: "tm",
+      staffType: "scout",
+      staffId: "s-2",
+      stepSlug: "hiring_interview_1",
+      status: "requested",
+      philosophyReveal: null,
+      staffFitReveal: null,
+      createdAt: new Date(0),
+      updatedAt: new Date(0),
+    },
+  ];
+  const offers: HiringOfferRow[] = [
+    {
+      id: "o-1",
+      leagueId: "lg",
+      teamId: "tm",
+      staffType: "coach",
+      staffId: "s-1",
+      stepSlug: "hiring_offers",
+      status: "pending",
+      salary: 3_000_000,
+      contractYears: 2,
+      buyoutMultiplier: "0.50",
+      incentives: [],
+      preferenceScore: null,
+      createdAt: new Date(0),
+      updatedAt: new Date(0),
+    },
+  ];
+  const decisions: HiringDecisionRow[] = [
+    {
+      id: "d-1",
+      leagueId: "lg",
+      staffType: "coach",
+      staffId: "s-1",
+      chosenOfferId: "o-1",
+      wave: 1,
+      decidedAt: new Date(0),
+      createdAt: new Date(0),
+      updatedAt: new Date(0),
+    },
+  ];
+  const unassignedCoaches: UnassignedCandidate[] = [
+    {
+      id: "c-pool",
+      leagueId: "lg",
+      firstName: "A",
+      lastName: "B",
+      role: "OC",
+      marketTierPref: 50,
+      philosophyFitPref: 50,
+      staffFitPref: 50,
+      compensationPref: 50,
+      minimumThreshold: 30,
+    },
+  ];
+  const unassignedScouts: UnassignedCandidate[] = [];
+
+  const service = createHiringService({
+    repo: stubRepo({
+      listInterestsByLeague: (leagueId) => {
+        assertEquals(leagueId, "lg");
+        return Promise.resolve(interests);
+      },
+      listInterviewsByLeague: () => Promise.resolve(interviews),
+      listOffersByLeague: () => Promise.resolve(offers),
+      listDecisionsByLeague: () => Promise.resolve(decisions),
+      listUnassignedCoaches: () => Promise.resolve(unassignedCoaches),
+      listUnassignedScouts: () => Promise.resolve(unassignedScouts),
+    }),
+    log: silentLog(),
+  });
+
+  const state = await service.getHiringState("lg");
+  assertEquals(state.leagueId, "lg");
+  assertEquals(state.interests, interests);
+  assertEquals(state.interviews, interviews);
+  assertEquals(state.offers, offers);
+  assertEquals(state.decisions, decisions);
+  assertEquals(state.unassignedCoaches, unassignedCoaches);
+  assertEquals(state.unassignedScouts, unassignedScouts);
+});

--- a/server/features/hiring/hiring.service.ts
+++ b/server/features/hiring/hiring.service.ts
@@ -1,0 +1,142 @@
+import { DomainError } from "@zone-blitz/shared";
+import type pino from "pino";
+import type {
+  HiringDecisionRow,
+  HiringInterestRow,
+  HiringInterviewRow,
+  HiringOfferRow,
+  HiringRepository,
+  StaffType,
+  UnassignedCandidate,
+} from "./hiring.repository.ts";
+
+export interface InterestTarget {
+  staffType: StaffType;
+  staffId: string;
+}
+
+export interface DraftOffer {
+  staffType: StaffType;
+  staffId: string;
+  salary: number;
+  contractYears: number;
+  buyoutMultiplier: string;
+  incentives?: unknown;
+}
+
+export interface HiringState {
+  leagueId: string;
+  interests: HiringInterestRow[];
+  interviews: HiringInterviewRow[];
+  offers: HiringOfferRow[];
+  decisions: HiringDecisionRow[];
+  unassignedCoaches: UnassignedCandidate[];
+  unassignedScouts: UnassignedCandidate[];
+}
+
+export interface HiringService {
+  openMarket(leagueId: string): Promise<void>;
+  expressInterest(input: {
+    leagueId: string;
+    teamId: string;
+    staffType: StaffType;
+    staffId: string;
+    stepSlug: string;
+  }): Promise<HiringInterestRow>;
+  requestInterviews(input: {
+    leagueId: string;
+    teamId: string;
+    stepSlug: string;
+    targets: InterestTarget[];
+  }): Promise<HiringInterviewRow[]>;
+  resolveInterviewDeclines(
+    leagueId: string,
+    stepSlug: string,
+  ): Promise<HiringInterviewRow[]>;
+  submitOffers(input: {
+    leagueId: string;
+    teamId: string;
+    stepSlug: string;
+    offers: DraftOffer[];
+  }): Promise<HiringOfferRow[]>;
+  resolveDecisions(
+    leagueId: string,
+    wave: number,
+  ): Promise<HiringDecisionRow[]>;
+  finalize(leagueId: string): Promise<HiringDecisionRow[]>;
+  getHiringState(leagueId: string): Promise<HiringState>;
+}
+
+function notImplemented<T>(step: string): Promise<T> {
+  return Promise.reject(
+    new DomainError(
+      "NOT_IMPLEMENTED",
+      `Hiring step "${step}" is not yet implemented`,
+    ),
+  );
+}
+
+export function createHiringService(deps: {
+  repo: HiringRepository;
+  log: pino.Logger;
+}): HiringService {
+  const log = deps.log.child({ module: "hiring.service" });
+
+  return {
+    openMarket(_leagueId) {
+      return notImplemented("openMarket");
+    },
+
+    expressInterest(_input) {
+      return notImplemented("expressInterest");
+    },
+
+    requestInterviews(_input) {
+      return notImplemented("requestInterviews");
+    },
+
+    resolveInterviewDeclines(_leagueId, _stepSlug) {
+      return notImplemented("resolveInterviewDeclines");
+    },
+
+    submitOffers(_input) {
+      return notImplemented("submitOffers");
+    },
+
+    resolveDecisions(_leagueId, _wave) {
+      return notImplemented("resolveDecisions");
+    },
+
+    finalize(_leagueId) {
+      return notImplemented("finalize");
+    },
+
+    async getHiringState(leagueId) {
+      log.debug({ leagueId }, "fetching hiring state");
+      const [
+        interests,
+        interviews,
+        offers,
+        decisions,
+        unassignedCoaches,
+        unassignedScouts,
+      ] = await Promise.all([
+        deps.repo.listInterestsByLeague(leagueId),
+        deps.repo.listInterviewsByLeague(leagueId),
+        deps.repo.listOffersByLeague(leagueId),
+        deps.repo.listDecisionsByLeague(leagueId),
+        deps.repo.listUnassignedCoaches(leagueId),
+        deps.repo.listUnassignedScouts(leagueId),
+      ]);
+      return {
+        leagueId,
+        interests,
+        interviews,
+        offers,
+        decisions,
+        unassignedCoaches,
+        unassignedScouts,
+      };
+    },
+  };
+}

--- a/server/features/hiring/mod.ts
+++ b/server/features/hiring/mod.ts
@@ -1,0 +1,20 @@
+export { createHiringRepository } from "./hiring.repository.ts";
+export type {
+  HiringDecisionRow,
+  HiringInterestRow,
+  HiringInterestStatus,
+  HiringInterviewRow,
+  HiringInterviewStatus,
+  HiringOfferRow,
+  HiringOfferStatus,
+  HiringRepository,
+  StaffType,
+  UnassignedCandidate,
+} from "./hiring.repository.ts";
+export { createHiringService } from "./hiring.service.ts";
+export type {
+  DraftOffer,
+  HiringService,
+  HiringState,
+  InterestTarget,
+} from "./hiring.service.ts";

--- a/server/features/mod.ts
+++ b/server/features/mod.ts
@@ -63,6 +63,7 @@ import {
   createFranchiseRouter,
   createFranchiseService,
 } from "./franchise/mod.ts";
+import { createHiringRepository, createHiringService } from "./hiring/mod.ts";
 import { createTransactionRunner } from "../db/transaction-runner.ts";
 
 export function createFeatureRouters(
@@ -154,6 +155,10 @@ export function createFeatureRouters(
   const franchiseRepo = createFranchiseRepository({ db, log });
   const franchiseService = createFranchiseService({ franchiseRepo, log });
 
+  // Hiring (staff-hiring feature) — skeleton wired in; per-step logic lands in a follow-up.
+  const hiringRepo = createHiringRepository({ db, log });
+  const hiringService = createHiringService({ repo: hiringRepo, log });
+
   const leagueService = createLeagueService({
     txRunner,
     leagueRepo,
@@ -201,5 +206,6 @@ export function createFeatureRouters(
     scoutsRouter,
     rosterRouter,
     playersRouter,
+    hiringService,
   };
 }


### PR DESCRIPTION
## Summary

- Adds `server/features/hiring/` with a Drizzle-backed `HiringRepository` covering CRUD for interests, interviews, offers, and decisions, plus unassigned-staff queries (coaches/scouts with `teamId = null`) that use the `staff_type` discriminator from #431.
- Introduces `HiringService` with the step-oriented surface from ADR 0032 (`openMarket`, `expressInterest`, `requestInterviews`, `resolveInterviewDeclines`, `submitOffers`, `resolveDecisions`, `finalize`, `getHiringState`). Mutating steps reject with a `NOT_IMPLEMENTED` domain error; `getHiringState` aggregates the repo reads that are ready now, so later tickets can fill in per-step logic without re-plumbing the DI graph.
- Wires both factories into `server/features/mod.ts`.

Closes #435