### PR TITLE
fix(logger): include response body as reason for 4xx/5xx logs

### DIFF
--- a/server/middleware/logger.test.ts
+++ b/server/middleware/logger.test.ts
@@ -1,0 +1,126 @@
+import { assertEquals } from "@std/assert";
+import { Hono } from "hono";
+import type pino from "pino";
+import { loggerMiddleware } from "./logger.ts";
+import type { AppEnv } from "../env.ts";
+
+interface LogEntry {
+  level: "debug" | "info" | "warn" | "error";
+  data: Record<string, unknown>;
+  msg: string;
+}
+
+function createCapturingLogger() {
+  const entries: LogEntry[] = [];
+  const make = (): pino.Logger => {
+    const record =
+      (level: LogEntry["level"]) =>
+      (data: Record<string, unknown>, msg: string) => {
+        entries.push({ level, data, msg });
+      };
+    return {
+      child: () => make(),
+      debug: record("debug"),
+      info: record("info"),
+      warn: record("warn"),
+      error: record("error"),
+    } as unknown as pino.Logger;
+  };
+  return { log: make(), entries };
+}
+
+function createTestApp(log: pino.Logger) {
+  return new Hono<AppEnv>()
+    .use((c, next) => {
+      c.set("log", log);
+      c.set("requestId", "test-request-id");
+      return next();
+    })
+    .use(loggerMiddleware())
+    .get("/ok", (c) => c.json({ data: "ok" }))
+    .get(
+      "/bad-json",
+      (c) => c.json({ error: "VALIDATION", message: "Bad input" }, 400),
+    )
+    .get("/unauthorized", (c) => c.json({ error: "UNAUTHORIZED" }, 401))
+    .get("/plain-text", (c) => c.text("Not Found", 404))
+    .get("/boom", () => {
+      throw new Error("boom");
+    });
+}
+
+Deno.test("logger middleware", async (t) => {
+  await t.step("logs 2xx as info without a reason field", async () => {
+    const { log, entries } = createCapturingLogger();
+    const app = createTestApp(log);
+
+    const res = await app.request("/ok");
+    assertEquals(res.status, 200);
+
+    const entry = entries.at(-1);
+    assertEquals(entry?.level, "info");
+    assertEquals(entry?.data.status, 200);
+    assertEquals("reason" in (entry?.data ?? {}), false);
+  });
+
+  await t.step(
+    "logs 4xx JSON responses as warn with the parsed body as reason",
+    async () => {
+      const { log, entries } = createCapturingLogger();
+      const app = createTestApp(log);
+
+      const res = await app.request("/bad-json");
+      assertEquals(res.status, 400);
+
+      const entry = entries.at(-1);
+      assertEquals(entry?.level, "warn");
+      assertEquals(entry?.data.status, 400);
+      assertEquals(entry?.data.reason, {
+        error: "VALIDATION",
+        message: "Bad input",
+      });
+    },
+  );
+
+  await t.step(
+    "logs 401 UNAUTHORIZED with the reason body",
+    async () => {
+      const { log, entries } = createCapturingLogger();
+      const app = createTestApp(log);
+
+      const res = await app.request("/unauthorized");
+      assertEquals(res.status, 401);
+
+      const entry = entries.at(-1);
+      assertEquals(entry?.level, "warn");
+      assertEquals(entry?.data.reason, { error: "UNAUTHORIZED" });
+    },
+  );
+
+  await t.step(
+    "falls back to raw text when the 4xx body is not JSON",
+    async () => {
+      const { log, entries } = createCapturingLogger();
+      const app = createTestApp(log);
+
+      const res = await app.request("/plain-text");
+      assertEquals(res.status, 404);
+
+      const entry = entries.at(-1);
+      assertEquals(entry?.level, "warn");
+      assertEquals(entry?.data.reason, "Not Found");
+    },
+  );
+
+  await t.step(
+    "preserves the response body consumable by the caller",
+    async () => {
+      const { log } = createCapturingLogger();
+      const app = createTestApp(log);
+
+      const res = await app.request("/bad-json");
+      const body = await res.json();
+      assertEquals(body, { error: "VALIDATION", message: "Bad input" });
+    },
+  );
+});

--- a/server/middleware/logger.ts
+++ b/server/middleware/logger.ts
@@ -1,6 +1,25 @@
 import type { MiddlewareHandler } from "hono";
 import type { AppEnv } from "../env.ts";
 
+const MAX_REASON_LENGTH = 2048;
+
+async function readReason(res: Response): Promise<unknown> {
+  try {
+    const text = await res.clone().text();
+    if (!text) return undefined;
+    const truncated = text.length > MAX_REASON_LENGTH
+      ? `${text.slice(0, MAX_REASON_LENGTH)}…`
+      : text;
+    try {
+      return JSON.parse(truncated);
+    } catch {
+      return truncated;
+    }
+  } catch {
+    return undefined;
+  }
+}
+
 export function loggerMiddleware(): MiddlewareHandler<AppEnv> {
   return async (c, next) => {
     const start = Date.now();
@@ -8,13 +27,18 @@ export function loggerMiddleware(): MiddlewareHandler<AppEnv> {
 
     const log = c.get("log");
     const status = c.res.status;
-    const data = {
+    const data: Record<string, unknown> = {
       method: c.req.method,
       path: c.req.path,
       status,
       responseTime: Date.now() - start,
     };
     const msg = `${c.req.method} ${c.req.path}`;
+
+    if (status >= 400) {
+      const reason = await readReason(c.res);
+      if (reason !== undefined) data.reason = reason;
+    }
 
     if (status >= 500) log.error(data, msg);
     else if (status >= 400) log.warn(data, msg);


### PR DESCRIPTION
## Summary

- `loggerMiddleware` now reads the response body on any status >= 400 and attaches the parsed payload (or raw text fallback, truncated to 2KB) as a `reason` field on the log line.
- Makes dev logs actually show *why* a request failed: Zod validation rejections, `DomainError` bodies, auth-guard `UNAUTHORIZED`, and router `NOT_FOUND` branches all flow through the same error response path, so one change covers every 4xx source.
- 2xx paths are unchanged — no body reads, no extra overhead on the hot path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)