### PR TITLE
feat(league-clock): add genesis_draft_scouting to phase enum

### DIFF
--- a/client/src/features/league/nav-config.test.ts
+++ b/client/src/features/league/nav-config.test.ts
@@ -126,6 +126,16 @@ describe("navGroups", () => {
     expect(visibleLabels("regular_season")).not.toContain("Allocation Draft");
   });
 
+  it("accommodates genesis_draft_scouting without showing Founding Pool or Allocation Draft", () => {
+    const labels = visibleLabels("genesis_draft_scouting");
+    expect(labels).toContain("Home");
+    expect(labels).toContain("Scouts");
+    expect(labels).not.toContain("Founding Pool");
+    expect(labels).not.toContain("Allocation Draft");
+    expect(labels).not.toContain("Roster");
+    expect(labels).not.toContain("Salary Cap");
+  });
+
   it("every item is visible in at least one phase", () => {
     for (const group of navGroups) {
       for (const item of group.items) {

--- a/client/src/types/league-phase.test.ts
+++ b/client/src/types/league-phase.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+import { LEAGUE_PHASES } from "./league-phase.ts";
+
+// Mirrors server/features/league-clock/league-clock.schema.test.ts. When the
+// server enum changes, this list must change in lockstep — the client's
+// LEAGUE_PHASES is the client-side projection of the server's leaguePhaseEnum.
+const EXPECTED_PHASES = [
+  "genesis_staff_hiring",
+  "genesis_founding_pool",
+  "genesis_draft_scouting",
+  "genesis_allocation_draft",
+  "genesis_free_agency",
+  "genesis_kickoff",
+  "offseason_review",
+  "coaching_carousel",
+  "tag_window",
+  "restricted_fa",
+  "legal_tampering",
+  "free_agency",
+  "pre_draft",
+  "draft",
+  "udfa",
+  "offseason_program",
+  "preseason",
+  "regular_season",
+  "playoffs",
+  "offseason_rollover",
+] as const;
+
+describe("LEAGUE_PHASES", () => {
+  it("has all 20 phases in deterministic order", () => {
+    expect([...LEAGUE_PHASES]).toEqual([...EXPECTED_PHASES]);
+  });
+
+  it("places genesis_draft_scouting between genesis_founding_pool and genesis_allocation_draft (ADR 0034)", () => {
+    const foundingPoolIndex = LEAGUE_PHASES.indexOf("genesis_founding_pool");
+    const draftScoutingIndex = LEAGUE_PHASES.indexOf("genesis_draft_scouting");
+    const allocationDraftIndex = LEAGUE_PHASES.indexOf(
+      "genesis_allocation_draft",
+    );
+    expect(draftScoutingIndex).toBe(foundingPoolIndex + 1);
+    expect(allocationDraftIndex).toBe(draftScoutingIndex + 1);
+  });
+});

--- a/client/src/types/league-phase.ts
+++ b/client/src/types/league-phase.ts
@@ -1,6 +1,7 @@
 export const LEAGUE_PHASES = [
   "genesis_staff_hiring",
   "genesis_founding_pool",
+  "genesis_draft_scouting",
   "genesis_allocation_draft",
   "genesis_free_agency",
   "genesis_kickoff",

--- a/server/db/migrations/0044_loud_gravity.sql
+++ b/server/db/migrations/0044_loud_gravity.sql
@@ -1,0 +1,1 @@
+ALTER TYPE "public"."league_phase" ADD VALUE 'genesis_draft_scouting' BEFORE 'genesis_allocation_draft';

--- a/server/db/migrations/meta/0044_snapshot.json
+++ b/server/db/migrations/meta/0044_snapshot.json
@@ -1,0 +1,8114 @@
+{
+  "id": "70d67c88-1aab-4779-8820-21cdbcb66dd8",
+  "prevId": "17f0573f-4870-4ccc-9da3-1c4ab9171e2a",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.accounts": {
+      "name": "accounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "accounts_user_id_users_id_fk": {
+          "name": "accounts_user_id_users_id_fk",
+          "tableFrom": "accounts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.cities": {
+      "name": "cities",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state_id": {
+          "name": "state_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "cities_state_id_states_id_fk": {
+          "name": "cities_state_id_states_id_fk",
+          "tableFrom": "cities",
+          "tableTo": "states",
+          "columnsFrom": [
+            "state_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "cities_name_state_id_unique": {
+          "name": "cities_name_state_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name",
+            "state_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.coach_accolades": {
+      "name": "coach_accolades",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "coach_id": {
+          "name": "coach_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "season": {
+          "name": "season",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "coach_accolade_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "detail": {
+          "name": "detail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "coach_accolades_coach_id_coaches_id_fk": {
+          "name": "coach_accolades_coach_id_coaches_id_fk",
+          "tableFrom": "coach_accolades",
+          "tableTo": "coaches",
+          "columnsFrom": [
+            "coach_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.coach_career_stops": {
+      "name": "coach_career_stops",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "coach_id": {
+          "name": "coach_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "team_name": {
+          "name": "team_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_year": {
+          "name": "start_year",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_year": {
+          "name": "end_year",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "team_wins": {
+          "name": "team_wins",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "team_losses": {
+          "name": "team_losses",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "team_ties": {
+          "name": "team_ties",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "unit_rank": {
+          "name": "unit_rank",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "unit_side": {
+          "name": "unit_side",
+          "type": "coach_tenure_unit_side",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "coach_career_stops_coach_id_coaches_id_fk": {
+          "name": "coach_career_stops_coach_id_coaches_id_fk",
+          "tableFrom": "coach_career_stops",
+          "tableTo": "coaches",
+          "columnsFrom": [
+            "coach_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "coach_career_stops_team_id_teams_id_fk": {
+          "name": "coach_career_stops_team_id_teams_id_fk",
+          "tableFrom": "coach_career_stops",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.coach_connections": {
+      "name": "coach_connections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "coach_id": {
+          "name": "coach_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "other_coach_id": {
+          "name": "other_coach_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "relation": {
+          "name": "relation",
+          "type": "coach_connection_relation",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "coach_connections_coach_id_coaches_id_fk": {
+          "name": "coach_connections_coach_id_coaches_id_fk",
+          "tableFrom": "coach_connections",
+          "tableTo": "coaches",
+          "columnsFrom": [
+            "coach_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "coach_connections_other_coach_id_coaches_id_fk": {
+          "name": "coach_connections_other_coach_id_coaches_id_fk",
+          "tableFrom": "coach_connections",
+          "tableTo": "coaches",
+          "columnsFrom": [
+            "other_coach_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.coach_depth_chart_notes": {
+      "name": "coach_depth_chart_notes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "coach_id": {
+          "name": "coach_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "season": {
+          "name": "season",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "coach_depth_chart_notes_coach_id_coaches_id_fk": {
+          "name": "coach_depth_chart_notes_coach_id_coaches_id_fk",
+          "tableFrom": "coach_depth_chart_notes",
+          "tableTo": "coaches",
+          "columnsFrom": [
+            "coach_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.coach_reputation_labels": {
+      "name": "coach_reputation_labels",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "coach_id": {
+          "name": "coach_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "coach_reputation_labels_coach_id_coaches_id_fk": {
+          "name": "coach_reputation_labels_coach_id_coaches_id_fk",
+          "tableFrom": "coach_reputation_labels",
+          "tableTo": "coaches",
+          "columnsFrom": [
+            "coach_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.coach_tendencies": {
+      "name": "coach_tendencies",
+      "schema": "",
+      "columns": {
+        "coach_id": {
+          "name": "coach_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "run_pass_lean": {
+          "name": "run_pass_lean",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tempo": {
+          "name": "tempo",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "personnel_weight": {
+          "name": "personnel_weight",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "formation_under_center_shotgun": {
+          "name": "formation_under_center_shotgun",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pre_snap_motion_rate": {
+          "name": "pre_snap_motion_rate",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "passing_style": {
+          "name": "passing_style",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "passing_depth": {
+          "name": "passing_depth",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "run_game_blocking": {
+          "name": "run_game_blocking",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rpo_integration": {
+          "name": "rpo_integration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "front_odd_even": {
+          "name": "front_odd_even",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gap_responsibility": {
+          "name": "gap_responsibility",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sub_package_lean": {
+          "name": "sub_package_lean",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "coverage_man_zone": {
+          "name": "coverage_man_zone",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "coverage_shell": {
+          "name": "coverage_shell",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "corner_press_off": {
+          "name": "corner_press_off",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pressure_rate": {
+          "name": "pressure_rate",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "disguise_rate": {
+          "name": "disguise_rate",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "coach_tendencies_coach_id_coaches_id_fk": {
+          "name": "coach_tendencies_coach_id_coaches_id_fk",
+          "tableFrom": "coach_tendencies",
+          "tableTo": "coaches",
+          "columnsFrom": [
+            "coach_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.coach_tenure_player_dev": {
+      "name": "coach_tenure_player_dev",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "coach_id": {
+          "name": "coach_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "player_id": {
+          "name": "player_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "season": {
+          "name": "season",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "delta": {
+          "name": "delta",
+          "type": "coach_player_dev_delta",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "coach_tenure_player_dev_coach_id_coaches_id_fk": {
+          "name": "coach_tenure_player_dev_coach_id_coaches_id_fk",
+          "tableFrom": "coach_tenure_player_dev",
+          "tableTo": "coaches",
+          "columnsFrom": [
+            "coach_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "coach_tenure_player_dev_player_id_players_id_fk": {
+          "name": "coach_tenure_player_dev_player_id_players_id_fk",
+          "tableFrom": "coach_tenure_player_dev",
+          "tableTo": "players",
+          "columnsFrom": [
+            "player_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.coach_tenure_unit_performance": {
+      "name": "coach_tenure_unit_performance",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "coach_id": {
+          "name": "coach_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "season": {
+          "name": "season",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "unit_side": {
+          "name": "unit_side",
+          "type": "coach_tenure_unit_side",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rank": {
+          "name": "rank",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metrics": {
+          "name": "metrics",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "coach_tenure_unit_performance_coach_id_coaches_id_fk": {
+          "name": "coach_tenure_unit_performance_coach_id_coaches_id_fk",
+          "tableFrom": "coach_tenure_unit_performance",
+          "tableTo": "coaches",
+          "columnsFrom": [
+            "coach_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.coaches": {
+      "name": "coaches",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "league_id": {
+          "name": "league_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "coach_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reports_to_id": {
+          "name": "reports_to_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "play_caller": {
+          "name": "play_caller",
+          "type": "coach_play_caller",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "age": {
+          "name": "age",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hired_at": {
+          "name": "hired_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contract_years": {
+          "name": "contract_years",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contract_salary": {
+          "name": "contract_salary",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contract_buyout": {
+          "name": "contract_buyout",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "college_id": {
+          "name": "college_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "specialty": {
+          "name": "specialty",
+          "type": "coach_specialty",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_vacancy": {
+          "name": "is_vacancy",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "mentor_coach_id": {
+          "name": "mentor_coach_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "market_tier_pref": {
+          "name": "market_tier_pref",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "philosophy_fit_pref": {
+          "name": "philosophy_fit_pref",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "staff_fit_pref": {
+          "name": "staff_fit_pref",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "compensation_pref": {
+          "name": "compensation_pref",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "minimum_threshold": {
+          "name": "minimum_threshold",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "coaches_league_id_leagues_id_fk": {
+          "name": "coaches_league_id_leagues_id_fk",
+          "tableFrom": "coaches",
+          "tableTo": "leagues",
+          "columnsFrom": [
+            "league_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "coaches_team_id_teams_id_fk": {
+          "name": "coaches_team_id_teams_id_fk",
+          "tableFrom": "coaches",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "coaches_reports_to_id_coaches_id_fk": {
+          "name": "coaches_reports_to_id_coaches_id_fk",
+          "tableFrom": "coaches",
+          "tableTo": "coaches",
+          "columnsFrom": [
+            "reports_to_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "coaches_college_id_colleges_id_fk": {
+          "name": "coaches_college_id_colleges_id_fk",
+          "tableFrom": "coaches",
+          "tableTo": "colleges",
+          "columnsFrom": [
+            "college_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "coaches_mentor_coach_id_coaches_id_fk": {
+          "name": "coaches_mentor_coach_id_coaches_id_fk",
+          "tableFrom": "coaches",
+          "tableTo": "coaches",
+          "columnsFrom": [
+            "mentor_coach_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.colleges": {
+      "name": "colleges",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "short_name": {
+          "name": "short_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "nickname": {
+          "name": "nickname",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "city_id": {
+          "name": "city_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conference": {
+          "name": "conference",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subdivision": {
+          "name": "subdivision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "colleges_city_id_cities_id_fk": {
+          "name": "colleges_city_id_cities_id_fk",
+          "tableFrom": "colleges",
+          "tableTo": "cities",
+          "columnsFrom": [
+            "city_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "colleges_name_unique": {
+          "name": "colleges_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.contract_bonus_prorations": {
+      "name": "contract_bonus_prorations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "contract_id": {
+          "name": "contract_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_year": {
+          "name": "first_year",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "years": {
+          "name": "years",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "contract_bonus_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "contract_bonus_prorations_contract_id_contracts_id_fk": {
+          "name": "contract_bonus_prorations_contract_id_contracts_id_fk",
+          "tableFrom": "contract_bonus_prorations",
+          "tableTo": "contracts",
+          "columnsFrom": [
+            "contract_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.contract_history": {
+      "name": "contract_history",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "player_id": {
+          "name": "player_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contract_type": {
+          "name": "contract_type",
+          "type": "contract_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'veteran'"
+        },
+        "signed_in_year": {
+          "name": "signed_in_year",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_years": {
+          "name": "total_years",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_salary": {
+          "name": "total_salary",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "guaranteed_money": {
+          "name": "guaranteed_money",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "signing_bonus": {
+          "name": "signing_bonus",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "termination_reason": {
+          "name": "termination_reason",
+          "type": "contract_termination_reason",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "ended_in_year": {
+          "name": "ended_in_year",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "contract_history_player_id_players_id_fk": {
+          "name": "contract_history_player_id_players_id_fk",
+          "tableFrom": "contract_history",
+          "tableTo": "players",
+          "columnsFrom": [
+            "player_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "contract_history_team_id_teams_id_fk": {
+          "name": "contract_history_team_id_teams_id_fk",
+          "tableFrom": "contract_history",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.contract_option_bonuses": {
+      "name": "contract_option_bonuses",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "contract_id": {
+          "name": "contract_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "exercise_year": {
+          "name": "exercise_year",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "proration_years": {
+          "name": "proration_years",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "exercised_at": {
+          "name": "exercised_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "contract_option_bonuses_contract_id_contracts_id_fk": {
+          "name": "contract_option_bonuses_contract_id_contracts_id_fk",
+          "tableFrom": "contract_option_bonuses",
+          "tableTo": "contracts",
+          "columnsFrom": [
+            "contract_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.contract_years": {
+      "name": "contract_years",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "contract_id": {
+          "name": "contract_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "league_year": {
+          "name": "league_year",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "base": {
+          "name": "base",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "roster_bonus": {
+          "name": "roster_bonus",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "workout_bonus": {
+          "name": "workout_bonus",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "per_game_roster_bonus": {
+          "name": "per_game_roster_bonus",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "guarantee_type": {
+          "name": "guarantee_type",
+          "type": "contract_guarantee_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'none'"
+        },
+        "is_void": {
+          "name": "is_void",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "contract_years_contract_id_contracts_id_fk": {
+          "name": "contract_years_contract_id_contracts_id_fk",
+          "tableFrom": "contract_years",
+          "tableTo": "contracts",
+          "columnsFrom": [
+            "contract_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.contracts": {
+      "name": "contracts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "player_id": {
+          "name": "player_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "signed_year": {
+          "name": "signed_year",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_years": {
+          "name": "total_years",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "real_years": {
+          "name": "real_years",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "signing_bonus": {
+          "name": "signing_bonus",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "is_rookie_deal": {
+          "name": "is_rookie_deal",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "rookie_draft_pick": {
+          "name": "rookie_draft_pick",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tag_type": {
+          "name": "tag_type",
+          "type": "contract_tag_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "contracts_player_id_players_id_fk": {
+          "name": "contracts_player_id_players_id_fk",
+          "tableFrom": "contracts",
+          "tableTo": "players",
+          "columnsFrom": [
+            "player_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "contracts_team_id_teams_id_fk": {
+          "name": "contracts_team_id_teams_id_fk",
+          "tableFrom": "contracts",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.depth_chart_entries": {
+      "name": "depth_chart_entries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "player_id": {
+          "name": "player_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slot_ordinal": {
+          "name": "slot_ordinal",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_inactive": {
+          "name": "is_inactive",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "published_by_coach_id": {
+          "name": "published_by_coach_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "depth_chart_entries_team_id_teams_id_fk": {
+          "name": "depth_chart_entries_team_id_teams_id_fk",
+          "tableFrom": "depth_chart_entries",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "depth_chart_entries_player_id_players_id_fk": {
+          "name": "depth_chart_entries_player_id_players_id_fk",
+          "tableFrom": "depth_chart_entries",
+          "tableTo": "players",
+          "columnsFrom": [
+            "player_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "depth_chart_entries_published_by_coach_id_coaches_id_fk": {
+          "name": "depth_chart_entries_published_by_coach_id_coaches_id_fk",
+          "tableFrom": "depth_chart_entries",
+          "tableTo": "coaches",
+          "columnsFrom": [
+            "published_by_coach_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "depth_chart_entries_team_position_slot_unique": {
+          "name": "depth_chart_entries_team_position_slot_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "team_id",
+            "position",
+            "slot_ordinal"
+          ]
+        },
+        "depth_chart_entries_team_player_unique": {
+          "name": "depth_chart_entries_team_player_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "team_id",
+            "player_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.franchises": {
+      "name": "franchises",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "city_id": {
+          "name": "city_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "abbreviation": {
+          "name": "abbreviation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "primary_color": {
+          "name": "primary_color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "secondary_color": {
+          "name": "secondary_color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "accent_color": {
+          "name": "accent_color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "backstory": {
+          "name": "backstory",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "conference": {
+          "name": "conference",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "division": {
+          "name": "division",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "franchises_city_id_cities_id_fk": {
+          "name": "franchises_city_id_cities_id_fk",
+          "tableFrom": "franchises",
+          "tableTo": "cities",
+          "columnsFrom": [
+            "city_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "franchises_abbreviation_unique": {
+          "name": "franchises_abbreviation_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "abbreviation"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.front_office_staff": {
+      "name": "front_office_staff",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "league_id": {
+          "name": "league_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "front_office_staff_league_id_leagues_id_fk": {
+          "name": "front_office_staff_league_id_leagues_id_fk",
+          "tableFrom": "front_office_staff",
+          "tableTo": "leagues",
+          "columnsFrom": [
+            "league_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "front_office_staff_team_id_teams_id_fk": {
+          "name": "front_office_staff_team_id_teams_id_fk",
+          "tableFrom": "front_office_staff",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.games": {
+      "name": "games",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "season_id": {
+          "name": "season_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "week": {
+          "name": "week",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "home_team_id": {
+          "name": "home_team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "away_team_id": {
+          "name": "away_team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "games_season_id_seasons_id_fk": {
+          "name": "games_season_id_seasons_id_fk",
+          "tableFrom": "games",
+          "tableTo": "seasons",
+          "columnsFrom": [
+            "season_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "games_home_team_id_teams_id_fk": {
+          "name": "games_home_team_id_teams_id_fk",
+          "tableFrom": "games",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "home_team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "games_away_team_id_teams_id_fk": {
+          "name": "games_away_team_id_teams_id_fk",
+          "tableFrom": "games",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "away_team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.health_checks": {
+      "name": "health_checks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "checked_at": {
+          "name": "checked_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.hiring_decisions": {
+      "name": "hiring_decisions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "league_id": {
+          "name": "league_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "staff_type": {
+          "name": "staff_type",
+          "type": "staff_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "staff_id": {
+          "name": "staff_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chosen_offer_id": {
+          "name": "chosen_offer_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "wave": {
+          "name": "wave",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "decided_at": {
+          "name": "decided_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "hiring_decisions_league_id_leagues_id_fk": {
+          "name": "hiring_decisions_league_id_leagues_id_fk",
+          "tableFrom": "hiring_decisions",
+          "tableTo": "leagues",
+          "columnsFrom": [
+            "league_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "hiring_decisions_chosen_offer_id_hiring_offers_id_fk": {
+          "name": "hiring_decisions_chosen_offer_id_hiring_offers_id_fk",
+          "tableFrom": "hiring_decisions",
+          "tableTo": "hiring_offers",
+          "columnsFrom": [
+            "chosen_offer_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.hiring_interests": {
+      "name": "hiring_interests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "league_id": {
+          "name": "league_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "staff_type": {
+          "name": "staff_type",
+          "type": "staff_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "staff_id": {
+          "name": "staff_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "step_slug": {
+          "name": "step_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "hiring_interest_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "hiring_interests_league_id_leagues_id_fk": {
+          "name": "hiring_interests_league_id_leagues_id_fk",
+          "tableFrom": "hiring_interests",
+          "tableTo": "leagues",
+          "columnsFrom": [
+            "league_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "hiring_interests_team_id_teams_id_fk": {
+          "name": "hiring_interests_team_id_teams_id_fk",
+          "tableFrom": "hiring_interests",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.hiring_interviews": {
+      "name": "hiring_interviews",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "league_id": {
+          "name": "league_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "staff_type": {
+          "name": "staff_type",
+          "type": "staff_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "staff_id": {
+          "name": "staff_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "step_slug": {
+          "name": "step_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "hiring_interview_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'requested'"
+        },
+        "philosophy_reveal": {
+          "name": "philosophy_reveal",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "staff_fit_reveal": {
+          "name": "staff_fit_reveal",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "hiring_interviews_league_id_leagues_id_fk": {
+          "name": "hiring_interviews_league_id_leagues_id_fk",
+          "tableFrom": "hiring_interviews",
+          "tableTo": "leagues",
+          "columnsFrom": [
+            "league_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "hiring_interviews_team_id_teams_id_fk": {
+          "name": "hiring_interviews_team_id_teams_id_fk",
+          "tableFrom": "hiring_interviews",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.hiring_offers": {
+      "name": "hiring_offers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "league_id": {
+          "name": "league_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "staff_type": {
+          "name": "staff_type",
+          "type": "staff_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "staff_id": {
+          "name": "staff_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "step_slug": {
+          "name": "step_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "hiring_offer_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "salary": {
+          "name": "salary",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contract_years": {
+          "name": "contract_years",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "buyout_multiplier": {
+          "name": "buyout_multiplier",
+          "type": "numeric(3, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "incentives": {
+          "name": "incentives",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "preference_score": {
+          "name": "preference_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "hiring_offers_league_id_leagues_id_fk": {
+          "name": "hiring_offers_league_id_leagues_id_fk",
+          "tableFrom": "hiring_offers",
+          "tableTo": "leagues",
+          "columnsFrom": [
+            "league_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "hiring_offers_team_id_teams_id_fk": {
+          "name": "hiring_offers_team_id_teams_id_fk",
+          "tableFrom": "hiring_offers",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.league_advance_vote": {
+      "name": "league_advance_vote",
+      "schema": "",
+      "columns": {
+        "league_id": {
+          "name": "league_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "phase": {
+          "name": "phase",
+          "type": "league_phase",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "step_index": {
+          "name": "step_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ready_at": {
+          "name": "ready_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "league_advance_vote_league_id_leagues_id_fk": {
+          "name": "league_advance_vote_league_id_leagues_id_fk",
+          "tableFrom": "league_advance_vote",
+          "tableTo": "leagues",
+          "columnsFrom": [
+            "league_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "league_advance_vote_team_id_teams_id_fk": {
+          "name": "league_advance_vote_team_id_teams_id_fk",
+          "tableFrom": "league_advance_vote",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "league_advance_vote_league_id_team_id_phase_step_index_pk": {
+          "name": "league_advance_vote_league_id_team_id_phase_step_index_pk",
+          "columns": [
+            "league_id",
+            "team_id",
+            "phase",
+            "step_index"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.league_clock": {
+      "name": "league_clock",
+      "schema": "",
+      "columns": {
+        "league_id": {
+          "name": "league_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "season_year": {
+          "name": "season_year",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "phase": {
+          "name": "phase",
+          "type": "league_phase",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "step_index": {
+          "name": "step_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "advanced_at": {
+          "name": "advanced_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "advanced_by_user_id": {
+          "name": "advanced_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "override_reason": {
+          "name": "override_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "override_blockers": {
+          "name": "override_blockers",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "has_completed_genesis": {
+          "name": "has_completed_genesis",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "league_clock_league_id_leagues_id_fk": {
+          "name": "league_clock_league_id_leagues_id_fk",
+          "tableFrom": "league_clock",
+          "tableTo": "leagues",
+          "columnsFrom": [
+            "league_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "league_clock_advanced_by_user_id_users_id_fk": {
+          "name": "league_clock_advanced_by_user_id_users_id_fk",
+          "tableFrom": "league_clock",
+          "tableTo": "users",
+          "columnsFrom": [
+            "advanced_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.league_phase_step": {
+      "name": "league_phase_step",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "phase": {
+          "name": "phase",
+          "type": "league_phase",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "step_index": {
+          "name": "step_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "step_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "flavor_date": {
+          "name": "flavor_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.leagues": {
+      "name": "leagues",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_team_id": {
+          "name": "user_team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "number_of_teams": {
+          "name": "number_of_teams",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 32
+        },
+        "season_length": {
+          "name": "season_length",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 17
+        },
+        "salary_cap": {
+          "name": "salary_cap",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 255000000
+        },
+        "cap_floor_percent": {
+          "name": "cap_floor_percent",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 89
+        },
+        "cap_growth_rate": {
+          "name": "cap_growth_rate",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 5
+        },
+        "roster_size": {
+          "name": "roster_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 53
+        },
+        "advance_policy": {
+          "name": "advance_policy",
+          "type": "advance_policy",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'commissioner'"
+        },
+        "staff_budget": {
+          "name": "staff_budget",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 50000000
+        },
+        "interest_cap": {
+          "name": "interest_cap",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 10
+        },
+        "interviews_per_week": {
+          "name": "interviews_per_week",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 4
+        },
+        "max_concurrent_offers": {
+          "name": "max_concurrent_offers",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 5
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_played_at": {
+          "name": "last_played_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "leagues_user_team_id_teams_id_fk": {
+          "name": "leagues_user_team_id_teams_id_fk",
+          "tableFrom": "leagues",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "user_team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.player_accolades": {
+      "name": "player_accolades",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "player_id": {
+          "name": "player_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "season_year": {
+          "name": "season_year",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "player_accolade_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "detail": {
+          "name": "detail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "player_accolades_player_id_players_id_fk": {
+          "name": "player_accolades_player_id_players_id_fk",
+          "tableFrom": "player_accolades",
+          "tableTo": "players",
+          "columnsFrom": [
+            "player_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.player_attributes": {
+      "name": "player_attributes",
+      "schema": "",
+      "columns": {
+        "player_id": {
+          "name": "player_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "speed": {
+          "name": "speed",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "speed_potential": {
+          "name": "speed_potential",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "acceleration": {
+          "name": "acceleration",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "acceleration_potential": {
+          "name": "acceleration_potential",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agility": {
+          "name": "agility",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agility_potential": {
+          "name": "agility_potential",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "strength": {
+          "name": "strength",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "strength_potential": {
+          "name": "strength_potential",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "jumping": {
+          "name": "jumping",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "jumping_potential": {
+          "name": "jumping_potential",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stamina": {
+          "name": "stamina",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stamina_potential": {
+          "name": "stamina_potential",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "durability": {
+          "name": "durability",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "durability_potential": {
+          "name": "durability_potential",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "arm_strength": {
+          "name": "arm_strength",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "arm_strength_potential": {
+          "name": "arm_strength_potential",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "accuracy_short": {
+          "name": "accuracy_short",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "accuracy_short_potential": {
+          "name": "accuracy_short_potential",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "accuracy_medium": {
+          "name": "accuracy_medium",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "accuracy_medium_potential": {
+          "name": "accuracy_medium_potential",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "accuracy_deep": {
+          "name": "accuracy_deep",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "accuracy_deep_potential": {
+          "name": "accuracy_deep_potential",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "accuracy_on_the_run": {
+          "name": "accuracy_on_the_run",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "accuracy_on_the_run_potential": {
+          "name": "accuracy_on_the_run_potential",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "touch": {
+          "name": "touch",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "touch_potential": {
+          "name": "touch_potential",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "release": {
+          "name": "release",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "release_potential": {
+          "name": "release_potential",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ball_carrying": {
+          "name": "ball_carrying",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ball_carrying_potential": {
+          "name": "ball_carrying_potential",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "elusiveness": {
+          "name": "elusiveness",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "elusiveness_potential": {
+          "name": "elusiveness_potential",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "route_running": {
+          "name": "route_running",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "route_running_potential": {
+          "name": "route_running_potential",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "catching": {
+          "name": "catching",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "catching_potential": {
+          "name": "catching_potential",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contested_catching": {
+          "name": "contested_catching",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contested_catching_potential": {
+          "name": "contested_catching_potential",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_after_catch": {
+          "name": "run_after_catch",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_after_catch_potential": {
+          "name": "run_after_catch_potential",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pass_blocking": {
+          "name": "pass_blocking",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pass_blocking_potential": {
+          "name": "pass_blocking_potential",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_blocking": {
+          "name": "run_blocking",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_blocking_potential": {
+          "name": "run_blocking_potential",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "block_shedding": {
+          "name": "block_shedding",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "block_shedding_potential": {
+          "name": "block_shedding_potential",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tackling": {
+          "name": "tackling",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tackling_potential": {
+          "name": "tackling_potential",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "man_coverage": {
+          "name": "man_coverage",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "man_coverage_potential": {
+          "name": "man_coverage_potential",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "zone_coverage": {
+          "name": "zone_coverage",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "zone_coverage_potential": {
+          "name": "zone_coverage_potential",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pass_rushing": {
+          "name": "pass_rushing",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pass_rushing_potential": {
+          "name": "pass_rushing_potential",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_defense": {
+          "name": "run_defense",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_defense_potential": {
+          "name": "run_defense_potential",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kicking_power": {
+          "name": "kicking_power",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kicking_power_potential": {
+          "name": "kicking_power_potential",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kicking_accuracy": {
+          "name": "kicking_accuracy",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kicking_accuracy_potential": {
+          "name": "kicking_accuracy_potential",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "punting_power": {
+          "name": "punting_power",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "punting_power_potential": {
+          "name": "punting_power_potential",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "punting_accuracy": {
+          "name": "punting_accuracy",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "punting_accuracy_potential": {
+          "name": "punting_accuracy_potential",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "snap_accuracy": {
+          "name": "snap_accuracy",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "snap_accuracy_potential": {
+          "name": "snap_accuracy_potential",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "football_iq": {
+          "name": "football_iq",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "football_iq_potential": {
+          "name": "football_iq_potential",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "decision_making": {
+          "name": "decision_making",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "decision_making_potential": {
+          "name": "decision_making_potential",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "anticipation": {
+          "name": "anticipation",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "anticipation_potential": {
+          "name": "anticipation_potential",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "composure": {
+          "name": "composure",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "composure_potential": {
+          "name": "composure_potential",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "clutch": {
+          "name": "clutch",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "clutch_potential": {
+          "name": "clutch_potential",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consistency": {
+          "name": "consistency",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consistency_potential": {
+          "name": "consistency_potential",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "work_ethic": {
+          "name": "work_ethic",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "work_ethic_potential": {
+          "name": "work_ethic_potential",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "coachability": {
+          "name": "coachability",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "coachability_potential": {
+          "name": "coachability_potential",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "leadership": {
+          "name": "leadership",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "leadership_potential": {
+          "name": "leadership_potential",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "greed": {
+          "name": "greed",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "greed_potential": {
+          "name": "greed_potential",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "loyalty": {
+          "name": "loyalty",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "loyalty_potential": {
+          "name": "loyalty_potential",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ambition": {
+          "name": "ambition",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ambition_potential": {
+          "name": "ambition_potential",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vanity": {
+          "name": "vanity",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vanity_potential": {
+          "name": "vanity_potential",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scheme_attachment": {
+          "name": "scheme_attachment",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scheme_attachment_potential": {
+          "name": "scheme_attachment_potential",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "media_sensitivity": {
+          "name": "media_sensitivity",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "media_sensitivity_potential": {
+          "name": "media_sensitivity_potential",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "player_attributes_player_id_players_id_fk": {
+          "name": "player_attributes_player_id_players_id_fk",
+          "tableFrom": "player_attributes",
+          "tableTo": "players",
+          "columnsFrom": [
+            "player_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "player_attributes_speed_range": {
+          "name": "player_attributes_speed_range",
+          "value": "speed BETWEEN 0 AND 100"
+        },
+        "player_attributes_speed_potential_range": {
+          "name": "player_attributes_speed_potential_range",
+          "value": "speed_potential BETWEEN 0 AND 100"
+        },
+        "player_attributes_acceleration_range": {
+          "name": "player_attributes_acceleration_range",
+          "value": "acceleration BETWEEN 0 AND 100"
+        },
+        "player_attributes_acceleration_potential_range": {
+          "name": "player_attributes_acceleration_potential_range",
+          "value": "acceleration_potential BETWEEN 0 AND 100"
+        },
+        "player_attributes_agility_range": {
+          "name": "player_attributes_agility_range",
+          "value": "agility BETWEEN 0 AND 100"
+        },
+        "player_attributes_agility_potential_range": {
+          "name": "player_attributes_agility_potential_range",
+          "value": "agility_potential BETWEEN 0 AND 100"
+        },
+        "player_attributes_strength_range": {
+          "name": "player_attributes_strength_range",
+          "value": "strength BETWEEN 0 AND 100"
+        },
+        "player_attributes_strength_potential_range": {
+          "name": "player_attributes_strength_potential_range",
+          "value": "strength_potential BETWEEN 0 AND 100"
+        },
+        "player_attributes_jumping_range": {
+          "name": "player_attributes_jumping_range",
+          "value": "jumping BETWEEN 0 AND 100"
+        },
+        "player_attributes_jumping_potential_range": {
+          "name": "player_attributes_jumping_potential_range",
+          "value": "jumping_potential BETWEEN 0 AND 100"
+        },
+        "player_attributes_stamina_range": {
+          "name": "player_attributes_stamina_range",
+          "value": "stamina BETWEEN 0 AND 100"
+        },
+        "player_attributes_stamina_potential_range": {
+          "name": "player_attributes_stamina_potential_range",
+          "value": "stamina_potential BETWEEN 0 AND 100"
+        },
+        "player_attributes_durability_range": {
+          "name": "player_attributes_durability_range",
+          "value": "durability BETWEEN 0 AND 100"
+        },
+        "player_attributes_durability_potential_range": {
+          "name": "player_attributes_durability_potential_range",
+          "value": "durability_potential BETWEEN 0 AND 100"
+        },
+        "player_attributes_arm_strength_range": {
+          "name": "player_attributes_arm_strength_range",
+          "value": "arm_strength BETWEEN 0 AND 100"
+        },
+        "player_attributes_arm_strength_potential_range": {
+          "name": "player_attributes_arm_strength_potential_range",
+          "value": "arm_strength_potential BETWEEN 0 AND 100"
+        },
+        "player_attributes_accuracy_short_range": {
+          "name": "player_attributes_accuracy_short_range",
+          "value": "accuracy_short BETWEEN 0 AND 100"
+        },
+        "player_attributes_accuracy_short_potential_range": {
+          "name": "player_attributes_accuracy_short_potential_range",
+          "value": "accuracy_short_potential BETWEEN 0 AND 100"
+        },
+        "player_attributes_accuracy_medium_range": {
+          "name": "player_attributes_accuracy_medium_range",
+          "value": "accuracy_medium BETWEEN 0 AND 100"
+        },
+        "player_attributes_accuracy_medium_potential_range": {
+          "name": "player_attributes_accuracy_medium_potential_range",
+          "value": "accuracy_medium_potential BETWEEN 0 AND 100"
+        },
+        "player_attributes_accuracy_deep_range": {
+          "name": "player_attributes_accuracy_deep_range",
+          "value": "accuracy_deep BETWEEN 0 AND 100"
+        },
+        "player_attributes_accuracy_deep_potential_range": {
+          "name": "player_attributes_accuracy_deep_potential_range",
+          "value": "accuracy_deep_potential BETWEEN 0 AND 100"
+        },
+        "player_attributes_accuracy_on_the_run_range": {
+          "name": "player_attributes_accuracy_on_the_run_range",
+          "value": "accuracy_on_the_run BETWEEN 0 AND 100"
+        },
+        "player_attributes_accuracy_on_the_run_potential_range": {
+          "name": "player_attributes_accuracy_on_the_run_potential_range",
+          "value": "accuracy_on_the_run_potential BETWEEN 0 AND 100"
+        },
+        "player_attributes_touch_range": {
+          "name": "player_attributes_touch_range",
+          "value": "touch BETWEEN 0 AND 100"
+        },
+        "player_attributes_touch_potential_range": {
+          "name": "player_attributes_touch_potential_range",
+          "value": "touch_potential BETWEEN 0 AND 100"
+        },
+        "player_attributes_release_range": {
+          "name": "player_attributes_release_range",
+          "value": "release BETWEEN 0 AND 100"
+        },
+        "player_attributes_release_potential_range": {
+          "name": "player_attributes_release_potential_range",
+          "value": "release_potential BETWEEN 0 AND 100"
+        },
+        "player_attributes_ball_carrying_range": {
+          "name": "player_attributes_ball_carrying_range",
+          "value": "ball_carrying BETWEEN 0 AND 100"
+        },
+        "player_attributes_ball_carrying_potential_range": {
+          "name": "player_attributes_ball_carrying_potential_range",
+          "value": "ball_carrying_potential BETWEEN 0 AND 100"
+        },
+        "player_attributes_elusiveness_range": {
+          "name": "player_attributes_elusiveness_range",
+          "value": "elusiveness BETWEEN 0 AND 100"
+        },
+        "player_attributes_elusiveness_potential_range": {
+          "name": "player_attributes_elusiveness_potential_range",
+          "value": "elusiveness_potential BETWEEN 0 AND 100"
+        },
+        "player_attributes_route_running_range": {
+          "name": "player_attributes_route_running_range",
+          "value": "route_running BETWEEN 0 AND 100"
+        },
+        "player_attributes_route_running_potential_range": {
+          "name": "player_attributes_route_running_potential_range",
+          "value": "route_running_potential BETWEEN 0 AND 100"
+        },
+        "player_attributes_catching_range": {
+          "name": "player_attributes_catching_range",
+          "value": "catching BETWEEN 0 AND 100"
+        },
+        "player_attributes_catching_potential_range": {
+          "name": "player_attributes_catching_potential_range",
+          "value": "catching_potential BETWEEN 0 AND 100"
+        },
+        "player_attributes_contested_catching_range": {
+          "name": "player_attributes_contested_catching_range",
+          "value": "contested_catching BETWEEN 0 AND 100"
+        },
+        "player_attributes_contested_catching_potential_range": {
+          "name": "player_attributes_contested_catching_potential_range",
+          "value": "contested_catching_potential BETWEEN 0 AND 100"
+        },
+        "player_attributes_run_after_catch_range": {
+          "name": "player_attributes_run_after_catch_range",
+          "value": "run_after_catch BETWEEN 0 AND 100"
+        },
+        "player_attributes_run_after_catch_potential_range": {
+          "name": "player_attributes_run_after_catch_potential_range",
+          "value": "run_after_catch_potential BETWEEN 0 AND 100"
+        },
+        "player_attributes_pass_blocking_range": {
+          "name": "player_attributes_pass_blocking_range",
+          "value": "pass_blocking BETWEEN 0 AND 100"
+        },
+        "player_attributes_pass_blocking_potential_range": {
+          "name": "player_attributes_pass_blocking_potential_range",
+          "value": "pass_blocking_potential BETWEEN 0 AND 100"
+        },
+        "player_attributes_run_blocking_range": {
+          "name": "player_attributes_run_blocking_range",
+          "value": "run_blocking BETWEEN 0 AND 100"
+        },
+        "player_attributes_run_blocking_potential_range": {
+          "name": "player_attributes_run_blocking_potential_range",
+          "value": "run_blocking_potential BETWEEN 0 AND 100"
+        },
+        "player_attributes_block_shedding_range": {
+          "name": "player_attributes_block_shedding_range",
+          "value": "block_shedding BETWEEN 0 AND 100"
+        },
+        "player_attributes_block_shedding_potential_range": {
+          "name": "player_attributes_block_shedding_potential_range",
+          "value": "block_shedding_potential BETWEEN 0 AND 100"
+        },
+        "player_attributes_tackling_range": {
+          "name": "player_attributes_tackling_range",
+          "value": "tackling BETWEEN 0 AND 100"
+        },
+        "player_attributes_tackling_potential_range": {
+          "name": "player_attributes_tackling_potential_range",
+          "value": "tackling_potential BETWEEN 0 AND 100"
+        },
+        "player_attributes_man_coverage_range": {
+          "name": "player_attributes_man_coverage_range",
+          "value": "man_coverage BETWEEN 0 AND 100"
+        },
+        "player_attributes_man_coverage_potential_range": {
+          "name": "player_attributes_man_coverage_potential_range",
+          "value": "man_coverage_potential BETWEEN 0 AND 100"
+        },
+        "player_attributes_zone_coverage_range": {
+          "name": "player_attributes_zone_coverage_range",
+          "value": "zone_coverage BETWEEN 0 AND 100"
+        },
+        "player_attributes_zone_coverage_potential_range": {
+          "name": "player_attributes_zone_coverage_potential_range",
+          "value": "zone_coverage_potential BETWEEN 0 AND 100"
+        },
+        "player_attributes_pass_rushing_range": {
+          "name": "player_attributes_pass_rushing_range",
+          "value": "pass_rushing BETWEEN 0 AND 100"
+        },
+        "player_attributes_pass_rushing_potential_range": {
+          "name": "player_attributes_pass_rushing_potential_range",
+          "value": "pass_rushing_potential BETWEEN 0 AND 100"
+        },
+        "player_attributes_run_defense_range": {
+          "name": "player_attributes_run_defense_range",
+          "value": "run_defense BETWEEN 0 AND 100"
+        },
+        "player_attributes_run_defense_potential_range": {
+          "name": "player_attributes_run_defense_potential_range",
+          "value": "run_defense_potential BETWEEN 0 AND 100"
+        },
+        "player_attributes_kicking_power_range": {
+          "name": "player_attributes_kicking_power_range",
+          "value": "kicking_power BETWEEN 0 AND 100"
+        },
+        "player_attributes_kicking_power_potential_range": {
+          "name": "player_attributes_kicking_power_potential_range",
+          "value": "kicking_power_potential BETWEEN 0 AND 100"
+        },
+        "player_attributes_kicking_accuracy_range": {
+          "name": "player_attributes_kicking_accuracy_range",
+          "value": "kicking_accuracy BETWEEN 0 AND 100"
+        },
+        "player_attributes_kicking_accuracy_potential_range": {
+          "name": "player_attributes_kicking_accuracy_potential_range",
+          "value": "kicking_accuracy_potential BETWEEN 0 AND 100"
+        },
+        "player_attributes_punting_power_range": {
+          "name": "player_attributes_punting_power_range",
+          "value": "punting_power BETWEEN 0 AND 100"
+        },
+        "player_attributes_punting_power_potential_range": {
+          "name": "player_attributes_punting_power_potential_range",
+          "value": "punting_power_potential BETWEEN 0 AND 100"
+        },
+        "player_attributes_punting_accuracy_range": {
+          "name": "player_attributes_punting_accuracy_range",
+          "value": "punting_accuracy BETWEEN 0 AND 100"
+        },
+        "player_attributes_punting_accuracy_potential_range": {
+          "name": "player_attributes_punting_accuracy_potential_range",
+          "value": "punting_accuracy_potential BETWEEN 0 AND 100"
+        },
+        "player_attributes_snap_accuracy_range": {
+          "name": "player_attributes_snap_accuracy_range",
+          "value": "snap_accuracy BETWEEN 0 AND 100"
+        },
+        "player_attributes_snap_accuracy_potential_range": {
+          "name": "player_attributes_snap_accuracy_potential_range",
+          "value": "snap_accuracy_potential BETWEEN 0 AND 100"
+        },
+        "player_attributes_football_iq_range": {
+          "name": "player_attributes_football_iq_range",
+          "value": "football_iq BETWEEN 0 AND 100"
+        },
+        "player_attributes_football_iq_potential_range": {
+          "name": "player_attributes_football_iq_potential_range",
+          "value": "football_iq_potential BETWEEN 0 AND 100"
+        },
+        "player_attributes_decision_making_range": {
+          "name": "player_attributes_decision_making_range",
+          "value": "decision_making BETWEEN 0 AND 100"
+        },
+        "player_attributes_decision_making_potential_range": {
+          "name": "player_attributes_decision_making_potential_range",
+          "value": "decision_making_potential BETWEEN 0 AND 100"
+        },
+        "player_attributes_anticipation_range": {
+          "name": "player_attributes_anticipation_range",
+          "value": "anticipation BETWEEN 0 AND 100"
+        },
+        "player_attributes_anticipation_potential_range": {
+          "name": "player_attributes_anticipation_potential_range",
+          "value": "anticipation_potential BETWEEN 0 AND 100"
+        },
+        "player_attributes_composure_range": {
+          "name": "player_attributes_composure_range",
+          "value": "composure BETWEEN 0 AND 100"
+        },
+        "player_attributes_composure_potential_range": {
+          "name": "player_attributes_composure_potential_range",
+          "value": "composure_potential BETWEEN 0 AND 100"
+        },
+        "player_attributes_clutch_range": {
+          "name": "player_attributes_clutch_range",
+          "value": "clutch BETWEEN 0 AND 100"
+        },
+        "player_attributes_clutch_potential_range": {
+          "name": "player_attributes_clutch_potential_range",
+          "value": "clutch_potential BETWEEN 0 AND 100"
+        },
+        "player_attributes_consistency_range": {
+          "name": "player_attributes_consistency_range",
+          "value": "consistency BETWEEN 0 AND 100"
+        },
+        "player_attributes_consistency_potential_range": {
+          "name": "player_attributes_consistency_potential_range",
+          "value": "consistency_potential BETWEEN 0 AND 100"
+        },
+        "player_attributes_work_ethic_range": {
+          "name": "player_attributes_work_ethic_range",
+          "value": "work_ethic BETWEEN 0 AND 100"
+        },
+        "player_attributes_work_ethic_potential_range": {
+          "name": "player_attributes_work_ethic_potential_range",
+          "value": "work_ethic_potential BETWEEN 0 AND 100"
+        },
+        "player_attributes_coachability_range": {
+          "name": "player_attributes_coachability_range",
+          "value": "coachability BETWEEN 0 AND 100"
+        },
+        "player_attributes_coachability_potential_range": {
+          "name": "player_attributes_coachability_potential_range",
+          "value": "coachability_potential BETWEEN 0 AND 100"
+        },
+        "player_attributes_leadership_range": {
+          "name": "player_attributes_leadership_range",
+          "value": "leadership BETWEEN 0 AND 100"
+        },
+        "player_attributes_leadership_potential_range": {
+          "name": "player_attributes_leadership_potential_range",
+          "value": "leadership_potential BETWEEN 0 AND 100"
+        },
+        "player_attributes_greed_range": {
+          "name": "player_attributes_greed_range",
+          "value": "greed BETWEEN 0 AND 100"
+        },
+        "player_attributes_greed_potential_range": {
+          "name": "player_attributes_greed_potential_range",
+          "value": "greed_potential BETWEEN 0 AND 100"
+        },
+        "player_attributes_loyalty_range": {
+          "name": "player_attributes_loyalty_range",
+          "value": "loyalty BETWEEN 0 AND 100"
+        },
+        "player_attributes_loyalty_potential_range": {
+          "name": "player_attributes_loyalty_potential_range",
+          "value": "loyalty_potential BETWEEN 0 AND 100"
+        },
+        "player_attributes_ambition_range": {
+          "name": "player_attributes_ambition_range",
+          "value": "ambition BETWEEN 0 AND 100"
+        },
+        "player_attributes_ambition_potential_range": {
+          "name": "player_attributes_ambition_potential_range",
+          "value": "ambition_potential BETWEEN 0 AND 100"
+        },
+        "player_attributes_vanity_range": {
+          "name": "player_attributes_vanity_range",
+          "value": "vanity BETWEEN 0 AND 100"
+        },
+        "player_attributes_vanity_potential_range": {
+          "name": "player_attributes_vanity_potential_range",
+          "value": "vanity_potential BETWEEN 0 AND 100"
+        },
+        "player_attributes_scheme_attachment_range": {
+          "name": "player_attributes_scheme_attachment_range",
+          "value": "scheme_attachment BETWEEN 0 AND 100"
+        },
+        "player_attributes_scheme_attachment_potential_range": {
+          "name": "player_attributes_scheme_attachment_potential_range",
+          "value": "scheme_attachment_potential BETWEEN 0 AND 100"
+        },
+        "player_attributes_media_sensitivity_range": {
+          "name": "player_attributes_media_sensitivity_range",
+          "value": "media_sensitivity BETWEEN 0 AND 100"
+        },
+        "player_attributes_media_sensitivity_potential_range": {
+          "name": "player_attributes_media_sensitivity_potential_range",
+          "value": "media_sensitivity_potential BETWEEN 0 AND 100"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.player_draft_profile": {
+      "name": "player_draft_profile",
+      "schema": "",
+      "columns": {
+        "player_id": {
+          "name": "player_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "season_id": {
+          "name": "season_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "draft_class_year": {
+          "name": "draft_class_year",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "projected_round": {
+          "name": "projected_round",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scouting_notes": {
+          "name": "scouting_notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "speed": {
+          "name": "speed",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "speed_potential": {
+          "name": "speed_potential",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "acceleration": {
+          "name": "acceleration",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "acceleration_potential": {
+          "name": "acceleration_potential",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agility": {
+          "name": "agility",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agility_potential": {
+          "name": "agility_potential",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "strength": {
+          "name": "strength",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "strength_potential": {
+          "name": "strength_potential",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "jumping": {
+          "name": "jumping",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "jumping_potential": {
+          "name": "jumping_potential",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stamina": {
+          "name": "stamina",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stamina_potential": {
+          "name": "stamina_potential",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "durability": {
+          "name": "durability",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "durability_potential": {
+          "name": "durability_potential",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "arm_strength": {
+          "name": "arm_strength",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "arm_strength_potential": {
+          "name": "arm_strength_potential",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "accuracy_short": {
+          "name": "accuracy_short",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "accuracy_short_potential": {
+          "name": "accuracy_short_potential",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "accuracy_medium": {
+          "name": "accuracy_medium",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "accuracy_medium_potential": {
+          "name": "accuracy_medium_potential",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "accuracy_deep": {
+          "name": "accuracy_deep",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "accuracy_deep_potential": {
+          "name": "accuracy_deep_potential",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "accuracy_on_the_run": {
+          "name": "accuracy_on_the_run",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "accuracy_on_the_run_potential": {
+          "name": "accuracy_on_the_run_potential",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "touch": {
+          "name": "touch",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "touch_potential": {
+          "name": "touch_potential",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "release": {
+          "name": "release",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "release_potential": {
+          "name": "release_potential",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ball_carrying": {
+          "name": "ball_carrying",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ball_carrying_potential": {
+          "name": "ball_carrying_potential",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "elusiveness": {
+          "name": "elusiveness",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "elusiveness_potential": {
+          "name": "elusiveness_potential",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "route_running": {
+          "name": "route_running",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "route_running_potential": {
+          "name": "route_running_potential",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "catching": {
+          "name": "catching",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "catching_potential": {
+          "name": "catching_potential",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contested_catching": {
+          "name": "contested_catching",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contested_catching_potential": {
+          "name": "contested_catching_potential",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_after_catch": {
+          "name": "run_after_catch",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_after_catch_potential": {
+          "name": "run_after_catch_potential",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pass_blocking": {
+          "name": "pass_blocking",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pass_blocking_potential": {
+          "name": "pass_blocking_potential",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_blocking": {
+          "name": "run_blocking",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_blocking_potential": {
+          "name": "run_blocking_potential",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "block_shedding": {
+          "name": "block_shedding",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "block_shedding_potential": {
+          "name": "block_shedding_potential",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tackling": {
+          "name": "tackling",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tackling_potential": {
+          "name": "tackling_potential",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "man_coverage": {
+          "name": "man_coverage",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "man_coverage_potential": {
+          "name": "man_coverage_potential",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "zone_coverage": {
+          "name": "zone_coverage",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "zone_coverage_potential": {
+          "name": "zone_coverage_potential",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pass_rushing": {
+          "name": "pass_rushing",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pass_rushing_potential": {
+          "name": "pass_rushing_potential",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_defense": {
+          "name": "run_defense",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_defense_potential": {
+          "name": "run_defense_potential",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kicking_power": {
+          "name": "kicking_power",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kicking_power_potential": {
+          "name": "kicking_power_potential",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kicking_accuracy": {
+          "name": "kicking_accuracy",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kicking_accuracy_potential": {
+          "name": "kicking_accuracy_potential",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "punting_power": {
+          "name": "punting_power",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "punting_power_potential": {
+          "name": "punting_power_potential",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "punting_accuracy": {
+          "name": "punting_accuracy",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "punting_accuracy_potential": {
+          "name": "punting_accuracy_potential",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "snap_accuracy": {
+          "name": "snap_accuracy",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "snap_accuracy_potential": {
+          "name": "snap_accuracy_potential",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "football_iq": {
+          "name": "football_iq",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "football_iq_potential": {
+          "name": "football_iq_potential",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "decision_making": {
+          "name": "decision_making",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "decision_making_potential": {
+          "name": "decision_making_potential",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "anticipation": {
+          "name": "anticipation",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "anticipation_potential": {
+          "name": "anticipation_potential",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "composure": {
+          "name": "composure",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "composure_potential": {
+          "name": "composure_potential",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "clutch": {
+          "name": "clutch",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "clutch_potential": {
+          "name": "clutch_potential",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consistency": {
+          "name": "consistency",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consistency_potential": {
+          "name": "consistency_potential",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "work_ethic": {
+          "name": "work_ethic",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "work_ethic_potential": {
+          "name": "work_ethic_potential",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "coachability": {
+          "name": "coachability",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "coachability_potential": {
+          "name": "coachability_potential",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "leadership": {
+          "name": "leadership",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "leadership_potential": {
+          "name": "leadership_potential",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "greed": {
+          "name": "greed",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "greed_potential": {
+          "name": "greed_potential",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "loyalty": {
+          "name": "loyalty",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "loyalty_potential": {
+          "name": "loyalty_potential",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ambition": {
+          "name": "ambition",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ambition_potential": {
+          "name": "ambition_potential",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vanity": {
+          "name": "vanity",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vanity_potential": {
+          "name": "vanity_potential",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scheme_attachment": {
+          "name": "scheme_attachment",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scheme_attachment_potential": {
+          "name": "scheme_attachment_potential",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "media_sensitivity": {
+          "name": "media_sensitivity",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "media_sensitivity_potential": {
+          "name": "media_sensitivity_potential",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "player_draft_profile_player_id_players_id_fk": {
+          "name": "player_draft_profile_player_id_players_id_fk",
+          "tableFrom": "player_draft_profile",
+          "tableTo": "players",
+          "columnsFrom": [
+            "player_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "player_draft_profile_season_id_seasons_id_fk": {
+          "name": "player_draft_profile_season_id_seasons_id_fk",
+          "tableFrom": "player_draft_profile",
+          "tableTo": "seasons",
+          "columnsFrom": [
+            "season_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "player_draft_profile_speed_range": {
+          "name": "player_draft_profile_speed_range",
+          "value": "speed BETWEEN 0 AND 100"
+        },
+        "player_draft_profile_speed_potential_range": {
+          "name": "player_draft_profile_speed_potential_range",
+          "value": "speed_potential BETWEEN 0 AND 100"
+        },
+        "player_draft_profile_acceleration_range": {
+          "name": "player_draft_profile_acceleration_range",
+          "value": "acceleration BETWEEN 0 AND 100"
+        },
+        "player_draft_profile_acceleration_potential_range": {
+          "name": "player_draft_profile_acceleration_potential_range",
+          "value": "acceleration_potential BETWEEN 0 AND 100"
+        },
+        "player_draft_profile_agility_range": {
+          "name": "player_draft_profile_agility_range",
+          "value": "agility BETWEEN 0 AND 100"
+        },
+        "player_draft_profile_agility_potential_range": {
+          "name": "player_draft_profile_agility_potential_range",
+          "value": "agility_potential BETWEEN 0 AND 100"
+        },
+        "player_draft_profile_strength_range": {
+          "name": "player_draft_profile_strength_range",
+          "value": "strength BETWEEN 0 AND 100"
+        },
+        "player_draft_profile_strength_potential_range": {
+          "name": "player_draft_profile_strength_potential_range",
+          "value": "strength_potential BETWEEN 0 AND 100"
+        },
+        "player_draft_profile_jumping_range": {
+          "name": "player_draft_profile_jumping_range",
+          "value": "jumping BETWEEN 0 AND 100"
+        },
+        "player_draft_profile_jumping_potential_range": {
+          "name": "player_draft_profile_jumping_potential_range",
+          "value": "jumping_potential BETWEEN 0 AND 100"
+        },
+        "player_draft_profile_stamina_range": {
+          "name": "player_draft_profile_stamina_range",
+          "value": "stamina BETWEEN 0 AND 100"
+        },
+        "player_draft_profile_stamina_potential_range": {
+          "name": "player_draft_profile_stamina_potential_range",
+          "value": "stamina_potential BETWEEN 0 AND 100"
+        },
+        "player_draft_profile_durability_range": {
+          "name": "player_draft_profile_durability_range",
+          "value": "durability BETWEEN 0 AND 100"
+        },
+        "player_draft_profile_durability_potential_range": {
+          "name": "player_draft_profile_durability_potential_range",
+          "value": "durability_potential BETWEEN 0 AND 100"
+        },
+        "player_draft_profile_arm_strength_range": {
+          "name": "player_draft_profile_arm_strength_range",
+          "value": "arm_strength BETWEEN 0 AND 100"
+        },
+        "player_draft_profile_arm_strength_potential_range": {
+          "name": "player_draft_profile_arm_strength_potential_range",
+          "value": "arm_strength_potential BETWEEN 0 AND 100"
+        },
+        "player_draft_profile_accuracy_short_range": {
+          "name": "player_draft_profile_accuracy_short_range",
+          "value": "accuracy_short BETWEEN 0 AND 100"
+        },
+        "player_draft_profile_accuracy_short_potential_range": {
+          "name": "player_draft_profile_accuracy_short_potential_range",
+          "value": "accuracy_short_potential BETWEEN 0 AND 100"
+        },
+        "player_draft_profile_accuracy_medium_range": {
+          "name": "player_draft_profile_accuracy_medium_range",
+          "value": "accuracy_medium BETWEEN 0 AND 100"
+        },
+        "player_draft_profile_accuracy_medium_potential_range": {
+          "name": "player_draft_profile_accuracy_medium_potential_range",
+          "value": "accuracy_medium_potential BETWEEN 0 AND 100"
+        },
+        "player_draft_profile_accuracy_deep_range": {
+          "name": "player_draft_profile_accuracy_deep_range",
+          "value": "accuracy_deep BETWEEN 0 AND 100"
+        },
+        "player_draft_profile_accuracy_deep_potential_range": {
+          "name": "player_draft_profile_accuracy_deep_potential_range",
+          "value": "accuracy_deep_potential BETWEEN 0 AND 100"
+        },
+        "player_draft_profile_accuracy_on_the_run_range": {
+          "name": "player_draft_profile_accuracy_on_the_run_range",
+          "value": "accuracy_on_the_run BETWEEN 0 AND 100"
+        },
+        "player_draft_profile_accuracy_on_the_run_potential_range": {
+          "name": "player_draft_profile_accuracy_on_the_run_potential_range",
+          "value": "accuracy_on_the_run_potential BETWEEN 0 AND 100"
+        },
+        "player_draft_profile_touch_range": {
+          "name": "player_draft_profile_touch_range",
+          "value": "touch BETWEEN 0 AND 100"
+        },
+        "player_draft_profile_touch_potential_range": {
+          "name": "player_draft_profile_touch_potential_range",
+          "value": "touch_potential BETWEEN 0 AND 100"
+        },
+        "player_draft_profile_release_range": {
+          "name": "player_draft_profile_release_range",
+          "value": "release BETWEEN 0 AND 100"
+        },
+        "player_draft_profile_release_potential_range": {
+          "name": "player_draft_profile_release_potential_range",
+          "value": "release_potential BETWEEN 0 AND 100"
+        },
+        "player_draft_profile_ball_carrying_range": {
+          "name": "player_draft_profile_ball_carrying_range",
+          "value": "ball_carrying BETWEEN 0 AND 100"
+        },
+        "player_draft_profile_ball_carrying_potential_range": {
+          "name": "player_draft_profile_ball_carrying_potential_range",
+          "value": "ball_carrying_potential BETWEEN 0 AND 100"
+        },
+        "player_draft_profile_elusiveness_range": {
+          "name": "player_draft_profile_elusiveness_range",
+          "value": "elusiveness BETWEEN 0 AND 100"
+        },
+        "player_draft_profile_elusiveness_potential_range": {
+          "name": "player_draft_profile_elusiveness_potential_range",
+          "value": "elusiveness_potential BETWEEN 0 AND 100"
+        },
+        "player_draft_profile_route_running_range": {
+          "name": "player_draft_profile_route_running_range",
+          "value": "route_running BETWEEN 0 AND 100"
+        },
+        "player_draft_profile_route_running_potential_range": {
+          "name": "player_draft_profile_route_running_potential_range",
+          "value": "route_running_potential BETWEEN 0 AND 100"
+        },
+        "player_draft_profile_catching_range": {
+          "name": "player_draft_profile_catching_range",
+          "value": "catching BETWEEN 0 AND 100"
+        },
+        "player_draft_profile_catching_potential_range": {
+          "name": "player_draft_profile_catching_potential_range",
+          "value": "catching_potential BETWEEN 0 AND 100"
+        },
+        "player_draft_profile_contested_catching_range": {
+          "name": "player_draft_profile_contested_catching_range",
+          "value": "contested_catching BETWEEN 0 AND 100"
+        },
+        "player_draft_profile_contested_catching_potential_range": {
+          "name": "player_draft_profile_contested_catching_potential_range",
+          "value": "contested_catching_potential BETWEEN 0 AND 100"
+        },
+        "player_draft_profile_run_after_catch_range": {
+          "name": "player_draft_profile_run_after_catch_range",
+          "value": "run_after_catch BETWEEN 0 AND 100"
+        },
+        "player_draft_profile_run_after_catch_potential_range": {
+          "name": "player_draft_profile_run_after_catch_potential_range",
+          "value": "run_after_catch_potential BETWEEN 0 AND 100"
+        },
+        "player_draft_profile_pass_blocking_range": {
+          "name": "player_draft_profile_pass_blocking_range",
+          "value": "pass_blocking BETWEEN 0 AND 100"
+        },
+        "player_draft_profile_pass_blocking_potential_range": {
+          "name": "player_draft_profile_pass_blocking_potential_range",
+          "value": "pass_blocking_potential BETWEEN 0 AND 100"
+        },
+        "player_draft_profile_run_blocking_range": {
+          "name": "player_draft_profile_run_blocking_range",
+          "value": "run_blocking BETWEEN 0 AND 100"
+        },
+        "player_draft_profile_run_blocking_potential_range": {
+          "name": "player_draft_profile_run_blocking_potential_range",
+          "value": "run_blocking_potential BETWEEN 0 AND 100"
+        },
+        "player_draft_profile_block_shedding_range": {
+          "name": "player_draft_profile_block_shedding_range",
+          "value": "block_shedding BETWEEN 0 AND 100"
+        },
+        "player_draft_profile_block_shedding_potential_range": {
+          "name": "player_draft_profile_block_shedding_potential_range",
+          "value": "block_shedding_potential BETWEEN 0 AND 100"
+        },
+        "player_draft_profile_tackling_range": {
+          "name": "player_draft_profile_tackling_range",
+          "value": "tackling BETWEEN 0 AND 100"
+        },
+        "player_draft_profile_tackling_potential_range": {
+          "name": "player_draft_profile_tackling_potential_range",
+          "value": "tackling_potential BETWEEN 0 AND 100"
+        },
+        "player_draft_profile_man_coverage_range": {
+          "name": "player_draft_profile_man_coverage_range",
+          "value": "man_coverage BETWEEN 0 AND 100"
+        },
+        "player_draft_profile_man_coverage_potential_range": {
+          "name": "player_draft_profile_man_coverage_potential_range",
+          "value": "man_coverage_potential BETWEEN 0 AND 100"
+        },
+        "player_draft_profile_zone_coverage_range": {
+          "name": "player_draft_profile_zone_coverage_range",
+          "value": "zone_coverage BETWEEN 0 AND 100"
+        },
+        "player_draft_profile_zone_coverage_potential_range": {
+          "name": "player_draft_profile_zone_coverage_potential_range",
+          "value": "zone_coverage_potential BETWEEN 0 AND 100"
+        },
+        "player_draft_profile_pass_rushing_range": {
+          "name": "player_draft_profile_pass_rushing_range",
+          "value": "pass_rushing BETWEEN 0 AND 100"
+        },
+        "player_draft_profile_pass_rushing_potential_range": {
+          "name": "player_draft_profile_pass_rushing_potential_range",
+          "value": "pass_rushing_potential BETWEEN 0 AND 100"
+        },
+        "player_draft_profile_run_defense_range": {
+          "name": "player_draft_profile_run_defense_range",
+          "value": "run_defense BETWEEN 0 AND 100"
+        },
+        "player_draft_profile_run_defense_potential_range": {
+          "name": "player_draft_profile_run_defense_potential_range",
+          "value": "run_defense_potential BETWEEN 0 AND 100"
+        },
+        "player_draft_profile_kicking_power_range": {
+          "name": "player_draft_profile_kicking_power_range",
+          "value": "kicking_power BETWEEN 0 AND 100"
+        },
+        "player_draft_profile_kicking_power_potential_range": {
+          "name": "player_draft_profile_kicking_power_potential_range",
+          "value": "kicking_power_potential BETWEEN 0 AND 100"
+        },
+        "player_draft_profile_kicking_accuracy_range": {
+          "name": "player_draft_profile_kicking_accuracy_range",
+          "value": "kicking_accuracy BETWEEN 0 AND 100"
+        },
+        "player_draft_profile_kicking_accuracy_potential_range": {
+          "name": "player_draft_profile_kicking_accuracy_potential_range",
+          "value": "kicking_accuracy_potential BETWEEN 0 AND 100"
+        },
+        "player_draft_profile_punting_power_range": {
+          "name": "player_draft_profile_punting_power_range",
+          "value": "punting_power BETWEEN 0 AND 100"
+        },
+        "player_draft_profile_punting_power_potential_range": {
+          "name": "player_draft_profile_punting_power_potential_range",
+          "value": "punting_power_potential BETWEEN 0 AND 100"
+        },
+        "player_draft_profile_punting_accuracy_range": {
+          "name": "player_draft_profile_punting_accuracy_range",
+          "value": "punting_accuracy BETWEEN 0 AND 100"
+        },
+        "player_draft_profile_punting_accuracy_potential_range": {
+          "name": "player_draft_profile_punting_accuracy_potential_range",
+          "value": "punting_accuracy_potential BETWEEN 0 AND 100"
+        },
+        "player_draft_profile_snap_accuracy_range": {
+          "name": "player_draft_profile_snap_accuracy_range",
+          "value": "snap_accuracy BETWEEN 0 AND 100"
+        },
+        "player_draft_profile_snap_accuracy_potential_range": {
+          "name": "player_draft_profile_snap_accuracy_potential_range",
+          "value": "snap_accuracy_potential BETWEEN 0 AND 100"
+        },
+        "player_draft_profile_football_iq_range": {
+          "name": "player_draft_profile_football_iq_range",
+          "value": "football_iq BETWEEN 0 AND 100"
+        },
+        "player_draft_profile_football_iq_potential_range": {
+          "name": "player_draft_profile_football_iq_potential_range",
+          "value": "football_iq_potential BETWEEN 0 AND 100"
+        },
+        "player_draft_profile_decision_making_range": {
+          "name": "player_draft_profile_decision_making_range",
+          "value": "decision_making BETWEEN 0 AND 100"
+        },
+        "player_draft_profile_decision_making_potential_range": {
+          "name": "player_draft_profile_decision_making_potential_range",
+          "value": "decision_making_potential BETWEEN 0 AND 100"
+        },
+        "player_draft_profile_anticipation_range": {
+          "name": "player_draft_profile_anticipation_range",
+          "value": "anticipation BETWEEN 0 AND 100"
+        },
+        "player_draft_profile_anticipation_potential_range": {
+          "name": "player_draft_profile_anticipation_potential_range",
+          "value": "anticipation_potential BETWEEN 0 AND 100"
+        },
+        "player_draft_profile_composure_range": {
+          "name": "player_draft_profile_composure_range",
+          "value": "composure BETWEEN 0 AND 100"
+        },
+        "player_draft_profile_composure_potential_range": {
+          "name": "player_draft_profile_composure_potential_range",
+          "value": "composure_potential BETWEEN 0 AND 100"
+        },
+        "player_draft_profile_clutch_range": {
+          "name": "player_draft_profile_clutch_range",
+          "value": "clutch BETWEEN 0 AND 100"
+        },
+        "player_draft_profile_clutch_potential_range": {
+          "name": "player_draft_profile_clutch_potential_range",
+          "value": "clutch_potential BETWEEN 0 AND 100"
+        },
+        "player_draft_profile_consistency_range": {
+          "name": "player_draft_profile_consistency_range",
+          "value": "consistency BETWEEN 0 AND 100"
+        },
+        "player_draft_profile_consistency_potential_range": {
+          "name": "player_draft_profile_consistency_potential_range",
+          "value": "consistency_potential BETWEEN 0 AND 100"
+        },
+        "player_draft_profile_work_ethic_range": {
+          "name": "player_draft_profile_work_ethic_range",
+          "value": "work_ethic BETWEEN 0 AND 100"
+        },
+        "player_draft_profile_work_ethic_potential_range": {
+          "name": "player_draft_profile_work_ethic_potential_range",
+          "value": "work_ethic_potential BETWEEN 0 AND 100"
+        },
+        "player_draft_profile_coachability_range": {
+          "name": "player_draft_profile_coachability_range",
+          "value": "coachability BETWEEN 0 AND 100"
+        },
+        "player_draft_profile_coachability_potential_range": {
+          "name": "player_draft_profile_coachability_potential_range",
+          "value": "coachability_potential BETWEEN 0 AND 100"
+        },
+        "player_draft_profile_leadership_range": {
+          "name": "player_draft_profile_leadership_range",
+          "value": "leadership BETWEEN 0 AND 100"
+        },
+        "player_draft_profile_leadership_potential_range": {
+          "name": "player_draft_profile_leadership_potential_range",
+          "value": "leadership_potential BETWEEN 0 AND 100"
+        },
+        "player_draft_profile_greed_range": {
+          "name": "player_draft_profile_greed_range",
+          "value": "greed BETWEEN 0 AND 100"
+        },
+        "player_draft_profile_greed_potential_range": {
+          "name": "player_draft_profile_greed_potential_range",
+          "value": "greed_potential BETWEEN 0 AND 100"
+        },
+        "player_draft_profile_loyalty_range": {
+          "name": "player_draft_profile_loyalty_range",
+          "value": "loyalty BETWEEN 0 AND 100"
+        },
+        "player_draft_profile_loyalty_potential_range": {
+          "name": "player_draft_profile_loyalty_potential_range",
+          "value": "loyalty_potential BETWEEN 0 AND 100"
+        },
+        "player_draft_profile_ambition_range": {
+          "name": "player_draft_profile_ambition_range",
+          "value": "ambition BETWEEN 0 AND 100"
+        },
+        "player_draft_profile_ambition_potential_range": {
+          "name": "player_draft_profile_ambition_potential_range",
+          "value": "ambition_potential BETWEEN 0 AND 100"
+        },
+        "player_draft_profile_vanity_range": {
+          "name": "player_draft_profile_vanity_range",
+          "value": "vanity BETWEEN 0 AND 100"
+        },
+        "player_draft_profile_vanity_potential_range": {
+          "name": "player_draft_profile_vanity_potential_range",
+          "value": "vanity_potential BETWEEN 0 AND 100"
+        },
+        "player_draft_profile_scheme_attachment_range": {
+          "name": "player_draft_profile_scheme_attachment_range",
+          "value": "scheme_attachment BETWEEN 0 AND 100"
+        },
+        "player_draft_profile_scheme_attachment_potential_range": {
+          "name": "player_draft_profile_scheme_attachment_potential_range",
+          "value": "scheme_attachment_potential BETWEEN 0 AND 100"
+        },
+        "player_draft_profile_media_sensitivity_range": {
+          "name": "player_draft_profile_media_sensitivity_range",
+          "value": "media_sensitivity BETWEEN 0 AND 100"
+        },
+        "player_draft_profile_media_sensitivity_potential_range": {
+          "name": "player_draft_profile_media_sensitivity_potential_range",
+          "value": "media_sensitivity_potential BETWEEN 0 AND 100"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.player_season_ratings": {
+      "name": "player_season_ratings",
+      "schema": "",
+      "columns": {
+        "player_id": {
+          "name": "player_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "season_id": {
+          "name": "season_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "speed": {
+          "name": "speed",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "speed_potential": {
+          "name": "speed_potential",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "acceleration": {
+          "name": "acceleration",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "acceleration_potential": {
+          "name": "acceleration_potential",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agility": {
+          "name": "agility",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agility_potential": {
+          "name": "agility_potential",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "strength": {
+          "name": "strength",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "strength_potential": {
+          "name": "strength_potential",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "jumping": {
+          "name": "jumping",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "jumping_potential": {
+          "name": "jumping_potential",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stamina": {
+          "name": "stamina",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stamina_potential": {
+          "name": "stamina_potential",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "durability": {
+          "name": "durability",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "durability_potential": {
+          "name": "durability_potential",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "arm_strength": {
+          "name": "arm_strength",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "arm_strength_potential": {
+          "name": "arm_strength_potential",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "accuracy_short": {
+          "name": "accuracy_short",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "accuracy_short_potential": {
+          "name": "accuracy_short_potential",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "accuracy_medium": {
+          "name": "accuracy_medium",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "accuracy_medium_potential": {
+          "name": "accuracy_medium_potential",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "accuracy_deep": {
+          "name": "accuracy_deep",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "accuracy_deep_potential": {
+          "name": "accuracy_deep_potential",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "accuracy_on_the_run": {
+          "name": "accuracy_on_the_run",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "accuracy_on_the_run_potential": {
+          "name": "accuracy_on_the_run_potential",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "touch": {
+          "name": "touch",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "touch_potential": {
+          "name": "touch_potential",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "release": {
+          "name": "release",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "release_potential": {
+          "name": "release_potential",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ball_carrying": {
+          "name": "ball_carrying",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ball_carrying_potential": {
+          "name": "ball_carrying_potential",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "elusiveness": {
+          "name": "elusiveness",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "elusiveness_potential": {
+          "name": "elusiveness_potential",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "route_running": {
+          "name": "route_running",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "route_running_potential": {
+          "name": "route_running_potential",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "catching": {
+          "name": "catching",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "catching_potential": {
+          "name": "catching_potential",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contested_catching": {
+          "name": "contested_catching",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contested_catching_potential": {
+          "name": "contested_catching_potential",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_after_catch": {
+          "name": "run_after_catch",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_after_catch_potential": {
+          "name": "run_after_catch_potential",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pass_blocking": {
+          "name": "pass_blocking",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pass_blocking_potential": {
+          "name": "pass_blocking_potential",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_blocking": {
+          "name": "run_blocking",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_blocking_potential": {
+          "name": "run_blocking_potential",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "block_shedding": {
+          "name": "block_shedding",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "block_shedding_potential": {
+          "name": "block_shedding_potential",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tackling": {
+          "name": "tackling",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tackling_potential": {
+          "name": "tackling_potential",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "man_coverage": {
+          "name": "man_coverage",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "man_coverage_potential": {
+          "name": "man_coverage_potential",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "zone_coverage": {
+          "name": "zone_coverage",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "zone_coverage_potential": {
+          "name": "zone_coverage_potential",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pass_rushing": {
+          "name": "pass_rushing",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pass_rushing_potential": {
+          "name": "pass_rushing_potential",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_defense": {
+          "name": "run_defense",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_defense_potential": {
+          "name": "run_defense_potential",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kicking_power": {
+          "name": "kicking_power",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kicking_power_potential": {
+          "name": "kicking_power_potential",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kicking_accuracy": {
+          "name": "kicking_accuracy",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kicking_accuracy_potential": {
+          "name": "kicking_accuracy_potential",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "punting_power": {
+          "name": "punting_power",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "punting_power_potential": {
+          "name": "punting_power_potential",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "punting_accuracy": {
+          "name": "punting_accuracy",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "punting_accuracy_potential": {
+          "name": "punting_accuracy_potential",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "snap_accuracy": {
+          "name": "snap_accuracy",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "snap_accuracy_potential": {
+          "name": "snap_accuracy_potential",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "football_iq": {
+          "name": "football_iq",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "football_iq_potential": {
+          "name": "football_iq_potential",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "decision_making": {
+          "name": "decision_making",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "decision_making_potential": {
+          "name": "decision_making_potential",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "anticipation": {
+          "name": "anticipation",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "anticipation_potential": {
+          "name": "anticipation_potential",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "composure": {
+          "name": "composure",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "composure_potential": {
+          "name": "composure_potential",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "clutch": {
+          "name": "clutch",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "clutch_potential": {
+          "name": "clutch_potential",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consistency": {
+          "name": "consistency",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consistency_potential": {
+          "name": "consistency_potential",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "work_ethic": {
+          "name": "work_ethic",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "work_ethic_potential": {
+          "name": "work_ethic_potential",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "coachability": {
+          "name": "coachability",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "coachability_potential": {
+          "name": "coachability_potential",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "leadership": {
+          "name": "leadership",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "leadership_potential": {
+          "name": "leadership_potential",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "greed": {
+          "name": "greed",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "greed_potential": {
+          "name": "greed_potential",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "loyalty": {
+          "name": "loyalty",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "loyalty_potential": {
+          "name": "loyalty_potential",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ambition": {
+          "name": "ambition",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ambition_potential": {
+          "name": "ambition_potential",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vanity": {
+          "name": "vanity",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vanity_potential": {
+          "name": "vanity_potential",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scheme_attachment": {
+          "name": "scheme_attachment",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scheme_attachment_potential": {
+          "name": "scheme_attachment_potential",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "media_sensitivity": {
+          "name": "media_sensitivity",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "media_sensitivity_potential": {
+          "name": "media_sensitivity_potential",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "player_season_ratings_player_id_players_id_fk": {
+          "name": "player_season_ratings_player_id_players_id_fk",
+          "tableFrom": "player_season_ratings",
+          "tableTo": "players",
+          "columnsFrom": [
+            "player_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "player_season_ratings_season_id_seasons_id_fk": {
+          "name": "player_season_ratings_season_id_seasons_id_fk",
+          "tableFrom": "player_season_ratings",
+          "tableTo": "seasons",
+          "columnsFrom": [
+            "season_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "player_season_ratings_pk": {
+          "name": "player_season_ratings_pk",
+          "columns": [
+            "player_id",
+            "season_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "player_season_ratings_speed_range": {
+          "name": "player_season_ratings_speed_range",
+          "value": "speed BETWEEN 0 AND 100"
+        },
+        "player_season_ratings_speed_potential_range": {
+          "name": "player_season_ratings_speed_potential_range",
+          "value": "speed_potential BETWEEN 0 AND 100"
+        },
+        "player_season_ratings_acceleration_range": {
+          "name": "player_season_ratings_acceleration_range",
+          "value": "acceleration BETWEEN 0 AND 100"
+        },
+        "player_season_ratings_acceleration_potential_range": {
+          "name": "player_season_ratings_acceleration_potential_range",
+          "value": "acceleration_potential BETWEEN 0 AND 100"
+        },
+        "player_season_ratings_agility_range": {
+          "name": "player_season_ratings_agility_range",
+          "value": "agility BETWEEN 0 AND 100"
+        },
+        "player_season_ratings_agility_potential_range": {
+          "name": "player_season_ratings_agility_potential_range",
+          "value": "agility_potential BETWEEN 0 AND 100"
+        },
+        "player_season_ratings_strength_range": {
+          "name": "player_season_ratings_strength_range",
+          "value": "strength BETWEEN 0 AND 100"
+        },
+        "player_season_ratings_strength_potential_range": {
+          "name": "player_season_ratings_strength_potential_range",
+          "value": "strength_potential BETWEEN 0 AND 100"
+        },
+        "player_season_ratings_jumping_range": {
+          "name": "player_season_ratings_jumping_range",
+          "value": "jumping BETWEEN 0 AND 100"
+        },
+        "player_season_ratings_jumping_potential_range": {
+          "name": "player_season_ratings_jumping_potential_range",
+          "value": "jumping_potential BETWEEN 0 AND 100"
+        },
+        "player_season_ratings_stamina_range": {
+          "name": "player_season_ratings_stamina_range",
+          "value": "stamina BETWEEN 0 AND 100"
+        },
+        "player_season_ratings_stamina_potential_range": {
+          "name": "player_season_ratings_stamina_potential_range",
+          "value": "stamina_potential BETWEEN 0 AND 100"
+        },
+        "player_season_ratings_durability_range": {
+          "name": "player_season_ratings_durability_range",
+          "value": "durability BETWEEN 0 AND 100"
+        },
+        "player_season_ratings_durability_potential_range": {
+          "name": "player_season_ratings_durability_potential_range",
+          "value": "durability_potential BETWEEN 0 AND 100"
+        },
+        "player_season_ratings_arm_strength_range": {
+          "name": "player_season_ratings_arm_strength_range",
+          "value": "arm_strength BETWEEN 0 AND 100"
+        },
+        "player_season_ratings_arm_strength_potential_range": {
+          "name": "player_season_ratings_arm_strength_potential_range",
+          "value": "arm_strength_potential BETWEEN 0 AND 100"
+        },
+        "player_season_ratings_accuracy_short_range": {
+          "name": "player_season_ratings_accuracy_short_range",
+          "value": "accuracy_short BETWEEN 0 AND 100"
+        },
+        "player_season_ratings_accuracy_short_potential_range": {
+          "name": "player_season_ratings_accuracy_short_potential_range",
+          "value": "accuracy_short_potential BETWEEN 0 AND 100"
+        },
+        "player_season_ratings_accuracy_medium_range": {
+          "name": "player_season_ratings_accuracy_medium_range",
+          "value": "accuracy_medium BETWEEN 0 AND 100"
+        },
+        "player_season_ratings_accuracy_medium_potential_range": {
+          "name": "player_season_ratings_accuracy_medium_potential_range",
+          "value": "accuracy_medium_potential BETWEEN 0 AND 100"
+        },
+        "player_season_ratings_accuracy_deep_range": {
+          "name": "player_season_ratings_accuracy_deep_range",
+          "value": "accuracy_deep BETWEEN 0 AND 100"
+        },
+        "player_season_ratings_accuracy_deep_potential_range": {
+          "name": "player_season_ratings_accuracy_deep_potential_range",
+          "value": "accuracy_deep_potential BETWEEN 0 AND 100"
+        },
+        "player_season_ratings_accuracy_on_the_run_range": {
+          "name": "player_season_ratings_accuracy_on_the_run_range",
+          "value": "accuracy_on_the_run BETWEEN 0 AND 100"
+        },
+        "player_season_ratings_accuracy_on_the_run_potential_range": {
+          "name": "player_season_ratings_accuracy_on_the_run_potential_range",
+          "value": "accuracy_on_the_run_potential BETWEEN 0 AND 100"
+        },
+        "player_season_ratings_touch_range": {
+          "name": "player_season_ratings_touch_range",
+          "value": "touch BETWEEN 0 AND 100"
+        },
+        "player_season_ratings_touch_potential_range": {
+          "name": "player_season_ratings_touch_potential_range",
+          "value": "touch_potential BETWEEN 0 AND 100"
+        },
+        "player_season_ratings_release_range": {
+          "name": "player_season_ratings_release_range",
+          "value": "release BETWEEN 0 AND 100"
+        },
+        "player_season_ratings_release_potential_range": {
+          "name": "player_season_ratings_release_potential_range",
+          "value": "release_potential BETWEEN 0 AND 100"
+        },
+        "player_season_ratings_ball_carrying_range": {
+          "name": "player_season_ratings_ball_carrying_range",
+          "value": "ball_carrying BETWEEN 0 AND 100"
+        },
+        "player_season_ratings_ball_carrying_potential_range": {
+          "name": "player_season_ratings_ball_carrying_potential_range",
+          "value": "ball_carrying_potential BETWEEN 0 AND 100"
+        },
+        "player_season_ratings_elusiveness_range": {
+          "name": "player_season_ratings_elusiveness_range",
+          "value": "elusiveness BETWEEN 0 AND 100"
+        },
+        "player_season_ratings_elusiveness_potential_range": {
+          "name": "player_season_ratings_elusiveness_potential_range",
+          "value": "elusiveness_potential BETWEEN 0 AND 100"
+        },
+        "player_season_ratings_route_running_range": {
+          "name": "player_season_ratings_route_running_range",
+          "value": "route_running BETWEEN 0 AND 100"
+        },
+        "player_season_ratings_route_running_potential_range": {
+          "name": "player_season_ratings_route_running_potential_range",
+          "value": "route_running_potential BETWEEN 0 AND 100"
+        },
+        "player_season_ratings_catching_range": {
+          "name": "player_season_ratings_catching_range",
+          "value": "catching BETWEEN 0 AND 100"
+        },
+        "player_season_ratings_catching_potential_range": {
+          "name": "player_season_ratings_catching_potential_range",
+          "value": "catching_potential BETWEEN 0 AND 100"
+        },
+        "player_season_ratings_contested_catching_range": {
+          "name": "player_season_ratings_contested_catching_range",
+          "value": "contested_catching BETWEEN 0 AND 100"
+        },
+        "player_season_ratings_contested_catching_potential_range": {
+          "name": "player_season_ratings_contested_catching_potential_range",
+          "value": "contested_catching_potential BETWEEN 0 AND 100"
+        },
+        "player_season_ratings_run_after_catch_range": {
+          "name": "player_season_ratings_run_after_catch_range",
+          "value": "run_after_catch BETWEEN 0 AND 100"
+        },
+        "player_season_ratings_run_after_catch_potential_range": {
+          "name": "player_season_ratings_run_after_catch_potential_range",
+          "value": "run_after_catch_potential BETWEEN 0 AND 100"
+        },
+        "player_season_ratings_pass_blocking_range": {
+          "name": "player_season_ratings_pass_blocking_range",
+          "value": "pass_blocking BETWEEN 0 AND 100"
+        },
+        "player_season_ratings_pass_blocking_potential_range": {
+          "name": "player_season_ratings_pass_blocking_potential_range",
+          "value": "pass_blocking_potential BETWEEN 0 AND 100"
+        },
+        "player_season_ratings_run_blocking_range": {
+          "name": "player_season_ratings_run_blocking_range",
+          "value": "run_blocking BETWEEN 0 AND 100"
+        },
+        "player_season_ratings_run_blocking_potential_range": {
+          "name": "player_season_ratings_run_blocking_potential_range",
+          "value": "run_blocking_potential BETWEEN 0 AND 100"
+        },
+        "player_season_ratings_block_shedding_range": {
+          "name": "player_season_ratings_block_shedding_range",
+          "value": "block_shedding BETWEEN 0 AND 100"
+        },
+        "player_season_ratings_block_shedding_potential_range": {
+          "name": "player_season_ratings_block_shedding_potential_range",
+          "value": "block_shedding_potential BETWEEN 0 AND 100"
+        },
+        "player_season_ratings_tackling_range": {
+          "name": "player_season_ratings_tackling_range",
+          "value": "tackling BETWEEN 0 AND 100"
+        },
+        "player_season_ratings_tackling_potential_range": {
+          "name": "player_season_ratings_tackling_potential_range",
+          "value": "tackling_potential BETWEEN 0 AND 100"
+        },
+        "player_season_ratings_man_coverage_range": {
+          "name": "player_season_ratings_man_coverage_range",
+          "value": "man_coverage BETWEEN 0 AND 100"
+        },
+        "player_season_ratings_man_coverage_potential_range": {
+          "name": "player_season_ratings_man_coverage_potential_range",
+          "value": "man_coverage_potential BETWEEN 0 AND 100"
+        },
+        "player_season_ratings_zone_coverage_range": {
+          "name": "player_season_ratings_zone_coverage_range",
+          "value": "zone_coverage BETWEEN 0 AND 100"
+        },
+        "player_season_ratings_zone_coverage_potential_range": {
+          "name": "player_season_ratings_zone_coverage_potential_range",
+          "value": "zone_coverage_potential BETWEEN 0 AND 100"
+        },
+        "player_season_ratings_pass_rushing_range": {
+          "name": "player_season_ratings_pass_rushing_range",
+          "value": "pass_rushing BETWEEN 0 AND 100"
+        },
+        "player_season_ratings_pass_rushing_potential_range": {
+          "name": "player_season_ratings_pass_rushing_potential_range",
+          "value": "pass_rushing_potential BETWEEN 0 AND 100"
+        },
+        "player_season_ratings_run_defense_range": {
+          "name": "player_season_ratings_run_defense_range",
+          "value": "run_defense BETWEEN 0 AND 100"
+        },
+        "player_season_ratings_run_defense_potential_range": {
+          "name": "player_season_ratings_run_defense_potential_range",
+          "value": "run_defense_potential BETWEEN 0 AND 100"
+        },
+        "player_season_ratings_kicking_power_range": {
+          "name": "player_season_ratings_kicking_power_range",
+          "value": "kicking_power BETWEEN 0 AND 100"
+        },
+        "player_season_ratings_kicking_power_potential_range": {
+          "name": "player_season_ratings_kicking_power_potential_range",
+          "value": "kicking_power_potential BETWEEN 0 AND 100"
+        },
+        "player_season_ratings_kicking_accuracy_range": {
+          "name": "player_season_ratings_kicking_accuracy_range",
+          "value": "kicking_accuracy BETWEEN 0 AND 100"
+        },
+        "player_season_ratings_kicking_accuracy_potential_range": {
+          "name": "player_season_ratings_kicking_accuracy_potential_range",
+          "value": "kicking_accuracy_potential BETWEEN 0 AND 100"
+        },
+        "player_season_ratings_punting_power_range": {
+          "name": "player_season_ratings_punting_power_range",
+          "value": "punting_power BETWEEN 0 AND 100"
+        },
+        "player_season_ratings_punting_power_potential_range": {
+          "name": "player_season_ratings_punting_power_potential_range",
+          "value": "punting_power_potential BETWEEN 0 AND 100"
+        },
+        "player_season_ratings_punting_accuracy_range": {
+          "name": "player_season_ratings_punting_accuracy_range",
+          "value": "punting_accuracy BETWEEN 0 AND 100"
+        },
+        "player_season_ratings_punting_accuracy_potential_range": {
+          "name": "player_season_ratings_punting_accuracy_potential_range",
+          "value": "punting_accuracy_potential BETWEEN 0 AND 100"
+        },
+        "player_season_ratings_snap_accuracy_range": {
+          "name": "player_season_ratings_snap_accuracy_range",
+          "value": "snap_accuracy BETWEEN 0 AND 100"
+        },
+        "player_season_ratings_snap_accuracy_potential_range": {
+          "name": "player_season_ratings_snap_accuracy_potential_range",
+          "value": "snap_accuracy_potential BETWEEN 0 AND 100"
+        },
+        "player_season_ratings_football_iq_range": {
+          "name": "player_season_ratings_football_iq_range",
+          "value": "football_iq BETWEEN 0 AND 100"
+        },
+        "player_season_ratings_football_iq_potential_range": {
+          "name": "player_season_ratings_football_iq_potential_range",
+          "value": "football_iq_potential BETWEEN 0 AND 100"
+        },
+        "player_season_ratings_decision_making_range": {
+          "name": "player_season_ratings_decision_making_range",
+          "value": "decision_making BETWEEN 0 AND 100"
+        },
+        "player_season_ratings_decision_making_potential_range": {
+          "name": "player_season_ratings_decision_making_potential_range",
+          "value": "decision_making_potential BETWEEN 0 AND 100"
+        },
+        "player_season_ratings_anticipation_range": {
+          "name": "player_season_ratings_anticipation_range",
+          "value": "anticipation BETWEEN 0 AND 100"
+        },
+        "player_season_ratings_anticipation_potential_range": {
+          "name": "player_season_ratings_anticipation_potential_range",
+          "value": "anticipation_potential BETWEEN 0 AND 100"
+        },
+        "player_season_ratings_composure_range": {
+          "name": "player_season_ratings_composure_range",
+          "value": "composure BETWEEN 0 AND 100"
+        },
+        "player_season_ratings_composure_potential_range": {
+          "name": "player_season_ratings_composure_potential_range",
+          "value": "composure_potential BETWEEN 0 AND 100"
+        },
+        "player_season_ratings_clutch_range": {
+          "name": "player_season_ratings_clutch_range",
+          "value": "clutch BETWEEN 0 AND 100"
+        },
+        "player_season_ratings_clutch_potential_range": {
+          "name": "player_season_ratings_clutch_potential_range",
+          "value": "clutch_potential BETWEEN 0 AND 100"
+        },
+        "player_season_ratings_consistency_range": {
+          "name": "player_season_ratings_consistency_range",
+          "value": "consistency BETWEEN 0 AND 100"
+        },
+        "player_season_ratings_consistency_potential_range": {
+          "name": "player_season_ratings_consistency_potential_range",
+          "value": "consistency_potential BETWEEN 0 AND 100"
+        },
+        "player_season_ratings_work_ethic_range": {
+          "name": "player_season_ratings_work_ethic_range",
+          "value": "work_ethic BETWEEN 0 AND 100"
+        },
+        "player_season_ratings_work_ethic_potential_range": {
+          "name": "player_season_ratings_work_ethic_potential_range",
+          "value": "work_ethic_potential BETWEEN 0 AND 100"
+        },
+        "player_season_ratings_coachability_range": {
+          "name": "player_season_ratings_coachability_range",
+          "value": "coachability BETWEEN 0 AND 100"
+        },
+        "player_season_ratings_coachability_potential_range": {
+          "name": "player_season_ratings_coachability_potential_range",
+          "value": "coachability_potential BETWEEN 0 AND 100"
+        },
+        "player_season_ratings_leadership_range": {
+          "name": "player_season_ratings_leadership_range",
+          "value": "leadership BETWEEN 0 AND 100"
+        },
+        "player_season_ratings_leadership_potential_range": {
+          "name": "player_season_ratings_leadership_potential_range",
+          "value": "leadership_potential BETWEEN 0 AND 100"
+        },
+        "player_season_ratings_greed_range": {
+          "name": "player_season_ratings_greed_range",
+          "value": "greed BETWEEN 0 AND 100"
+        },
+        "player_season_ratings_greed_potential_range": {
+          "name": "player_season_ratings_greed_potential_range",
+          "value": "greed_potential BETWEEN 0 AND 100"
+        },
+        "player_season_ratings_loyalty_range": {
+          "name": "player_season_ratings_loyalty_range",
+          "value": "loyalty BETWEEN 0 AND 100"
+        },
+        "player_season_ratings_loyalty_potential_range": {
+          "name": "player_season_ratings_loyalty_potential_range",
+          "value": "loyalty_potential BETWEEN 0 AND 100"
+        },
+        "player_season_ratings_ambition_range": {
+          "name": "player_season_ratings_ambition_range",
+          "value": "ambition BETWEEN 0 AND 100"
+        },
+        "player_season_ratings_ambition_potential_range": {
+          "name": "player_season_ratings_ambition_potential_range",
+          "value": "ambition_potential BETWEEN 0 AND 100"
+        },
+        "player_season_ratings_vanity_range": {
+          "name": "player_season_ratings_vanity_range",
+          "value": "vanity BETWEEN 0 AND 100"
+        },
+        "player_season_ratings_vanity_potential_range": {
+          "name": "player_season_ratings_vanity_potential_range",
+          "value": "vanity_potential BETWEEN 0 AND 100"
+        },
+        "player_season_ratings_scheme_attachment_range": {
+          "name": "player_season_ratings_scheme_attachment_range",
+          "value": "scheme_attachment BETWEEN 0 AND 100"
+        },
+        "player_season_ratings_scheme_attachment_potential_range": {
+          "name": "player_season_ratings_scheme_attachment_potential_range",
+          "value": "scheme_attachment_potential BETWEEN 0 AND 100"
+        },
+        "player_season_ratings_media_sensitivity_range": {
+          "name": "player_season_ratings_media_sensitivity_range",
+          "value": "media_sensitivity BETWEEN 0 AND 100"
+        },
+        "player_season_ratings_media_sensitivity_potential_range": {
+          "name": "player_season_ratings_media_sensitivity_potential_range",
+          "value": "media_sensitivity_potential BETWEEN 0 AND 100"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.player_season_stats": {
+      "name": "player_season_stats",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "player_id": {
+          "name": "player_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "season_year": {
+          "name": "season_year",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "playoffs": {
+          "name": "playoffs",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "games_played": {
+          "name": "games_played",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "games_started": {
+          "name": "games_started",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "stats": {
+          "name": "stats",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "player_season_stats_unique": {
+          "name": "player_season_stats_unique",
+          "columns": [
+            {
+              "expression": "player_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "season_year",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "playoffs",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "player_season_stats_player_id_players_id_fk": {
+          "name": "player_season_stats_player_id_players_id_fk",
+          "tableFrom": "player_season_stats",
+          "tableTo": "players",
+          "columnsFrom": [
+            "player_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "player_season_stats_team_id_teams_id_fk": {
+          "name": "player_season_stats_team_id_teams_id_fk",
+          "tableFrom": "player_season_stats",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.player_transactions": {
+      "name": "player_transactions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "player_id": {
+          "name": "player_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "counterparty_team_id": {
+          "name": "counterparty_team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trade_id": {
+          "name": "trade_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "counterparty_player_id": {
+          "name": "counterparty_player_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "player_transaction_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "season_year": {
+          "name": "season_year",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "detail": {
+          "name": "detail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "player_transactions_player_id_players_id_fk": {
+          "name": "player_transactions_player_id_players_id_fk",
+          "tableFrom": "player_transactions",
+          "tableTo": "players",
+          "columnsFrom": [
+            "player_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "player_transactions_team_id_teams_id_fk": {
+          "name": "player_transactions_team_id_teams_id_fk",
+          "tableFrom": "player_transactions",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "player_transactions_counterparty_team_id_teams_id_fk": {
+          "name": "player_transactions_counterparty_team_id_teams_id_fk",
+          "tableFrom": "player_transactions",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "counterparty_team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "player_transactions_counterparty_player_id_players_id_fk": {
+          "name": "player_transactions_counterparty_player_id_players_id_fk",
+          "tableFrom": "player_transactions",
+          "tableTo": "players",
+          "columnsFrom": [
+            "counterparty_player_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.players": {
+      "name": "players",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "league_id": {
+          "name": "league_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "player_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "jersey_number": {
+          "name": "jersey_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "injury_status": {
+          "name": "injury_status",
+          "type": "player_injury_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'healthy'"
+        },
+        "height_inches": {
+          "name": "height_inches",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "weight_pounds": {
+          "name": "weight_pounds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "college": {
+          "name": "college",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hometown": {
+          "name": "hometown",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "birth_date": {
+          "name": "birth_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "draft_year": {
+          "name": "draft_year",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "draft_round": {
+          "name": "draft_round",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "draft_pick": {
+          "name": "draft_pick",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "drafting_team_id": {
+          "name": "drafting_team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "players_prospect_idx": {
+          "name": "players_prospect_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"players\".\"status\" = 'prospect'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "players_league_id_leagues_id_fk": {
+          "name": "players_league_id_leagues_id_fk",
+          "tableFrom": "players",
+          "tableTo": "leagues",
+          "columnsFrom": [
+            "league_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "players_team_id_teams_id_fk": {
+          "name": "players_team_id_teams_id_fk",
+          "tableFrom": "players",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "players_drafting_team_id_teams_id_fk": {
+          "name": "players_drafting_team_id_teams_id_fk",
+          "tableFrom": "players",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "drafting_team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.scout_career_stops": {
+      "name": "scout_career_stops",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "scout_id": {
+          "name": "scout_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_name": {
+          "name": "org_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_year": {
+          "name": "start_year",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_year": {
+          "name": "end_year",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "coverage_notes": {
+          "name": "coverage_notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "scout_career_stops_scout_id_scouts_id_fk": {
+          "name": "scout_career_stops_scout_id_scouts_id_fk",
+          "tableFrom": "scout_career_stops",
+          "tableTo": "scouts",
+          "columnsFrom": [
+            "scout_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.scout_connections": {
+      "name": "scout_connections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "scout_id": {
+          "name": "scout_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "other_scout_id": {
+          "name": "other_scout_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "relation": {
+          "name": "relation",
+          "type": "scout_connection_relation",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "scout_connections_scout_id_scouts_id_fk": {
+          "name": "scout_connections_scout_id_scouts_id_fk",
+          "tableFrom": "scout_connections",
+          "tableTo": "scouts",
+          "columnsFrom": [
+            "scout_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "scout_connections_other_scout_id_scouts_id_fk": {
+          "name": "scout_connections_other_scout_id_scouts_id_fk",
+          "tableFrom": "scout_connections",
+          "tableTo": "scouts",
+          "columnsFrom": [
+            "other_scout_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.scout_cross_checks": {
+      "name": "scout_cross_checks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "evaluation_id": {
+          "name": "evaluation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "other_scout_id": {
+          "name": "other_scout_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "other_grade": {
+          "name": "other_grade",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "winner": {
+          "name": "winner",
+          "type": "scout_cross_check_winner",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "scout_cross_checks_evaluation_id_scout_evaluations_id_fk": {
+          "name": "scout_cross_checks_evaluation_id_scout_evaluations_id_fk",
+          "tableFrom": "scout_cross_checks",
+          "tableTo": "scout_evaluations",
+          "columnsFrom": [
+            "evaluation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "scout_cross_checks_other_scout_id_scouts_id_fk": {
+          "name": "scout_cross_checks_other_scout_id_scouts_id_fk",
+          "tableFrom": "scout_cross_checks",
+          "tableTo": "scouts",
+          "columnsFrom": [
+            "other_scout_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.scout_evaluations": {
+      "name": "scout_evaluations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "scout_id": {
+          "name": "scout_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prospect_id": {
+          "name": "prospect_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prospect_name": {
+          "name": "prospect_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "draft_year": {
+          "name": "draft_year",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position_group": {
+          "name": "position_group",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "round_tier": {
+          "name": "round_tier",
+          "type": "scout_round_tier",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "grade": {
+          "name": "grade",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "evaluation_level": {
+          "name": "evaluation_level",
+          "type": "scout_evaluation_level",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "outcome": {
+          "name": "outcome",
+          "type": "scout_evaluation_outcome",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'unknown'"
+        },
+        "outcome_detail": {
+          "name": "outcome_detail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "scout_evaluations_scout_id_scouts_id_fk": {
+          "name": "scout_evaluations_scout_id_scouts_id_fk",
+          "tableFrom": "scout_evaluations",
+          "tableTo": "scouts",
+          "columnsFrom": [
+            "scout_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "scout_evaluations_prospect_id_players_id_fk": {
+          "name": "scout_evaluations_prospect_id_players_id_fk",
+          "tableFrom": "scout_evaluations",
+          "tableTo": "players",
+          "columnsFrom": [
+            "prospect_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.scout_external_track_record": {
+      "name": "scout_external_track_record",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "scout_id": {
+          "name": "scout_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_name": {
+          "name": "org_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_year": {
+          "name": "start_year",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_year": {
+          "name": "end_year",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "noisy_hit_rate_label": {
+          "name": "noisy_hit_rate_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "scout_external_track_record_scout_id_scouts_id_fk": {
+          "name": "scout_external_track_record_scout_id_scouts_id_fk",
+          "tableFrom": "scout_external_track_record",
+          "tableTo": "scouts",
+          "columnsFrom": [
+            "scout_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.scout_reputation_labels": {
+      "name": "scout_reputation_labels",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "scout_id": {
+          "name": "scout_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "scout_reputation_labels_scout_id_scouts_id_fk": {
+          "name": "scout_reputation_labels_scout_id_scouts_id_fk",
+          "tableFrom": "scout_reputation_labels",
+          "tableTo": "scouts",
+          "columnsFrom": [
+            "scout_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.scouts": {
+      "name": "scouts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "league_id": {
+          "name": "league_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "scout_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'AREA_SCOUT'"
+        },
+        "reports_to_id": {
+          "name": "reports_to_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "coverage": {
+          "name": "coverage",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "age": {
+          "name": "age",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 40
+        },
+        "hired_at": {
+          "name": "hired_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "contract_years": {
+          "name": "contract_years",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "contract_salary": {
+          "name": "contract_salary",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "contract_buyout": {
+          "name": "contract_buyout",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "work_capacity": {
+          "name": "work_capacity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 100
+        },
+        "is_vacancy": {
+          "name": "is_vacancy",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "market_tier_pref": {
+          "name": "market_tier_pref",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "philosophy_fit_pref": {
+          "name": "philosophy_fit_pref",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "staff_fit_pref": {
+          "name": "staff_fit_pref",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "compensation_pref": {
+          "name": "compensation_pref",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "minimum_threshold": {
+          "name": "minimum_threshold",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "scouts_league_id_leagues_id_fk": {
+          "name": "scouts_league_id_leagues_id_fk",
+          "tableFrom": "scouts",
+          "tableTo": "leagues",
+          "columnsFrom": [
+            "league_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "scouts_team_id_teams_id_fk": {
+          "name": "scouts_team_id_teams_id_fk",
+          "tableFrom": "scouts",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "scouts_reports_to_id_scouts_id_fk": {
+          "name": "scouts_reports_to_id_scouts_id_fk",
+          "tableFrom": "scouts",
+          "tableTo": "scouts",
+          "columnsFrom": [
+            "reports_to_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.seasons": {
+      "name": "seasons",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "league_id": {
+          "name": "league_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "year": {
+          "name": "year",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "phase": {
+          "name": "phase",
+          "type": "season_phase",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'preseason'"
+        },
+        "offseason_stage": {
+          "name": "offseason_stage",
+          "type": "offseason_stage",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "week": {
+          "name": "week",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "seasons_league_id_leagues_id_fk": {
+          "name": "seasons_league_id_leagues_id_fk",
+          "tableFrom": "seasons",
+          "tableTo": "leagues",
+          "columnsFrom": [
+            "league_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "sessions_token_unique": {
+          "name": "sessions_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.states": {
+      "name": "states",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "region": {
+          "name": "region",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "states_code_unique": {
+          "name": "states_code_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "code"
+          ]
+        },
+        "states_name_unique": {
+          "name": "states_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.teams": {
+      "name": "teams",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "league_id": {
+          "name": "league_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "franchise_id": {
+          "name": "franchise_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "city_id": {
+          "name": "city_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "abbreviation": {
+          "name": "abbreviation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "primary_color": {
+          "name": "primary_color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "secondary_color": {
+          "name": "secondary_color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "accent_color": {
+          "name": "accent_color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "backstory": {
+          "name": "backstory",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "conference": {
+          "name": "conference",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "division": {
+          "name": "division",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "teams_league_id_leagues_id_fk": {
+          "name": "teams_league_id_leagues_id_fk",
+          "tableFrom": "teams",
+          "tableTo": "leagues",
+          "columnsFrom": [
+            "league_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "teams_franchise_id_franchises_id_fk": {
+          "name": "teams_franchise_id_franchises_id_fk",
+          "tableFrom": "teams",
+          "tableTo": "franchises",
+          "columnsFrom": [
+            "franchise_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "teams_city_id_cities_id_fk": {
+          "name": "teams_city_id_cities_id_fk",
+          "tableFrom": "teams",
+          "tableTo": "cities",
+          "columnsFrom": [
+            "city_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "teams_league_id_franchise_id_unique": {
+          "name": "teams_league_id_franchise_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "league_id",
+            "franchise_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verifications": {
+      "name": "verifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.coach_accolade_type": {
+      "name": "coach_accolade_type",
+      "schema": "public",
+      "values": [
+        "coy_vote",
+        "championship",
+        "position_pro_bowl",
+        "other"
+      ]
+    },
+    "public.advance_policy": {
+      "name": "advance_policy",
+      "schema": "public",
+      "values": [
+        "commissioner",
+        "ready_check"
+      ]
+    },
+    "public.coach_play_caller": {
+      "name": "coach_play_caller",
+      "schema": "public",
+      "values": [
+        "offense",
+        "defense",
+        "ceo"
+      ]
+    },
+    "public.coach_role": {
+      "name": "coach_role",
+      "schema": "public",
+      "values": [
+        "HC",
+        "OC",
+        "DC",
+        "STC",
+        "QB",
+        "RB",
+        "WR",
+        "TE",
+        "OL",
+        "DL",
+        "LB",
+        "DB",
+        "ST_ASSISTANT"
+      ]
+    },
+    "public.coach_specialty": {
+      "name": "coach_specialty",
+      "schema": "public",
+      "values": [
+        "offense",
+        "defense",
+        "special_teams",
+        "quarterbacks",
+        "running_backs",
+        "wide_receivers",
+        "tight_ends",
+        "offensive_line",
+        "defensive_line",
+        "linebackers",
+        "defensive_backs",
+        "ceo"
+      ]
+    },
+    "public.coach_connection_relation": {
+      "name": "coach_connection_relation",
+      "schema": "public",
+      "values": [
+        "mentor",
+        "mentee",
+        "peer"
+      ]
+    },
+    "public.contract_bonus_source": {
+      "name": "contract_bonus_source",
+      "schema": "public",
+      "values": [
+        "signing",
+        "restructure",
+        "option"
+      ]
+    },
+    "public.contract_guarantee_type": {
+      "name": "contract_guarantee_type",
+      "schema": "public",
+      "values": [
+        "full",
+        "injury",
+        "none"
+      ]
+    },
+    "public.contract_tag_type": {
+      "name": "contract_tag_type",
+      "schema": "public",
+      "values": [
+        "franchise",
+        "transition"
+      ]
+    },
+    "public.contract_termination_reason": {
+      "name": "contract_termination_reason",
+      "schema": "public",
+      "values": [
+        "active",
+        "expired",
+        "released",
+        "traded",
+        "extended",
+        "restructured"
+      ]
+    },
+    "public.contract_type": {
+      "name": "contract_type",
+      "schema": "public",
+      "values": [
+        "rookie_scale",
+        "veteran",
+        "extension",
+        "franchise_tag",
+        "restructure"
+      ]
+    },
+    "public.hiring_interest_status": {
+      "name": "hiring_interest_status",
+      "schema": "public",
+      "values": [
+        "active",
+        "withdrawn"
+      ]
+    },
+    "public.hiring_interview_status": {
+      "name": "hiring_interview_status",
+      "schema": "public",
+      "values": [
+        "requested",
+        "accepted",
+        "declined",
+        "completed"
+      ]
+    },
+    "public.hiring_offer_status": {
+      "name": "hiring_offer_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "accepted",
+        "rejected",
+        "expired"
+      ]
+    },
+    "public.league_phase": {
+      "name": "league_phase",
+      "schema": "public",
+      "values": [
+        "genesis_staff_hiring",
+        "genesis_founding_pool",
+        "genesis_draft_scouting",
+        "genesis_allocation_draft",
+        "genesis_free_agency",
+        "genesis_kickoff",
+        "offseason_review",
+        "coaching_carousel",
+        "tag_window",
+        "restricted_fa",
+        "legal_tampering",
+        "free_agency",
+        "pre_draft",
+        "draft",
+        "udfa",
+        "offseason_program",
+        "preseason",
+        "regular_season",
+        "playoffs",
+        "offseason_rollover"
+      ]
+    },
+    "public.offseason_stage": {
+      "name": "offseason_stage",
+      "schema": "public",
+      "values": [
+        "awards_and_review",
+        "coaching_carousel",
+        "combine",
+        "free_agency",
+        "draft",
+        "udfa_signing",
+        "minicamp"
+      ]
+    },
+    "public.player_accolade_type": {
+      "name": "player_accolade_type",
+      "schema": "public",
+      "values": [
+        "pro_bowl",
+        "all_pro_first",
+        "all_pro_second",
+        "championship",
+        "mvp",
+        "offensive_player_of_the_year",
+        "defensive_player_of_the_year",
+        "offensive_rookie_of_the_year",
+        "defensive_rookie_of_the_year",
+        "comeback_player_of_the_year",
+        "statistical_milestone",
+        "other"
+      ]
+    },
+    "public.coach_player_dev_delta": {
+      "name": "coach_player_dev_delta",
+      "schema": "public",
+      "values": [
+        "improved",
+        "stagnated",
+        "regressed"
+      ]
+    },
+    "public.player_injury_status": {
+      "name": "player_injury_status",
+      "schema": "public",
+      "values": [
+        "healthy",
+        "questionable",
+        "doubtful",
+        "out",
+        "ir",
+        "pup"
+      ]
+    },
+    "public.player_status": {
+      "name": "player_status",
+      "schema": "public",
+      "values": [
+        "prospect",
+        "active",
+        "retired"
+      ]
+    },
+    "public.player_transaction_type": {
+      "name": "player_transaction_type",
+      "schema": "public",
+      "values": [
+        "drafted",
+        "signed",
+        "released",
+        "traded",
+        "extended",
+        "franchise_tagged",
+        "claimed_on_waivers",
+        "placed_on_ir",
+        "activated",
+        "suspended",
+        "retired"
+      ]
+    },
+    "public.scout_connection_relation": {
+      "name": "scout_connection_relation",
+      "schema": "public",
+      "values": [
+        "worked_under",
+        "peer",
+        "mentee"
+      ]
+    },
+    "public.scout_cross_check_winner": {
+      "name": "scout_cross_check_winner",
+      "schema": "public",
+      "values": [
+        "this",
+        "other",
+        "tie",
+        "pending"
+      ]
+    },
+    "public.scout_evaluation_level": {
+      "name": "scout_evaluation_level",
+      "schema": "public",
+      "values": [
+        "quick",
+        "standard",
+        "deep"
+      ]
+    },
+    "public.scout_evaluation_outcome": {
+      "name": "scout_evaluation_outcome",
+      "schema": "public",
+      "values": [
+        "starter",
+        "contributor",
+        "bust",
+        "unknown"
+      ]
+    },
+    "public.scout_role": {
+      "name": "scout_role",
+      "schema": "public",
+      "values": [
+        "DIRECTOR",
+        "NATIONAL_CROSS_CHECKER",
+        "AREA_SCOUT"
+      ]
+    },
+    "public.scout_round_tier": {
+      "name": "scout_round_tier",
+      "schema": "public",
+      "values": [
+        "1-3",
+        "4-5",
+        "6-7",
+        "UDFA"
+      ]
+    },
+    "public.season_phase": {
+      "name": "season_phase",
+      "schema": "public",
+      "values": [
+        "preseason",
+        "regular_season",
+        "playoffs",
+        "offseason"
+      ]
+    },
+    "public.staff_type": {
+      "name": "staff_type",
+      "schema": "public",
+      "values": [
+        "coach",
+        "scout"
+      ]
+    },
+    "public.step_kind": {
+      "name": "step_kind",
+      "schema": "public",
+      "values": [
+        "event",
+        "week",
+        "window"
+      ]
+    },
+    "public.coach_tenure_unit_side": {
+      "name": "coach_tenure_unit_side",
+      "schema": "public",
+      "values": [
+        "offense",
+        "defense",
+        "special_teams"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/server/db/migrations/meta/_journal.json
+++ b/server/db/migrations/meta/_journal.json
@@ -309,6 +309,13 @@
       "when": 1776556800006,
       "tag": "0043_hiring_schema_foundation",
       "breakpoints": true
+    },
+    {
+      "idx": 44,
+      "version": "7",
+      "when": 1776556800007,
+      "tag": "0044_loud_gravity",
+      "breakpoints": true
     }
   ]
 }

--- a/server/features/league-clock/default-phase-steps.test.ts
+++ b/server/features/league-clock/default-phase-steps.test.ts
@@ -1,7 +1,11 @@
 import { assertEquals } from "@std/assert";
 import { DEFAULT_PHASE_STEPS } from "./default-phase-steps.ts";
 
-const ALL_PHASES = [
+// genesis_draft_scouting is intentionally excluded from step-seeding
+// expectations in this test: ADR 0034 accepts the phase and enum value, but
+// the four-step catalog (scouting_pool_reveal, scouting_first_reports,
+// scouting_deep_eval, scouting_board_lock) is seeded in a follow-up ticket.
+const ALL_PHASES_WITH_STEPS = [
   "genesis_staff_hiring",
   "genesis_founding_pool",
   "genesis_allocation_draft",
@@ -23,9 +27,9 @@ const ALL_PHASES = [
   "offseason_rollover",
 ] as const;
 
-Deno.test("every phase has at least one step", () => {
+Deno.test("every seeded phase has at least one step", () => {
   const phasesWithSteps = new Set(DEFAULT_PHASE_STEPS.map((s) => s.phase));
-  for (const phase of ALL_PHASES) {
+  for (const phase of ALL_PHASES_WITH_STEPS) {
     assertEquals(
       phasesWithSteps.has(phase),
       true,
@@ -182,7 +186,9 @@ Deno.test("all steps have non-empty slugs", () => {
   }
 });
 
-Deno.test("each genesis phase has at least one step", () => {
+Deno.test("each seeded genesis phase has at least one step", () => {
+  // genesis_draft_scouting is defined in the enum (ADR 0034) but its step
+  // catalog is seeded in a follow-up ticket, so it is not yet required here.
   const genesisPhases = [
     "genesis_staff_hiring",
     "genesis_founding_pool",

--- a/server/features/league-clock/league-clock.schema.test.ts
+++ b/server/features/league-clock/league-clock.schema.test.ts
@@ -10,6 +10,7 @@ import {
 const EXPECTED_PHASES = [
   "genesis_staff_hiring",
   "genesis_founding_pool",
+  "genesis_draft_scouting",
   "genesis_allocation_draft",
   "genesis_free_agency",
   "genesis_kickoff",
@@ -31,9 +32,21 @@ const EXPECTED_PHASES = [
 
 const EXPECTED_STEP_KINDS = ["event", "week", "window"] as const;
 
-Deno.test("leaguePhaseEnum has all 19 phases in deterministic order", () => {
+Deno.test("leaguePhaseEnum has all 20 phases in deterministic order", () => {
   assertEquals(leaguePhaseEnum.enumValues, [...EXPECTED_PHASES]);
 });
+
+Deno.test(
+  "genesis_draft_scouting sits between genesis_founding_pool and genesis_allocation_draft (ADR 0034)",
+  () => {
+    const phases = leaguePhaseEnum.enumValues;
+    const foundingPoolIndex = phases.indexOf("genesis_founding_pool");
+    const draftScoutingIndex = phases.indexOf("genesis_draft_scouting");
+    const allocationDraftIndex = phases.indexOf("genesis_allocation_draft");
+    assertEquals(draftScoutingIndex, foundingPoolIndex + 1);
+    assertEquals(allocationDraftIndex, draftScoutingIndex + 1);
+  },
+);
 
 Deno.test("genesis phases are ordered before offseason_review", () => {
   const phases = leaguePhaseEnum.enumValues;

--- a/server/features/league-clock/league-clock.schema.ts
+++ b/server/features/league-clock/league-clock.schema.ts
@@ -16,6 +16,7 @@ import { teams } from "../team/team.schema.ts";
 export const leaguePhaseEnum = pgEnum("league_phase", [
   "genesis_staff_hiring",
   "genesis_founding_pool",
+  "genesis_draft_scouting",
   "genesis_allocation_draft",
   "genesis_free_agency",
   "genesis_kickoff",


### PR DESCRIPTION
## Summary

- Adds `genesis_draft_scouting` to `leaguePhaseEnum` (server) and `LEAGUE_PHASES` (client) in the ordinal slot between `genesis_founding_pool` and `genesis_allocation_draft`, per ADR 0034.
- Generates Drizzle migration `0044_loud_gravity.sql` that `ALTER`s the Postgres `league_phase` enum with a `BEFORE 'genesis_allocation_draft'` clause to preserve the ordinal.
- Locks in the ordering with explicit server + client tests; updates existing step-catalog tests to exempt the new phase, since the four-step seeding is a follow-up ticket (#452).

Closes #451