### PR TITLE
docs(scouting): propose ADRs 0035-0039 for draft-scouting phase follow-ups

### DIFF
--- a/docs/product/decisions/0035-scouting-advocacy-dissent-event-model.md
+++ b/docs/product/decisions/0035-scouting-advocacy-dissent-event-model.md
@@ -1,0 +1,130 @@
+# 0035 — Scouting advocacy and dissent event model
+
+- **Date:** 2026-04-16
+- **Status:** Proposed
+- **Area:** [Scouting](../north-star/scouting.md),
+  [0034 — Genesis draft scouting phase](./0034-genesis-draft-scouting-phase.md)
+
+## Context
+
+ADR 0034 established the `GENESIS_DRAFT_SCOUTING` phase and named "advocacy and
+dissent between scouts" as the core gameplay loop — but deferred the event model
+itself. The scouting north-star describes reports landing in the GM's inbox,
+scouts championing "their guys," cross-checkers pushing back, and media mocks
+landing in the middle of the phase; all of these beats need a uniform data shape
+so the inbox UI, the draft board decision log (0037), the director's consensus
+(0038), and retrospective tools can consume the same primitives.
+
+Without a shared event model, each surface will invent its own structure. Worse,
+dissent loses its linkage to the report it dissents from, and the decision log
+can't reference the moment that motivated a tier change.
+
+## Decision
+
+Model every scouting occurrence during the phase as an immutable row in a single
+`scouting_events` log with a typed `event_kind` discriminator and a polymorphic
+payload. The GM inbox, the decision log, and the director's consensus are all
+projections over this log.
+
+### Event kinds
+
+Seven kinds cover the phase's activity:
+
+1. **`report_published`** — A scout published a report at a depth level
+   (`quick_look`, `standard`, `deep`). Payload: grade vector, confidence,
+   strength/weakness tags, flavor text.
+2. **`advocacy`** — A scout explicitly champions a prospect above their own
+   grade ("I don't care what the tape says, I've been in his living room").
+   Emitted autonomously by scouts with high conviction traits.
+3. **`dissent`** — A scout pushes back against another scout's grade. Requires
+   `target_event_id` referencing the report being contested.
+4. **`cross_check_requested`** — The GM requested a second opinion on a prospect
+   (spending an allowance from ADR 0036).
+5. **`cross_check_resolved`** — A cross-checker published their second opinion.
+   References the originating `cross_check_requested` event.
+6. **`media_mock_published`** — A media analyst published a mock draft. Payload
+   is the full first-round projection.
+7. **`director_consensus_update`** — The director's consensus board shifted (new
+   tier placement, new rank). Payload is the delta, not the full board.
+
+### Authority rules
+
+- Scouts emit `report_published`, `advocacy`, `dissent`, and (as cross-checkers)
+  `cross_check_resolved` **autonomously**, driven by their hidden attributes.
+  The GM cannot generate these events.
+- The GM emits only `cross_check_requested`.
+- Media and the director emit their own kinds on the phase's internal clock.
+- All events carry a `scout_id` (or `analyst_id` / `director_id`) so authorship
+  is explicit and auditable.
+
+### GM responses are a separate surface
+
+The GM does not mutate events. Instead, the GM's reactions live in a companion
+`scouting_event_responses` table: `(event_id, response,
+created_at)` where
+`response` is one of `acknowledge`, `agree`, `disagree`, `defer`. Responses feed
+the draft board's decision log (ADR 0037) — when the GM moves a prospect up a
+tier in response to a piece of advocacy, the decision-log entry carries the
+`event_id` so the "why" is preserved.
+
+### Append-only, even for corrections
+
+Scouts changing their minds produce **new** events (a second `report_
+published`
+or a self-dissent), not mutations of prior ones. The log is a historical record;
+later retrospective tools depend on being able to reconstruct what was known
+when.
+
+### NPC behavior
+
+NPC franchises auto-acknowledge all events addressed to them and rely on their
+director's consensus board at lock time. NPC scouts still emit advocacy and
+dissent — the events are generated league-wide regardless of which franchise
+employs the scout. (Full NPC scouting behavior is its own downstream ADR.)
+
+## Alternatives considered
+
+- **Single flat "opinion" table with booleans.** One table with `is_dissent`,
+  `is_advocacy` flags. Rejected: can't cleanly express `target_event_id` for
+  dissent, doesn't accommodate media mocks or director updates, and every new
+  event type forces a schema change.
+- **Embed advocacy/dissent as JSON arrays on the report row.** Rejected: events
+  can't be queried independently; media mocks and director consensus updates
+  don't belong on a report; retrospective tools can't diff the event stream over
+  time.
+- **Skip dissent entirely; only report grades.** Rejected — dissent is the most
+  distinctive beat of the phase and is load-bearing for the "judgment call on
+  the people you hired" feel ADR 0034 commits to.
+- **Event sourcing with projection tables rebuilt from the log on every read.**
+  Rejected as overkill for v1. The log is append-only and the inbox is a simple
+  filter over it; projections can be added later if performance demands.
+
+## Consequences
+
+- **One event log drives multiple surfaces.** The inbox, the decision log, the
+  director's consensus, the mock-draft history, and the post-draft retrospective
+  tools all read from `scouting_events`. No per-surface denormalization.
+- **Scout attributes have a direct observable effect.** Advocacy and dissent
+  emission rates, conviction levels, and cross-check agreement patterns all flow
+  from hidden scout attributes — the Phase 3 hiring decisions from ADR 0032 now
+  produce visible, measurable output.
+- **Log is append-only.** Amendments are new events. This simplifies concurrency
+  (no row-level locks on opinions), produces a clean audit trail, and matches
+  how real scouting departments operate.
+- **Enables NPC behavior and flavor text.** Downstream ADRs (NPC scouting AI,
+  ADR 0039 flavor text) consume the same event stream without special- casing.
+- **Follow-up work:**
+  - Define the per-kind payload schemas and a migration for `scouting_events`
+    and `scouting_event_responses`.
+  - Wire advocacy and dissent emission to the phase step-advance hook so events
+    land at the right weekly beat.
+  - Implement the inbox projection and the GM response action surface.
+  - Draft the NPC scouting behavior ADR (how NPC scouts choose when to advocate
+    and dissent based on hidden attributes).
+
+## Related decisions
+
+- [0014 — Season calendar and phase state machine](./0014-season-calendar-phase-state-machine.md)
+- [0018 — Genesis phase state machine](./0018-genesis-phase-state-machine.md)
+- [0032 — Multi-week staff hiring process](./0032-multi-week-staff-hiring.md)
+- [0034 — Genesis draft scouting phase](./0034-genesis-draft-scouting-phase.md)

