### PR TITLE
feat(staff-hiring): implement per-step hiring service logic

### DIFF
--- a/server/features/hiring/hiring.repository.test.ts
+++ b/server/features/hiring/hiring.repository.test.ts
@@ -5,6 +5,7 @@ import postgres from "postgres";
 import pino from "pino";
 import * as schema from "../../db/schema.ts";
 import { coaches } from "../coaches/coach.schema.ts";
+import { coachTendencies } from "../coaches/coach-tendencies.schema.ts";
 import { scouts } from "../scouts/scout.schema.ts";
 import { leagues } from "../league/league.schema.ts";
 import { teams } from "../team/team.schema.ts";
@@ -777,6 +778,577 @@ Deno.test({
         undefined,
       );
     } finally {
+      await client.end();
+    }
+  },
+});
+
+Deno.test({
+  name:
+    "hiringRepository.listInterestsByTeam + findActiveInterest: scope to team and respect status",
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    const { db, client } = createTestDb();
+    const ctx = emptyCtx(db);
+    try {
+      const { league, team } = await setupFixtures(db);
+      ctx.leagueIds.push(league.id);
+      ctx.teamIds.push(team.id);
+
+      const repo = createHiringRepository({ db, log: createTestLogger() });
+      const candidate = crypto.randomUUID();
+      const active = await repo.createInterest({
+        leagueId: league.id,
+        teamId: team.id,
+        staffType: "coach",
+        staffId: candidate,
+        stepSlug: "hiring_market_survey",
+      });
+      const withdrawn = await repo.createInterest({
+        leagueId: league.id,
+        teamId: team.id,
+        staffType: "scout",
+        staffId: crypto.randomUUID(),
+        stepSlug: "hiring_market_survey",
+      });
+      await repo.updateInterestStatus(withdrawn.id, "withdrawn");
+      ctx.interestIds.push(active.id, withdrawn.id);
+
+      const teamInterests = await repo.listInterestsByTeam(
+        league.id,
+        team.id,
+      );
+      assertEquals(teamInterests.length, 2);
+
+      const found = await repo.findActiveInterest(
+        league.id,
+        team.id,
+        "coach",
+        candidate,
+      );
+      assertExists(found);
+
+      const withdrawnSearch = await repo.findActiveInterest(
+        league.id,
+        team.id,
+        "scout",
+        withdrawn.staffId,
+      );
+      assertEquals(withdrawnSearch, undefined);
+    } finally {
+      await cleanup(ctx);
+      await client.end();
+    }
+  },
+});
+
+Deno.test({
+  name:
+    "hiringRepository.listInterviewsByTeam / Step + findInterview: scope correctly",
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    const { db, client } = createTestDb();
+    const ctx = emptyCtx(db);
+    try {
+      const { league, team } = await setupFixtures(db);
+      ctx.leagueIds.push(league.id);
+      ctx.teamIds.push(team.id);
+
+      const repo = createHiringRepository({ db, log: createTestLogger() });
+      const candidateA = crypto.randomUUID();
+      const candidateB = crypto.randomUUID();
+      const week1 = await repo.createInterview({
+        leagueId: league.id,
+        teamId: team.id,
+        staffType: "coach",
+        staffId: candidateA,
+        stepSlug: "hiring_interview_1",
+      });
+      const week2 = await repo.createInterview({
+        leagueId: league.id,
+        teamId: team.id,
+        staffType: "scout",
+        staffId: candidateB,
+        stepSlug: "hiring_interview_2",
+      });
+      ctx.interviewIds.push(week1.id, week2.id);
+
+      const teamRows = await repo.listInterviewsByTeam(league.id, team.id);
+      assertEquals(teamRows.length, 2);
+
+      const stepRows = await repo.listInterviewsByStep(
+        league.id,
+        "hiring_interview_2",
+      );
+      assertEquals(stepRows.length, 1);
+      assertEquals(stepRows[0].id, week2.id);
+
+      const matched = await repo.findInterview(
+        league.id,
+        team.id,
+        "coach",
+        candidateA,
+      );
+      assertExists(matched);
+
+      const unmatched = await repo.findInterview(
+        league.id,
+        team.id,
+        "coach",
+        crypto.randomUUID(),
+      );
+      assertEquals(unmatched, undefined);
+    } finally {
+      await cleanup(ctx);
+      await client.end();
+    }
+  },
+});
+
+Deno.test({
+  name:
+    "hiringRepository.listOffersByTeam + listPendingOffersByLeague: filter by team and status",
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    const { db, client } = createTestDb();
+    const ctx = emptyCtx(db);
+    try {
+      const { league, team } = await setupFixtures(db);
+      ctx.leagueIds.push(league.id);
+      ctx.teamIds.push(team.id);
+
+      const repo = createHiringRepository({ db, log: createTestLogger() });
+      const pending = await repo.createOffer({
+        leagueId: league.id,
+        teamId: team.id,
+        staffType: "coach",
+        staffId: crypto.randomUUID(),
+        stepSlug: "hiring_offers",
+        salary: 1_000_000,
+        contractYears: 2,
+        buyoutMultiplier: "0.50",
+      });
+      const accepted = await repo.createOffer({
+        leagueId: league.id,
+        teamId: team.id,
+        staffType: "scout",
+        staffId: crypto.randomUUID(),
+        stepSlug: "hiring_offers",
+        salary: 200_000,
+        contractYears: 2,
+        buyoutMultiplier: "0.50",
+      });
+      await repo.updateOffer(accepted.id, { status: "accepted" });
+      ctx.offerIds.push(pending.id, accepted.id);
+
+      const teamOffers = await repo.listOffersByTeam(league.id, team.id);
+      assertEquals(teamOffers.length, 2);
+
+      const pendingOffers = await repo.listPendingOffersByLeague(league.id);
+      assertEquals(pendingOffers.length, 1);
+      assertEquals(pendingOffers[0].id, pending.id);
+    } finally {
+      await cleanup(ctx);
+      await client.end();
+    }
+  },
+});
+
+Deno.test({
+  name:
+    "hiringRepository.getCandidateScoringContext: returns coach preferences and tendencies",
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    const { db, client } = createTestDb();
+    const ctx = emptyCtx(db);
+    const coachId = crypto.randomUUID();
+    try {
+      const { league } = await setupFixtures(db);
+      ctx.leagueIds.push(league.id);
+
+      await db.insert(coaches).values({
+        id: coachId,
+        leagueId: league.id,
+        teamId: null,
+        firstName: "Pool",
+        lastName: "Coach",
+        role: "OC",
+        age: 45,
+        hiredAt: new Date("2027-01-01T00:00:00Z"),
+        contractYears: 0,
+        contractSalary: 0,
+        contractBuyout: 0,
+        marketTierPref: 70,
+        philosophyFitPref: 60,
+        staffFitPref: 55,
+        compensationPref: 80,
+        minimumThreshold: 40,
+      });
+      ctx.coachIds.push(coachId);
+
+      await db.insert(coachTendencies).values({
+        coachId,
+        runPassLean: 60,
+        tempo: 70,
+        personnelWeight: 50,
+        formationUnderCenterShotgun: 40,
+        preSnapMotionRate: 45,
+        passingStyle: 50,
+        passingDepth: 55,
+        runGameBlocking: 50,
+        rpoIntegration: 30,
+      });
+
+      const repo = createHiringRepository({ db, log: createTestLogger() });
+      const ctxOut = await repo.getCandidateScoringContext("coach", coachId);
+      assertExists(ctxOut);
+      assertEquals(ctxOut?.role, "OC");
+      assertEquals(ctxOut?.preferences.marketTierPref, 70);
+      assertExists(ctxOut?.offense);
+      assertEquals(ctxOut?.defense, null);
+
+      assertEquals(
+        await repo.getCandidateScoringContext("coach", crypto.randomUUID()),
+        undefined,
+      );
+    } finally {
+      await db.delete(coachTendencies).where(
+        eq(coachTendencies.coachId, coachId),
+      );
+      await cleanup(ctx);
+      await client.end();
+    }
+  },
+});
+
+Deno.test({
+  name:
+    "hiringRepository.getCandidateScoringContext: returns scout preferences with no tendencies",
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    const { db, client } = createTestDb();
+    const ctx = emptyCtx(db);
+    try {
+      const { league } = await setupFixtures(db);
+      ctx.leagueIds.push(league.id);
+
+      const scoutId = crypto.randomUUID();
+      await db.insert(scouts).values({
+        id: scoutId,
+        leagueId: league.id,
+        teamId: null,
+        firstName: "Pool",
+        lastName: "Scout",
+        role: "AREA_SCOUT",
+        marketTierPref: 30,
+        philosophyFitPref: 40,
+        staffFitPref: 50,
+        compensationPref: 60,
+        minimumThreshold: 20,
+      });
+      ctx.scoutIds.push(scoutId);
+
+      const repo = createHiringRepository({ db, log: createTestLogger() });
+      const result = await repo.getCandidateScoringContext("scout", scoutId);
+      assertExists(result);
+      assertEquals(result?.staffType, "scout");
+      assertEquals(result?.preferences.minimumThreshold, 20);
+      assertEquals(result?.offense, null);
+      assertEquals(result?.defense, null);
+
+      assertEquals(
+        await repo.getCandidateScoringContext("scout", crypto.randomUUID()),
+        undefined,
+      );
+    } finally {
+      await cleanup(ctx);
+      await client.end();
+    }
+  },
+});
+
+Deno.test({
+  name:
+    "hiringRepository.getFranchiseScoringProfile: derives market tier and existing staff",
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    const { db, client } = createTestDb();
+    const ctx = emptyCtx(db);
+    const coachId = crypto.randomUUID();
+    try {
+      const { league, team } = await setupFixtures(db);
+      ctx.leagueIds.push(league.id);
+      ctx.teamIds.push(team.id);
+
+      await db.insert(coaches).values({
+        id: coachId,
+        leagueId: league.id,
+        teamId: team.id,
+        firstName: "Existing",
+        lastName: "OC",
+        role: "OC",
+        age: 45,
+        hiredAt: new Date("2027-01-01T00:00:00Z"),
+        contractYears: 3,
+        contractSalary: 4_000_000,
+        contractBuyout: 6_000_000,
+      });
+      ctx.coachIds.push(coachId);
+
+      await db.insert(coachTendencies).values({
+        coachId,
+        runPassLean: 50,
+        tempo: 50,
+        personnelWeight: 50,
+        formationUnderCenterShotgun: 50,
+        preSnapMotionRate: 50,
+        passingStyle: 50,
+        passingDepth: 50,
+        runGameBlocking: 50,
+        rpoIntegration: 50,
+      });
+
+      const repo = createHiringRepository({ db, log: createTestLogger() });
+      const profile = await repo.getFranchiseScoringProfile(team.id);
+      assertExists(profile);
+      assertEquals(profile?.teamId, team.id);
+      // Test fixture cities are random — neither Large nor Medium tier — so
+      // the profile resolves to the small-market default.
+      assertEquals(profile?.marketTier, "small");
+      assertEquals(profile?.existingStaff.length, 1);
+      assertEquals(profile?.existingStaff[0].role, "OC");
+
+      assertEquals(
+        await repo.getFranchiseScoringProfile(crypto.randomUUID()),
+        undefined,
+      );
+    } finally {
+      await db.delete(coachTendencies).where(
+        eq(coachTendencies.coachId, coachId),
+      );
+      await cleanup(ctx);
+      await client.end();
+    }
+  },
+});
+
+Deno.test({
+  name:
+    "hiringRepository.sumSignedStaffSalaries: aggregates coach + scout salaries",
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    const { db, client } = createTestDb();
+    const ctx = emptyCtx(db);
+    try {
+      const { league, team } = await setupFixtures(db);
+      ctx.leagueIds.push(league.id);
+      ctx.teamIds.push(team.id);
+
+      const coachId = crypto.randomUUID();
+      const scoutId = crypto.randomUUID();
+      await db.insert(coaches).values({
+        id: coachId,
+        leagueId: league.id,
+        teamId: team.id,
+        firstName: "Signed",
+        lastName: "Coach",
+        role: "HC",
+        age: 50,
+        hiredAt: new Date("2027-01-01T00:00:00Z"),
+        contractYears: 4,
+        contractSalary: 8_000_000,
+        contractBuyout: 16_000_000,
+      });
+      await db.insert(scouts).values({
+        id: scoutId,
+        leagueId: league.id,
+        teamId: team.id,
+        firstName: "Signed",
+        lastName: "Scout",
+        role: "DIRECTOR",
+        contractSalary: 500_000,
+      });
+      ctx.coachIds.push(coachId);
+      ctx.scoutIds.push(scoutId);
+
+      const repo = createHiringRepository({ db, log: createTestLogger() });
+      const total = await repo.sumSignedStaffSalaries(team.id);
+      assertEquals(total, 8_500_000);
+
+      const empty = await repo.sumSignedStaffSalaries(crypto.randomUUID());
+      assertEquals(empty, 0);
+    } finally {
+      await cleanup(ctx);
+      await client.end();
+    }
+  },
+});
+
+Deno.test({
+  name:
+    "hiringRepository.listTeamsForLeague + listSignedStaffByTeam: enumerate teams and signed staff",
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    const { db, client } = createTestDb();
+    const ctx = emptyCtx(db);
+    try {
+      const { league, team } = await setupFixtures(db);
+      ctx.leagueIds.push(league.id);
+      ctx.teamIds.push(team.id);
+
+      const coachId = crypto.randomUUID();
+      const scoutId = crypto.randomUUID();
+      await db.insert(coaches).values({
+        id: coachId,
+        leagueId: league.id,
+        teamId: team.id,
+        firstName: "Signed",
+        lastName: "Coach",
+        role: "HC",
+        age: 50,
+        hiredAt: new Date("2027-01-01T00:00:00Z"),
+        contractYears: 3,
+        contractSalary: 6_000_000,
+        contractBuyout: 12_000_000,
+      });
+      await db.insert(scouts).values({
+        id: scoutId,
+        leagueId: league.id,
+        teamId: team.id,
+        firstName: "Signed",
+        lastName: "Scout",
+        role: "DIRECTOR",
+        contractSalary: 400_000,
+      });
+      ctx.coachIds.push(coachId);
+      ctx.scoutIds.push(scoutId);
+
+      const repo = createHiringRepository({ db, log: createTestLogger() });
+      const teamsList = await repo.listTeamsForLeague(league.id);
+      assertEquals(teamsList.length, 1);
+      assertEquals(teamsList[0].teamId, team.id);
+
+      const signed = await repo.listSignedStaffByTeam(league.id, team.id);
+      assertEquals(signed.length, 2);
+      const coachEntry = signed.find((m) => m.staffType === "coach");
+      const scoutEntry = signed.find((m) => m.staffType === "scout");
+      assertEquals(coachEntry?.role, "HC");
+      assertEquals(scoutEntry?.role, "DIRECTOR");
+    } finally {
+      await cleanup(ctx);
+      await client.end();
+    }
+  },
+});
+
+Deno.test({
+  name: "hiringRepository.assignCoach: writes hire fields onto the coach row",
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    const { db, client } = createTestDb();
+    const ctx = emptyCtx(db);
+    try {
+      const { league, team } = await setupFixtures(db);
+      ctx.leagueIds.push(league.id);
+      ctx.teamIds.push(team.id);
+
+      const coachId = crypto.randomUUID();
+      await db.insert(coaches).values({
+        id: coachId,
+        leagueId: league.id,
+        teamId: null,
+        firstName: "Pool",
+        lastName: "Coach",
+        role: "OC",
+        age: 42,
+        hiredAt: new Date("2024-01-01T00:00:00Z"),
+        contractYears: 0,
+        contractSalary: 0,
+        contractBuyout: 0,
+      });
+      ctx.coachIds.push(coachId);
+
+      const repo = createHiringRepository({ db, log: createTestLogger() });
+      const hiredAt = new Date("2027-04-16T00:00:00Z");
+      await repo.assignCoach(coachId, {
+        teamId: team.id,
+        reportsToId: null,
+        contractSalary: 3_000_000,
+        contractYears: 3,
+        contractBuyout: 4_500_000,
+        hiredAt,
+      });
+
+      const [row] = await db
+        .select()
+        .from(coaches)
+        .where(eq(coaches.id, coachId))
+        .limit(1);
+      assertEquals(row.teamId, team.id);
+      assertEquals(row.contractSalary, 3_000_000);
+      assertEquals(row.contractYears, 3);
+      assertEquals(row.contractBuyout, 4_500_000);
+      assertEquals(row.hiredAt.toISOString(), hiredAt.toISOString());
+    } finally {
+      await cleanup(ctx);
+      await client.end();
+    }
+  },
+});
+
+Deno.test({
+  name: "hiringRepository.assignScout: writes hire fields onto the scout row",
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    const { db, client } = createTestDb();
+    const ctx = emptyCtx(db);
+    try {
+      const { league, team } = await setupFixtures(db);
+      ctx.leagueIds.push(league.id);
+      ctx.teamIds.push(team.id);
+
+      const scoutId = crypto.randomUUID();
+      await db.insert(scouts).values({
+        id: scoutId,
+        leagueId: league.id,
+        teamId: null,
+        firstName: "Pool",
+        lastName: "Scout",
+        role: "AREA_SCOUT",
+      });
+      ctx.scoutIds.push(scoutId);
+
+      const repo = createHiringRepository({ db, log: createTestLogger() });
+      const hiredAt = new Date("2027-04-16T00:00:00Z");
+      await repo.assignScout(scoutId, {
+        teamId: team.id,
+        contractSalary: 150_000,
+        contractYears: 2,
+        contractBuyout: 150_000,
+        hiredAt,
+      });
+
+      const [row] = await db
+        .select()
+        .from(scouts)
+        .where(eq(scouts.id, scoutId))
+        .limit(1);
+      assertEquals(row.teamId, team.id);
+      assertEquals(row.contractSalary, 150_000);
+      assertEquals(row.contractYears, 2);
+      assertEquals(row.hiredAt.toISOString(), hiredAt.toISOString());
+    } finally {
+      await cleanup(ctx);
       await client.end();
     }
   },

--- a/server/features/hiring/hiring.repository.ts
+++ b/server/features/hiring/hiring.repository.ts
@@ -1,5 +1,11 @@
-import { and, eq, isNull } from "drizzle-orm";
+import { and, eq, inArray, isNotNull, isNull, sql } from "drizzle-orm";
 import type pino from "pino";
+import type {
+  CoachRole,
+  DefensiveTendencies,
+  OffensiveTendencies,
+  ScoutRole,
+} from "@zone-blitz/shared";
 import type { Database, Executor } from "../../db/connection.ts";
 import {
   hiringDecisions,
@@ -9,6 +15,11 @@ import {
 } from "./hiring.schema.ts";
 import { coaches } from "../coaches/coach.schema.ts";
 import { scouts } from "../scouts/scout.schema.ts";
+import { coachTendencies } from "../coaches/coach-tendencies.schema.ts";
+import { teams } from "../team/team.schema.ts";
+import { cities } from "../cities/city.schema.ts";
+import { marketTierForCity } from "./preference-scoring.ts";
+import type { FranchiseStaffMember, MarketTier } from "./preference-scoring.ts";
 
 export type StaffType = "coach" | "scout";
 export type HiringInterestStatus = "active" | "withdrawn";
@@ -91,6 +102,56 @@ export interface UnassignedCandidate {
   minimumThreshold: number | null;
 }
 
+export interface CandidateScoringContext {
+  staffType: StaffType;
+  staffId: string;
+  role: CoachRole | ScoutRole;
+  preferences: {
+    marketTierPref: number;
+    philosophyFitPref: number;
+    staffFitPref: number;
+    compensationPref: number;
+    minimumThreshold: number;
+  };
+  offense: OffensiveTendencies | null;
+  defense: DefensiveTendencies | null;
+}
+
+export interface FranchiseScoringProfile {
+  teamId: string;
+  marketTier: MarketTier;
+  existingStaff: FranchiseStaffMember[];
+}
+
+export interface SignedStaffMember {
+  staffType: StaffType;
+  staffId: string;
+  role: CoachRole | ScoutRole;
+  contractSalary: number;
+}
+
+export interface TeamScoringSummary {
+  teamId: string;
+  marketTier: MarketTier;
+}
+
+export interface AssignCoachPatch {
+  teamId: string;
+  reportsToId: string | null;
+  contractSalary: number;
+  contractYears: number;
+  contractBuyout: number;
+  hiredAt: Date;
+}
+
+export interface AssignScoutPatch {
+  teamId: string;
+  contractSalary: number;
+  contractYears: number;
+  contractBuyout: number;
+  hiredAt: Date;
+}
+
 export interface HiringRepository {
   createInterest(
     input: {
@@ -110,6 +171,18 @@ export interface HiringRepository {
     leagueId: string,
     tx?: Executor,
   ): Promise<HiringInterestRow[]>;
+  listInterestsByTeam(
+    leagueId: string,
+    teamId: string,
+    tx?: Executor,
+  ): Promise<HiringInterestRow[]>;
+  findActiveInterest(
+    leagueId: string,
+    teamId: string,
+    staffType: StaffType,
+    staffId: string,
+    tx?: Executor,
+  ): Promise<HiringInterestRow | undefined>;
   updateInterestStatus(
     id: string,
     status: HiringInterestStatus,
@@ -134,6 +207,23 @@ export interface HiringRepository {
     leagueId: string,
     tx?: Executor,
   ): Promise<HiringInterviewRow[]>;
+  listInterviewsByTeam(
+    leagueId: string,
+    teamId: string,
+    tx?: Executor,
+  ): Promise<HiringInterviewRow[]>;
+  listInterviewsByStep(
+    leagueId: string,
+    stepSlug: string,
+    tx?: Executor,
+  ): Promise<HiringInterviewRow[]>;
+  findInterview(
+    leagueId: string,
+    teamId: string,
+    staffType: StaffType,
+    staffId: string,
+    tx?: Executor,
+  ): Promise<HiringInterviewRow | undefined>;
   updateInterview(
     id: string,
     patch: {
@@ -163,6 +253,15 @@ export interface HiringRepository {
     tx?: Executor,
   ): Promise<HiringOfferRow | undefined>;
   listOffersByLeague(
+    leagueId: string,
+    tx?: Executor,
+  ): Promise<HiringOfferRow[]>;
+  listOffersByTeam(
+    leagueId: string,
+    teamId: string,
+    tx?: Executor,
+  ): Promise<HiringOfferRow[]>;
+  listPendingOffersByLeague(
     leagueId: string,
     tx?: Executor,
   ): Promise<HiringOfferRow[]>;
@@ -198,6 +297,37 @@ export interface HiringRepository {
     leagueId: string,
     tx?: Executor,
   ): Promise<UnassignedCandidate[]>;
+
+  getCandidateScoringContext(
+    staffType: StaffType,
+    staffId: string,
+    tx?: Executor,
+  ): Promise<CandidateScoringContext | undefined>;
+  getFranchiseScoringProfile(
+    teamId: string,
+    tx?: Executor,
+  ): Promise<FranchiseScoringProfile | undefined>;
+  sumSignedStaffSalaries(teamId: string, tx?: Executor): Promise<number>;
+  listTeamsForLeague(
+    leagueId: string,
+    tx?: Executor,
+  ): Promise<TeamScoringSummary[]>;
+  listSignedStaffByTeam(
+    leagueId: string,
+    teamId: string,
+    tx?: Executor,
+  ): Promise<SignedStaffMember[]>;
+
+  assignCoach(
+    coachId: string,
+    patch: AssignCoachPatch,
+    tx?: Executor,
+  ): Promise<void>;
+  assignScout(
+    scoutId: string,
+    patch: AssignScoutPatch,
+    tx?: Executor,
+  ): Promise<void>;
 }
 
 export function createHiringRepository(deps: {
@@ -241,6 +371,35 @@ export function createHiringRepository(deps: {
         .where(eq(hiringInterests.leagueId, leagueId));
     },
 
+    async listInterestsByTeam(leagueId, teamId, tx) {
+      return await (tx ?? deps.db)
+        .select()
+        .from(hiringInterests)
+        .where(
+          and(
+            eq(hiringInterests.leagueId, leagueId),
+            eq(hiringInterests.teamId, teamId),
+          ),
+        );
+    },
+
+    async findActiveInterest(leagueId, teamId, staffType, staffId, tx) {
+      const [row] = await (tx ?? deps.db)
+        .select()
+        .from(hiringInterests)
+        .where(
+          and(
+            eq(hiringInterests.leagueId, leagueId),
+            eq(hiringInterests.teamId, teamId),
+            eq(hiringInterests.staffType, staffType),
+            eq(hiringInterests.staffId, staffId),
+            eq(hiringInterests.status, "active"),
+          ),
+        )
+        .limit(1);
+      return row ?? undefined;
+    },
+
     async updateInterestStatus(id, status, tx) {
       const [row] = await (tx ?? deps.db)
         .update(hiringInterests)
@@ -282,6 +441,46 @@ export function createHiringRepository(deps: {
         .select()
         .from(hiringInterviews)
         .where(eq(hiringInterviews.leagueId, leagueId));
+    },
+
+    async listInterviewsByTeam(leagueId, teamId, tx) {
+      return await (tx ?? deps.db)
+        .select()
+        .from(hiringInterviews)
+        .where(
+          and(
+            eq(hiringInterviews.leagueId, leagueId),
+            eq(hiringInterviews.teamId, teamId),
+          ),
+        );
+    },
+
+    async listInterviewsByStep(leagueId, stepSlug, tx) {
+      return await (tx ?? deps.db)
+        .select()
+        .from(hiringInterviews)
+        .where(
+          and(
+            eq(hiringInterviews.leagueId, leagueId),
+            eq(hiringInterviews.stepSlug, stepSlug),
+          ),
+        );
+    },
+
+    async findInterview(leagueId, teamId, staffType, staffId, tx) {
+      const [row] = await (tx ?? deps.db)
+        .select()
+        .from(hiringInterviews)
+        .where(
+          and(
+            eq(hiringInterviews.leagueId, leagueId),
+            eq(hiringInterviews.teamId, teamId),
+            eq(hiringInterviews.staffType, staffType),
+            eq(hiringInterviews.staffId, staffId),
+          ),
+        )
+        .limit(1);
+      return row ?? undefined;
     },
 
     async updateInterview(id, patch, tx) {
@@ -339,6 +538,30 @@ export function createHiringRepository(deps: {
         .select()
         .from(hiringOffers)
         .where(eq(hiringOffers.leagueId, leagueId));
+    },
+
+    async listOffersByTeam(leagueId, teamId, tx) {
+      return await (tx ?? deps.db)
+        .select()
+        .from(hiringOffers)
+        .where(
+          and(
+            eq(hiringOffers.leagueId, leagueId),
+            eq(hiringOffers.teamId, teamId),
+          ),
+        );
+    },
+
+    async listPendingOffersByLeague(leagueId, tx) {
+      return await (tx ?? deps.db)
+        .select()
+        .from(hiringOffers)
+        .where(
+          and(
+            eq(hiringOffers.leagueId, leagueId),
+            eq(hiringOffers.status, "pending"),
+          ),
+        );
     },
 
     async updateOffer(id, patch, tx) {
@@ -420,6 +643,293 @@ export function createHiringRepository(deps: {
           and(eq(scouts.leagueId, leagueId), isNull(scouts.teamId)),
         );
       return rows.map((r) => ({ ...r, role: r.role as string }));
+    },
+
+    async getCandidateScoringContext(staffType, staffId, tx) {
+      const exec = tx ?? deps.db;
+      if (staffType === "coach") {
+        const [row] = await exec
+          .select({
+            id: coaches.id,
+            role: coaches.role,
+            marketTierPref: coaches.marketTierPref,
+            philosophyFitPref: coaches.philosophyFitPref,
+            staffFitPref: coaches.staffFitPref,
+            compensationPref: coaches.compensationPref,
+            minimumThreshold: coaches.minimumThreshold,
+          })
+          .from(coaches)
+          .where(eq(coaches.id, staffId))
+          .limit(1);
+        if (!row) return undefined;
+        const tendencies = await exec
+          .select()
+          .from(coachTendencies)
+          .where(eq(coachTendencies.coachId, staffId))
+          .limit(1);
+        const tendRow = tendencies[0];
+        const offense = tendRow && tendRow.runPassLean !== null
+          ? {
+            runPassLean: tendRow.runPassLean ?? 0,
+            tempo: tendRow.tempo ?? 0,
+            personnelWeight: tendRow.personnelWeight ?? 0,
+            formationUnderCenterShotgun: tendRow.formationUnderCenterShotgun ??
+              0,
+            preSnapMotionRate: tendRow.preSnapMotionRate ?? 0,
+            passingStyle: tendRow.passingStyle ?? 0,
+            passingDepth: tendRow.passingDepth ?? 0,
+            runGameBlocking: tendRow.runGameBlocking ?? 0,
+            rpoIntegration: tendRow.rpoIntegration ?? 0,
+          } as OffensiveTendencies
+          : null;
+        const defense = tendRow && tendRow.frontOddEven !== null
+          ? {
+            frontOddEven: tendRow.frontOddEven ?? 0,
+            gapResponsibility: tendRow.gapResponsibility ?? 0,
+            subPackageLean: tendRow.subPackageLean ?? 0,
+            coverageManZone: tendRow.coverageManZone ?? 0,
+            coverageShell: tendRow.coverageShell ?? 0,
+            cornerPressOff: tendRow.cornerPressOff ?? 0,
+            pressureRate: tendRow.pressureRate ?? 0,
+            disguiseRate: tendRow.disguiseRate ?? 0,
+          } as DefensiveTendencies
+          : null;
+        return {
+          staffType: "coach",
+          staffId,
+          role: row.role as CoachRole,
+          preferences: {
+            marketTierPref: row.marketTierPref ?? 50,
+            philosophyFitPref: row.philosophyFitPref ?? 50,
+            staffFitPref: row.staffFitPref ?? 50,
+            compensationPref: row.compensationPref ?? 50,
+            minimumThreshold: row.minimumThreshold ?? 50,
+          },
+          offense,
+          defense,
+        };
+      }
+
+      const [row] = await exec
+        .select({
+          id: scouts.id,
+          role: scouts.role,
+          marketTierPref: scouts.marketTierPref,
+          philosophyFitPref: scouts.philosophyFitPref,
+          staffFitPref: scouts.staffFitPref,
+          compensationPref: scouts.compensationPref,
+          minimumThreshold: scouts.minimumThreshold,
+        })
+        .from(scouts)
+        .where(eq(scouts.id, staffId))
+        .limit(1);
+      if (!row) return undefined;
+      return {
+        staffType: "scout",
+        staffId,
+        role: row.role as ScoutRole,
+        preferences: {
+          marketTierPref: row.marketTierPref ?? 50,
+          philosophyFitPref: row.philosophyFitPref ?? 50,
+          staffFitPref: row.staffFitPref ?? 50,
+          compensationPref: row.compensationPref ?? 50,
+          minimumThreshold: row.minimumThreshold ?? 50,
+        },
+        offense: null,
+        defense: null,
+      };
+    },
+
+    async getFranchiseScoringProfile(teamId, tx) {
+      const exec = tx ?? deps.db;
+      const [team] = await exec
+        .select({ id: teams.id, cityId: teams.cityId })
+        .from(teams)
+        .where(eq(teams.id, teamId))
+        .limit(1);
+      if (!team) return undefined;
+      const [city] = await exec
+        .select({ name: cities.name })
+        .from(cities)
+        .where(eq(cities.id, team.cityId))
+        .limit(1);
+      const cityName = city?.name ?? "";
+      const marketTier = marketTierForCity(cityName);
+
+      const coachRows = await exec
+        .select({
+          id: coaches.id,
+          role: coaches.role,
+        })
+        .from(coaches)
+        .where(eq(coaches.teamId, teamId));
+
+      const tendencyRows = coachRows.length === 0 ? [] : await exec
+        .select()
+        .from(coachTendencies)
+        .where(
+          inArray(
+            coachTendencies.coachId,
+            coachRows.map((c) => c.id),
+          ),
+        );
+      const tendencyById = new Map(
+        tendencyRows.map((row) => [row.coachId, row]),
+      );
+
+      const existingStaff: FranchiseStaffMember[] = coachRows.map((coach) => {
+        const tend = tendencyById.get(coach.id);
+        const offense = tend && tend.runPassLean !== null
+          ? {
+            runPassLean: tend.runPassLean ?? 0,
+            tempo: tend.tempo ?? 0,
+            personnelWeight: tend.personnelWeight ?? 0,
+            formationUnderCenterShotgun: tend.formationUnderCenterShotgun ?? 0,
+            preSnapMotionRate: tend.preSnapMotionRate ?? 0,
+            passingStyle: tend.passingStyle ?? 0,
+            passingDepth: tend.passingDepth ?? 0,
+            runGameBlocking: tend.runGameBlocking ?? 0,
+            rpoIntegration: tend.rpoIntegration ?? 0,
+          } as OffensiveTendencies
+          : null;
+        const defense = tend && tend.frontOddEven !== null
+          ? {
+            frontOddEven: tend.frontOddEven ?? 0,
+            gapResponsibility: tend.gapResponsibility ?? 0,
+            subPackageLean: tend.subPackageLean ?? 0,
+            coverageManZone: tend.coverageManZone ?? 0,
+            coverageShell: tend.coverageShell ?? 0,
+            cornerPressOff: tend.cornerPressOff ?? 0,
+            pressureRate: tend.pressureRate ?? 0,
+            disguiseRate: tend.disguiseRate ?? 0,
+          } as DefensiveTendencies
+          : null;
+        return {
+          staffType: "coach",
+          role: coach.role as CoachRole,
+          offense,
+          defense,
+        };
+      });
+
+      return { teamId, marketTier, existingStaff };
+    },
+
+    async sumSignedStaffSalaries(teamId, tx) {
+      const exec = tx ?? deps.db;
+      const [coachSum] = await exec
+        .select({
+          total: sql<number>`coalesce(sum(${coaches.contractSalary}), 0)`
+            .as("total"),
+        })
+        .from(coaches)
+        .where(eq(coaches.teamId, teamId));
+      const [scoutSum] = await exec
+        .select({
+          total: sql<number>`coalesce(sum(${scouts.contractSalary}), 0)`.as(
+            "total",
+          ),
+        })
+        .from(scouts)
+        .where(eq(scouts.teamId, teamId));
+      return Number(coachSum?.total ?? 0) + Number(scoutSum?.total ?? 0);
+    },
+
+    async listTeamsForLeague(leagueId, tx) {
+      const exec = tx ?? deps.db;
+      const rows = await exec
+        .select({
+          teamId: teams.id,
+          cityName: cities.name,
+        })
+        .from(teams)
+        .innerJoin(cities, eq(cities.id, teams.cityId))
+        .where(eq(teams.leagueId, leagueId));
+      return rows.map((row) => ({
+        teamId: row.teamId,
+        marketTier: marketTierForCity(row.cityName),
+      }));
+    },
+
+    async listSignedStaffByTeam(leagueId, teamId, tx) {
+      const exec = tx ?? deps.db;
+      const coachRows = await exec
+        .select({
+          id: coaches.id,
+          role: coaches.role,
+          contractSalary: coaches.contractSalary,
+        })
+        .from(coaches)
+        .where(
+          and(
+            eq(coaches.leagueId, leagueId),
+            eq(coaches.teamId, teamId),
+            isNotNull(coaches.teamId),
+          ),
+        );
+      const scoutRows = await exec
+        .select({
+          id: scouts.id,
+          role: scouts.role,
+          contractSalary: scouts.contractSalary,
+        })
+        .from(scouts)
+        .where(
+          and(
+            eq(scouts.leagueId, leagueId),
+            eq(scouts.teamId, teamId),
+            isNotNull(scouts.teamId),
+          ),
+        );
+      const result: SignedStaffMember[] = [];
+      for (const row of coachRows) {
+        result.push({
+          staffType: "coach",
+          staffId: row.id,
+          role: row.role as CoachRole,
+          contractSalary: row.contractSalary,
+        });
+      }
+      for (const row of scoutRows) {
+        result.push({
+          staffType: "scout",
+          staffId: row.id,
+          role: row.role as ScoutRole,
+          contractSalary: row.contractSalary,
+        });
+      }
+      return result;
+    },
+
+    async assignCoach(coachId, patch, tx) {
+      log.debug({ coachId, teamId: patch.teamId }, "assigning coach");
+      await (tx ?? deps.db)
+        .update(coaches)
+        .set({
+          teamId: patch.teamId,
+          reportsToId: patch.reportsToId,
+          contractSalary: patch.contractSalary,
+          contractYears: patch.contractYears,
+          contractBuyout: patch.contractBuyout,
+          hiredAt: patch.hiredAt,
+          updatedAt: new Date(),
+        })
+        .where(eq(coaches.id, coachId));
+    },
+
+    async assignScout(scoutId, patch, tx) {
+      log.debug({ scoutId, teamId: patch.teamId }, "assigning scout");
+      await (tx ?? deps.db)
+        .update(scouts)
+        .set({
+          teamId: patch.teamId,
+          contractSalary: patch.contractSalary,
+          contractYears: patch.contractYears,
+          contractBuyout: patch.contractBuyout,
+          hiredAt: patch.hiredAt,
+          updatedAt: new Date(),
+        })
+        .where(eq(scouts.id, scoutId));
     },
   };
 }

--- a/server/features/hiring/hiring.service.test.ts
+++ b/server/features/hiring/hiring.service.test.ts
@@ -1,133 +1,999 @@
-import { assertEquals, assertRejects } from "@std/assert";
+import { assertEquals, assertExists, assertRejects } from "@std/assert";
 import { DomainError } from "@zone-blitz/shared";
 import pino from "pino";
 import type {
+  CandidateScoringContext,
+  FranchiseScoringProfile,
   HiringDecisionRow,
   HiringInterestRow,
   HiringInterviewRow,
   HiringOfferRow,
   HiringRepository,
+  SignedStaffMember,
+  TeamScoringSummary,
   UnassignedCandidate,
 } from "./hiring.repository.ts";
 import { createHiringService } from "./hiring.service.ts";
-
-function stubRepo(
-  overrides: Partial<HiringRepository> = {},
-): HiringRepository {
-  const base: HiringRepository = {
-    createInterest: () => Promise.resolve({} as unknown as HiringInterestRow),
-    getInterestById: () => Promise.resolve(undefined),
-    listInterestsByLeague: () => Promise.resolve([]),
-    updateInterestStatus: () =>
-      Promise.resolve({} as unknown as HiringInterestRow),
-    createInterview: () => Promise.resolve({} as unknown as HiringInterviewRow),
-    getInterviewById: () => Promise.resolve(undefined),
-    listInterviewsByLeague: () => Promise.resolve([]),
-    updateInterview: () => Promise.resolve({} as unknown as HiringInterviewRow),
-    createOffer: () => Promise.resolve({} as unknown as HiringOfferRow),
-    getOfferById: () => Promise.resolve(undefined),
-    listOffersByLeague: () => Promise.resolve([]),
-    updateOffer: () => Promise.resolve({} as unknown as HiringOfferRow),
-    createDecision: () => Promise.resolve({} as unknown as HiringDecisionRow),
-    listDecisionsByLeague: () => Promise.resolve([]),
-    listUnassignedCoaches: () => Promise.resolve([] as UnassignedCandidate[]),
-    listUnassignedScouts: () => Promise.resolve([] as UnassignedCandidate[]),
-  };
-  return { ...base, ...overrides };
-}
 
 function silentLog() {
   return pino({ level: "silent" });
 }
 
-Deno.test("hiringService: step methods throw NOT_IMPLEMENTED until the logic ticket lands", async () => {
+interface StubLeague {
+  id: string;
+  numberOfTeams: number;
+  staffBudget: number;
+  interestCap: number;
+  interviewsPerWeek: number;
+  maxConcurrentOffers: number;
+  userTeamId: string | null;
+}
+
+function stubLeagueRepo(league: StubLeague) {
+  return {
+    getById: (id: string) => {
+      assertEquals(id, league.id);
+      return Promise.resolve(league);
+    },
+  };
+}
+
+function stubGenerator() {
+  const calls: { leagueId: string; numberOfTeams: number }[] = [];
+  return {
+    calls,
+    generatePool: (input: { leagueId: string; numberOfTeams: number }) => {
+      calls.push(input);
+      return Promise.resolve({ coachCount: 0, scoutCount: 0 });
+    },
+  };
+}
+
+function makeInterest(
+  overrides: Partial<HiringInterestRow> = {},
+): HiringInterestRow {
+  return {
+    id: crypto.randomUUID(),
+    leagueId: "lg",
+    teamId: "tm",
+    staffType: "coach",
+    staffId: crypto.randomUUID(),
+    stepSlug: "hiring_market_survey",
+    status: "active",
+    createdAt: new Date(0),
+    updatedAt: new Date(0),
+    ...overrides,
+  };
+}
+
+function makeInterview(
+  overrides: Partial<HiringInterviewRow> = {},
+): HiringInterviewRow {
+  return {
+    id: crypto.randomUUID(),
+    leagueId: "lg",
+    teamId: "tm",
+    staffType: "coach",
+    staffId: crypto.randomUUID(),
+    stepSlug: "hiring_interview_1",
+    status: "requested",
+    philosophyReveal: null,
+    staffFitReveal: null,
+    createdAt: new Date(0),
+    updatedAt: new Date(0),
+    ...overrides,
+  };
+}
+
+function makeOffer(overrides: Partial<HiringOfferRow> = {}): HiringOfferRow {
+  return {
+    id: crypto.randomUUID(),
+    leagueId: "lg",
+    teamId: "tm",
+    staffType: "coach",
+    staffId: crypto.randomUUID(),
+    stepSlug: "hiring_offers",
+    status: "pending",
+    salary: 1_000_000,
+    contractYears: 2,
+    buyoutMultiplier: "0.50",
+    incentives: [],
+    preferenceScore: null,
+    createdAt: new Date(0),
+    updatedAt: new Date(0),
+    ...overrides,
+  };
+}
+
+function stubRepo(
+  overrides: Partial<HiringRepository> = {},
+): HiringRepository {
+  const base: HiringRepository = {
+    createInterest: () => Promise.resolve(makeInterest()),
+    getInterestById: () => Promise.resolve(undefined),
+    listInterestsByLeague: () => Promise.resolve([]),
+    listInterestsByTeam: () => Promise.resolve([]),
+    findActiveInterest: () => Promise.resolve(undefined),
+    updateInterestStatus: () => Promise.resolve(makeInterest()),
+    createInterview: () => Promise.resolve(makeInterview()),
+    getInterviewById: () => Promise.resolve(undefined),
+    listInterviewsByLeague: () => Promise.resolve([]),
+    listInterviewsByTeam: () => Promise.resolve([]),
+    listInterviewsByStep: () => Promise.resolve([]),
+    findInterview: () => Promise.resolve(undefined),
+    updateInterview: () => Promise.resolve(makeInterview()),
+    createOffer: () => Promise.resolve(makeOffer()),
+    getOfferById: () => Promise.resolve(undefined),
+    listOffersByLeague: () => Promise.resolve([]),
+    listOffersByTeam: () => Promise.resolve([]),
+    listPendingOffersByLeague: () => Promise.resolve([]),
+    updateOffer: () => Promise.resolve(makeOffer()),
+    createDecision: () =>
+      Promise.resolve(
+        {
+          id: crypto.randomUUID(),
+          leagueId: "lg",
+          staffType: "coach",
+          staffId: crypto.randomUUID(),
+          chosenOfferId: null,
+          wave: 1,
+          decidedAt: new Date(0),
+          createdAt: new Date(0),
+          updatedAt: new Date(0),
+        } as HiringDecisionRow,
+      ),
+    listDecisionsByLeague: () => Promise.resolve([]),
+    listUnassignedCoaches: () => Promise.resolve([] as UnassignedCandidate[]),
+    listUnassignedScouts: () => Promise.resolve([] as UnassignedCandidate[]),
+    getCandidateScoringContext: () => Promise.resolve(undefined),
+    getFranchiseScoringProfile: () => Promise.resolve(undefined),
+    sumSignedStaffSalaries: () => Promise.resolve(0),
+    listTeamsForLeague: () => Promise.resolve([]),
+    listSignedStaffByTeam: () => Promise.resolve([]),
+    assignCoach: () => Promise.resolve(),
+    assignScout: () => Promise.resolve(),
+  };
+  return { ...base, ...overrides };
+}
+
+const baseLeague: StubLeague = {
+  id: "lg",
+  numberOfTeams: 4,
+  staffBudget: 50_000_000,
+  interestCap: 3,
+  interviewsPerWeek: 2,
+  maxConcurrentOffers: 2,
+  userTeamId: "user-team",
+};
+
+Deno.test("openMarket: invokes coach + scout pool generation with the league size", async () => {
+  const coachGen = stubGenerator();
+  const scoutGen = stubGenerator();
   const service = createHiringService({
     repo: stubRepo(),
+    leagueRepo: stubLeagueRepo(baseLeague),
+    coachesService: coachGen,
+    scoutsService: scoutGen,
     log: silentLog(),
   });
 
-  for (
-    const call of [
-      () => service.openMarket("lg"),
-      () =>
-        service.expressInterest({
-          leagueId: "lg",
-          teamId: "tm",
-          staffType: "coach",
-          staffId: "st",
-          stepSlug: "hiring_market_survey",
-        }),
-      () =>
-        service.requestInterviews({
-          leagueId: "lg",
-          teamId: "tm",
-          stepSlug: "hiring_interview_1",
-          targets: [{ staffType: "coach", staffId: "st" }],
-        }),
-      () => service.resolveInterviewDeclines("lg", "hiring_interview_1"),
-      () =>
-        service.submitOffers({
-          leagueId: "lg",
-          teamId: "tm",
-          stepSlug: "hiring_offers",
-          offers: [],
-        }),
-      () => service.resolveDecisions("lg", 1),
-      () => service.finalize("lg"),
-    ]
-  ) {
-    const err = await assertRejects(call, DomainError);
-    assertEquals((err as DomainError).code, "NOT_IMPLEMENTED");
-  }
+  await service.openMarket("lg");
+
+  assertEquals(coachGen.calls, [{ leagueId: "lg", numberOfTeams: 4 }]);
+  assertEquals(scoutGen.calls, [{ leagueId: "lg", numberOfTeams: 4 }]);
 });
 
-Deno.test("hiringService.getHiringState: aggregates league rows from the repository", async () => {
-  const interests: HiringInterestRow[] = [
-    {
-      id: "i-1",
-      leagueId: "lg",
-      teamId: "tm",
-      staffType: "coach",
-      staffId: "s-1",
-      stepSlug: "hiring_market_survey",
-      status: "active",
-      createdAt: new Date(0),
-      updatedAt: new Date(0),
-    },
+Deno.test("openMarket: throws when the league is not found", async () => {
+  const service = createHiringService({
+    repo: stubRepo(),
+    leagueRepo: { getById: () => Promise.resolve(undefined) },
+    coachesService: stubGenerator(),
+    scoutsService: stubGenerator(),
+    log: silentLog(),
+  });
+
+  const err = await assertRejects(
+    () => service.openMarket("missing"),
+    DomainError,
+  );
+  assertEquals((err as DomainError).code, "NOT_FOUND");
+});
+
+Deno.test("expressInterest: creates an interest row when below the cap", async () => {
+  const created = makeInterest({ teamId: "tm" });
+  const service = createHiringService({
+    repo: stubRepo({
+      listInterestsByTeam: () => Promise.resolve([makeInterest()]),
+      createInterest: (input) => {
+        assertEquals(input.teamId, "tm");
+        assertEquals(input.staffType, "coach");
+        return Promise.resolve(created);
+      },
+    }),
+    leagueRepo: stubLeagueRepo(baseLeague),
+    coachesService: stubGenerator(),
+    scoutsService: stubGenerator(),
+    log: silentLog(),
+  });
+
+  const row = await service.expressInterest({
+    leagueId: "lg",
+    teamId: "tm",
+    staffType: "coach",
+    staffId: created.staffId,
+    stepSlug: "hiring_market_survey",
+  });
+  assertEquals(row.id, created.id);
+});
+
+Deno.test("expressInterest: rejects when the interest cap is reached", async () => {
+  const existing = [
+    makeInterest({ teamId: "tm" }),
+    makeInterest({ teamId: "tm" }),
+    makeInterest({ teamId: "tm" }),
   ];
-  const interviews: HiringInterviewRow[] = [
-    {
-      id: "iv-1",
-      leagueId: "lg",
-      teamId: "tm",
+  const service = createHiringService({
+    repo: stubRepo({
+      listInterestsByTeam: () => Promise.resolve(existing),
+    }),
+    leagueRepo: stubLeagueRepo(baseLeague),
+    coachesService: stubGenerator(),
+    scoutsService: stubGenerator(),
+    log: silentLog(),
+  });
+
+  const err = await assertRejects(
+    () =>
+      service.expressInterest({
+        leagueId: "lg",
+        teamId: "tm",
+        staffType: "scout",
+        staffId: crypto.randomUUID(),
+        stepSlug: "hiring_market_survey",
+      }),
+    DomainError,
+  );
+  assertEquals((err as DomainError).code, "INTEREST_CAP_EXCEEDED");
+});
+
+Deno.test("expressInterest: ignores withdrawn interests when counting against the cap", async () => {
+  const existing = [
+    makeInterest({ teamId: "tm", status: "withdrawn" }),
+    makeInterest({ teamId: "tm", status: "withdrawn" }),
+    makeInterest({ teamId: "tm", status: "withdrawn" }),
+  ];
+  const created = makeInterest({ teamId: "tm" });
+  const service = createHiringService({
+    repo: stubRepo({
+      listInterestsByTeam: () => Promise.resolve(existing),
+      createInterest: () => Promise.resolve(created),
+    }),
+    leagueRepo: stubLeagueRepo(baseLeague),
+    coachesService: stubGenerator(),
+    scoutsService: stubGenerator(),
+    log: silentLog(),
+  });
+
+  const row = await service.expressInterest({
+    leagueId: "lg",
+    teamId: "tm",
+    staffType: "coach",
+    staffId: created.staffId,
+    stepSlug: "hiring_market_survey",
+  });
+  assertEquals(row.id, created.id);
+});
+
+Deno.test("requestInterviews: creates a row per target when bandwidth allows", async () => {
+  const targetA = crypto.randomUUID();
+  const targetB = crypto.randomUUID();
+  const interests = [
+    makeInterest({ teamId: "tm", staffType: "coach", staffId: targetA }),
+    makeInterest({ teamId: "tm", staffType: "scout", staffId: targetB }),
+  ];
+  const created: HiringInterviewRow[] = [];
+  const service = createHiringService({
+    repo: stubRepo({
+      listInterestsByTeam: () => Promise.resolve(interests),
+      listInterviewsByTeam: () => Promise.resolve([]),
+      findActiveInterest: (_l, _t, staffType, staffId) => {
+        const match = interests.find(
+          (i) => i.staffType === staffType && i.staffId === staffId,
+        );
+        return Promise.resolve(match);
+      },
+      createInterview: (input) => {
+        const row = makeInterview({
+          teamId: input.teamId,
+          staffType: input.staffType,
+          staffId: input.staffId,
+          stepSlug: input.stepSlug,
+        });
+        created.push(row);
+        return Promise.resolve(row);
+      },
+    }),
+    leagueRepo: stubLeagueRepo(baseLeague),
+    coachesService: stubGenerator(),
+    scoutsService: stubGenerator(),
+    log: silentLog(),
+  });
+
+  const rows = await service.requestInterviews({
+    leagueId: "lg",
+    teamId: "tm",
+    stepSlug: "hiring_interview_1",
+    targets: [
+      { staffType: "coach", staffId: targetA },
+      { staffType: "scout", staffId: targetB },
+    ],
+  });
+
+  assertEquals(rows.length, 2);
+  assertEquals(rows[0].stepSlug, "hiring_interview_1");
+  assertEquals(created.length, 2);
+});
+
+Deno.test("requestInterviews: rejects when a target was not in the interest list", async () => {
+  const service = createHiringService({
+    repo: stubRepo({
+      listInterestsByTeam: () => Promise.resolve([]),
+      findActiveInterest: () => Promise.resolve(undefined),
+    }),
+    leagueRepo: stubLeagueRepo(baseLeague),
+    coachesService: stubGenerator(),
+    scoutsService: stubGenerator(),
+    log: silentLog(),
+  });
+
+  const err = await assertRejects(
+    () =>
+      service.requestInterviews({
+        leagueId: "lg",
+        teamId: "tm",
+        stepSlug: "hiring_interview_1",
+        targets: [{ staffType: "coach", staffId: crypto.randomUUID() }],
+      }),
+    DomainError,
+  );
+  assertEquals((err as DomainError).code, "INTEREST_REQUIRED");
+});
+
+Deno.test("requestInterviews: rejects when the per-week interview cap is exceeded", async () => {
+  const targetA = crypto.randomUUID();
+  const targetB = crypto.randomUUID();
+  const targetC = crypto.randomUUID();
+  const interests = [
+    makeInterest({ teamId: "tm", staffId: targetA }),
+    makeInterest({ teamId: "tm", staffId: targetB }),
+    makeInterest({ teamId: "tm", staffId: targetC }),
+  ];
+  const existingThisWeek = [
+    makeInterview({ teamId: "tm", stepSlug: "hiring_interview_1" }),
+  ];
+  const service = createHiringService({
+    repo: stubRepo({
+      listInterestsByTeam: () => Promise.resolve(interests),
+      listInterviewsByTeam: () => Promise.resolve(existingThisWeek),
+      findActiveInterest: (_l, _t, staffType, staffId) =>
+        Promise.resolve(
+          interests.find((i) =>
+            i.staffType === staffType && i.staffId === staffId
+          ),
+        ),
+    }),
+    leagueRepo: stubLeagueRepo(baseLeague),
+    coachesService: stubGenerator(),
+    scoutsService: stubGenerator(),
+    log: silentLog(),
+  });
+
+  const err = await assertRejects(
+    () =>
+      service.requestInterviews({
+        leagueId: "lg",
+        teamId: "tm",
+        stepSlug: "hiring_interview_1",
+        targets: [
+          { staffType: "coach", staffId: targetA },
+          { staffType: "coach", staffId: targetB },
+        ],
+      }),
+    DomainError,
+  );
+  assertEquals((err as DomainError).code, "INTERVIEW_CAP_EXCEEDED");
+});
+
+Deno.test("resolveInterviewDeclines: declines interviews below the candidate threshold and accepts above", async () => {
+  const lowCandidateId = crypto.randomUUID();
+  const highCandidateId = crypto.randomUUID();
+  const lowInterview = makeInterview({
+    staffType: "coach",
+    staffId: lowCandidateId,
+    teamId: "tm",
+    stepSlug: "hiring_interview_1",
+    status: "requested",
+  });
+  const highInterview = makeInterview({
+    staffType: "scout",
+    staffId: highCandidateId,
+    teamId: "tm",
+    stepSlug: "hiring_interview_1",
+    status: "requested",
+  });
+
+  const candidates: Record<string, CandidateScoringContext> = {
+    [lowCandidateId]: {
+      staffType: "coach",
+      staffId: lowCandidateId,
+      role: "QB",
+      preferences: {
+        marketTierPref: 0,
+        philosophyFitPref: 0,
+        staffFitPref: 0,
+        compensationPref: 100,
+        minimumThreshold: 90,
+      },
+      offense: null,
+      defense: null,
+    },
+    [highCandidateId]: {
       staffType: "scout",
-      staffId: "s-2",
-      stepSlug: "hiring_interview_1",
-      status: "requested",
-      philosophyReveal: null,
-      staffFitReveal: null,
-      createdAt: new Date(0),
-      updatedAt: new Date(0),
+      staffId: highCandidateId,
+      role: "AREA_SCOUT",
+      preferences: {
+        marketTierPref: 100,
+        philosophyFitPref: 0,
+        staffFitPref: 0,
+        compensationPref: 0,
+        minimumThreshold: 10,
+      },
+      offense: null,
+      defense: null,
     },
+  };
+  const profile: FranchiseScoringProfile = {
+    teamId: "tm",
+    marketTier: "large",
+    existingStaff: [],
+  };
+
+  const updates: { id: string; status: string }[] = [];
+  const service = createHiringService({
+    repo: stubRepo({
+      listInterviewsByStep: () =>
+        Promise.resolve([lowInterview, highInterview]),
+      getCandidateScoringContext: (_st, id) => Promise.resolve(candidates[id]),
+      getFranchiseScoringProfile: (teamId) => {
+        assertEquals(teamId, "tm");
+        return Promise.resolve(profile);
+      },
+      updateInterview: (id, patch) => {
+        updates.push({ id, status: patch.status as string });
+        return Promise.resolve(
+          makeInterview({
+            id,
+            status: patch.status as
+              | "requested"
+              | "accepted"
+              | "declined"
+              | "completed",
+          }),
+        );
+      },
+    }),
+    leagueRepo: stubLeagueRepo(baseLeague),
+    coachesService: stubGenerator(),
+    scoutsService: stubGenerator(),
+    log: silentLog(),
+  });
+
+  const rows = await service.resolveInterviewDeclines(
+    "lg",
+    "hiring_interview_1",
+  );
+
+  assertEquals(rows.length, 2);
+  const declined = updates.find((u) => u.id === lowInterview.id);
+  const completed = updates.find((u) => u.id === highInterview.id);
+  assertEquals(declined?.status, "declined");
+  assertEquals(completed?.status, "completed");
+});
+
+Deno.test("submitOffers: persists offers when interview is completed and budget allows", async () => {
+  const candidateId = crypto.randomUUID();
+  const interview = makeInterview({
+    teamId: "tm",
+    staffType: "coach",
+    staffId: candidateId,
+    status: "completed",
+    stepSlug: "hiring_interview_1",
+  });
+  const offerInputs = {
+    leagueId: "lg",
+    teamId: "tm",
+    stepSlug: "hiring_offers",
+    offers: [
+      {
+        staffType: "coach" as const,
+        staffId: candidateId,
+        salary: 2_000_000,
+        contractYears: 3,
+        buyoutMultiplier: "0.75",
+        incentives: [{ type: "playoff", value: 250_000 }],
+      },
+    ],
+  };
+  const created: HiringOfferRow[] = [];
+  const service = createHiringService({
+    repo: stubRepo({
+      listOffersByTeam: () => Promise.resolve([]),
+      sumSignedStaffSalaries: () => Promise.resolve(10_000_000),
+      findInterview: (_l, _t, st, id) => {
+        if (st === "coach" && id === candidateId) {
+          return Promise.resolve(interview);
+        }
+        return Promise.resolve(undefined);
+      },
+      createOffer: (input) => {
+        const row = makeOffer({
+          teamId: input.teamId,
+          staffType: input.staffType,
+          staffId: input.staffId,
+          stepSlug: input.stepSlug,
+          salary: input.salary,
+          contractYears: input.contractYears,
+          buyoutMultiplier: input.buyoutMultiplier,
+          incentives: input.incentives ?? [],
+        });
+        created.push(row);
+        return Promise.resolve(row);
+      },
+    }),
+    leagueRepo: stubLeagueRepo(baseLeague),
+    coachesService: stubGenerator(),
+    scoutsService: stubGenerator(),
+    log: silentLog(),
+  });
+
+  const rows = await service.submitOffers(offerInputs);
+  assertEquals(rows.length, 1);
+  assertEquals(rows[0].salary, 2_000_000);
+  assertEquals(created[0].buyoutMultiplier, "0.75");
+});
+
+Deno.test("submitOffers: rejects when the team has no completed interview for the candidate", async () => {
+  const service = createHiringService({
+    repo: stubRepo({
+      listOffersByTeam: () => Promise.resolve([]),
+      findInterview: () => Promise.resolve(undefined),
+    }),
+    leagueRepo: stubLeagueRepo(baseLeague),
+    coachesService: stubGenerator(),
+    scoutsService: stubGenerator(),
+    log: silentLog(),
+  });
+
+  const err = await assertRejects(
+    () =>
+      service.submitOffers({
+        leagueId: "lg",
+        teamId: "tm",
+        stepSlug: "hiring_offers",
+        offers: [
+          {
+            staffType: "coach",
+            staffId: crypto.randomUUID(),
+            salary: 1_000_000,
+            contractYears: 2,
+            buyoutMultiplier: "0.50",
+          },
+        ],
+      }),
+    DomainError,
+  );
+  assertEquals((err as DomainError).code, "INTERVIEW_REQUIRED");
+});
+
+Deno.test("submitOffers: rejects when concurrent offer cap is exceeded", async () => {
+  const existing = [
+    makeOffer({ teamId: "tm" }),
+    makeOffer({ teamId: "tm" }),
   ];
-  const offers: HiringOfferRow[] = [
+  const service = createHiringService({
+    repo: stubRepo({
+      listOffersByTeam: () => Promise.resolve(existing),
+      sumSignedStaffSalaries: () => Promise.resolve(0),
+      findInterview: () =>
+        Promise.resolve(makeInterview({ status: "completed" })),
+    }),
+    leagueRepo: stubLeagueRepo(baseLeague),
+    coachesService: stubGenerator(),
+    scoutsService: stubGenerator(),
+    log: silentLog(),
+  });
+
+  const err = await assertRejects(
+    () =>
+      service.submitOffers({
+        leagueId: "lg",
+        teamId: "tm",
+        stepSlug: "hiring_offers",
+        offers: [
+          {
+            staffType: "coach",
+            staffId: crypto.randomUUID(),
+            salary: 1_000_000,
+            contractYears: 2,
+            buyoutMultiplier: "0.50",
+          },
+        ],
+      }),
+    DomainError,
+  );
+  assertEquals((err as DomainError).code, "OFFER_CAP_EXCEEDED");
+});
+
+Deno.test("submitOffers: rejects when proposed salary plus existing obligations exceeds the staff budget", async () => {
+  const candidateId = crypto.randomUUID();
+  const interview = makeInterview({
+    teamId: "tm",
+    staffId: candidateId,
+    status: "completed",
+  });
+  const service = createHiringService({
+    repo: stubRepo({
+      listOffersByTeam: () =>
+        Promise.resolve([
+          makeOffer({ teamId: "tm", salary: 30_000_000 }),
+        ]),
+      sumSignedStaffSalaries: () => Promise.resolve(15_000_000),
+      findInterview: () => Promise.resolve(interview),
+    }),
+    leagueRepo: stubLeagueRepo(baseLeague),
+    coachesService: stubGenerator(),
+    scoutsService: stubGenerator(),
+    log: silentLog(),
+  });
+
+  const err = await assertRejects(
+    () =>
+      service.submitOffers({
+        leagueId: "lg",
+        teamId: "tm",
+        stepSlug: "hiring_offers",
+        offers: [
+          {
+            staffType: "coach",
+            staffId: candidateId,
+            salary: 6_000_000,
+            contractYears: 3,
+            buyoutMultiplier: "0.50",
+          },
+        ],
+      }),
+    DomainError,
+  );
+  assertEquals((err as DomainError).code, "STAFF_BUDGET_EXCEEDED");
+});
+
+Deno.test("resolveDecisions: chooses the winning offer per candidate, updates the staff row, and creates a decision", async () => {
+  const candidateId = crypto.randomUUID();
+  const winningTeam = "tm-winner";
+  const losingTeam = "tm-loser";
+
+  const winningOffer = makeOffer({
+    teamId: winningTeam,
+    staffType: "coach",
+    staffId: candidateId,
+    salary: 4_000_000,
+    contractYears: 4,
+    buyoutMultiplier: "0.75",
+  });
+  const losingOffer = makeOffer({
+    teamId: losingTeam,
+    staffType: "coach",
+    staffId: candidateId,
+    salary: 1_000_000,
+    contractYears: 2,
+    buyoutMultiplier: "0.50",
+  });
+
+  const candidate: CandidateScoringContext = {
+    staffType: "coach",
+    staffId: candidateId,
+    role: "OC",
+    preferences: {
+      marketTierPref: 0,
+      philosophyFitPref: 0,
+      staffFitPref: 0,
+      compensationPref: 100,
+      minimumThreshold: 0,
+    },
+    offense: null,
+    defense: null,
+  };
+
+  const profiles: Record<string, FranchiseScoringProfile> = {
+    [winningTeam]: {
+      teamId: winningTeam,
+      marketTier: "small",
+      existingStaff: [],
+    },
+    [losingTeam]: {
+      teamId: losingTeam,
+      marketTier: "small",
+      existingStaff: [],
+    },
+  };
+
+  const updatedOffers: { id: string; status: string }[] = [];
+  const decisions: HiringDecisionRow[] = [];
+  const assigned: {
+    coachId: string;
+    teamId: string;
+    reportsToId?: string | null;
+  }[] = [];
+
+  const service = createHiringService({
+    repo: stubRepo({
+      listPendingOffersByLeague: () =>
+        Promise.resolve([losingOffer, winningOffer]),
+      getCandidateScoringContext: () => Promise.resolve(candidate),
+      getFranchiseScoringProfile: (teamId) => Promise.resolve(profiles[teamId]),
+      listSignedStaffByTeam: () => Promise.resolve([]),
+      updateOffer: (id, patch) => {
+        updatedOffers.push({ id, status: patch.status as string });
+        return Promise.resolve(makeOffer({ id }));
+      },
+      createDecision: (input) => {
+        const row: HiringDecisionRow = {
+          id: crypto.randomUUID(),
+          leagueId: input.leagueId,
+          staffType: input.staffType,
+          staffId: input.staffId,
+          chosenOfferId: input.chosenOfferId,
+          wave: input.wave,
+          decidedAt: new Date(0),
+          createdAt: new Date(0),
+          updatedAt: new Date(0),
+        };
+        decisions.push(row);
+        return Promise.resolve(row);
+      },
+      assignCoach: (coachId, patch) => {
+        assigned.push({
+          coachId,
+          teamId: patch.teamId,
+          reportsToId: patch.reportsToId,
+        });
+        return Promise.resolve();
+      },
+    }),
+    leagueRepo: stubLeagueRepo(baseLeague),
+    coachesService: stubGenerator(),
+    scoutsService: stubGenerator(),
+    log: silentLog(),
+  });
+
+  const result = await service.resolveDecisions("lg", 1);
+
+  assertEquals(result.length, 1);
+  assertEquals(result[0].chosenOfferId, winningOffer.id);
+  const winningPatch = updatedOffers.find((u) => u.id === winningOffer.id);
+  const losingPatch = updatedOffers.find((u) => u.id === losingOffer.id);
+  assertEquals(winningPatch?.status, "accepted");
+  assertEquals(losingPatch?.status, "rejected");
+  assertEquals(assigned.length, 1);
+  assertEquals(assigned[0].teamId, winningTeam);
+});
+
+Deno.test("resolveDecisions: records a no-signing when the candidate refuses every offer", async () => {
+  const candidateId = crypto.randomUUID();
+  const offer = makeOffer({
+    teamId: "tm",
+    staffType: "scout",
+    staffId: candidateId,
+    salary: 50_000,
+  });
+  const candidate: CandidateScoringContext = {
+    staffType: "scout",
+    staffId: candidateId,
+    role: "AREA_SCOUT",
+    preferences: {
+      marketTierPref: 0,
+      philosophyFitPref: 0,
+      staffFitPref: 0,
+      compensationPref: 100,
+      minimumThreshold: 95,
+    },
+    offense: null,
+    defense: null,
+  };
+  const profile: FranchiseScoringProfile = {
+    teamId: "tm",
+    marketTier: "small",
+    existingStaff: [],
+  };
+
+  const updatedOffers: { id: string; status: string }[] = [];
+  const decisions: HiringDecisionRow[] = [];
+  let assignmentCount = 0;
+  const service = createHiringService({
+    repo: stubRepo({
+      listPendingOffersByLeague: () => Promise.resolve([offer]),
+      getCandidateScoringContext: () => Promise.resolve(candidate),
+      getFranchiseScoringProfile: () => Promise.resolve(profile),
+      updateOffer: (id, patch) => {
+        updatedOffers.push({ id, status: patch.status as string });
+        return Promise.resolve(makeOffer({ id }));
+      },
+      createDecision: (input) => {
+        const row: HiringDecisionRow = {
+          id: crypto.randomUUID(),
+          leagueId: input.leagueId,
+          staffType: input.staffType,
+          staffId: input.staffId,
+          chosenOfferId: input.chosenOfferId,
+          wave: input.wave,
+          decidedAt: new Date(0),
+          createdAt: new Date(0),
+          updatedAt: new Date(0),
+        };
+        decisions.push(row);
+        return Promise.resolve(row);
+      },
+      assignScout: () => {
+        assignmentCount++;
+        return Promise.resolve();
+      },
+    }),
+    leagueRepo: stubLeagueRepo(baseLeague),
+    coachesService: stubGenerator(),
+    scoutsService: stubGenerator(),
+    log: silentLog(),
+  });
+
+  const result = await service.resolveDecisions("lg", 1);
+
+  assertEquals(result.length, 1);
+  assertEquals(result[0].chosenOfferId, null);
+  assertEquals(updatedOffers[0].status, "rejected");
+  assertEquals(assignmentCount, 0);
+});
+
+Deno.test("finalize: auto-assigns NPC teams missing mandatory roles and lists blockers for the human team", async () => {
+  const userTeam = "user-team";
+  const npcTeam = "npc-team";
+  const teams: TeamScoringSummary[] = [
+    { teamId: userTeam, marketTier: "large" },
+    { teamId: npcTeam, marketTier: "small" },
+  ];
+
+  const npcStaff: Record<string, SignedStaffMember[]> = {
+    [userTeam]: [],
+    [npcTeam]: [],
+  };
+
+  const hcCandidate: UnassignedCandidate = {
+    id: crypto.randomUUID(),
+    leagueId: "lg",
+    firstName: "Auto",
+    lastName: "HC",
+    role: "HC",
+    marketTierPref: 100,
+    philosophyFitPref: 0,
+    staffFitPref: 0,
+    compensationPref: 0,
+    minimumThreshold: 0,
+  };
+  const directorCandidate: UnassignedCandidate = {
+    id: crypto.randomUUID(),
+    leagueId: "lg",
+    firstName: "Auto",
+    lastName: "Dir",
+    role: "DIRECTOR",
+    marketTierPref: 100,
+    philosophyFitPref: 0,
+    staffFitPref: 0,
+    compensationPref: 0,
+    minimumThreshold: 0,
+  };
+
+  const assignedCoaches: { coachId: string; teamId: string }[] = [];
+  const assignedScouts: { scoutId: string; teamId: string }[] = [];
+  const decisions: HiringDecisionRow[] = [];
+
+  const service = createHiringService({
+    repo: stubRepo({
+      listTeamsForLeague: () => Promise.resolve(teams),
+      listSignedStaffByTeam: (_l, teamId) =>
+        Promise.resolve(npcStaff[teamId] ?? []),
+      listUnassignedCoaches: () => Promise.resolve([hcCandidate]),
+      listUnassignedScouts: () => Promise.resolve([directorCandidate]),
+      assignCoach: (coachId, patch) => {
+        assignedCoaches.push({ coachId, teamId: patch.teamId });
+        return Promise.resolve();
+      },
+      assignScout: (scoutId, patch) => {
+        assignedScouts.push({ scoutId, teamId: patch.teamId });
+        return Promise.resolve();
+      },
+      createDecision: (input) => {
+        const row: HiringDecisionRow = {
+          id: crypto.randomUUID(),
+          leagueId: input.leagueId,
+          staffType: input.staffType,
+          staffId: input.staffId,
+          chosenOfferId: input.chosenOfferId,
+          wave: input.wave,
+          decidedAt: new Date(0),
+          createdAt: new Date(0),
+          updatedAt: new Date(0),
+        };
+        decisions.push(row);
+        return Promise.resolve(row);
+      },
+    }),
+    leagueRepo: stubLeagueRepo({ ...baseLeague, userTeamId: userTeam }),
+    coachesService: stubGenerator(),
+    scoutsService: stubGenerator(),
+    log: silentLog(),
+  });
+
+  const result = await service.finalize("lg");
+
+  assertEquals(assignedCoaches.length, 1);
+  assertEquals(assignedCoaches[0].teamId, npcTeam);
+  assertEquals(assignedScouts.length, 1);
+  assertEquals(assignedScouts[0].teamId, npcTeam);
+  assertEquals(result.decisions.length, 2);
+  assertEquals(result.blockers.length, 1);
+  assertEquals(result.blockers[0].teamId, userTeam);
+  assertEquals(result.blockers[0].missingRoles.sort(), ["DIRECTOR", "HC"]);
+});
+
+Deno.test("finalize: returns no blockers when every team is filled", async () => {
+  const userTeam = "user-team";
+  const teams: TeamScoringSummary[] = [
+    { teamId: userTeam, marketTier: "large" },
+  ];
+  const filledStaff: SignedStaffMember[] = [
     {
-      id: "o-1",
-      leagueId: "lg",
-      teamId: "tm",
       staffType: "coach",
-      staffId: "s-1",
-      stepSlug: "hiring_offers",
-      status: "pending",
-      salary: 3_000_000,
-      contractYears: 2,
-      buyoutMultiplier: "0.50",
-      incentives: [],
-      preferenceScore: null,
-      createdAt: new Date(0),
-      updatedAt: new Date(0),
+      staffId: crypto.randomUUID(),
+      role: "HC",
+      contractSalary: 1_000_000,
+    },
+    {
+      staffType: "scout",
+      staffId: crypto.randomUUID(),
+      role: "DIRECTOR",
+      contractSalary: 250_000,
     },
   ];
+  const service = createHiringService({
+    repo: stubRepo({
+      listTeamsForLeague: () => Promise.resolve(teams),
+      listSignedStaffByTeam: () => Promise.resolve(filledStaff),
+      listUnassignedCoaches: () => Promise.resolve([]),
+      listUnassignedScouts: () => Promise.resolve([]),
+    }),
+    leagueRepo: stubLeagueRepo({ ...baseLeague, userTeamId: userTeam }),
+    coachesService: stubGenerator(),
+    scoutsService: stubGenerator(),
+    log: silentLog(),
+  });
+
+  const result = await service.finalize("lg");
+  assertEquals(result.blockers, []);
+  assertEquals(result.decisions, []);
+});
+
+Deno.test("getHiringState: aggregates league rows from the repository", async () => {
+  const interests = [makeInterest()];
+  const interviews = [makeInterview()];
+  const offers = [makeOffer()];
   const decisions: HiringDecisionRow[] = [
     {
       id: "d-1",
@@ -141,20 +1007,7 @@ Deno.test("hiringService.getHiringState: aggregates league rows from the reposit
       updatedAt: new Date(0),
     },
   ];
-  const unassignedCoaches: UnassignedCandidate[] = [
-    {
-      id: "c-pool",
-      leagueId: "lg",
-      firstName: "A",
-      lastName: "B",
-      role: "OC",
-      marketTierPref: 50,
-      philosophyFitPref: 50,
-      staffFitPref: 50,
-      compensationPref: 50,
-      minimumThreshold: 30,
-    },
-  ];
+  const unassignedCoaches: UnassignedCandidate[] = [];
   const unassignedScouts: UnassignedCandidate[] = [];
 
   const service = createHiringService({
@@ -169,6 +1022,9 @@ Deno.test("hiringService.getHiringState: aggregates league rows from the reposit
       listUnassignedCoaches: () => Promise.resolve(unassignedCoaches),
       listUnassignedScouts: () => Promise.resolve(unassignedScouts),
     }),
+    leagueRepo: stubLeagueRepo(baseLeague),
+    coachesService: stubGenerator(),
+    scoutsService: stubGenerator(),
     log: silentLog(),
   });
 
@@ -180,4 +1036,5 @@ Deno.test("hiringService.getHiringState: aggregates league rows from the reposit
   assertEquals(state.decisions, decisions);
   assertEquals(state.unassignedCoaches, unassignedCoaches);
   assertEquals(state.unassignedScouts, unassignedScouts);
+  assertExists(state);
 });

--- a/server/features/hiring/hiring.service.ts
+++ b/server/features/hiring/hiring.service.ts
@@ -1,6 +1,9 @@
 import { DomainError } from "@zone-blitz/shared";
+import type { CoachRole, ScoutRole } from "@zone-blitz/shared";
 import type pino from "pino";
 import type {
+  CandidateScoringContext,
+  FranchiseScoringProfile,
   HiringDecisionRow,
   HiringInterestRow,
   HiringInterviewRow,
@@ -9,6 +12,16 @@ import type {
   StaffType,
   UnassignedCandidate,
 } from "./hiring.repository.ts";
+import {
+  type CompetingOffer,
+  computePreferenceScore,
+  type FranchiseProfile,
+  type Incentive,
+  type Offer,
+  resolveContestForCandidate,
+  type SalaryBand,
+  type StaffCandidate,
+} from "./preference-scoring.ts";
 
 export interface InterestTarget {
   staffType: StaffType;
@@ -21,7 +34,7 @@ export interface DraftOffer {
   salary: number;
   contractYears: number;
   buyoutMultiplier: string;
-  incentives?: unknown;
+  incentives?: Incentive[];
 }
 
 export interface HiringState {
@@ -32,6 +45,16 @@ export interface HiringState {
   decisions: HiringDecisionRow[];
   unassignedCoaches: UnassignedCandidate[];
   unassignedScouts: UnassignedCandidate[];
+}
+
+export interface FinalizeBlocker {
+  teamId: string;
+  missingRoles: string[];
+}
+
+export interface FinalizeResult {
+  decisions: HiringDecisionRow[];
+  blockers: FinalizeBlocker[];
 }
 
 export interface HiringService {
@@ -63,52 +86,598 @@ export interface HiringService {
     leagueId: string,
     wave: number,
   ): Promise<HiringDecisionRow[]>;
-  finalize(leagueId: string): Promise<HiringDecisionRow[]>;
+  finalize(leagueId: string): Promise<FinalizeResult>;
   getHiringState(leagueId: string): Promise<HiringState>;
 }
 
-function notImplemented<T>(step: string): Promise<T> {
-  return Promise.reject(
-    new DomainError(
-      "NOT_IMPLEMENTED",
-      `Hiring step "${step}" is not yet implemented`,
-    ),
+export interface HiringLeagueSummary {
+  id: string;
+  numberOfTeams: number;
+  staffBudget: number;
+  interestCap: number;
+  interviewsPerWeek: number;
+  maxConcurrentOffers: number;
+  userTeamId: string | null;
+}
+
+export interface HiringLeagueRepository {
+  getById(id: string): Promise<HiringLeagueSummary | undefined>;
+}
+
+export interface HiringPoolGenerator {
+  generatePool(
+    input: { leagueId: string; numberOfTeams: number },
+  ): Promise<unknown>;
+}
+
+// Per ADR 0032 salary bands. The compensation component of the candidate
+// preference function compares the offer against the role's market band
+// — a salary near the ceiling scores 100, near the floor scores 0.
+const COACH_SALARY_BANDS: Record<CoachRole, SalaryBand> = {
+  HC: { min: 5_000_000, max: 20_000_000 },
+  OC: { min: 1_500_000, max: 6_000_000 },
+  DC: { min: 1_500_000, max: 5_000_000 },
+  STC: { min: 800_000, max: 2_000_000 },
+  QB: { min: 500_000, max: 1_500_000 },
+  RB: { min: 300_000, max: 1_200_000 },
+  WR: { min: 300_000, max: 1_200_000 },
+  TE: { min: 300_000, max: 1_200_000 },
+  OL: { min: 300_000, max: 1_200_000 },
+  DL: { min: 300_000, max: 1_200_000 },
+  LB: { min: 300_000, max: 1_200_000 },
+  DB: { min: 300_000, max: 1_200_000 },
+  ST_ASSISTANT: { min: 250_000, max: 600_000 },
+};
+
+const SCOUT_SALARY_BANDS: Record<ScoutRole, SalaryBand> = {
+  DIRECTOR: { min: 250_000, max: 800_000 },
+  NATIONAL_CROSS_CHECKER: { min: 150_000, max: 400_000 },
+  AREA_SCOUT: { min: 80_000, max: 200_000 },
+};
+
+// Wave reserved for finalize auto-assigns. Waves 1 and 2 represent the
+// primary and second-wave decision steps; 99 marks the terminal
+// finalization step so consumers can distinguish auto-fills from contests.
+const FINALIZE_WAVE = 99;
+
+const COORDINATOR_PARENTS: Partial<Record<CoachRole, CoachRole>> = {
+  OC: "HC",
+  DC: "HC",
+  STC: "HC",
+  QB: "OC",
+  RB: "OC",
+  WR: "OC",
+  TE: "OC",
+  OL: "OC",
+  DL: "DC",
+  LB: "DC",
+  DB: "DC",
+  ST_ASSISTANT: "STC",
+};
+
+const MANDATORY_COACH_ROLES: CoachRole[] = ["HC"];
+const MANDATORY_SCOUT_ROLES: ScoutRole[] = ["DIRECTOR"];
+
+function bandFor(
+  staffType: StaffType,
+  role: CoachRole | ScoutRole,
+): SalaryBand {
+  if (staffType === "coach") {
+    return COACH_SALARY_BANDS[role as CoachRole];
+  }
+  return SCOUT_SALARY_BANDS[role as ScoutRole];
+}
+
+function toStaffCandidate(ctx: CandidateScoringContext): StaffCandidate {
+  if (ctx.staffType === "coach") {
+    return {
+      staffType: "coach",
+      id: ctx.staffId,
+      role: ctx.role as CoachRole,
+      offense: ctx.offense,
+      defense: ctx.defense,
+      ...ctx.preferences,
+    };
+  }
+  return {
+    staffType: "scout",
+    id: ctx.staffId,
+    role: ctx.role as ScoutRole,
+    ...ctx.preferences,
+  };
+}
+
+function toIncentives(raw: unknown): Incentive[] {
+  if (!Array.isArray(raw)) return [];
+  return raw.filter(
+    (entry): entry is Incentive =>
+      typeof entry === "object" && entry !== null &&
+      typeof (entry as Incentive).type === "string" &&
+      typeof (entry as Incentive).value === "number",
   );
+}
+
+function toOffer(row: HiringOfferRow): Offer {
+  return {
+    id: row.id,
+    franchiseId: row.teamId,
+    salary: row.salary,
+    contractYears: row.contractYears,
+    incentives: toIncentives(row.incentives),
+  };
+}
+
+function toFranchiseProfile(
+  profile: FranchiseScoringProfile,
+): FranchiseProfile {
+  return {
+    franchiseId: profile.teamId,
+    marketTier: profile.marketTier,
+    existingStaff: profile.existingStaff,
+  };
+}
+
+function pickReportsTo(
+  role: CoachRole,
+  signedCoaches: { staffId: string; role: CoachRole }[],
+): string | null {
+  const parentRole = COORDINATOR_PARENTS[role];
+  if (!parentRole) return null;
+  const match = signedCoaches.find((c) => c.role === parentRole);
+  return match?.staffId ?? null;
+}
+
+function buyoutFromMultiplier(
+  salary: number,
+  contractYears: number,
+  multiplier: string,
+): number {
+  const factor = Number(multiplier);
+  if (Number.isNaN(factor)) return 0;
+  return Math.round(salary * contractYears * factor);
 }
 
 export function createHiringService(deps: {
   repo: HiringRepository;
+  leagueRepo: HiringLeagueRepository;
+  coachesService: HiringPoolGenerator;
+  scoutsService: HiringPoolGenerator;
   log: pino.Logger;
+  now?: () => Date;
 }): HiringService {
   const log = deps.log.child({ module: "hiring.service" });
+  const now = deps.now ?? (() => new Date());
+
+  async function loadLeague(leagueId: string): Promise<HiringLeagueSummary> {
+    const league = await deps.leagueRepo.getById(leagueId);
+    if (!league) {
+      throw new DomainError("NOT_FOUND", `League ${leagueId} not found`);
+    }
+    return league;
+  }
 
   return {
-    openMarket(_leagueId) {
-      return notImplemented("openMarket");
+    async openMarket(leagueId) {
+      log.info({ leagueId }, "opening hiring market");
+      const league = await loadLeague(leagueId);
+      await deps.coachesService.generatePool({
+        leagueId,
+        numberOfTeams: league.numberOfTeams,
+      });
+      await deps.scoutsService.generatePool({
+        leagueId,
+        numberOfTeams: league.numberOfTeams,
+      });
     },
 
-    expressInterest(_input) {
-      return notImplemented("expressInterest");
+    async expressInterest(input) {
+      const league = await loadLeague(input.leagueId);
+      const interests = await deps.repo.listInterestsByTeam(
+        input.leagueId,
+        input.teamId,
+      );
+      const activeCount = interests.filter((i) => i.status === "active").length;
+      if (activeCount >= league.interestCap) {
+        throw new DomainError(
+          "INTEREST_CAP_EXCEEDED",
+          `Team ${input.teamId} already has ${activeCount} active interests (cap ${league.interestCap})`,
+        );
+      }
+      return await deps.repo.createInterest({
+        leagueId: input.leagueId,
+        teamId: input.teamId,
+        staffType: input.staffType,
+        staffId: input.staffId,
+        stepSlug: input.stepSlug,
+      });
     },
 
-    requestInterviews(_input) {
-      return notImplemented("requestInterviews");
+    async requestInterviews(input) {
+      const league = await loadLeague(input.leagueId);
+      const existingInterviews = await deps.repo.listInterviewsByTeam(
+        input.leagueId,
+        input.teamId,
+      );
+      const existingThisStep = existingInterviews.filter(
+        (iv) => iv.stepSlug === input.stepSlug,
+      ).length;
+      if (existingThisStep + input.targets.length > league.interviewsPerWeek) {
+        throw new DomainError(
+          "INTERVIEW_CAP_EXCEEDED",
+          `Team ${input.teamId} would exceed interviewsPerWeek (${league.interviewsPerWeek}) for step ${input.stepSlug}`,
+        );
+      }
+
+      const created: HiringInterviewRow[] = [];
+      for (const target of input.targets) {
+        const interest = await deps.repo.findActiveInterest(
+          input.leagueId,
+          input.teamId,
+          target.staffType,
+          target.staffId,
+        );
+        if (!interest) {
+          throw new DomainError(
+            "INTEREST_REQUIRED",
+            `Team ${input.teamId} has no active interest in ${target.staffType} ${target.staffId}`,
+          );
+        }
+        const row = await deps.repo.createInterview({
+          leagueId: input.leagueId,
+          teamId: input.teamId,
+          staffType: target.staffType,
+          staffId: target.staffId,
+          stepSlug: input.stepSlug,
+        });
+        created.push(row);
+      }
+      return created;
     },
 
-    resolveInterviewDeclines(_leagueId, _stepSlug) {
-      return notImplemented("resolveInterviewDeclines");
+    async resolveInterviewDeclines(leagueId, stepSlug) {
+      const interviews = await deps.repo.listInterviewsByStep(
+        leagueId,
+        stepSlug,
+      );
+      const pending = interviews.filter((iv) => iv.status === "requested");
+      const profiles = new Map<string, FranchiseScoringProfile | undefined>();
+      const candidates = new Map<
+        string,
+        CandidateScoringContext | undefined
+      >();
+      const updated: HiringInterviewRow[] = [];
+
+      for (const interview of pending) {
+        const candidateKey = `${interview.staffType}:${interview.staffId}`;
+        if (!candidates.has(candidateKey)) {
+          candidates.set(
+            candidateKey,
+            await deps.repo.getCandidateScoringContext(
+              interview.staffType,
+              interview.staffId,
+            ),
+          );
+        }
+        if (!profiles.has(interview.teamId)) {
+          profiles.set(
+            interview.teamId,
+            await deps.repo.getFranchiseScoringProfile(interview.teamId),
+          );
+        }
+        const candidate = candidates.get(candidateKey);
+        const profile = profiles.get(interview.teamId);
+        if (!candidate || !profile) {
+          updated.push(interview);
+          continue;
+        }
+        const band = bandFor(candidate.staffType, candidate.role);
+        const probeOffer: Offer = {
+          id: `probe-${interview.id}`,
+          franchiseId: profile.teamId,
+          salary: Math.round((band.min + band.max) / 2),
+          contractYears: 2,
+          incentives: [],
+        };
+        const score = computePreferenceScore(
+          toStaffCandidate(candidate),
+          toFranchiseProfile(profile),
+          probeOffer,
+          band,
+        );
+        const nextStatus = score >= candidate.preferences.minimumThreshold
+          ? "completed"
+          : "declined";
+        const row = await deps.repo.updateInterview(interview.id, {
+          status: nextStatus,
+        });
+        updated.push(row);
+      }
+      return updated;
     },
 
-    submitOffers(_input) {
-      return notImplemented("submitOffers");
+    async submitOffers(input) {
+      const league = await loadLeague(input.leagueId);
+      const existingOffers = await deps.repo.listOffersByTeam(
+        input.leagueId,
+        input.teamId,
+      );
+      const concurrent = existingOffers.filter(
+        (o) => o.status === "pending",
+      ).length;
+      if (concurrent + input.offers.length > league.maxConcurrentOffers) {
+        throw new DomainError(
+          "OFFER_CAP_EXCEEDED",
+          `Team ${input.teamId} would exceed maxConcurrentOffers (${league.maxConcurrentOffers})`,
+        );
+      }
+
+      const signedTotal = await deps.repo.sumSignedStaffSalaries(input.teamId);
+      const pendingTotal = existingOffers
+        .filter((o) => o.status === "pending")
+        .reduce((sum, o) => sum + o.salary, 0);
+      const newTotal = input.offers.reduce((sum, o) => sum + o.salary, 0);
+      if (signedTotal + pendingTotal + newTotal > league.staffBudget) {
+        throw new DomainError(
+          "STAFF_BUDGET_EXCEEDED",
+          `Team ${input.teamId} would exceed staff budget ${league.staffBudget}`,
+        );
+      }
+
+      const created: HiringOfferRow[] = [];
+      for (const offer of input.offers) {
+        const interview = await deps.repo.findInterview(
+          input.leagueId,
+          input.teamId,
+          offer.staffType,
+          offer.staffId,
+        );
+        if (
+          !interview || (interview.status !== "completed" &&
+            interview.status !== "accepted")
+        ) {
+          throw new DomainError(
+            "INTERVIEW_REQUIRED",
+            `Team ${input.teamId} has no completed interview for ${offer.staffType} ${offer.staffId}`,
+          );
+        }
+        const row = await deps.repo.createOffer({
+          leagueId: input.leagueId,
+          teamId: input.teamId,
+          staffType: offer.staffType,
+          staffId: offer.staffId,
+          stepSlug: input.stepSlug,
+          salary: offer.salary,
+          contractYears: offer.contractYears,
+          buyoutMultiplier: offer.buyoutMultiplier,
+          incentives: offer.incentives ?? [],
+        });
+        created.push(row);
+      }
+      return created;
     },
 
-    resolveDecisions(_leagueId, _wave) {
-      return notImplemented("resolveDecisions");
+    async resolveDecisions(leagueId, wave) {
+      log.info({ leagueId, wave }, "resolving hiring decisions");
+      const offers = await deps.repo.listPendingOffersByLeague(leagueId);
+      const grouped = new Map<string, HiringOfferRow[]>();
+      for (const offer of offers) {
+        const key = `${offer.staffType}:${offer.staffId}`;
+        const list = grouped.get(key) ?? [];
+        list.push(offer);
+        grouped.set(key, list);
+      }
+
+      const profileCache = new Map<
+        string,
+        FranchiseScoringProfile | undefined
+      >();
+      async function profileFor(teamId: string) {
+        if (!profileCache.has(teamId)) {
+          profileCache.set(
+            teamId,
+            await deps.repo.getFranchiseScoringProfile(teamId),
+          );
+        }
+        return profileCache.get(teamId);
+      }
+
+      const decisions: HiringDecisionRow[] = [];
+      for (const [, candidateOffers] of grouped) {
+        const sample = candidateOffers[0];
+        const candidate = await deps.repo.getCandidateScoringContext(
+          sample.staffType,
+          sample.staffId,
+        );
+        if (!candidate) continue;
+        const competing: CompetingOffer[] = [];
+        for (const offer of candidateOffers) {
+          const profile = await profileFor(offer.teamId);
+          if (!profile) continue;
+          competing.push({
+            franchise: toFranchiseProfile(profile),
+            offer: toOffer(offer),
+            roleBand: bandFor(candidate.staffType, candidate.role),
+          });
+        }
+
+        const result = resolveContestForCandidate(
+          toStaffCandidate(candidate),
+          competing,
+        );
+
+        for (const offer of candidateOffers) {
+          const status = offer.id === result.chosenOfferId
+            ? "accepted"
+            : "rejected";
+          await deps.repo.updateOffer(offer.id, { status });
+        }
+
+        if (result.chosenOfferId) {
+          const winning = candidateOffers.find(
+            (o) => o.id === result.chosenOfferId,
+          );
+          if (winning) {
+            const hiredAt = now();
+            const buyout = buyoutFromMultiplier(
+              winning.salary,
+              winning.contractYears,
+              winning.buyoutMultiplier,
+            );
+            if (candidate.staffType === "coach") {
+              const signed = await deps.repo.listSignedStaffByTeam(
+                leagueId,
+                winning.teamId,
+              );
+              const signedCoaches = signed
+                .filter((m) => m.staffType === "coach")
+                .map((m) => ({
+                  staffId: m.staffId,
+                  role: m.role as CoachRole,
+                }));
+              const reportsToId = pickReportsTo(
+                candidate.role as CoachRole,
+                signedCoaches,
+              );
+              await deps.repo.assignCoach(candidate.staffId, {
+                teamId: winning.teamId,
+                reportsToId,
+                contractSalary: winning.salary,
+                contractYears: winning.contractYears,
+                contractBuyout: buyout,
+                hiredAt,
+              });
+            } else {
+              await deps.repo.assignScout(candidate.staffId, {
+                teamId: winning.teamId,
+                contractSalary: winning.salary,
+                contractYears: winning.contractYears,
+                contractBuyout: buyout,
+                hiredAt,
+              });
+            }
+          }
+        }
+
+        const decision = await deps.repo.createDecision({
+          leagueId,
+          staffType: candidate.staffType,
+          staffId: candidate.staffId,
+          chosenOfferId: result.chosenOfferId,
+          wave,
+        });
+        decisions.push(decision);
+      }
+      return decisions;
     },
 
-    finalize(_leagueId) {
-      return notImplemented("finalize");
+    async finalize(leagueId) {
+      log.info({ leagueId }, "finalizing hiring phase");
+      const league = await loadLeague(leagueId);
+      const teamSummaries = await deps.repo.listTeamsForLeague(leagueId);
+      const unassignedCoaches = await deps.repo.listUnassignedCoaches(leagueId);
+      const unassignedScouts = await deps.repo.listUnassignedScouts(leagueId);
+      const pickedCoachIds = new Set<string>();
+      const pickedScoutIds = new Set<string>();
+
+      const decisions: HiringDecisionRow[] = [];
+      const blockers: FinalizeBlocker[] = [];
+
+      for (const team of teamSummaries) {
+        const signed = await deps.repo.listSignedStaffByTeam(
+          leagueId,
+          team.teamId,
+        );
+        const signedCoachRoles = new Set(
+          signed.filter((m) => m.staffType === "coach").map((m) => m.role),
+        );
+        const signedScoutRoles = new Set(
+          signed.filter((m) => m.staffType === "scout").map((m) => m.role),
+        );
+
+        const missingCoachRoles = MANDATORY_COACH_ROLES.filter(
+          (r) => !signedCoachRoles.has(r),
+        );
+        const missingScoutRoles = MANDATORY_SCOUT_ROLES.filter(
+          (r) => !signedScoutRoles.has(r),
+        );
+
+        if (missingCoachRoles.length === 0 && missingScoutRoles.length === 0) {
+          continue;
+        }
+
+        const isHumanTeam = league.userTeamId === team.teamId;
+        if (isHumanTeam) {
+          blockers.push({
+            teamId: team.teamId,
+            missingRoles: [
+              ...missingCoachRoles,
+              ...missingScoutRoles,
+            ],
+          });
+          continue;
+        }
+
+        for (const role of missingCoachRoles) {
+          const candidate = pickBestCandidateForRole(
+            unassignedCoaches,
+            role,
+            pickedCoachIds,
+          );
+          if (!candidate) continue;
+          pickedCoachIds.add(candidate.id);
+          const band = COACH_SALARY_BANDS[role];
+          const salary = Math.round((band.min + band.max) / 2);
+          const contractYears = 2;
+          const buyout = Math.round(salary * contractYears * 0.5);
+          await deps.repo.assignCoach(candidate.id, {
+            teamId: team.teamId,
+            reportsToId: null,
+            contractSalary: salary,
+            contractYears,
+            contractBuyout: buyout,
+            hiredAt: now(),
+          });
+          const decision = await deps.repo.createDecision({
+            leagueId,
+            staffType: "coach",
+            staffId: candidate.id,
+            chosenOfferId: null,
+            wave: FINALIZE_WAVE,
+          });
+          decisions.push(decision);
+        }
+
+        for (const role of missingScoutRoles) {
+          const candidate = pickBestCandidateForRole(
+            unassignedScouts,
+            role,
+            pickedScoutIds,
+          );
+          if (!candidate) continue;
+          pickedScoutIds.add(candidate.id);
+          const band = SCOUT_SALARY_BANDS[role];
+          const salary = Math.round((band.min + band.max) / 2);
+          const contractYears = 2;
+          const buyout = Math.round(salary * contractYears * 0.5);
+          await deps.repo.assignScout(candidate.id, {
+            teamId: team.teamId,
+            contractSalary: salary,
+            contractYears,
+            contractBuyout: buyout,
+            hiredAt: now(),
+          });
+          const decision = await deps.repo.createDecision({
+            leagueId,
+            staffType: "scout",
+            staffId: candidate.id,
+            chosenOfferId: null,
+            wave: FINALIZE_WAVE,
+          });
+          decisions.push(decision);
+        }
+      }
+
+      return { decisions, blockers };
     },
 
     async getHiringState(leagueId) {
@@ -139,4 +708,26 @@ export function createHiringService(deps: {
       };
     },
   };
+}
+
+function pickBestCandidateForRole(
+  pool: UnassignedCandidate[],
+  role: string,
+  taken: Set<string>,
+): UnassignedCandidate | undefined {
+  let best: UnassignedCandidate | undefined;
+  for (const candidate of pool) {
+    if (candidate.role !== role) continue;
+    if (taken.has(candidate.id)) continue;
+    if (!best) {
+      best = candidate;
+      continue;
+    }
+    const score = (candidate.compensationPref ?? 50) +
+      (candidate.philosophyFitPref ?? 50);
+    const bestScore = (best.compensationPref ?? 50) +
+      (best.philosophyFitPref ?? 50);
+    if (score > bestScore) best = candidate;
+  }
+  return best;
 }

--- a/server/features/mod.ts
+++ b/server/features/mod.ts
@@ -155,9 +155,15 @@ export function createFeatureRouters(
   const franchiseRepo = createFranchiseRepository({ db, log });
   const franchiseService = createFranchiseService({ franchiseRepo, log });
 
-  // Hiring (staff-hiring feature) — skeleton wired in; per-step logic lands in a follow-up.
+  // Hiring (staff-hiring feature)
   const hiringRepo = createHiringRepository({ db, log });
-  const hiringService = createHiringService({ repo: hiringRepo, log });
+  const hiringService = createHiringService({
+    repo: hiringRepo,
+    leagueRepo,
+    coachesService,
+    scoutsService,
+    log,
+  });
 
   const leagueService = createLeagueService({
     txRunner,


### PR DESCRIPTION
## Summary

- Replaces the `NOT_IMPLEMENTED` stubs in `hiring.service.ts` with the
  real ADR 0032 logic: `openMarket`, `expressInterest`,
  `requestInterviews`, `resolveInterviewDeclines`, `submitOffers`,
  `resolveDecisions`, and `finalize`. Each enforces the relevant
  league setting (`interest_cap`, `interviews_per_week`,
  `max_concurrent_offers`, `staff_budget`) and the workflow
  preconditions (active interest, completed interview, pending offer)
  before mutating state, raising `DomainError` codes that the UI/route
  layer can map.
- `resolveDecisions` groups pending offers per candidate, runs them
  through the existing preference-scoring engine, marks losing offers
  as rejected, and writes winning hires onto the coach/scout rows
  (coaches get a `reportsToId` derived from the team's existing
  staff). `finalize` walks every team, auto-assigns the best remaining
  candidate for NPC vacancies, and returns a blocker list for human
  teams that still have unfilled mandatory roles.
- Extends the hiring repository with the focused reads/writes the
  service needs (per-team listings, candidate/franchise scoring
  contexts, signed-staff aggregates, salary obligation sums, coach/
  scout assignment patches) and adds integration tests per method.
  Wires the new dependencies (`leagueRepo`, `coachesService`,
  `scoutsService`) into `features/mod.ts`.

Closes #437