### PR TITLE
feat(staff-hiring): implement NPC hiring AI

### DIFF
--- a/server/features/hiring/mod.ts
+++ b/server/features/hiring/mod.ts
@@ -18,3 +18,5 @@ export type {
   HiringState,
   InterestTarget,
 } from "./hiring.service.ts";
+export { createNpcHiringAi } from "./npc-hiring-ai.ts";
+export type { NpcHiringAi } from "./npc-hiring-ai.ts";

--- a/server/features/hiring/npc-hiring-ai.test.ts
+++ b/server/features/hiring/npc-hiring-ai.test.ts
@@ -1,0 +1,1154 @@
+import { assertEquals } from "@std/assert";
+import { mulberry32 } from "@zone-blitz/shared";
+import pino from "pino";
+import type {
+  CandidateScoringContext,
+  FranchiseScoringProfile,
+  HiringInterestRow,
+  HiringInterviewRow,
+  HiringOfferRow,
+  HiringRepository,
+  SignedStaffMember,
+  UnassignedCandidate,
+} from "./hiring.repository.ts";
+import type {
+  DraftOffer,
+  HiringLeagueRepository,
+  HiringLeagueSummary,
+  HiringService,
+  InterestTarget,
+} from "./hiring.service.ts";
+import { createNpcHiringAi } from "./npc-hiring-ai.ts";
+
+function silentLog() {
+  return pino({ level: "silent" });
+}
+
+function makeInterest(
+  overrides: Partial<HiringInterestRow> = {},
+): HiringInterestRow {
+  return {
+    id: crypto.randomUUID(),
+    leagueId: "lg",
+    teamId: "npc-a",
+    staffType: "coach",
+    staffId: crypto.randomUUID(),
+    stepSlug: "hiring_market_survey",
+    status: "active",
+    createdAt: new Date(0),
+    updatedAt: new Date(0),
+    ...overrides,
+  };
+}
+
+function makeInterview(
+  overrides: Partial<HiringInterviewRow> = {},
+): HiringInterviewRow {
+  return {
+    id: crypto.randomUUID(),
+    leagueId: "lg",
+    teamId: "npc-a",
+    staffType: "coach",
+    staffId: crypto.randomUUID(),
+    stepSlug: "hiring_interview_1",
+    status: "requested",
+    philosophyReveal: null,
+    staffFitReveal: null,
+    createdAt: new Date(0),
+    updatedAt: new Date(0),
+    ...overrides,
+  };
+}
+
+function makeOffer(overrides: Partial<HiringOfferRow> = {}): HiringOfferRow {
+  return {
+    id: crypto.randomUUID(),
+    leagueId: "lg",
+    teamId: "npc-a",
+    staffType: "coach",
+    staffId: crypto.randomUUID(),
+    stepSlug: "hiring_offers",
+    status: "pending",
+    salary: 1_000_000,
+    contractYears: 2,
+    buyoutMultiplier: "0.50",
+    incentives: [],
+    preferenceScore: null,
+    createdAt: new Date(0),
+    updatedAt: new Date(0),
+    ...overrides,
+  };
+}
+
+function makeUnassigned(
+  overrides: Partial<UnassignedCandidate> = {},
+): UnassignedCandidate {
+  return {
+    id: crypto.randomUUID(),
+    leagueId: "lg",
+    firstName: "First",
+    lastName: "Last",
+    role: "HC",
+    marketTierPref: 50,
+    philosophyFitPref: 50,
+    staffFitPref: 50,
+    compensationPref: 50,
+    minimumThreshold: 40,
+    ...overrides,
+  };
+}
+
+function toContext(
+  c: UnassignedCandidate,
+  staffType: "coach" | "scout" = "coach",
+): CandidateScoringContext {
+  return {
+    staffType,
+    staffId: c.id,
+    role: c.role as CandidateScoringContext["role"],
+    preferences: {
+      marketTierPref: c.marketTierPref ?? 50,
+      philosophyFitPref: c.philosophyFitPref ?? 50,
+      staffFitPref: c.staffFitPref ?? 50,
+      compensationPref: c.compensationPref ?? 50,
+      minimumThreshold: c.minimumThreshold ?? 50,
+    },
+    offense: null,
+    defense: null,
+  };
+}
+
+const defaultLeague: HiringLeagueSummary = {
+  id: "lg",
+  numberOfTeams: 4,
+  staffBudget: 50_000_000,
+  interestCap: 3,
+  interviewsPerWeek: 2,
+  maxConcurrentOffers: 2,
+  userTeamId: null,
+};
+
+function stubLeagueRepo(
+  league: HiringLeagueSummary = defaultLeague,
+): HiringLeagueRepository {
+  return {
+    getById: (id) => {
+      assertEquals(id, league.id);
+      return Promise.resolve(league);
+    },
+  };
+}
+
+function stubRepo(overrides: Partial<HiringRepository> = {}): HiringRepository {
+  const base: HiringRepository = {
+    createInterest: () => Promise.resolve(makeInterest()),
+    getInterestById: () => Promise.resolve(undefined),
+    listInterestsByLeague: () => Promise.resolve([]),
+    listInterestsByTeam: () => Promise.resolve([]),
+    findActiveInterest: () => Promise.resolve(undefined),
+    updateInterestStatus: () => Promise.resolve(makeInterest()),
+    createInterview: () => Promise.resolve(makeInterview()),
+    getInterviewById: () => Promise.resolve(undefined),
+    listInterviewsByLeague: () => Promise.resolve([]),
+    listInterviewsByTeam: () => Promise.resolve([]),
+    listInterviewsByStep: () => Promise.resolve([]),
+    findInterview: () => Promise.resolve(undefined),
+    updateInterview: () => Promise.resolve(makeInterview()),
+    createOffer: () => Promise.resolve(makeOffer()),
+    getOfferById: () => Promise.resolve(undefined),
+    listOffersByLeague: () => Promise.resolve([]),
+    listOffersByTeam: () => Promise.resolve([]),
+    listPendingOffersByLeague: () => Promise.resolve([]),
+    updateOffer: () => Promise.resolve(makeOffer()),
+    createDecision: () =>
+      Promise.resolve({
+        id: crypto.randomUUID(),
+        leagueId: "lg",
+        staffType: "coach",
+        staffId: crypto.randomUUID(),
+        chosenOfferId: null,
+        wave: 1,
+        decidedAt: new Date(0),
+        createdAt: new Date(0),
+        updatedAt: new Date(0),
+      }),
+    listDecisionsByLeague: () => Promise.resolve([]),
+    listUnassignedCoaches: () => Promise.resolve([]),
+    listUnassignedScouts: () => Promise.resolve([]),
+    getCandidateScoringContext: () => Promise.resolve(undefined),
+    getFranchiseScoringProfile: () => Promise.resolve(undefined),
+    sumSignedStaffSalaries: () => Promise.resolve(0),
+    listTeamsForLeague: () => Promise.resolve([]),
+    listSignedStaffByTeam: () => Promise.resolve([]),
+    assignCoach: () => Promise.resolve(),
+    assignScout: () => Promise.resolve(),
+  };
+  return { ...base, ...overrides };
+}
+
+interface ServiceCalls {
+  interest: {
+    leagueId: string;
+    teamId: string;
+    staffType: "coach" | "scout";
+    staffId: string;
+    stepSlug: string;
+  }[];
+  interviews: {
+    leagueId: string;
+    teamId: string;
+    stepSlug: string;
+    targets: InterestTarget[];
+  }[];
+  offers: {
+    leagueId: string;
+    teamId: string;
+    stepSlug: string;
+    offers: DraftOffer[];
+  }[];
+}
+
+function stubService(overrides: Partial<HiringService> = {}): {
+  service: HiringService;
+  calls: ServiceCalls;
+} {
+  const calls: ServiceCalls = {
+    interest: [],
+    interviews: [],
+    offers: [],
+  };
+  const base: HiringService = {
+    openMarket: () => Promise.resolve(),
+    expressInterest: (input) => {
+      calls.interest.push({ ...input });
+      return Promise.resolve(
+        makeInterest({
+          leagueId: input.leagueId,
+          teamId: input.teamId,
+          staffType: input.staffType,
+          staffId: input.staffId,
+          stepSlug: input.stepSlug,
+        }),
+      );
+    },
+    requestInterviews: (input) => {
+      calls.interviews.push({
+        leagueId: input.leagueId,
+        teamId: input.teamId,
+        stepSlug: input.stepSlug,
+        targets: [...input.targets],
+      });
+      return Promise.resolve(
+        input.targets.map((t) =>
+          makeInterview({
+            leagueId: input.leagueId,
+            teamId: input.teamId,
+            staffType: t.staffType,
+            staffId: t.staffId,
+            stepSlug: input.stepSlug,
+          })
+        ),
+      );
+    },
+    resolveInterviewDeclines: () => Promise.resolve([]),
+    submitOffers: (input) => {
+      calls.offers.push({
+        leagueId: input.leagueId,
+        teamId: input.teamId,
+        stepSlug: input.stepSlug,
+        offers: [...input.offers],
+      });
+      return Promise.resolve(
+        input.offers.map((o) =>
+          makeOffer({
+            leagueId: input.leagueId,
+            teamId: input.teamId,
+            staffType: o.staffType,
+            staffId: o.staffId,
+            stepSlug: input.stepSlug,
+            salary: o.salary,
+            contractYears: o.contractYears,
+            buyoutMultiplier: o.buyoutMultiplier,
+            incentives: o.incentives ?? [],
+          })
+        ),
+      );
+    },
+    resolveDecisions: () => Promise.resolve([]),
+    finalize: () => Promise.resolve({ decisions: [], blockers: [] }),
+    getHiringState: () =>
+      Promise.resolve({
+        leagueId: "lg",
+        interests: [],
+        interviews: [],
+        offers: [],
+        decisions: [],
+        unassignedCoaches: [],
+        unassignedScouts: [],
+      }),
+  };
+  return { service: { ...base, ...overrides }, calls };
+}
+
+Deno.test("executeNpcInterest: prioritizes missing HC before other roles", async () => {
+  const hc = makeUnassigned({ role: "HC" });
+  const oc = makeUnassigned({ role: "OC" });
+  const areaScout = makeUnassigned({ role: "AREA_SCOUT" });
+  const director = makeUnassigned({ role: "DIRECTOR" });
+
+  const { service, calls } = stubService();
+  const ai = createNpcHiringAi({
+    repo: stubRepo({
+      listUnassignedCoaches: () => Promise.resolve([oc, hc]),
+      listUnassignedScouts: () => Promise.resolve([areaScout, director]),
+      listInterestsByTeam: () => Promise.resolve([]),
+      listSignedStaffByTeam: () => Promise.resolve([]),
+      getFranchiseScoringProfile: (teamId) =>
+        Promise.resolve({
+          teamId,
+          marketTier: "medium",
+          existingStaff: [],
+        } as FranchiseScoringProfile),
+      getCandidateScoringContext: (staffType, id) => {
+        const candidate = [hc, oc, director, areaScout].find((c) =>
+          c.id === id
+        );
+        if (!candidate) return Promise.resolve(undefined);
+        return Promise.resolve(toContext(candidate, staffType));
+      },
+    }),
+    leagueRepo: stubLeagueRepo({ ...defaultLeague, interestCap: 3 }),
+    service,
+    log: silentLog(),
+  });
+
+  await ai.executeNpcInterest({
+    leagueId: "lg",
+    npcTeamIds: ["npc-a"],
+    stepSlug: "hiring_market_survey",
+  });
+
+  // First interest must be HC because it is the highest-priority unfilled role.
+  assertEquals(calls.interest.length, 3);
+  assertEquals(calls.interest[0].staffId, hc.id);
+  assertEquals(calls.interest[0].staffType, "coach");
+  assertEquals(calls.interest[1].staffId, oc.id);
+  // Third slot should pick the director (higher-priority scout role) over the
+  // area scout.
+  assertEquals(calls.interest[2].staffId, director.id);
+  assertEquals(calls.interest[2].staffType, "scout");
+});
+
+Deno.test("executeNpcInterest: respects interest cap minus existing active interests", async () => {
+  const hc = makeUnassigned({ role: "HC" });
+  const oc = makeUnassigned({ role: "OC" });
+  const dc = makeUnassigned({ role: "DC" });
+
+  const existing = [
+    makeInterest({ teamId: "npc-a", staffType: "coach", staffId: "prev-1" }),
+    makeInterest({
+      teamId: "npc-a",
+      staffType: "coach",
+      staffId: "prev-2",
+      status: "withdrawn",
+    }),
+  ];
+
+  const { service, calls } = stubService();
+  const ai = createNpcHiringAi({
+    repo: stubRepo({
+      listUnassignedCoaches: () => Promise.resolve([hc, oc, dc]),
+      listUnassignedScouts: () => Promise.resolve([]),
+      listInterestsByTeam: () => Promise.resolve(existing),
+      listSignedStaffByTeam: () => Promise.resolve([]),
+      getFranchiseScoringProfile: (teamId) =>
+        Promise.resolve({
+          teamId,
+          marketTier: "small",
+          existingStaff: [],
+        } as FranchiseScoringProfile),
+      getCandidateScoringContext: (staffType, id) => {
+        const candidate = [hc, oc, dc].find((c) => c.id === id);
+        if (!candidate) return Promise.resolve(undefined);
+        return Promise.resolve(toContext(candidate, staffType));
+      },
+    }),
+    leagueRepo: stubLeagueRepo({ ...defaultLeague, interestCap: 3 }),
+    service,
+    log: silentLog(),
+  });
+
+  await ai.executeNpcInterest({
+    leagueId: "lg",
+    npcTeamIds: ["npc-a"],
+    stepSlug: "hiring_market_survey",
+  });
+
+  // 3 cap minus 1 active = 2 slots available
+  assertEquals(calls.interest.length, 2);
+  assertEquals(calls.interest[0].staffId, hc.id);
+});
+
+Deno.test("executeNpcInterest: skips roles the team already filled", async () => {
+  const hc2 = makeUnassigned({ role: "HC" });
+  const oc = makeUnassigned({ role: "OC" });
+
+  const signed: SignedStaffMember[] = [
+    {
+      staffType: "coach",
+      staffId: "already-hc",
+      role: "HC",
+      contractSalary: 10_000_000,
+    },
+  ];
+
+  const { service, calls } = stubService();
+  const ai = createNpcHiringAi({
+    repo: stubRepo({
+      listUnassignedCoaches: () => Promise.resolve([hc2, oc]),
+      listUnassignedScouts: () => Promise.resolve([]),
+      listInterestsByTeam: () => Promise.resolve([]),
+      listSignedStaffByTeam: () => Promise.resolve(signed),
+      getFranchiseScoringProfile: (teamId) =>
+        Promise.resolve({
+          teamId,
+          marketTier: "medium",
+          existingStaff: [],
+        } as FranchiseScoringProfile),
+      getCandidateScoringContext: (staffType, id) => {
+        const candidate = [hc2, oc].find((c) => c.id === id);
+        if (!candidate) return Promise.resolve(undefined);
+        return Promise.resolve(toContext(candidate, staffType));
+      },
+    }),
+    leagueRepo: stubLeagueRepo(),
+    service,
+    log: silentLog(),
+  });
+
+  await ai.executeNpcInterest({
+    leagueId: "lg",
+    npcTeamIds: ["npc-a"],
+    stepSlug: "hiring_market_survey",
+  });
+
+  const hcInterest = calls.interest.find((i) => i.staffId === hc2.id);
+  const ocInterest = calls.interest.find((i) => i.staffId === oc.id);
+  assertEquals(hcInterest, undefined);
+  assertEquals(ocInterest?.staffType, "coach");
+});
+
+Deno.test("executeNpcInterest: deterministic with a seeded rng when candidates tie", async () => {
+  const hcA = makeUnassigned({ role: "HC" });
+  const hcB = makeUnassigned({ role: "HC" });
+
+  async function run(seed: number) {
+    const { service, calls } = stubService();
+    const ai = createNpcHiringAi({
+      repo: stubRepo({
+        listUnassignedCoaches: () => Promise.resolve([hcA, hcB]),
+        listUnassignedScouts: () => Promise.resolve([]),
+        listInterestsByTeam: () => Promise.resolve([]),
+        listSignedStaffByTeam: () => Promise.resolve([]),
+        getFranchiseScoringProfile: (teamId) =>
+          Promise.resolve({
+            teamId,
+            marketTier: "medium",
+            existingStaff: [],
+          } as FranchiseScoringProfile),
+        getCandidateScoringContext: (staffType, id) => {
+          const candidate = [hcA, hcB].find((c) => c.id === id);
+          if (!candidate) return Promise.resolve(undefined);
+          return Promise.resolve(toContext(candidate, staffType));
+        },
+      }),
+      leagueRepo: stubLeagueRepo({ ...defaultLeague, interestCap: 1 }),
+      service,
+      log: silentLog(),
+      rng: mulberry32(seed),
+    });
+    await ai.executeNpcInterest({
+      leagueId: "lg",
+      npcTeamIds: ["npc-a"],
+      stepSlug: "hiring_market_survey",
+    });
+    return calls.interest.map((i) => i.staffId);
+  }
+
+  const run1 = await run(42);
+  const run2 = await run(42);
+  assertEquals(run1, run2);
+  assertEquals(run1.length, 1);
+});
+
+Deno.test("executeNpcInterviews: interviews candidates from active interests in role-priority order", async () => {
+  const hcInterest = makeInterest({
+    teamId: "npc-a",
+    staffType: "coach",
+    staffId: "hc-1",
+  });
+  const ocInterest = makeInterest({
+    teamId: "npc-a",
+    staffType: "coach",
+    staffId: "oc-1",
+  });
+  const scoutInterest = makeInterest({
+    teamId: "npc-a",
+    staffType: "scout",
+    staffId: "scout-1",
+  });
+
+  const candidates: Record<string, CandidateScoringContext> = {
+    "hc-1": {
+      staffType: "coach",
+      staffId: "hc-1",
+      role: "HC",
+      preferences: {
+        marketTierPref: 50,
+        philosophyFitPref: 50,
+        staffFitPref: 50,
+        compensationPref: 50,
+        minimumThreshold: 40,
+      },
+      offense: null,
+      defense: null,
+    },
+    "oc-1": {
+      staffType: "coach",
+      staffId: "oc-1",
+      role: "OC",
+      preferences: {
+        marketTierPref: 50,
+        philosophyFitPref: 50,
+        staffFitPref: 50,
+        compensationPref: 50,
+        minimumThreshold: 40,
+      },
+      offense: null,
+      defense: null,
+    },
+    "scout-1": {
+      staffType: "scout",
+      staffId: "scout-1",
+      role: "DIRECTOR",
+      preferences: {
+        marketTierPref: 50,
+        philosophyFitPref: 50,
+        staffFitPref: 50,
+        compensationPref: 50,
+        minimumThreshold: 40,
+      },
+      offense: null,
+      defense: null,
+    },
+  };
+
+  const { service, calls } = stubService();
+  const ai = createNpcHiringAi({
+    repo: stubRepo({
+      listInterestsByTeam: () =>
+        Promise.resolve([scoutInterest, ocInterest, hcInterest]),
+      listInterviewsByTeam: () => Promise.resolve([]),
+      getCandidateScoringContext: (_st, id) => Promise.resolve(candidates[id]),
+      getFranchiseScoringProfile: (teamId) =>
+        Promise.resolve({
+          teamId,
+          marketTier: "medium",
+          existingStaff: [],
+        } as FranchiseScoringProfile),
+    }),
+    leagueRepo: stubLeagueRepo({ ...defaultLeague, interviewsPerWeek: 2 }),
+    service,
+    log: silentLog(),
+  });
+
+  await ai.executeNpcInterviews({
+    leagueId: "lg",
+    npcTeamIds: ["npc-a"],
+    stepSlug: "hiring_interview_1",
+  });
+
+  assertEquals(calls.interviews.length, 1);
+  const [req] = calls.interviews;
+  assertEquals(req.targets.length, 2);
+  // HC is highest priority, must come first.
+  assertEquals(req.targets[0].staffId, "hc-1");
+  assertEquals(req.targets[1].staffId, "oc-1");
+});
+
+Deno.test("executeNpcInterviews: does not re-request interviews for candidates already interviewed this step", async () => {
+  const hcInterest = makeInterest({
+    teamId: "npc-a",
+    staffType: "coach",
+    staffId: "hc-1",
+  });
+  const existingInterview = makeInterview({
+    teamId: "npc-a",
+    staffType: "coach",
+    staffId: "hc-1",
+    stepSlug: "hiring_interview_1",
+  });
+
+  const { service, calls } = stubService();
+  const ai = createNpcHiringAi({
+    repo: stubRepo({
+      listInterestsByTeam: () => Promise.resolve([hcInterest]),
+      listInterviewsByTeam: () => Promise.resolve([existingInterview]),
+      getCandidateScoringContext: () =>
+        Promise.resolve({
+          staffType: "coach",
+          staffId: "hc-1",
+          role: "HC",
+          preferences: {
+            marketTierPref: 50,
+            philosophyFitPref: 50,
+            staffFitPref: 50,
+            compensationPref: 50,
+            minimumThreshold: 40,
+          },
+          offense: null,
+          defense: null,
+        }),
+      getFranchiseScoringProfile: (teamId) =>
+        Promise.resolve({
+          teamId,
+          marketTier: "small",
+          existingStaff: [],
+        } as FranchiseScoringProfile),
+    }),
+    leagueRepo: stubLeagueRepo(),
+    service,
+    log: silentLog(),
+  });
+
+  await ai.executeNpcInterviews({
+    leagueId: "lg",
+    npcTeamIds: ["npc-a"],
+    stepSlug: "hiring_interview_1",
+  });
+
+  assertEquals(calls.interviews.length, 0);
+});
+
+Deno.test("executeNpcInterviews: respects interviewsPerWeek cap across waves", async () => {
+  const candidateIds = ["a", "b", "c"];
+  const interests = candidateIds.map((id) =>
+    makeInterest({
+      teamId: "npc-a",
+      staffType: "coach",
+      staffId: id,
+    })
+  );
+
+  const contexts: Record<string, CandidateScoringContext> = Object.fromEntries(
+    candidateIds.map((id) => [
+      id,
+      {
+        staffType: "coach",
+        staffId: id,
+        role: "HC",
+        preferences: {
+          marketTierPref: 50,
+          philosophyFitPref: 50,
+          staffFitPref: 50,
+          compensationPref: 50,
+          minimumThreshold: 40,
+        },
+        offense: null,
+        defense: null,
+      } as CandidateScoringContext,
+    ]),
+  );
+
+  const { service, calls } = stubService();
+  const ai = createNpcHiringAi({
+    repo: stubRepo({
+      listInterestsByTeam: () => Promise.resolve(interests),
+      listInterviewsByTeam: () => Promise.resolve([]),
+      getCandidateScoringContext: (_st, id) => Promise.resolve(contexts[id]),
+      getFranchiseScoringProfile: (teamId) =>
+        Promise.resolve({
+          teamId,
+          marketTier: "medium",
+          existingStaff: [],
+        } as FranchiseScoringProfile),
+    }),
+    leagueRepo: stubLeagueRepo({ ...defaultLeague, interviewsPerWeek: 2 }),
+    service,
+    log: silentLog(),
+  });
+
+  await ai.executeNpcInterviews({
+    leagueId: "lg",
+    npcTeamIds: ["npc-a"],
+    stepSlug: "hiring_interview_1",
+  });
+
+  assertEquals(calls.interviews[0].targets.length, 2);
+});
+
+Deno.test("executeNpcOffers: submits a mid-band offer for each completed interview in priority order", async () => {
+  const hcInterview = makeInterview({
+    teamId: "npc-a",
+    staffType: "coach",
+    staffId: "hc-1",
+    status: "completed",
+    stepSlug: "hiring_interview_1",
+  });
+  const ocInterview = makeInterview({
+    teamId: "npc-a",
+    staffType: "coach",
+    staffId: "oc-1",
+    status: "completed",
+    stepSlug: "hiring_interview_1",
+  });
+  const contexts: Record<string, CandidateScoringContext> = {
+    "hc-1": {
+      staffType: "coach",
+      staffId: "hc-1",
+      role: "HC",
+      preferences: {
+        marketTierPref: 50,
+        philosophyFitPref: 50,
+        staffFitPref: 50,
+        compensationPref: 50,
+        minimumThreshold: 40,
+      },
+      offense: null,
+      defense: null,
+    },
+    "oc-1": {
+      staffType: "coach",
+      staffId: "oc-1",
+      role: "OC",
+      preferences: {
+        marketTierPref: 50,
+        philosophyFitPref: 50,
+        staffFitPref: 50,
+        compensationPref: 50,
+        minimumThreshold: 40,
+      },
+      offense: null,
+      defense: null,
+    },
+  };
+
+  const { service, calls } = stubService();
+  const ai = createNpcHiringAi({
+    repo: stubRepo({
+      listInterviewsByTeam: () => Promise.resolve([ocInterview, hcInterview]),
+      listOffersByTeam: () => Promise.resolve([]),
+      listSignedStaffByTeam: () => Promise.resolve([]),
+      getCandidateScoringContext: (_st, id) => Promise.resolve(contexts[id]),
+      getFranchiseScoringProfile: (teamId) =>
+        Promise.resolve({
+          teamId,
+          marketTier: "medium",
+          existingStaff: [],
+        } as FranchiseScoringProfile),
+      sumSignedStaffSalaries: () => Promise.resolve(0),
+    }),
+    leagueRepo: stubLeagueRepo({ ...defaultLeague, maxConcurrentOffers: 5 }),
+    service,
+    log: silentLog(),
+  });
+
+  await ai.executeNpcOffers({
+    leagueId: "lg",
+    npcTeamIds: ["npc-a"],
+    stepSlug: "hiring_offers",
+  });
+
+  assertEquals(calls.offers.length, 1);
+  const draft = calls.offers[0].offers;
+  assertEquals(draft.length, 2);
+  // HC first
+  assertEquals(draft[0].staffId, "hc-1");
+  // HC mid band is (5M + 20M) / 2 = 12.5M
+  assertEquals(draft[0].salary, 12_500_000);
+  assertEquals(draft[1].staffId, "oc-1");
+  // OC mid band is (1.5M + 6M) / 2 = 3.75M
+  assertEquals(draft[1].salary, 3_750_000);
+});
+
+Deno.test("executeNpcOffers: large-market teams offer above mid-band; small-market teams offer below", async () => {
+  const hcInterview = makeInterview({
+    teamId: "npc-a",
+    staffType: "coach",
+    staffId: "hc-1",
+    status: "completed",
+  });
+  const context: CandidateScoringContext = {
+    staffType: "coach",
+    staffId: "hc-1",
+    role: "HC",
+    preferences: {
+      marketTierPref: 50,
+      philosophyFitPref: 50,
+      staffFitPref: 50,
+      compensationPref: 50,
+      minimumThreshold: 40,
+    },
+    offense: null,
+    defense: null,
+  };
+
+  async function offerFor(
+    marketTier: "large" | "medium" | "small",
+  ): Promise<number> {
+    const { service, calls } = stubService();
+    const ai = createNpcHiringAi({
+      repo: stubRepo({
+        listInterviewsByTeam: () => Promise.resolve([hcInterview]),
+        listOffersByTeam: () => Promise.resolve([]),
+        listSignedStaffByTeam: () => Promise.resolve([]),
+        getCandidateScoringContext: () => Promise.resolve(context),
+        getFranchiseScoringProfile: (teamId) =>
+          Promise.resolve({
+            teamId,
+            marketTier,
+            existingStaff: [],
+          } as FranchiseScoringProfile),
+        sumSignedStaffSalaries: () => Promise.resolve(0),
+      }),
+      leagueRepo: stubLeagueRepo(),
+      service,
+      log: silentLog(),
+    });
+    await ai.executeNpcOffers({
+      leagueId: "lg",
+      npcTeamIds: ["npc-a"],
+      stepSlug: "hiring_offers",
+    });
+    return calls.offers[0].offers[0].salary;
+  }
+
+  const large = await offerFor("large");
+  const medium = await offerFor("medium");
+  const small = await offerFor("small");
+
+  // HC band: 5M–20M. Mid = 12.5M. Large > medium > small.
+  assertEquals(medium, 12_500_000);
+  if (!(large > medium)) {
+    throw new Error(`expected large (${large}) > medium (${medium})`);
+  }
+  if (!(small < medium)) {
+    throw new Error(`expected small (${small}) < medium (${medium})`);
+  }
+});
+
+Deno.test("executeNpcOffers: drops offers that would exceed the staff budget", async () => {
+  const hcInterview = makeInterview({
+    teamId: "npc-a",
+    staffType: "coach",
+    staffId: "hc-1",
+    status: "completed",
+  });
+  const ocInterview = makeInterview({
+    teamId: "npc-a",
+    staffType: "coach",
+    staffId: "oc-1",
+    status: "completed",
+  });
+  const contexts: Record<string, CandidateScoringContext> = {
+    "hc-1": {
+      staffType: "coach",
+      staffId: "hc-1",
+      role: "HC",
+      preferences: {
+        marketTierPref: 50,
+        philosophyFitPref: 50,
+        staffFitPref: 50,
+        compensationPref: 50,
+        minimumThreshold: 40,
+      },
+      offense: null,
+      defense: null,
+    },
+    "oc-1": {
+      staffType: "coach",
+      staffId: "oc-1",
+      role: "OC",
+      preferences: {
+        marketTierPref: 50,
+        philosophyFitPref: 50,
+        staffFitPref: 50,
+        compensationPref: 50,
+        minimumThreshold: 40,
+      },
+      offense: null,
+      defense: null,
+    },
+  };
+
+  const { service, calls } = stubService();
+  const ai = createNpcHiringAi({
+    repo: stubRepo({
+      listInterviewsByTeam: () => Promise.resolve([hcInterview, ocInterview]),
+      listOffersByTeam: () => Promise.resolve([]),
+      listSignedStaffByTeam: () => Promise.resolve([]),
+      getCandidateScoringContext: (_st, id) => Promise.resolve(contexts[id]),
+      getFranchiseScoringProfile: (teamId) =>
+        Promise.resolve({
+          teamId,
+          marketTier: "medium",
+          existingStaff: [],
+        } as FranchiseScoringProfile),
+      // Already 40M committed; HC mid = 12.5M → fits (52.5M would not, but
+      // budget is 50M). So HC should be dropped, OC (3.75M) fits 43.75M.
+      sumSignedStaffSalaries: () => Promise.resolve(40_000_000),
+    }),
+    leagueRepo: stubLeagueRepo({
+      ...defaultLeague,
+      staffBudget: 50_000_000,
+      maxConcurrentOffers: 5,
+    }),
+    service,
+    log: silentLog(),
+  });
+
+  await ai.executeNpcOffers({
+    leagueId: "lg",
+    npcTeamIds: ["npc-a"],
+    stepSlug: "hiring_offers",
+  });
+
+  assertEquals(calls.offers.length, 1);
+  const draft = calls.offers[0].offers;
+  assertEquals(draft.length, 1);
+  assertEquals(draft[0].staffId, "oc-1");
+});
+
+Deno.test("executeNpcOffers: respects maxConcurrentOffers minus existing pending offers", async () => {
+  const interviews = ["a", "b", "c"].map((id) =>
+    makeInterview({
+      teamId: "npc-a",
+      staffType: "coach",
+      staffId: id,
+      status: "completed",
+    })
+  );
+  const contexts: Record<string, CandidateScoringContext> = Object.fromEntries(
+    interviews.map((iv) => [
+      iv.staffId,
+      {
+        staffType: "coach",
+        staffId: iv.staffId,
+        role: "HC",
+        preferences: {
+          marketTierPref: 50,
+          philosophyFitPref: 50,
+          staffFitPref: 50,
+          compensationPref: 50,
+          minimumThreshold: 40,
+        },
+        offense: null,
+        defense: null,
+      } as CandidateScoringContext,
+    ]),
+  );
+
+  const { service, calls } = stubService();
+  const ai = createNpcHiringAi({
+    repo: stubRepo({
+      listInterviewsByTeam: () => Promise.resolve(interviews),
+      listOffersByTeam: () =>
+        Promise.resolve([
+          makeOffer({ teamId: "npc-a", status: "pending" }),
+        ]),
+      listSignedStaffByTeam: () => Promise.resolve([]),
+      getCandidateScoringContext: (_st, id) => Promise.resolve(contexts[id]),
+      getFranchiseScoringProfile: (teamId) =>
+        Promise.resolve({
+          teamId,
+          marketTier: "medium",
+          existingStaff: [],
+        } as FranchiseScoringProfile),
+      sumSignedStaffSalaries: () => Promise.resolve(0),
+    }),
+    leagueRepo: stubLeagueRepo({
+      ...defaultLeague,
+      maxConcurrentOffers: 2,
+    }),
+    service,
+    log: silentLog(),
+  });
+
+  await ai.executeNpcOffers({
+    leagueId: "lg",
+    npcTeamIds: ["npc-a"],
+    stepSlug: "hiring_offers",
+  });
+
+  // 2 cap minus 1 existing pending = 1 remaining slot.
+  assertEquals(calls.offers[0].offers.length, 1);
+});
+
+Deno.test("executeNpcOffers: skips candidates that already have a pending offer from this team", async () => {
+  const hcInterview = makeInterview({
+    teamId: "npc-a",
+    staffType: "coach",
+    staffId: "hc-1",
+    status: "completed",
+  });
+  const ocInterview = makeInterview({
+    teamId: "npc-a",
+    staffType: "coach",
+    staffId: "oc-1",
+    status: "completed",
+  });
+  const contexts: Record<string, CandidateScoringContext> = {
+    "hc-1": {
+      staffType: "coach",
+      staffId: "hc-1",
+      role: "HC",
+      preferences: {
+        marketTierPref: 50,
+        philosophyFitPref: 50,
+        staffFitPref: 50,
+        compensationPref: 50,
+        minimumThreshold: 40,
+      },
+      offense: null,
+      defense: null,
+    },
+    "oc-1": {
+      staffType: "coach",
+      staffId: "oc-1",
+      role: "OC",
+      preferences: {
+        marketTierPref: 50,
+        philosophyFitPref: 50,
+        staffFitPref: 50,
+        compensationPref: 50,
+        minimumThreshold: 40,
+      },
+      offense: null,
+      defense: null,
+    },
+  };
+
+  const { service, calls } = stubService();
+  const ai = createNpcHiringAi({
+    repo: stubRepo({
+      listInterviewsByTeam: () => Promise.resolve([hcInterview, ocInterview]),
+      listOffersByTeam: () =>
+        Promise.resolve([
+          makeOffer({
+            teamId: "npc-a",
+            staffType: "coach",
+            staffId: "hc-1",
+            status: "pending",
+          }),
+        ]),
+      listSignedStaffByTeam: () => Promise.resolve([]),
+      getCandidateScoringContext: (_st, id) => Promise.resolve(contexts[id]),
+      getFranchiseScoringProfile: (teamId) =>
+        Promise.resolve({
+          teamId,
+          marketTier: "medium",
+          existingStaff: [],
+        } as FranchiseScoringProfile),
+      sumSignedStaffSalaries: () => Promise.resolve(0),
+    }),
+    leagueRepo: stubLeagueRepo({
+      ...defaultLeague,
+      maxConcurrentOffers: 5,
+    }),
+    service,
+    log: silentLog(),
+  });
+
+  await ai.executeNpcOffers({
+    leagueId: "lg",
+    npcTeamIds: ["npc-a"],
+    stepSlug: "hiring_offers",
+  });
+
+  const [submitted] = calls.offers;
+  assertEquals(submitted.offers.length, 1);
+  assertEquals(submitted.offers[0].staffId, "oc-1");
+});
+
+Deno.test("executeNpcOffers: handles coach and scout candidates in the same pass", async () => {
+  const hcInterview = makeInterview({
+    teamId: "npc-a",
+    staffType: "coach",
+    staffId: "hc-1",
+    status: "completed",
+  });
+  const directorInterview = makeInterview({
+    teamId: "npc-a",
+    staffType: "scout",
+    staffId: "dir-1",
+    status: "completed",
+  });
+  const contexts: Record<string, CandidateScoringContext> = {
+    "hc-1": {
+      staffType: "coach",
+      staffId: "hc-1",
+      role: "HC",
+      preferences: {
+        marketTierPref: 50,
+        philosophyFitPref: 50,
+        staffFitPref: 50,
+        compensationPref: 50,
+        minimumThreshold: 40,
+      },
+      offense: null,
+      defense: null,
+    },
+    "dir-1": {
+      staffType: "scout",
+      staffId: "dir-1",
+      role: "DIRECTOR",
+      preferences: {
+        marketTierPref: 50,
+        philosophyFitPref: 50,
+        staffFitPref: 50,
+        compensationPref: 50,
+        minimumThreshold: 40,
+      },
+      offense: null,
+      defense: null,
+    },
+  };
+
+  const { service, calls } = stubService();
+  const ai = createNpcHiringAi({
+    repo: stubRepo({
+      listInterviewsByTeam: () =>
+        Promise.resolve([directorInterview, hcInterview]),
+      listOffersByTeam: () => Promise.resolve([]),
+      listSignedStaffByTeam: () => Promise.resolve([]),
+      getCandidateScoringContext: (_staffType, id) =>
+        Promise.resolve(contexts[id]),
+      getFranchiseScoringProfile: (teamId) =>
+        Promise.resolve({
+          teamId,
+          marketTier: "medium",
+          existingStaff: [],
+        } as FranchiseScoringProfile),
+      sumSignedStaffSalaries: () => Promise.resolve(0),
+    }),
+    leagueRepo: stubLeagueRepo({ ...defaultLeague, maxConcurrentOffers: 5 }),
+    service,
+    log: silentLog(),
+  });
+
+  await ai.executeNpcOffers({
+    leagueId: "lg",
+    npcTeamIds: ["npc-a"],
+    stepSlug: "hiring_offers",
+  });
+
+  const draft = calls.offers[0].offers;
+  assertEquals(draft.length, 2);
+  // HC (coach) ranks higher than DIRECTOR (scout).
+  assertEquals(draft[0].staffType, "coach");
+  assertEquals(draft[0].staffId, "hc-1");
+  assertEquals(draft[1].staffType, "scout");
+  assertEquals(draft[1].staffId, "dir-1");
+  // Director mid band = (250K + 800K)/2 = 525K
+  assertEquals(draft[1].salary, 525_000);
+});