--- a/docs/product/decisions/0036-league-wide-scouting-allowances.md
+++ b/docs/product/decisions/0036-league-wide-scouting-allowances.md
@@ -1,0 +1,130 @@
+# 0036 — League-wide scouting allowances
+
+- **Date:** 2026-04-16
+- **Status:** Proposed
+- **Area:** [Scouting](../north-star/scouting.md),
+  [0034 — Genesis draft scouting phase](./0034-genesis-draft-scouting-phase.md),
+  [0035 — Scouting advocacy and dissent event model](./0035-scouting-advocacy-dissent-event-model.md)
+
+## Context
+
+ADR 0034 commits to pre-draft visits, private workouts, and cross-check requests
+being available to the GM during the scouting phase but leaves exact caps and
+tuning to a follow-up ADR. ADR 0034 also commits to a strict competitive-parity
+principle: every franchise gets the same structural resources; differentiation
+comes from _who_ was hired in Phase 3, not from how much the GM can afford to
+spend.
+
+Without pinned numbers, NPC behavior, UI builders, and the allowance-spend UX
+all stall. And without an explicit league-wide policy, there is no natural place
+in the schema to store per-franchise counters that UI surfaces can read.
+
+## Decision
+
+Define three pre-draft allowances, **identical for every franchise in a given
+league**, with defaults chosen to mirror real NFL practice. All three are league
+settings — their defaults are hard-coded but their values are overridable at
+league creation, with the constraint that the override applies uniformly to
+every franchise.
+
+### The three allowances
+
+| Allowance            | Default cap per franchise | Available from |
+| -------------------- | ------------------------- | -------------- |
+| Pre-draft visits     | 30                        | Week 2 onward  |
+| Private workouts     | 10                        | Week 2 onward  |
+| Cross-check requests | 15                        | Week 2 onward  |
+
+The **30 visits** default mirrors the NFL's "top-30 visits" rule. The **10
+workouts** and **15 cross-checks** defaults are tuned to the phase length (4
+weeks) and pool size (founding pool) to force prioritization without starving
+the GM. All caps are per-phase totals; unused allowances do not roll forward
+into any future phase.
+
+### Caps are per franchise, not per scout
+
+More scouts do not give you more visits. Better scouts do not give you more
+cross-checks. What scout quality affects is the **signal density** of each
+allowance's output — a better area scout extracts more from a visit; a better
+cross-checker produces a more informative second opinion. The allowance count is
+structural; the allowance value is earned through hiring.
+
+This is load-bearing for ADR 0034's competitive-parity principle: a rich
+franchise cannot buy more visits, and a cheap franchise is not starved of them.
+
+### Cross-check fulfillment
+
+A cross-check request targets a specific prospect and routes through the
+scouting director. The director assigns an available cross-checker from the
+franchise's staff. If the franchise has **no cross-checker on payroll**, the
+request is "parked" with an explicit GM-visible blocker: "No cross-checker on
+staff to fulfill this request." The request consumes no allowance until it
+resolves. This is an observable consequence of under-hiring the scouting
+department during Phase 3.
+
+Resolved cross-checks emit a `cross_check_resolved` event (per ADR 0035) 2–5
+simulated days after the request.
+
+### Scheduling granularity
+
+Visits and workouts consume a simulated-day slot on the phase's internal 4-week
+× 7-day micro-calendar. Multiple allowances can fit into one simulated day,
+subject to a small per-day cap (3 visits or 1 workout) that reflects real travel
+constraints. Each prospect can be visited at most once and worked out at most
+once by any given franchise.
+
+### NPC consumption
+
+NPC franchises spend their allowances as part of their scouting AI (downstream
+ADR). The caps apply to NPCs identically — the NPC AI does not get a hidden
+boost.
+
+## Alternatives considered
+
+- **GM can purchase additional allowances with budget.** Rejected: explicitly
+  violates the competitive-parity principle from ADR 0034. "Outspending" has no
+  path to a scouting advantage.
+- **Variable per-franchise caps based on franchise reputation or market size.**
+  Rejected: reputation is a mature-league concept with no baseline in genesis,
+  and introducing a variable cap now contradicts the structural parity the
+  genesis phase commits to.
+- **Unlimited allowances.** Rejected: scarcity of scouting attention is exactly
+  the tradeoff that makes the phase interesting. Unlimited allowances collapse
+  the strategic decision of _which_ prospects deserve a visit.
+- **Per-scout allowances (each scout gets N visits).** Rejected: creates
+  bookkeeping burden without corresponding strategic depth. The GM operates at
+  the franchise level; internal scout-to-prospect assignment is not a GM
+  decision (per ADR 0034).
+- **Roll over unused allowances to the allocation draft phase.** Rejected: no
+  mechanism in the draft phase consumes them, and rollover invites hoarding that
+  empties the scouting phase of activity.
+
+## Consequences
+
+- **Parity is enforced at the data layer.** A single
+  `league_scouting_allowances` settings row per league, plus per-franchise
+  counters on `franchise_scouting_state`, make it impossible for any franchise
+  to exceed the cap.
+- **Allowance UI is simple.** Three counters, a scheduling micro-calendar, and a
+  "no cross-checker on staff" blocker when applicable. No pricing, no budget
+  field.
+- **Hiring decisions in Phase 3 pay off here.** Cross-checker quality,
+  area-scout-to-prospect fit, and director quality all shape the _value_ of each
+  allowance. The allowance count is fixed; the payoff is not.
+- **Caps are tunable league-wide but not per-franchise.** Post-MVP, a league
+  creator can loosen or tighten caps to suit league philosophy; the parity
+  constraint is preserved because every franchise sees the same new cap.
+- **Follow-up work:**
+  - Add `league_scouting_allowances` with the three cap columns and sane
+    defaults.
+  - Add `franchise_scouting_state` with per-phase counters.
+  - Add `scouting_visits`, `scouting_workouts`, `cross_check_requests` tables
+    keyed by franchise + prospect + simulated-day slot.
+  - Wire the cross-check director routing logic (including the "no cross-checker
+    on staff" blocker).
+  - Surface the allowance counters in the scouting phase UI.
+
+## Related decisions
+
+- [0034 — Genesis draft scouting phase](./0034-genesis-draft-scouting-phase.md)
+- [0035 — Scouting advocacy and dissent event model](./0035-scouting-advocacy-dissent-event-model.md)

--- a/docs/product/decisions/0037-draft-board-data-model.md
+++ b/docs/product/decisions/0037-draft-board-data-model.md
@@ -1,0 +1,151 @@
+# 0037 — Draft board data model
+
+- **Date:** 2026-04-16
+- **Status:** Proposed
+- **Area:** [Scouting](../north-star/scouting.md),
+  [Drafting](../north-star/drafting.md),
+  [0034 — Genesis draft scouting phase](./0034-genesis-draft-scouting-phase.md),
+  [0035 — Scouting advocacy and dissent event model](./0035-scouting-advocacy-dissent-event-model.md)
+
+## Context
+
+ADR 0034 gates `scouting_board_lock` on "the franchise has submitted a ranked
+draft board." ADR 0035 emits a stream of scouting events the GM has been
+reacting to across the four-week phase. The allocation draft phase (ADR 0024)
+expects a locked board to exist when it begins. None of these commitments is
+executable without a data model for the board itself — how entries are ranked,
+how tiers are expressed, how GM notes attach, and how the "why" of each
+placement links back to the events that motivated it.
+
+A flat ranked list would technically satisfy the gate but would miss two things
+the scouting north-star calls load-bearing: tier groupings (which are how real
+GMs actually think about draft boards — boundaries matter more than exact
+ranking within a tier) and a decision log (which is the connective tissue
+between the scouting phase and the post-draft retrospective tools).
+
+## Decision
+
+Introduce four tables that together model the franchise's draft board, scoped to
+a specific draft (`draft_id`):
+
+### `draft_boards`
+
+One row per franchise per draft. Fields: `franchise_id`, `draft_id`, `source`
+(`'gm'` or `'director_consensus'`), `locked_at` (nullable),
+`inherited_from_consensus_at` (nullable — set when an unedited board is
+auto-seeded from the director at lock time).
+
+### `draft_board_tiers`
+
+Ordered list of tiers per board. Fields: `board_id`, `sort_order`, `label`
+(e.g., "Round 1 talent", "Developmental", "Avoid"). Tiers are free-form within a
+board — a GM can have 3 tiers or 12. The director's consensus board seeds a
+default tier layout that the GM can restructure.
+
+### `draft_board_entries`
+
+One row per prospect placed on the board. Fields: `board_id`, `tier_id`,
+`rank_within_tier` (explicit integer; no implicit ordering), `prospect_id`.
+Every prospect in the founding pool must appear on every franchise's board by
+the `scouting_board_lock` step — the gate validates exhaustive coverage, not
+just non-emptiness.
+
+### `draft_board_decisions`
+
+Append-only log of every mutation to the board. Fields: `board_id`, `action`
+(`'place'`, `'move'`, `'remove'`, `'tier_rename'`, `'tier_add'`,
+`'tier_remove'`, `'note_edit'`), `from_tier_id` / `to_tier_id` (nullable),
+`from_rank` / `to_rank` (nullable), `prospect_id` (nullable), `reason_event_id`
+(nullable, references `scouting_events` from ADR 0035), `note` (optional GM free
+text), `created_at`.
+
+The `reason_event_id` is the critical link: when the GM moves a prospect up a
+tier after a piece of advocacy lands in the inbox, the decision log captures
+which event motivated the move. This is what makes retrospective review possible
+in years 2+ ("I bumped him up because my ACC scout advocated — was that signal
+worth trusting?").
+
+### Notes
+
+GM free-text notes attach to entries via an optional `note` column on
+`draft_board_entries` (single latest note) and a full history via
+`action = 'note_edit'` decision-log entries. This keeps the hot path (rendering
+the board) simple while preserving history.
+
+### Lock semantics
+
+"Lock" is an explicit GM action that sets `locked_at`. A board cannot be locked
+if any founding-pool prospect is missing from it (gate rejects with a list of
+unplaced prospects). After lock:
+
+- Tiers and entries are frozen.
+- The decision log accepts no further entries.
+- The allocation draft phase reads entries sorted by
+  `(sort_order,
+  rank_within_tier)` to drive the pick queue.
+
+### Consensus pre-seed
+
+A GM who never touches their own board inherits the director's consensus board
+at Week 4 end via an atomic copy — a new `draft_boards` row with
+`source = 'gm'`, `inherited_from_consensus_at = now()`, tiers and entries
+duplicated from the consensus. This preserves per-franchise isolation (the
+director's consensus is shared reference data; the GM's board is their own). NPC
+franchises always use the same inheritance path at lock.
+
+### Invariants
+
+- Every prospect in the founding pool appears on every franchise's board exactly
+  once by lock time.
+- A prospect cannot appear in more than one tier on the same board.
+- `rank_within_tier` is unique per `(board_id, tier_id)`.
+- Decision-log entries are append-only; no updates, no deletes.
+
+## Alternatives considered
+
+- **Flat ranked list (no tiers).** A single `board_id`, `prospect_id`, `rank`
+  table. Simpler schema. Rejected: collapses the tier boundary semantics that
+  real NFL front offices rely on and that the scouting north-star references
+  throughout. Exact within-tier ordering is lower- signal than tier placement,
+  and conflating them makes the board less expressive.
+- **No decision log.** Retrospective tools compute "why" from timestamp
+  proximity between scouting events and board changes. Rejected: the heuristic
+  is fragile (events cluster, multi-prospect moves ambiguous) and the
+  retrospective tools — a core value driver from the scouting north-star — would
+  be guessing where they should be reading.
+- **Board is a derived projection over events.** Events like
+  `gm_placed_prospect` produce the board on read. Rejected: the GM's ranking is
+  a first-class authored artifact, not a reaction log. Mixing
+  derived-from-events with authored-by-GM blurs authorship in ways that make the
+  decision log harder to reason about.
+- **Shared board table across all drafts (current + future).** Skip the
+  `draft_id` scope. Rejected: multi-draft leagues (Year 2+) need clean
+  isolation; scoping to `draft_id` from day one avoids a migration later.
+
+## Consequences
+
+- **Allocation draft has a stable input contract.** ADR 0024's pick logic reads
+  locked boards via a single projection, with a clean fallback path for
+  franchises that inherited consensus.
+- **Retrospective tools have data to work with.** The decision log is the
+  substrate for the "draft class report card" and the scout-accuracy meta-game
+  the north-star describes. Without it, those tools cannot distinguish a pick
+  driven by scout advocacy from a pick driven by GM hunch.
+- **Director's consensus (ADR 0038) has a write target.** Consensus updates
+  write to the same tables, marked `source = 'director_consensus'`. Humans and
+  the director share one schema.
+- **Board operations are durable and auditable.** Append-only decisions mean the
+  board history survives forever — a multi-year league can see how a GM's board
+  philosophy evolved.
+- **Follow-up work:**
+  - Drizzle schema for the four tables; indexes on `(board_id, tier_id)` and
+    `(board_id, prospect_id)`.
+  - Board-lock gate function used by ADR 0034's `scouting_board_lock` step.
+  - Consensus inheritance action (copy-on-lock for unedited boards).
+  - Allocation-draft reader that serializes a locked board into a pick queue.
+
+## Related decisions
+
+- [0024 — Allocation draft as Year 1's only draft](./0024-allocation-draft-as-year-one-only-draft.md)
+- [0034 — Genesis draft scouting phase](./0034-genesis-draft-scouting-phase.md)
+- [0035 — Scouting advocacy and dissent event model](./0035-scouting-advocacy-dissent-event-model.md)

--- a/docs/product/decisions/0038-scouting-director-consensus-logic.md
+++ b/docs/product/decisions/0038-scouting-director-consensus-logic.md
@@ -1,0 +1,153 @@
+# 0038 — Scouting director consensus logic
+
+- **Date:** 2026-04-16
+- **Status:** Proposed
+- **Area:** [Scouting](../north-star/scouting.md),
+  [0034 — Genesis draft scouting phase](./0034-genesis-draft-scouting-phase.md),
+  [0035 — Scouting advocacy and dissent event model](./0035-scouting-advocacy-dissent-event-model.md),
+  [0037 — Draft board data model](./0037-draft-board-data-model.md)
+
+## Context
+
+ADR 0034 commits to a "director's consensus board" presented at Week 4: NPC
+franchises adopt it wholesale, and human franchises who never touched their own
+board inherit it at lock. ADR 0037 defines the board shape the consensus writes
+into. ADR 0035 defines the `director_consensus_update` event kind. What none of
+these ADRs pin is _how_ the director actually aggregates scout reports into a
+consensus ranking — the algorithm whose quality varies with the director's
+hidden attributes.
+
+Without a defined aggregation model, the director role becomes decorative — a
+box to check in Phase 3 hiring with no observable downstream consequence. The
+scouting north-star explicitly positions the director as "your top evaluator and
+the person who synthesizes reports from the full staff," and ADR 0032's entire
+case for a multi-week hiring process assumes those hires pay off in ways the
+player can feel.
+
+## Decision
+
+The director's consensus is a **weighted aggregation of scout grades**,
+re-computed incrementally whenever a new `report_published` event lands, and
+emitted as a `director_consensus_update` event (from ADR 0035) when the delta
+meaningfully changes tier placement or rank.
+
+The director's hidden attributes drive three aggregation behaviors:
+
+### 1. Scout weighting (`staff_reading`)
+
+Better directors assign higher weight to grades from higher-accuracy scouts.
+Weight is not uniform across the staff. Mathematically, the consensus grade for
+a prospect is a weighted mean of scout grades where weights are
+`staff_reading × scout_quality_estimate`. The weighting is **invisible to the
+GM** — consistent with the information-asymmetry principle. The player discovers
+over time that the director "trusts the right scouts" by observing consensus
+accuracy improve year over year.
+
+### 2. Bias correction (`bias_awareness`)
+
+A director with high bias-awareness partially cancels known systematic biases in
+his staff's grades (the mechanism the north-star describes under "Biases you'll
+discover over time"). Bias correction depends on a track record of observed
+scout outcomes — hit rate by position, bias direction, consistency over multiple
+drafts.
+
+**In genesis specifically, bias correction is disabled.** No prior drafts means
+no observed outcomes means no bias model to correct against. This is a feature,
+not a limitation: in genesis the director is working with the same imperfect
+information the GM has, which reinforces the "year 1 is harder" feel.
+
+### 3. Tier boundary placement (`tier_discipline`)
+
+The director decides where tier breaks fall. A high-discipline director places
+breaks at natural distribution gaps — when the grade histogram shows a cluster
+of prospects, breaks don't split the cluster. A low-discipline director places
+breaks mechanically (every 15 prospects, for instance) and produces an awkward
+board where similar talent gets split across tiers.
+
+For genesis, the director places tiers based on founding-pool archetype
+distribution: raw college athletes, practice-squad journeymen, back-end vets,
+and middling pros form natural clusters the director can (or can't) recognize.
+
+### Incremental recomputation
+
+When a new report lands, the director updates only the affected prospect's
+aggregated grade and re-checks whether the update crosses a tier boundary. This
+avoids recomputing the whole board on every event and keeps the
+`director_consensus_update` stream focused on meaningful changes. If the update
+only shifts rank within a tier, a lighter update event is emitted; if it crosses
+a tier boundary, a full entry-move event is emitted.
+
+### Visibility to the GM
+
+The consensus board is always readable by the GM during the phase, marked
+clearly as the director's board (not the GM's). The GM's own draft board (from
+ADR 0037) is a separate artifact. At `scouting_board_lock`:
+
+- If the GM touched their own board, their board is used.
+- If the GM did not touch their own board, the consensus is copied to a
+  `source = 'gm'` board (per ADR 0037's inheritance mechanism).
+- NPC franchises always inherit the consensus.
+
+The _weightings_, _bias corrections_, and _tier placement reasoning_ are never
+shown to the GM. The GM only sees the resulting board.
+
+## Alternatives considered
+
+- **Simple arithmetic mean of scout grades.** Every scout counts equally; no
+  director influence. Rejected: makes the director hire meaningless, defeats the
+  entire point of Phase 3's scouting hires, and contradicts the north-star's
+  framing of the director as a synthesizer.
+- **Show the GM the weighting table ("Director weights your ACC scout at
+  1.3x").** Rejected: violates information asymmetry. The player should infer
+  director quality from consensus accuracy over years, not read it off a
+  dashboard.
+- **Bias correction enabled from year 1 with synthetic priors.** Seed the
+  correction table with generic position-level biases (e.g., "OL grades are
+  systematically too high"). Rejected: injects designer opinions into the game
+  as if they were discovered truths; cleaner to start with a blank slate and let
+  bias correction emerge from real observed data in year 2+.
+- **Director-only global ranking; tiers are GM-only.** The director produces one
+  flat list; the GM groups into tiers themselves. Rejected: tiering is exactly
+  what real NFL directors do, and stripping it from the director makes the
+  consensus board less useful as a recommendation.
+- **LLM synthesis of scout reports into a qualitative recommendation.** Rejected
+  for v1 on the same cost/determinism grounds as ADR 0039. The mathematical
+  aggregation described here is stable, testable, and compatible with the
+  calibration harness (ADR 0021).
+
+## Consequences
+
+- **Director attributes become observable.** `staff_reading`, `bias_awareness`,
+  and `tier_discipline` now shape what the GM sees on the consensus board. A
+  great director hire from Phase 3 produces a sharper consensus; a poor one
+  produces a consensus the GM has to second-guess.
+- **The consensus board is a first-class artifact.** It's persisted, it emits
+  events, it participates in the decision log via the inheritance path in
+  ADR 0037.
+- **Testability.** The aggregation is a pure function over scout grades and
+  director attributes; unit tests with synthetic fixtures validate behavior
+  without needing a full phase simulation. The sim calibration harness
+  (ADR 0021) gets a new assertion: consensus accuracy should correlate with
+  director hidden attribute quality across seeded runs.
+- **Year 2+ gets richer automatically.** As real draft outcomes accumulate, bias
+  correction activates without code changes — the system naturally becomes more
+  sophisticated as the league ages. The "learning your scouts" meta-game
+  described in the scouting north-star lives partially inside the director.
+- **Follow-up work:**
+  - Implement the weighted-aggregation function with `staff_reading` and
+    `tier_discipline` inputs; stub `bias_awareness` to a no-op for genesis.
+  - Add a `director_consensus_boards` projection (or reuse `draft_boards` with
+    `source = 'director_consensus'` per ADR 0037) that materializes the current
+    consensus.
+  - Wire consensus recomputation to the `report_published` event hook so updates
+    are incremental.
+  - Add calibration harness assertion: consensus grade error correlates
+    inversely with director `staff_reading`.
+
+## Related decisions
+
+- [0021 — Sim calibration harness](./0021-sim-calibration-harness.md)
+- [0032 — Multi-week staff hiring process](./0032-multi-week-staff-hiring.md)
+- [0034 — Genesis draft scouting phase](./0034-genesis-draft-scouting-phase.md)
+- [0035 — Scouting advocacy and dissent event model](./0035-scouting-advocacy-dissent-event-model.md)
+- [0037 — Draft board data model](./0037-draft-board-data-model.md)

--- a/docs/product/decisions/0039-scouting-flavor-text-strategy.md
+++ b/docs/product/decisions/0039-scouting-flavor-text-strategy.md
@@ -1,0 +1,152 @@
+# 0039 — Scouting flavor text generation strategy
+
+- **Date:** 2026-04-16
+- **Status:** Proposed
+- **Area:** [Scouting](../north-star/scouting.md),
+  [Media](../north-star/media.md),
+  [0034 — Genesis draft scouting phase](./0034-genesis-draft-scouting-phase.md),
+  [0035 — Scouting advocacy and dissent event model](./0035-scouting-advocacy-dissent-event-model.md)
+
+## Context
+
+ADR 0034 acknowledges that flavor text — the prose in scouting reports, advocacy
+lines, dissent quotes, media mock blurbs, and the director's consensus
+commentary — is essential to the phase's feel but leaves generation strategy to
+a follow-up ADR. ADR 0035's event payloads have a designated slot for rendered
+text; without a generation strategy, every event type invents its own ad-hoc
+string construction and the scouting phase reads like a spreadsheet dump.
+
+MVP cannot ship with an LLM dependency: cost, latency, and determinism concerns
+conflict directly with the sim calibration harness (ADR 0021), which requires
+seeded runs to produce identical output. But a templated- only strategy for the
+lifetime of the product would lock us out of qualitative improvements that LLMs
+are well-suited for, so the schema has to make swapping in an LLM a bounded
+change rather than a rewrite.
+
+## Decision
+
+Ship MVP with deterministic, author-written templates. Structure the generation
+pipeline so that the LLM swap is a single DI change at the feature-wiring layer,
+without touching event payloads, consumers, or the calibration harness.
+
+### Template catalog
+
+A `flavor_text_templates` table (or bundled JSON, TBD at implementation time)
+with columns:
+
+- `event_kind` — one of the kinds from ADR 0035 (`report_published`, `advocacy`,
+  `dissent`, `cross_check_resolved`, `media_mock_published`,
+  `director_consensus_update`).
+- `scout_personality_tag` — `confident`, `hedger`, `contrarian`, `measured`
+  (drawn from the scout's hidden personality attribute).
+- `prospect_archetype_tag` — `freak_athlete`, `polished_technician`,
+  `character_risk`, `small_school_prospect`, `injury_concern`, `late_bloomer`,
+  etc.
+- `template_id` — deterministic primary key.
+- `body` — handlebars-style text with placeholders: `{{prospect.first_name}}`,
+  `{{prospect.position}}`, `{{scout.last_name}}`, `{{grade}}`,
+  `{{strength_trait}}`, `{{concern_trait}}`, etc.
+
+Target volume for MVP: roughly 30 templates per event kind, split across the
+personality × archetype combinations so that the same scout grading two
+different archetypes produces visibly distinct text, and two scouts with
+different personalities grading the same prospect sound different.
+
+### The resolver
+
+A `FlavorTextResolver` factory function (per the service-naming convention)
+takes a scout, a prospect, an event kind, and a structured context and returns a
+rendered string plus the `template_id` that produced it. Two implementations:
+
+1. **`TemplateResolver`** (MVP): filters templates by `event_kind`,
+   `scout_personality_tag`, and `prospect_archetype_tag`; picks one using a
+   seeded RNG scoped to the event; substitutes placeholders.
+2. **`LlmResolver`** (future): treats matched templates as few-shot examples;
+   sends the structured context to an LLM; caches output keyed by
+   `(event_id, template_set_version)` so re-renders are deterministic within a
+   session.
+
+Feature wiring selects the resolver via dependency injection at the
+scouting-feature factory. Every consumer takes the resolver interface, not an
+implementation.
+
+### Structured context retained on the event
+
+Event payloads (from ADR 0035) carry **both** the rendered string and the
+structured substitution context (scout attributes at emission time, prospect
+archetype tags, grade vectors). Retaining the context means:
+
+- Templates can be edited post-hoc and events re-rendered.
+- An LLM swap can re-generate historical flavor text from structured context
+  without needing to preserve the original template output.
+- Tests can assert structured fields independently of text quality.
+
+The rendered string lives in the payload because it participates in the
+historical record — the decision log (ADR 0037) references events, and those
+events need stable text for review years later.
+
+### Determinism
+
+The `TemplateResolver` uses a seeded RNG derived from `(league_id,
+event_id)` so
+the same event always produces the same text within a league run. This is what
+lets the calibration harness assert on text- bearing events without flakiness.
+The `LlmResolver`, when introduced, achieves determinism through caching on
+`event_id`.
+
+### Template authoring workflow
+
+Templates live in `packages/scouting/flavor/templates/` as JSON or handlebars
+files checked into the repo. Authors iterate without a code deploy — the
+template bundle is loaded at service startup. A simple linter validates
+placeholder usage against the declared context schema.
+
+## Alternatives considered
+
+- **LLM from day one.** Use an LLM for all flavor text generation in MVP.
+  Rejected: per-event latency + cost makes the calibration harness impractical;
+  determinism requires per-event caching which we can defer; template-first lets
+  us ship and iterate without API spend.
+- **Hardcoded strings at each emission site.** Build the text inline in the
+  event emitter for each event kind. Rejected: no iteration path for writers, no
+  localization hook, no LLM swap path, and the emission sites become
+  string-building factories instead of event-logic functions.
+- **Render flavor text lazily in the UI.** Generate text on read instead of at
+  emission. Rejected: decision-log history (ADR 0037) references events and
+  needs stable text; lazy rendering means historical entries can drift as
+  templates evolve, which breaks retrospective review.
+- **Structured text-object payload (no rendered string at all).** Events carry
+  only structured fields; every consumer renders on its own. Rejected:
+  duplicates rendering logic across inbox, decision log, and retrospective
+  tools; introduces inconsistency; breaks the "what did my scout actually say?"
+  record.
+
+## Consequences
+
+- **MVP ships without an LLM.** Cost, latency, and determinism are bounded
+  problems we don't solve yet.
+- **LLM swap is a scoped ADR in its own right when we're ready.** The swap is a
+  DI change; event shape, consumer code, and the calibration harness are
+  untouched.
+- **Writers have an iteration loop independent of engineering.** Template edits
+  are data changes; no code deploys required, no event re-emission required.
+- **Template quality is a soft goal.** Shipping with ~30 templates per kind is
+  enough for the MVP to feel varied; the catalog will grow over time as writers
+  identify gaps from real playthroughs.
+- **Event payloads are larger.** Retaining structured context on every event has
+  a storage cost; acceptable given the historical-record role the event log
+  plays and the small volume of scouting events per league-year.
+- **Follow-up work:**
+  - Implement `FlavorTextResolver` factory + `TemplateResolver`.
+  - Author initial template bundle covering all six event kinds × core
+    personality/archetype combinations.
+  - Add placeholder linter to catch missing context fields at build time.
+  - Extend ADR 0035 event payloads with a `flavor_context` column alongside the
+    rendered `body`.
+
+## Related decisions
+
+- [0021 — Sim calibration harness](./0021-sim-calibration-harness.md)
+- [0034 — Genesis draft scouting phase](./0034-genesis-draft-scouting-phase.md)
+- [0035 — Scouting advocacy and dissent event model](./0035-scouting-advocacy-dissent-event-model.md)
+- [0037 — Draft board data model](./0037-draft-board-data-model.md)

--- a/docs/product/decisions/README.md
+++ b/docs/product/decisions/README.md
@@ -95,3 +95,20 @@ as superseded.
 - [0031 — Post-generation landing on the first in-dashboard genesis phase](./0031-post-generation-land-in-first-genesis-phase.md)
   — after generation the founder lands straight in the dashboard at the earliest
   incomplete genesis phase; no confirmation screen (Accepted)
+- [0035 — Scouting advocacy and dissent event model](./0035-scouting-advocacy-dissent-event-model.md)
+  — single append-only `scouting_events` log with typed kinds (report, advocacy,
+  dissent, cross-check, media mock, director consensus); GM responses are a
+  separate surface (Proposed)
+- [0036 — League-wide scouting allowances](./0036-league-wide-scouting-allowances.md)
+  — uniform per-franchise caps (30 visits, 10 workouts, 15 cross-checks) for the
+  genesis scouting phase; scout quality shapes value, never quantity (Proposed)
+- [0037 — Draft board data model](./0037-draft-board-data-model.md) — tiered
+  board (`draft_boards` + tiers + entries) with an append-only decision log
+  linking moves to the scouting events that motivated them (Proposed)
+- [0038 — Scouting director consensus logic](./0038-scouting-director-consensus-logic.md)
+  — weighted aggregation of scout grades driven by hidden director attributes
+  (`staff_reading`, `bias_awareness`, `tier_discipline`); bias correction
+  disabled in genesis (Proposed)
+- [0039 — Scouting flavor text generation strategy](./0039-scouting-flavor-text-strategy.md)
+  — author-written templates with a resolver abstraction; MVP is deterministic,
+  LLM swap is a single DI change (Proposed)


### PR DESCRIPTION
## Summary

ADR 0034 (genesis draft scouting phase) explicitly defers five downstream decisions to follow-up ADRs. This PR drafts all five as `Proposed` so implementation tickets can be filed off a complete scaffold.

- **0035 — Advocacy and dissent event model.** Single append-only `scouting_events` log with seven typed kinds (report, advocacy, dissent, cross-check request/resolve, media mock, director consensus). GM responses are a separate surface; log is authored by scouts, not the GM.
- **0036 — League-wide scouting allowances.** Per-franchise caps (30 visits / 10 workouts / 15 cross-checks), identical for every franchise. Scout quality shapes signal density, never quantity — preserves the competitive-parity principle.
- **0037 — Draft board data model.** Four tables (`draft_boards`, `draft_board_tiers`, `draft_board_entries`, `draft_board_decisions`) with an append-only decision log whose entries carry `reason_event_id` linking back to the scouting event that motivated each move.
- **0038 — Scouting director consensus logic.** Weighted aggregation of scout grades driven by hidden director attributes (`staff_reading`, `bias_awareness`, `tier_discipline`). Bias correction disabled in genesis since there's no track record to correct against.
- **0039 — Scouting flavor text generation strategy.** Author-written templates for MVP with a `FlavorTextResolver` factory; LLM swap is a single DI change. Structured context retained on every event so text can be re-rendered later.

All five link back to 0034 and cross-reference each other. README log updated with Proposed entries.