--- a/server/features/hiring/npc-hiring-ai.ts
+++ b/server/features/hiring/npc-hiring-ai.ts
@@ -1,0 +1,520 @@
+import type { CoachRole, ScoutRole } from "@zone-blitz/shared";
+import type pino from "pino";
+import type {
+  CandidateScoringContext,
+  FranchiseScoringProfile,
+  HiringInterestRow,
+  HiringInterviewRow,
+  HiringOfferRow,
+  HiringRepository,
+  StaffType,
+  UnassignedCandidate,
+} from "./hiring.repository.ts";
+import type {
+  DraftOffer,
+  HiringLeagueRepository,
+  HiringLeagueSummary,
+  HiringService,
+} from "./hiring.service.ts";
+import {
+  computePreferenceScore,
+  type FranchiseProfile,
+  type MarketTier,
+  type Offer,
+  type SalaryBand,
+  type StaffCandidate,
+} from "./preference-scoring.ts";
+
+// Priority tiers for role-need ranking. Lower value = higher priority.
+// Must match the ADR 0032 hierarchy: HC, then coordinators, then position
+// coaches, then scout roles (director first, then other scouts).
+const COACH_ROLE_PRIORITY: Record<CoachRole, number> = {
+  HC: 0,
+  OC: 1,
+  DC: 1,
+  STC: 1,
+  QB: 2,
+  RB: 2,
+  WR: 2,
+  TE: 2,
+  OL: 2,
+  DL: 2,
+  LB: 2,
+  DB: 2,
+  ST_ASSISTANT: 2,
+};
+
+const SCOUT_ROLE_PRIORITY: Record<ScoutRole, number> = {
+  DIRECTOR: 3,
+  NATIONAL_CROSS_CHECKER: 4,
+  AREA_SCOUT: 4,
+};
+
+const COACH_SALARY_BANDS: Record<CoachRole, SalaryBand> = {
+  HC: { min: 5_000_000, max: 20_000_000 },
+  OC: { min: 1_500_000, max: 6_000_000 },
+  DC: { min: 1_500_000, max: 5_000_000 },
+  STC: { min: 800_000, max: 2_000_000 },
+  QB: { min: 500_000, max: 1_500_000 },
+  RB: { min: 300_000, max: 1_200_000 },
+  WR: { min: 300_000, max: 1_200_000 },
+  TE: { min: 300_000, max: 1_200_000 },
+  OL: { min: 300_000, max: 1_200_000 },
+  DL: { min: 300_000, max: 1_200_000 },
+  LB: { min: 300_000, max: 1_200_000 },
+  DB: { min: 300_000, max: 1_200_000 },
+  ST_ASSISTANT: { min: 250_000, max: 600_000 },
+};
+
+const SCOUT_SALARY_BANDS: Record<ScoutRole, SalaryBand> = {
+  DIRECTOR: { min: 250_000, max: 800_000 },
+  NATIONAL_CROSS_CHECKER: { min: 150_000, max: 400_000 },
+  AREA_SCOUT: { min: 80_000, max: 200_000 },
+};
+
+// Market-tier bias applied on top of the mid-band salary when an NPC team
+// drafts an offer. Large-market NPCs push slightly above mid; small-market
+// NPCs pull slightly below. Kept small so it does not blow the budget.
+const MARKET_TIER_OFFER_BIAS: Record<MarketTier, number> = {
+  large: 0.1,
+  medium: 0,
+  small: -0.1,
+};
+
+const DEFAULT_CONTRACT_YEARS = 3;
+const DEFAULT_BUYOUT_MULTIPLIER = "0.50";
+
+function priorityFor(staffType: StaffType, role: string): number {
+  if (staffType === "coach") {
+    return COACH_ROLE_PRIORITY[role as CoachRole] ?? 99;
+  }
+  return SCOUT_ROLE_PRIORITY[role as ScoutRole] ?? 99;
+}
+
+function bandFor(staffType: StaffType, role: string): SalaryBand {
+  if (staffType === "coach") {
+    return COACH_SALARY_BANDS[role as CoachRole];
+  }
+  return SCOUT_SALARY_BANDS[role as ScoutRole];
+}
+
+function toStaffCandidate(ctx: CandidateScoringContext): StaffCandidate {
+  if (ctx.staffType === "coach") {
+    return {
+      staffType: "coach",
+      id: ctx.staffId,
+      role: ctx.role as CoachRole,
+      offense: ctx.offense,
+      defense: ctx.defense,
+      ...ctx.preferences,
+    };
+  }
+  return {
+    staffType: "scout",
+    id: ctx.staffId,
+    role: ctx.role as ScoutRole,
+    ...ctx.preferences,
+  };
+}
+
+function toFranchiseProfile(
+  profile: FranchiseScoringProfile,
+): FranchiseProfile {
+  return {
+    franchiseId: profile.teamId,
+    marketTier: profile.marketTier,
+    existingStaff: profile.existingStaff,
+  };
+}
+
+function probeOffer(
+  franchiseId: string,
+  band: SalaryBand,
+): Offer {
+  return {
+    id: `probe-${franchiseId}`,
+    franchiseId,
+    salary: Math.round((band.min + band.max) / 2),
+    contractYears: DEFAULT_CONTRACT_YEARS,
+    incentives: [],
+  };
+}
+
+function reverseScore(
+  context: CandidateScoringContext,
+  profile: FranchiseScoringProfile,
+): number {
+  const band = bandFor(context.staffType, context.role);
+  return computePreferenceScore(
+    toStaffCandidate(context),
+    toFranchiseProfile(profile),
+    probeOffer(profile.teamId, band),
+    band,
+  );
+}
+
+function adjustedOfferSalary(
+  staffType: StaffType,
+  role: string,
+  marketTier: MarketTier,
+): number {
+  const band = bandFor(staffType, role);
+  const mid = (band.min + band.max) / 2;
+  const bias = MARKET_TIER_OFFER_BIAS[marketTier];
+  const spread = (band.max - band.min) / 2;
+  const candidate = Math.round(mid + bias * spread);
+  if (candidate < band.min) return band.min;
+  if (candidate > band.max) return band.max;
+  return candidate;
+}
+
+interface RankedCandidate {
+  staffType: StaffType;
+  staffId: string;
+  role: string;
+  priority: number;
+  score: number;
+  tiebreak: number;
+}
+
+function sortRanked(candidates: RankedCandidate[]): RankedCandidate[] {
+  return [...candidates].sort((a, b) => {
+    if (a.priority !== b.priority) return a.priority - b.priority;
+    if (a.score !== b.score) return b.score - a.score;
+    if (a.tiebreak !== b.tiebreak) return a.tiebreak - b.tiebreak;
+    return a.staffId < b.staffId ? -1 : a.staffId > b.staffId ? 1 : 0;
+  });
+}
+
+export interface NpcHiringAi {
+  executeNpcInterest(input: {
+    leagueId: string;
+    npcTeamIds: readonly string[];
+    stepSlug: string;
+  }): Promise<HiringInterestRow[]>;
+  executeNpcInterviews(input: {
+    leagueId: string;
+    npcTeamIds: readonly string[];
+    stepSlug: string;
+  }): Promise<HiringInterviewRow[]>;
+  executeNpcOffers(input: {
+    leagueId: string;
+    npcTeamIds: readonly string[];
+    stepSlug: string;
+  }): Promise<HiringOfferRow[]>;
+}
+
+/**
+ * Per-step NPC hiring AI described in ADR 0032. The strategy is to use the
+ * candidate preference function in reverse — for each NPC franchise, rank
+ * still-needed candidates by how likely each would accept a probe offer from
+ * that team, then express interest, request interviews, and submit offers in
+ * role-priority order while respecting the league's bandwidth caps and staff
+ * budget.
+ */
+export function createNpcHiringAi(deps: {
+  repo: HiringRepository;
+  leagueRepo: HiringLeagueRepository;
+  service: HiringService;
+  log: pino.Logger;
+  rng?: () => number;
+}): NpcHiringAi {
+  const log = deps.log.child({ module: "hiring.npcAi" });
+  const rng = deps.rng ?? Math.random;
+
+  async function loadLeague(leagueId: string): Promise<HiringLeagueSummary> {
+    const league = await deps.leagueRepo.getById(leagueId);
+    if (!league) {
+      throw new Error(`League ${leagueId} not found`);
+    }
+    return league;
+  }
+
+  async function rankUnassignedForTeam(
+    leagueId: string,
+    teamId: string,
+    neededCoachRoles: Set<string>,
+    neededScoutRoles: Set<string>,
+  ): Promise<RankedCandidate[]> {
+    const maybeProfile = await deps.repo.getFranchiseScoringProfile(teamId);
+    if (!maybeProfile) return [];
+    const profile: FranchiseScoringProfile = maybeProfile;
+
+    const [coaches, scouts] = await Promise.all([
+      deps.repo.listUnassignedCoaches(leagueId),
+      deps.repo.listUnassignedScouts(leagueId),
+    ]);
+
+    const ranked: RankedCandidate[] = [];
+
+    async function rankPool(
+      pool: UnassignedCandidate[],
+      staffType: StaffType,
+      needed: Set<string>,
+    ) {
+      for (const candidate of pool) {
+        if (!needed.has(candidate.role)) continue;
+        const context = await deps.repo.getCandidateScoringContext(
+          staffType,
+          candidate.id,
+        );
+        if (!context) continue;
+        ranked.push({
+          staffType,
+          staffId: candidate.id,
+          role: candidate.role,
+          priority: priorityFor(staffType, candidate.role),
+          score: reverseScore(context, profile),
+          tiebreak: rng(),
+        });
+      }
+    }
+
+    await rankPool(coaches, "coach", neededCoachRoles);
+    await rankPool(scouts, "scout", neededScoutRoles);
+
+    return sortRanked(ranked);
+  }
+
+  function neededRolesFor(
+    signedCoachRoles: Set<string>,
+    signedScoutRoles: Set<string>,
+  ): { coachRoles: Set<string>; scoutRoles: Set<string> } {
+    const coachRoles = new Set<string>(
+      Object.keys(COACH_ROLE_PRIORITY).filter(
+        (role) => !signedCoachRoles.has(role),
+      ),
+    );
+    const scoutRoles = new Set<string>(
+      Object.keys(SCOUT_ROLE_PRIORITY).filter(
+        (role) => !signedScoutRoles.has(role),
+      ),
+    );
+    return { coachRoles, scoutRoles };
+  }
+
+  return {
+    async executeNpcInterest(input) {
+      log.info(
+        { leagueId: input.leagueId, teamCount: input.npcTeamIds.length },
+        "executing npc interest",
+      );
+      const league = await loadLeague(input.leagueId);
+      const created: HiringInterestRow[] = [];
+
+      for (const teamId of input.npcTeamIds) {
+        const [interests, signed] = await Promise.all([
+          deps.repo.listInterestsByTeam(input.leagueId, teamId),
+          deps.repo.listSignedStaffByTeam(input.leagueId, teamId),
+        ]);
+        const activeInterestIds = new Set(
+          interests
+            .filter((i) => i.status === "active")
+            .map((i) => `${i.staffType}:${i.staffId}`),
+        );
+        const activeCount = activeInterestIds.size;
+        const slots = Math.max(0, league.interestCap - activeCount);
+        if (slots === 0) continue;
+
+        const signedCoachRoles = new Set(
+          signed.filter((m) => m.staffType === "coach").map((m) => m.role),
+        );
+        const signedScoutRoles = new Set(
+          signed.filter((m) => m.staffType === "scout").map((m) => m.role),
+        );
+        const { coachRoles, scoutRoles } = neededRolesFor(
+          signedCoachRoles,
+          signedScoutRoles,
+        );
+
+        const ranked = await rankUnassignedForTeam(
+          input.leagueId,
+          teamId,
+          coachRoles,
+          scoutRoles,
+        );
+
+        for (const entry of ranked) {
+          if (created.filter((c) => c.teamId === teamId).length >= slots) {
+            break;
+          }
+          const key = `${entry.staffType}:${entry.staffId}`;
+          if (activeInterestIds.has(key)) continue;
+          const row = await deps.service.expressInterest({
+            leagueId: input.leagueId,
+            teamId,
+            staffType: entry.staffType,
+            staffId: entry.staffId,
+            stepSlug: input.stepSlug,
+          });
+          created.push(row);
+          activeInterestIds.add(key);
+        }
+      }
+
+      return created;
+    },
+
+    async executeNpcInterviews(input) {
+      log.info(
+        { leagueId: input.leagueId, teamCount: input.npcTeamIds.length },
+        "executing npc interviews",
+      );
+      const league = await loadLeague(input.leagueId);
+      const created: HiringInterviewRow[] = [];
+
+      for (const teamId of input.npcTeamIds) {
+        const [interests, interviews, maybeProfile] = await Promise.all([
+          deps.repo.listInterestsByTeam(input.leagueId, teamId),
+          deps.repo.listInterviewsByTeam(input.leagueId, teamId),
+          deps.repo.getFranchiseScoringProfile(teamId),
+        ]);
+        if (!maybeProfile) continue;
+        const profile = maybeProfile;
+
+        const existingThisStep = interviews.filter(
+          (iv) => iv.stepSlug === input.stepSlug,
+        ).length;
+        const slots = Math.max(
+          0,
+          league.interviewsPerWeek - existingThisStep,
+        );
+        if (slots === 0) continue;
+
+        const alreadyInterviewed = new Set(
+          interviews.map((iv) => `${iv.staffType}:${iv.staffId}`),
+        );
+
+        const ranked: RankedCandidate[] = [];
+        for (const interest of interests) {
+          if (interest.status !== "active") continue;
+          const key = `${interest.staffType}:${interest.staffId}`;
+          if (alreadyInterviewed.has(key)) continue;
+          const context = await deps.repo.getCandidateScoringContext(
+            interest.staffType,
+            interest.staffId,
+          );
+          if (!context) continue;
+          ranked.push({
+            staffType: interest.staffType,
+            staffId: interest.staffId,
+            role: context.role,
+            priority: priorityFor(interest.staffType, context.role),
+            score: reverseScore(context, profile),
+            tiebreak: rng(),
+          });
+        }
+
+        const picked = sortRanked(ranked).slice(0, slots);
+        if (picked.length === 0) continue;
+
+        const rows = await deps.service.requestInterviews({
+          leagueId: input.leagueId,
+          teamId,
+          stepSlug: input.stepSlug,
+          targets: picked.map((p) => ({
+            staffType: p.staffType,
+            staffId: p.staffId,
+          })),
+        });
+        created.push(...rows);
+      }
+
+      return created;
+    },
+
+    async executeNpcOffers(input) {
+      log.info(
+        { leagueId: input.leagueId, teamCount: input.npcTeamIds.length },
+        "executing npc offers",
+      );
+      const league = await loadLeague(input.leagueId);
+      const created: HiringOfferRow[] = [];
+
+      for (const teamId of input.npcTeamIds) {
+        const [interviews, offers, maybeProfile, signedTotal] = await Promise
+          .all([
+            deps.repo.listInterviewsByTeam(input.leagueId, teamId),
+            deps.repo.listOffersByTeam(input.leagueId, teamId),
+            deps.repo.getFranchiseScoringProfile(teamId),
+            deps.repo.sumSignedStaffSalaries(teamId),
+          ]);
+        if (!maybeProfile) continue;
+        const profile = maybeProfile;
+
+        const pendingOffers = offers.filter((o) => o.status === "pending");
+        const pendingSalary = pendingOffers.reduce(
+          (sum, o) => sum + o.salary,
+          0,
+        );
+        const offerSlots = Math.max(
+          0,
+          league.maxConcurrentOffers - pendingOffers.length,
+        );
+        if (offerSlots === 0) continue;
+
+        const alreadyOffered = new Set(
+          offers
+            .filter((o) => o.status === "pending" || o.status === "accepted")
+            .map((o) => `${o.staffType}:${o.staffId}`),
+        );
+
+        const eligibleInterviews = interviews.filter((iv) =>
+          (iv.status === "completed" || iv.status === "accepted") &&
+          !alreadyOffered.has(`${iv.staffType}:${iv.staffId}`)
+        );
+
+        const ranked: RankedCandidate[] = [];
+        for (const interview of eligibleInterviews) {
+          const context = await deps.repo.getCandidateScoringContext(
+            interview.staffType,
+            interview.staffId,
+          );
+          if (!context) continue;
+          ranked.push({
+            staffType: interview.staffType,
+            staffId: interview.staffId,
+            role: context.role,
+            priority: priorityFor(interview.staffType, context.role),
+            score: reverseScore(context, profile),
+            tiebreak: rng(),
+          });
+        }
+
+        const ordered = sortRanked(ranked);
+        const drafts: DraftOffer[] = [];
+        let runningSalary = signedTotal + pendingSalary;
+
+        for (const entry of ordered) {
+          if (drafts.length >= offerSlots) break;
+          const salary = adjustedOfferSalary(
+            entry.staffType,
+            entry.role,
+            profile.marketTier,
+          );
+          if (runningSalary + salary > league.staffBudget) continue;
+          drafts.push({
+            staffType: entry.staffType,
+            staffId: entry.staffId,
+            salary,
+            contractYears: DEFAULT_CONTRACT_YEARS,
+            buyoutMultiplier: DEFAULT_BUYOUT_MULTIPLIER,
+          });
+          runningSalary += salary;
+        }
+
+        if (drafts.length === 0) continue;
+
+        const rows = await deps.service.submitOffers({
+          leagueId: input.leagueId,
+          teamId,
+          stepSlug: input.stepSlug,
+          offers: drafts,
+        });
+        created.push(...rows);
+      }
+
+      return created;
+    },
+  };
+}


### PR DESCRIPTION
## Summary

- Adds `createNpcHiringAi` factory and `NpcHiringAi` interface with `executeNpcInterest`, `executeNpcInterviews`, `executeNpcOffers` — the per-step NPC hiring AI described in ADR 0032.
- Each NPC franchise ranks candidates by reverse preference score (probe mid-band offer) and pursues them in role-priority order (HC → coordinators → position coaches → scouts), respecting `interest_cap`, `interviews_per_week`, `max_concurrent_offers`, and `staff_budget`.
- Handles both coach and scout hiring in the same pass, is deterministic when given a seeded RNG, and slightly tilts offer salaries above/below mid-band based on the franchise's market tier.

Closes #438