### PR TITLE
feat(hiring): overhaul hiring UI with data table, tabs, and cap badges

### DIFF
--- a/client/src/features/generate/index.test.tsx
+++ b/client/src/features/generate/index.test.tsx
@@ -9,7 +9,7 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { Generate, MILESTONE_COPY } from "./index.tsx";
 
-const mockFoundPost = vi.fn();
+const mockGeneratePost = vi.fn();
 const mockNavigate = vi.fn();
 
 vi.mock("../../api.ts", () => ({
@@ -17,8 +17,8 @@ vi.mock("../../api.ts", () => ({
     api: {
       leagues: {
         ":id": {
-          found: {
-            $post: (...args: unknown[]) => mockFoundPost(...args),
+          generate: {
+            $post: (...args: unknown[]) => mockGeneratePost(...args),
           },
         },
       },
@@ -54,7 +54,7 @@ afterEach(() => {
 
 describe("Generate", () => {
   it("shows the first milestone copy on mount", () => {
-    mockFoundPost.mockReturnValue(new Promise(() => {}));
+    mockGeneratePost.mockReturnValue(new Promise(() => {}));
     renderWithProviders();
     expect(
       screen.getByText("Creating coaches and league structure…"),
@@ -62,7 +62,7 @@ describe("Generate", () => {
   });
 
   it("cycles through narrative milestones while generation is pending", () => {
-    mockFoundPost.mockReturnValue(new Promise(() => {}));
+    mockGeneratePost.mockReturnValue(new Promise(() => {}));
     renderWithProviders();
 
     expect(screen.getByText(MILESTONE_COPY[0])).toBeDefined();
@@ -75,8 +75,8 @@ describe("Generate", () => {
     }
   });
 
-  it("calls the found endpoint and navigates to dashboard on success", async () => {
-    mockFoundPost.mockReturnValue(
+  it("calls the generate endpoint and navigates to dashboard on success", async () => {
+    mockGeneratePost.mockReturnValue(
       Promise.resolve({
         ok: true,
         json: () =>
@@ -92,7 +92,7 @@ describe("Generate", () => {
     renderWithProviders();
 
     await vi.waitFor(() => {
-      expect(mockFoundPost).toHaveBeenCalledWith({
+      expect(mockGeneratePost).toHaveBeenCalledWith({
         param: { id: "league-1" },
       });
     });
@@ -104,12 +104,12 @@ describe("Generate", () => {
     });
   });
 
-  it("only calls the found endpoint once across re-renders", async () => {
-    mockFoundPost.mockReturnValue(new Promise(() => {}));
+  it("only calls the generate endpoint once across re-renders", async () => {
+    mockGeneratePost.mockReturnValue(new Promise(() => {}));
     const { rerender } = renderWithProviders();
 
     await vi.waitFor(() => {
-      expect(mockFoundPost).toHaveBeenCalledTimes(1);
+      expect(mockGeneratePost).toHaveBeenCalledTimes(1);
     });
 
     const queryClient = new QueryClient({
@@ -121,11 +121,11 @@ describe("Generate", () => {
       </QueryClientProvider>,
     );
 
-    expect(mockFoundPost).toHaveBeenCalledTimes(1);
+    expect(mockGeneratePost).toHaveBeenCalledTimes(1);
   });
 
   it("shows error alert with retry control when generation fails", async () => {
-    mockFoundPost.mockReturnValue(
+    mockGeneratePost.mockReturnValue(
       Promise.resolve({ ok: false, status: 500 }),
     );
     renderWithProviders();
@@ -137,8 +137,8 @@ describe("Generate", () => {
     expect(screen.getByRole("button", { name: /try again/i })).toBeDefined();
   });
 
-  it("retries the found call when the user clicks Try again", async () => {
-    mockFoundPost.mockReturnValueOnce(
+  it("retries the generate call when the user clicks Try again", async () => {
+    mockGeneratePost.mockReturnValueOnce(
       Promise.resolve({ ok: false, status: 500 }),
     );
     renderWithProviders();
@@ -147,7 +147,7 @@ describe("Generate", () => {
       expect(screen.getByText("Generation failed")).toBeDefined();
     });
 
-    mockFoundPost.mockReturnValueOnce(
+    mockGeneratePost.mockReturnValueOnce(
       Promise.resolve({
         ok: true,
         json: () => Promise.resolve({ leagueId: "league-1" }),
@@ -156,7 +156,7 @@ describe("Generate", () => {
     fireEvent.click(screen.getByRole("button", { name: /try again/i }));
 
     await vi.waitFor(() => {
-      expect(mockFoundPost).toHaveBeenCalledTimes(2);
+      expect(mockGeneratePost).toHaveBeenCalledTimes(2);
     });
     await vi.waitFor(() => {
       expect(mockNavigate).toHaveBeenCalledWith({

--- a/client/src/features/generate/index.test.tsx
+++ b/client/src/features/generate/index.test.tsx
@@ -26,9 +26,11 @@ vi.mock("../../api.ts", () => ({
   },
 }));
 
+const mockUseParams = vi.fn(() => ({ leagueId: "league-1" }));
+
 vi.mock("@tanstack/react-router", () => ({
   useNavigate: () => mockNavigate,
-  useParams: () => ({ leagueId: "league-1" }),
+  useParams: () => mockUseParams(),
 }));
 
 function renderWithProviders() {
@@ -50,6 +52,7 @@ afterEach(() => {
   vi.useRealTimers();
   cleanup();
   vi.clearAllMocks();
+  mockUseParams.mockReturnValue({ leagueId: "league-1" });
 });
 
 describe("Generate", () => {
@@ -135,6 +138,29 @@ describe("Generate", () => {
     });
     expect(mockNavigate).not.toHaveBeenCalled();
     expect(screen.getByRole("button", { name: /try again/i })).toBeDefined();
+  });
+
+  it("does not call generate when no leagueId is present", () => {
+    mockUseParams.mockReturnValue(
+      {} as unknown as { leagueId: string },
+    );
+    renderWithProviders();
+    expect(mockGeneratePost).not.toHaveBeenCalled();
+  });
+
+  it("does nothing when retry is clicked without a leagueId", async () => {
+    mockGeneratePost.mockReturnValueOnce(
+      Promise.resolve({ ok: false, status: 500 }),
+    );
+    renderWithProviders();
+    await vi.waitFor(() => {
+      expect(screen.getByText("Generation failed")).toBeDefined();
+    });
+    mockUseParams.mockReturnValue(
+      {} as unknown as { leagueId: string },
+    );
+    fireEvent.click(screen.getByRole("button", { name: /try again/i }));
+    expect(mockGeneratePost).toHaveBeenCalledTimes(1);
   });
 
   it("retries the generate call when the user clicks Try again", async () => {

--- a/client/src/features/league/coaches/build-tree.test.ts
+++ b/client/src/features/league/coaches/build-tree.test.ts
@@ -63,6 +63,30 @@ describe("buildStaffTree", () => {
     expect(rootIds).toEqual(["hc", "orphan"]);
   });
 
+  it("falls back to last-name ordering when two reports share a role", () => {
+    const tree = buildStaffTree([
+      node({ id: "hc", role: "HC" }),
+      node({ id: "qb2", role: "QB", lastName: "Zebra", reportsToId: "hc" }),
+      node({ id: "qb1", role: "QB", lastName: "Adams", reportsToId: "hc" }),
+    ]);
+
+    expect(tree[0].reports.map((r) => r.id)).toEqual(["qb1", "qb2"]);
+  });
+
+  it("places coaches with unknown roles after canonical roles", () => {
+    const tree = buildStaffTree([
+      node({ id: "hc", role: "HC" }),
+      node({
+        id: "unknown",
+        role: "MYSTERY" as CoachRole,
+        reportsToId: "hc",
+      }),
+      node({ id: "oc", role: "OC", reportsToId: "hc" }),
+    ]);
+
+    expect(tree[0].reports.map((r) => r.id)).toEqual(["oc", "unknown"]);
+  });
+
   it("sorts direct reports by canonical role order", () => {
     const tree = buildStaffTree([
       node({ id: "hc", role: "HC" }),

--- a/client/src/features/league/hiring/candidate-detail.test.tsx
+++ b/client/src/features/league/hiring/candidate-detail.test.tsx
@@ -89,9 +89,10 @@ describe("CandidateDetail", () => {
     });
     renderPage();
     expect(screen.getByTestId("candidate-detail")).toBeTruthy();
-    expect(screen.getByTestId("preferences-card")).toBeTruthy();
     expect(screen.getByTestId("reveal-locked")).toBeTruthy();
     expect(screen.getByText("Andy Reid")).toBeTruthy();
+    expect(screen.getByText("Head Coach")).toBeTruthy();
+    expect(screen.queryByTestId("preferences-card")).toBeNull();
   });
 
   it("renders unlocked interview reveal when available", () => {
@@ -125,7 +126,7 @@ describe("CandidateDetail", () => {
     );
   });
 
-  it("renders a dash when a preference value is null", () => {
+  it("keeps the reveal locked when the reveal object has only null fields", () => {
     mockUseHiringCandidateDetail.mockReturnValue({
       data: {
         id: "c1",
@@ -139,12 +140,14 @@ describe("CandidateDetail", () => {
         staffFitPref: null,
         compensationPref: null,
         minimumThreshold: null,
-        interviewReveal: null,
+        interviewReveal: {
+          philosophyReveal: null,
+          staffFitReveal: null,
+        },
       },
       isLoading: false,
     });
     renderPage();
-    const prefs = screen.getByTestId("preferences-card");
-    expect(prefs.textContent).toContain("—");
+    expect(screen.getByTestId("reveal-locked")).toBeTruthy();
   });
 });

--- a/client/src/features/league/hiring/candidate-detail.test.tsx
+++ b/client/src/features/league/hiring/candidate-detail.test.tsx
@@ -126,6 +126,34 @@ describe("CandidateDetail", () => {
     );
   });
 
+  it("shows the unrevealed placeholder for reveal sections whose value is missing", () => {
+    mockUseHiringCandidateDetail.mockReturnValue({
+      data: {
+        id: "c1",
+        leagueId: "lg",
+        staffType: "coach",
+        firstName: "A",
+        lastName: "B",
+        role: "HC",
+        marketTierPref: null,
+        philosophyFitPref: null,
+        staffFitPref: null,
+        compensationPref: null,
+        minimumThreshold: null,
+        interviewReveal: {
+          philosophyReveal: null,
+          staffFitReveal: { conflictsWith: [] },
+        },
+      },
+      isLoading: false,
+    });
+    renderPage();
+    expect(screen.getByTestId("reveal-unlocked")).toBeTruthy();
+    expect(screen.getByTestId("philosophy-reveal").textContent).toContain(
+      "Not yet revealed",
+    );
+  });
+
   it("keeps the reveal locked when the reveal object has only null fields", () => {
     mockUseHiringCandidateDetail.mockReturnValue({
       data: {

--- a/client/src/features/league/hiring/candidate-detail.tsx
+++ b/client/src/features/league/hiring/candidate-detail.tsx
@@ -12,6 +12,7 @@ import {
 } from "@/components/ui/card";
 import { Skeleton } from "@/components/ui/skeleton";
 import { useHiringCandidateDetail } from "../../../hooks/use-hiring.ts";
+import { roleLabel } from "../role-labels.ts";
 import { bandFor, formatMoney } from "./salary-bands.ts";
 
 export function CandidateDetail() {
@@ -55,8 +56,9 @@ export function CandidateDetail() {
           <h1 className="text-3xl font-bold tracking-tight">
             {data.firstName} {data.lastName}
           </h1>
-          <Badge variant="secondary">{data.role}</Badge>
-          <Badge variant="outline">{data.staffType}</Badge>
+          <Badge variant="secondary">
+            {roleLabel(data.staffType, data.role)}
+          </Badge>
         </div>
         <p className="text-sm text-muted-foreground">
           Market band for this role: {formatMoney(band.min)} –{" "}
@@ -73,46 +75,55 @@ export function CandidateDetail() {
         </Button>
       </header>
 
-      <PreferencesCard detail={data} />
       <RevealCard detail={data} />
     </div>
   );
 }
 
-function PreferencesCard({ detail }: { detail: HiringCandidateDetail }) {
-  return (
-    <Card data-testid="preferences-card">
-      <CardHeader>
-        <CardTitle>What this candidate wants</CardTitle>
-        <CardDescription>
-          How strongly they weigh each factor when choosing where to sign. These
-          are public — coaches and scouts don't hide their priorities during
-          interviews.
-        </CardDescription>
-      </CardHeader>
-      <CardContent className="grid grid-cols-2 gap-4">
-        <PrefRow label="Market tier" value={detail.marketTierPref} />
-        <PrefRow label="Philosophy fit" value={detail.philosophyFitPref} />
-        <PrefRow label="Staff fit" value={detail.staffFitPref} />
-        <PrefRow label="Compensation" value={detail.compensationPref} />
-      </CardContent>
-    </Card>
-  );
+function hasReveal(value: unknown): boolean {
+  if (value === null || value === undefined) return false;
+  if (typeof value === "object") {
+    return Object.keys(value as Record<string, unknown>).length > 0;
+  }
+  return true;
 }
 
-function PrefRow({ label, value }: { label: string; value: number | null }) {
+function RevealSection(
+  { title, value, testId }: { title: string; value: unknown; testId: string },
+) {
+  if (!hasReveal(value)) {
+    return (
+      <section>
+        <h3 className="text-sm font-medium">{title}</h3>
+        <p
+          className="mt-1 text-sm text-muted-foreground"
+          data-testid={testId}
+        >
+          Not yet revealed — surfaces after a deeper interview.
+        </p>
+      </section>
+    );
+  }
   return (
-    <div className="flex flex-col">
-      <span className="text-xs uppercase tracking-wide text-muted-foreground">
-        {label}
-      </span>
-      <span className="text-lg font-semibold">{value ?? "—"}</span>
-    </div>
+    <section>
+      <h3 className="text-sm font-medium">{title}</h3>
+      <pre
+        className="mt-1 rounded-md bg-muted p-3 text-xs"
+        data-testid={testId}
+      >
+        {JSON.stringify(value, null, 2)}
+      </pre>
+    </section>
   );
 }
 
 function RevealCard({ detail }: { detail: HiringCandidateDetail }) {
-  if (!detail.interviewReveal) {
+  const reveal = detail.interviewReveal;
+  const philosophy = reveal?.philosophyReveal ?? null;
+  const staffFit = reveal?.staffFitReveal ?? null;
+  const anyRevealed = hasReveal(philosophy) || hasReveal(staffFit);
+
+  if (!reveal || !anyRevealed) {
     return (
       <Card data-testid="reveal-locked">
         <CardHeader>
@@ -136,24 +147,16 @@ function RevealCard({ detail }: { detail: HiringCandidateDetail }) {
         </CardDescription>
       </CardHeader>
       <CardContent className="flex flex-col gap-4">
-        <section>
-          <h3 className="text-sm font-medium">Philosophy</h3>
-          <pre
-            className="mt-1 rounded-md bg-muted p-3 text-xs"
-            data-testid="philosophy-reveal"
-          >
-            {JSON.stringify(detail.interviewReveal.philosophyReveal, null, 2)}
-          </pre>
-        </section>
-        <section>
-          <h3 className="text-sm font-medium">Staff fit</h3>
-          <pre
-            className="mt-1 rounded-md bg-muted p-3 text-xs"
-            data-testid="staff-fit-reveal"
-          >
-            {JSON.stringify(detail.interviewReveal.staffFitReveal, null, 2)}
-          </pre>
-        </section>
+        <RevealSection
+          title="Philosophy"
+          value={philosophy}
+          testId="philosophy-reveal"
+        />
+        <RevealSection
+          title="Staff fit"
+          value={staffFit}
+          testId="staff-fit-reveal"
+        />
       </CardContent>
     </Card>
   );

--- a/client/src/features/league/hiring/index.test.tsx
+++ b/client/src/features/league/hiring/index.test.tsx
@@ -5,6 +5,7 @@ import { Hiring } from "./index.tsx";
 
 const mockUseParams = vi.fn();
 const mockUseLeagueClock = vi.fn();
+const mockUseLeague = vi.fn();
 const mockUseTeamHiringState = vi.fn();
 const mockUseHiringCandidates = vi.fn();
 const mockUseHiringBlockers = vi.fn();
@@ -25,6 +26,10 @@ vi.mock("@tanstack/react-router", () => ({
 
 vi.mock("../../../hooks/use-league-clock.ts", () => ({
   useLeagueClock: (...args: unknown[]) => mockUseLeagueClock(...args),
+}));
+
+vi.mock("../../../hooks/use-league.ts", () => ({
+  useLeague: (...args: unknown[]) => mockUseLeague(...args),
 }));
 
 vi.mock("../../../hooks/use-hiring.ts", () => ({
@@ -91,6 +96,14 @@ beforeEach(() => {
     data: { slug: "hiring_market_survey" },
     isLoading: false,
   });
+  mockUseLeague.mockReturnValue({
+    data: {
+      interestCap: 10,
+      interviewsPerWeek: 5,
+      maxConcurrentOffers: 3,
+    },
+    isLoading: false,
+  });
 });
 
 afterEach(() => {
@@ -128,6 +141,12 @@ describe("Hiring page", () => {
   it("displays remaining staff budget", () => {
     renderPage();
     expect(screen.getByTestId("hiring-budget").textContent).toContain("$30M");
+  });
+
+  it("hides the interest counter when the league has no interest cap", () => {
+    mockUseLeague.mockReturnValue({ data: undefined, isLoading: false });
+    renderPage();
+    expect(screen.queryByTestId("hiring-interest-counter")).toBeNull();
   });
 });
 
@@ -232,6 +251,48 @@ describe("Interview view", () => {
   it("shows empty state when no interests are active", () => {
     renderPage();
     expect(screen.getByTestId("interview-empty")).toBeTruthy();
+  });
+
+  it("hides the interview counter when interviewsPerWeek is unknown", () => {
+    mockUseLeague.mockReturnValue({ data: undefined, isLoading: false });
+    mockUseHiringCandidates.mockReturnValue({
+      data: [
+        {
+          id: "c1",
+          leagueId: "lg",
+          staffType: "coach",
+          firstName: "Andy",
+          lastName: "Reid",
+          role: "HC",
+        },
+      ],
+      isLoading: false,
+    });
+    mockUseTeamHiringState.mockReturnValue({
+      data: {
+        leagueId: "lg",
+        teamId: "tm",
+        staffBudget: 0,
+        remainingBudget: 0,
+        interests: [
+          {
+            id: "i1",
+            leagueId: "lg",
+            teamId: "tm",
+            staffType: "coach",
+            staffId: "c1",
+            stepSlug: "hiring_market_survey",
+            status: "active",
+          },
+        ],
+        interviews: [],
+        offers: [],
+        decisions: [],
+      },
+      isLoading: false,
+    });
+    renderPage();
+    expect(screen.queryByTestId("hiring-interview-counter")).toBeNull();
   });
 
   it("shows loading state while candidates are loading", () => {

--- a/client/src/features/league/hiring/index.test.tsx
+++ b/client/src/features/league/hiring/index.test.tsx
@@ -759,14 +759,16 @@ describe("Finalize view", () => {
     );
   });
 
-  it("joins missing coach and scout roles with 'and' in the alert", () => {
+  it("lists missing coach and scout roles with human-readable labels in the alert", () => {
     mockUseHiringBlockers.mockReturnValue({
       data: { missingCoachRoles: ["HC"], missingScoutRoles: ["DIRECTOR"] },
       isLoading: false,
     });
     mockUseHiringCandidates.mockReturnValue({ data: [], isLoading: false });
     renderPage();
-    expect(screen.getByText(/HC and DIRECTOR/)).toBeTruthy();
+    expect(
+      screen.getByText(/Head Coach, Director of Scouting/),
+    ).toBeTruthy();
   });
 
   it("defaults to empty blocker and candidate lists when hooks return undefined", () => {

--- a/client/src/features/league/hiring/index.tsx
+++ b/client/src/features/league/hiring/index.tsx
@@ -1,6 +1,7 @@
 import { useMemo, useState } from "react";
 import { Link, useParams } from "@tanstack/react-router";
 import { toast } from "sonner";
+import type { ColumnDef } from "@tanstack/react-table";
 import type {
   HiringCandidateSummary,
   HiringDecisionView,
@@ -19,8 +20,10 @@ import {
   CardHeader,
   CardTitle,
 } from "@/components/ui/card";
+import { DataTable, SortableHeader } from "@/components/ui/data-table";
 import { Input } from "@/components/ui/input";
 import { Skeleton } from "@/components/ui/skeleton";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import {
   Table,
   TableBody,
@@ -29,6 +32,7 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/table";
+import { useLeague } from "../../../hooks/use-league.ts";
 import { useLeagueClock } from "../../../hooks/use-league-clock.ts";
 import {
   useExpressInterest,
@@ -39,12 +43,14 @@ import {
   useSubmitOffers,
   useTeamHiringState,
 } from "../../../hooks/use-hiring.ts";
+import { roleLabel } from "../role-labels.ts";
 import { bandFor, formatMoney, medianSalary } from "./salary-bands.ts";
 import { stepDescription, stepHeadline, stepViewFor } from "./step-view.ts";
 
 export function Hiring() {
   const { leagueId } = useParams({ strict: false }) as { leagueId: string };
   const { data: clock, isLoading: clockLoading } = useLeagueClock(leagueId);
+  const { data: league } = useLeague(leagueId);
   const { data: teamState, isLoading: stateLoading } = useTeamHiringState(
     leagueId,
   );
@@ -75,6 +81,9 @@ export function Hiring() {
     );
   }
 
+  const interestCap = (league as { interestCap?: number } | undefined)
+    ?.interestCap;
+
   return (
     <div className="flex flex-col gap-6 p-6">
       <header className="flex flex-col gap-2">
@@ -87,21 +96,21 @@ export function Hiring() {
         <p className="max-w-2xl text-muted-foreground">
           {stepDescription(slug)}
         </p>
-        {teamState && (
-          <p
-            className="text-sm text-muted-foreground"
-            data-testid="hiring-budget"
-          >
-            Staff budget: {formatMoney(teamState.remainingBudget)} of{" "}
-            {formatMoney(teamState.staffBudget)} remaining.
-          </p>
-        )}
+        <div className="flex flex-wrap gap-x-6 gap-y-1 text-sm text-muted-foreground">
+          {teamState && (
+            <span data-testid="hiring-budget">
+              Staff budget: {formatMoney(teamState.remainingBudget)} of{" "}
+              {formatMoney(teamState.staffBudget)} remaining
+            </span>
+          )}
+        </div>
       </header>
 
       {view === "market_survey" && (
         <MarketSurveyView
           leagueId={leagueId}
           interests={teamState?.interests ?? []}
+          interestCap={interestCap}
         />
       )}
       {view === "interview" && (
@@ -109,6 +118,11 @@ export function Hiring() {
           leagueId={leagueId}
           interests={teamState?.interests ?? []}
           interviews={teamState?.interviews ?? []}
+          stepSlug={slug}
+          interviewsPerWeek={(league as
+            | { interviewsPerWeek?: number }
+            | undefined)
+            ?.interviewsPerWeek}
         />
       )}
       {view === "offers" && (
@@ -117,6 +131,9 @@ export function Hiring() {
           interviews={teamState?.interviews ?? []}
           offers={teamState?.offers ?? []}
           remainingBudget={teamState?.remainingBudget ?? 0}
+          maxConcurrentOffers={(league as
+            | { maxConcurrentOffers?: number }
+            | undefined)?.maxConcurrentOffers}
         />
       )}
       {view === "decisions" && (
@@ -145,30 +162,23 @@ function useInterestedCandidateIds(
 }
 
 function MarketSurveyView(
-  { leagueId, interests }: {
+  { leagueId, interests, interestCap }: {
     leagueId: string;
     interests: HiringInterestView[];
+    interestCap: number | undefined;
   },
 ) {
-  const [search, setSearch] = useState("");
   const { data, isLoading } = useHiringCandidates(leagueId);
   const interestedIds = useInterestedCandidateIds(interests);
   const expressInterest = useExpressInterest();
-
-  const filtered = useMemo(() => {
-    if (!data) return [];
-    const needle = search.trim().toLowerCase();
-    if (!needle) return data;
-    return data.filter((c) =>
-      `${c.firstName} ${c.lastName} ${c.role}`.toLowerCase().includes(needle)
-    );
-  }, [data, search]);
 
   if (isLoading) {
     return (
       <Skeleton data-testid="candidates-loading" className="h-64 w-full" />
     );
   }
+
+  const atCap = interestCap !== undefined && interestedIds.size >= interestCap;
 
   const handleExpress = (candidateId: string) => {
     expressInterest.mutate(
@@ -180,40 +190,53 @@ function MarketSurveyView(
     );
   };
 
+  const renderAction = (c: HiringCandidateSummary) => {
+    const interested = interestedIds.has(c.id);
+    return (
+      <Button
+        size="sm"
+        variant={interested ? "secondary" : "default"}
+        disabled={interested || expressInterest.isPending || atCap}
+        onClick={() => handleExpress(c.id)}
+        data-testid={`express-interest-${c.id}`}
+      >
+        {interested ? "Interested" : "Express Interest"}
+      </Button>
+    );
+  };
+
+  const interestBadge = interestCap !== undefined
+    ? (
+      <Badge
+        variant={interestedIds.size >= interestCap ? "destructive" : "default"}
+        className="h-7 gap-2 px-3 text-sm font-semibold"
+        data-testid="hiring-interest-counter"
+      >
+        <span className="text-xs font-medium uppercase tracking-wide opacity-80">
+          Interests Shown
+        </span>
+        <span className="tabular-nums">
+          {interestedIds.size} / {interestCap}
+        </span>
+      </Badge>
+    )
+    : null;
+
   return (
     <Card data-testid="market-survey">
       <CardHeader>
         <CardTitle>Candidate Pool</CardTitle>
         <CardDescription>
-          {filtered.length} candidate{filtered.length === 1 ? "" : "s"}{" "}
-          available
+          Search, filter, and mark the candidates you want to pursue.
         </CardDescription>
       </CardHeader>
-      <CardContent className="flex flex-col gap-4">
-        <Input
-          aria-label="Search candidates"
-          placeholder="Search by name or role…"
-          value={search}
-          onChange={(e) => setSearch(e.target.value)}
-          className="max-w-sm"
-        />
-        <CandidateTable
-          candidates={filtered}
+      <CardContent>
+        <StaffTypeTabs
           leagueId={leagueId}
-          renderAction={(c) => {
-            const interested = interestedIds.has(c.id);
-            return (
-              <Button
-                size="sm"
-                variant={interested ? "secondary" : "default"}
-                disabled={interested || expressInterest.isPending}
-                onClick={() => handleExpress(c.id)}
-                data-testid={`express-interest-${c.id}`}
-              >
-                {interested ? "Interested" : "Express Interest"}
-              </Button>
-            );
-          }}
+          candidates={data ?? []}
+          renderAction={renderAction}
+          testIdPrefix="market"
+          toolbarEnd={interestBadge}
         />
       </CardContent>
     </Card>
@@ -225,10 +248,14 @@ function InterviewView(
     leagueId,
     interests,
     interviews,
+    stepSlug,
+    interviewsPerWeek,
   }: {
     leagueId: string;
     interests: HiringInterestView[];
     interviews: HiringInterviewView[];
+    stepSlug: string;
+    interviewsPerWeek: number | undefined;
   },
 ) {
   const { data: allCandidates, isLoading } = useHiringCandidates(leagueId);
@@ -239,6 +266,11 @@ function InterviewView(
     for (const iv of interviews) map.set(iv.staffId, iv);
     return map;
   }, [interviews]);
+
+  const requestedThisStep = useMemo(
+    () => interviews.filter((iv) => iv.stepSlug === stepSlug).length,
+    [interviews, stepSlug],
+  );
 
   const activeInterests = useMemo(
     () => interests.filter((i) => i.status === "active"),
@@ -284,6 +316,49 @@ function InterviewView(
     );
   };
 
+  const atCap = interviewsPerWeek !== undefined &&
+    requestedThisStep >= interviewsPerWeek;
+
+  const renderAction = (c: HiringCandidateSummary) => {
+    const iv = interviewByStaff.get(c.id);
+    if (iv?.status === "completed" || iv?.status === "accepted") {
+      return <Badge variant="secondary">Interviewed</Badge>;
+    }
+    if (iv?.status === "requested") {
+      return <Badge variant="outline">Pending</Badge>;
+    }
+    if (iv?.status === "declined") {
+      return <Badge variant="destructive">Declined</Badge>;
+    }
+    return (
+      <Button
+        size="sm"
+        disabled={requestInterviews.isPending || atCap}
+        onClick={() => handleRequest(c.id)}
+        data-testid={`request-interview-${c.id}`}
+      >
+        Request Interview
+      </Button>
+    );
+  };
+
+  const interviewBadge = interviewsPerWeek !== undefined
+    ? (
+      <Badge
+        variant={atCap ? "destructive" : "default"}
+        className="h-7 gap-2 px-3 text-sm font-semibold"
+        data-testid="hiring-interview-counter"
+      >
+        <span className="text-xs font-medium uppercase tracking-wide opacity-80">
+          Interviews Requested
+        </span>
+        <span className="tabular-nums">
+          {requestedThisStep} / {interviewsPerWeek}
+        </span>
+      </Badge>
+    )
+    : null;
+
   return (
     <Card data-testid="interview-view">
       <CardHeader>
@@ -294,31 +369,13 @@ function InterviewView(
         </CardDescription>
       </CardHeader>
       <CardContent>
-        <CandidateTable
-          candidates={interestedCandidates}
+        <StaffTypeTabs
           leagueId={leagueId}
-          renderAction={(c) => {
-            const iv = interviewByStaff.get(c.id);
-            if (iv?.status === "completed" || iv?.status === "accepted") {
-              return <Badge variant="secondary">Interviewed</Badge>;
-            }
-            if (iv?.status === "requested") {
-              return <Badge variant="outline">Pending</Badge>;
-            }
-            if (iv?.status === "declined") {
-              return <Badge variant="destructive">Declined</Badge>;
-            }
-            return (
-              <Button
-                size="sm"
-                disabled={requestInterviews.isPending}
-                onClick={() => handleRequest(c.id)}
-                data-testid={`request-interview-${c.id}`}
-              >
-                Request Interview
-              </Button>
-            );
-          }}
+          candidates={interestedCandidates}
+          renderAction={renderAction}
+          testIdPrefix="interview"
+          tabsEnd={interviewBadge}
+          searchable={false}
         />
       </CardContent>
     </Card>
@@ -331,11 +388,13 @@ function OffersView(
     interviews,
     offers,
     remainingBudget,
+    maxConcurrentOffers,
   }: {
     leagueId: string;
     interviews: HiringInterviewView[];
     offers: HiringOfferView[];
     remainingBudget: number;
+    maxConcurrentOffers: number | undefined;
   },
 ) {
   const { data: allCandidates, isLoading } = useHiringCandidates(leagueId);
@@ -370,14 +429,34 @@ function OffersView(
     );
   }
 
+  const pendingCount = offers.filter((o) => o.status === "pending").length;
+  const atOfferCap = maxConcurrentOffers !== undefined &&
+    pendingCount >= maxConcurrentOffers;
+
   return (
     <Card data-testid="offers-view">
-      <CardHeader>
-        <CardTitle>Extend Offers</CardTitle>
-        <CardDescription>
-          Offer a salary within the role's market band. Higher pay scores better
-          against competing bids.
-        </CardDescription>
+      <CardHeader className="flex flex-row items-start justify-between gap-4">
+        <div className="flex flex-col gap-1">
+          <CardTitle>Extend Offers</CardTitle>
+          <CardDescription>
+            Offer a salary within the role's market band. Higher pay scores
+            better against competing bids.
+          </CardDescription>
+        </div>
+        {maxConcurrentOffers !== undefined && (
+          <Badge
+            variant={atOfferCap ? "destructive" : "default"}
+            className="h-7 gap-2 px-3 text-sm font-semibold"
+            data-testid="hiring-offer-counter"
+          >
+            <span className="text-xs font-medium uppercase tracking-wide opacity-80">
+              Offers Outstanding
+            </span>
+            <span className="tabular-nums">
+              {pendingCount} / {maxConcurrentOffers}
+            </span>
+          </Badge>
+        )}
       </CardHeader>
       <CardContent className="flex flex-col gap-4">
         {eligible.map((c) => (
@@ -395,6 +474,7 @@ function OffersView(
                 },
               )}
             submitting={submitOffers.isPending}
+            disabledAtCap={atOfferCap}
           />
         ))}
       </CardContent>
@@ -403,12 +483,20 @@ function OffersView(
 }
 
 function OfferRow(
-  { candidate, existing, remainingBudget, onSubmit, submitting }: {
+  {
+    candidate,
+    existing,
+    remainingBudget,
+    onSubmit,
+    submitting,
+    disabledAtCap,
+  }: {
     candidate: HiringCandidateSummary;
     existing: HiringOfferView | null;
     remainingBudget: number;
     onSubmit: (offer: HiringOfferInput) => void;
     submitting: boolean;
+    disabledAtCap: boolean;
   },
 ) {
   const band = bandFor(candidate.staffType, candidate.role);
@@ -418,6 +506,7 @@ function OfferRow(
   const [contractYears, setContractYears] = useState(
     existing?.contractYears ?? 3,
   );
+  const displayRole = roleLabel(candidate.staffType, candidate.role);
 
   if (existing && existing.status !== "pending") {
     return (
@@ -427,7 +516,7 @@ function OfferRow(
       >
         <div className="flex items-center justify-between">
           <div className="font-medium">
-            {candidate.firstName} {candidate.lastName} ({candidate.role})
+            {candidate.firstName} {candidate.lastName} ({displayRole})
           </div>
           <Badge
             variant={existing.status === "accepted" ? "secondary" : "outline"}
@@ -445,7 +534,8 @@ function OfferRow(
   const underBand = salary < band.min;
   const overBand = salary > band.max;
   const overBudget = salary > remainingBudget;
-  const submitDisabled = submitting || overBudget || Boolean(existing);
+  const submitDisabled = submitting || overBudget || Boolean(existing) ||
+    disabledAtCap;
 
   const handleSubmit = () => {
     onSubmit({
@@ -463,7 +553,7 @@ function OfferRow(
     >
       <div className="flex flex-wrap items-center justify-between gap-2">
         <div className="font-medium">
-          {candidate.firstName} {candidate.lastName} ({candidate.role})
+          {candidate.firstName} {candidate.lastName} ({displayRole})
         </div>
         <span className="text-xs text-muted-foreground">
           Band: {formatMoney(band.min)} – {formatMoney(band.max)}
@@ -472,14 +562,22 @@ function OfferRow(
       <div className="flex flex-wrap items-center gap-2">
         <label className="flex items-center gap-2 text-sm">
           Salary
-          <Input
-            type="number"
-            min={0}
-            value={salary}
-            onChange={(e) => setSalary(Number(e.target.value))}
-            className="w-36"
-            data-testid={`offer-salary-${candidate.id}`}
-          />
+          <div className="relative">
+            <span className="pointer-events-none absolute inset-y-0 left-2 flex items-center text-muted-foreground">
+              $
+            </span>
+            <Input
+              type="text"
+              inputMode="numeric"
+              value={salary.toLocaleString("en-US")}
+              onChange={(e) => {
+                const digits = e.target.value.replace(/[^0-9]/g, "");
+                setSalary(digits === "" ? 0 : Number(digits));
+              }}
+              className="w-40 pl-5 tabular-nums"
+              data-testid={`offer-salary-${candidate.id}`}
+            />
+          </div>
         </label>
         <label className="flex items-center gap-2 text-sm">
           Years
@@ -627,11 +725,10 @@ function FinalizeView({ leagueId }: { leagueId: string }) {
       <Alert variant="destructive">
         <AlertTitle>Mandatory roles unfilled</AlertTitle>
         <AlertDescription>
-          You must fill {missingCoachRoles.join(", ")}
-          {missingCoachRoles.length > 0 && missingScoutRoles.length > 0
-            ? " and "
-            : ""}
-          {missingScoutRoles.join(", ")} before the hiring phase closes.
+          You must fill {missingCoachRoles
+            .map((r) => roleLabel("coach", r))
+            .concat(missingScoutRoles.map((r) => roleLabel("scout", r)))
+            .join(", ")} before the hiring phase closes.
         </AlertDescription>
       </Alert>
       {missingCoachRoles.map((role) => (
@@ -676,7 +773,7 @@ function BlockerSection(
   return (
     <Card data-testid={`blocker-${staffType}-${role}`}>
       <CardHeader>
-        <CardTitle>Fill {role}</CardTitle>
+        <CardTitle>Fill {roleLabel(staffType, role)}</CardTitle>
         <CardDescription>
           {roster.length} leftover candidate{roster.length === 1 ? "" : "s"}
           {" "}
@@ -691,7 +788,7 @@ function BlockerSection(
             </p>
           )
           : (
-            <CandidateTable
+            <CandidateDataTable
               candidates={roster}
               leagueId={leagueId}
               renderAction={(c) => (
@@ -704,6 +801,7 @@ function BlockerSection(
                   Hire
                 </Button>
               )}
+              testId={`blocker-table-${staffType}-${role}`}
             />
           )}
       </CardContent>
@@ -711,51 +809,186 @@ function BlockerSection(
   );
 }
 
-function CandidateTable(
-  { candidates, renderAction, leagueId }: {
+function StaffTypeTabs(
+  {
+    leagueId,
+    candidates,
+    renderAction,
+    testIdPrefix,
+    toolbarEnd,
+    tabsEnd,
+    searchable = true,
+  }: {
+    leagueId: string;
     candidates: HiringCandidateSummary[];
     renderAction: (c: HiringCandidateSummary) => React.ReactNode;
-    leagueId: string;
+    testIdPrefix: string;
+    toolbarEnd?: React.ReactNode;
+    tabsEnd?: React.ReactNode;
+    searchable?: boolean;
   },
 ) {
-  if (candidates.length === 0) {
-    return (
-      <p className="text-sm text-muted-foreground">
-        No candidates match.
-      </p>
-    );
-  }
+  const coaches = candidates.filter((c) => c.staffType === "coach");
+  const scouts = candidates.filter((c) => c.staffType === "scout");
+
   return (
-    <Table>
-      <TableHeader>
-        <TableRow>
-          <TableHead>Name</TableHead>
-          <TableHead>Role</TableHead>
-          <TableHead>Type</TableHead>
-          <TableHead className="text-right">Action</TableHead>
-        </TableRow>
-      </TableHeader>
-      <TableBody>
-        {candidates.map((c) => (
-          <TableRow key={c.id} data-testid={`candidate-row-${c.id}`}>
-            <TableCell className="font-medium">
-              <Link
-                to="/leagues/$leagueId/hiring/$candidateId"
-                params={{ leagueId, candidateId: c.id }}
-                className="underline-offset-2 hover:underline"
-                data-testid={`candidate-link-${c.id}`}
-              >
-                {c.firstName} {c.lastName}
-              </Link>
-            </TableCell>
-            <TableCell>{c.role}</TableCell>
-            <TableCell>
-              <Badge variant="outline">{c.staffType}</Badge>
-            </TableCell>
-            <TableCell className="text-right">{renderAction(c)}</TableCell>
-          </TableRow>
-        ))}
-      </TableBody>
-    </Table>
+    <Tabs defaultValue="coach" className="gap-4">
+      <div className="flex flex-wrap items-center justify-between gap-2">
+        <TabsList>
+          <TabsTrigger value="coach" data-testid={`${testIdPrefix}-tab-coach`}>
+            Coaches ({coaches.length})
+          </TabsTrigger>
+          <TabsTrigger value="scout" data-testid={`${testIdPrefix}-tab-scout`}>
+            Scouts ({scouts.length})
+          </TabsTrigger>
+        </TabsList>
+        {tabsEnd}
+      </div>
+      <TabsContent value="coach">
+        <CandidateDataTable
+          candidates={coaches}
+          leagueId={leagueId}
+          renderAction={renderAction}
+          testId={`${testIdPrefix}-coach-table`}
+          toolbarEnd={toolbarEnd}
+          searchable={searchable}
+        />
+      </TabsContent>
+      <TabsContent value="scout">
+        <CandidateDataTable
+          candidates={scouts}
+          leagueId={leagueId}
+          renderAction={renderAction}
+          testId={`${testIdPrefix}-scout-table`}
+          toolbarEnd={toolbarEnd}
+          searchable={searchable}
+        />
+      </TabsContent>
+    </Tabs>
+  );
+}
+
+type CandidateRow = HiringCandidateSummary & {
+  fullName: string;
+  displayRole: string;
+  bandMin: number;
+  bandMax: number;
+  medianSalary: number;
+};
+
+function toRows(candidates: HiringCandidateSummary[]): CandidateRow[] {
+  return candidates.map((c) => {
+    const band = bandFor(c.staffType, c.role);
+    return {
+      ...c,
+      fullName: `${c.firstName} ${c.lastName}`,
+      displayRole: roleLabel(c.staffType, c.role),
+      bandMin: band.min,
+      bandMax: band.max,
+      medianSalary: medianSalary(c.staffType, c.role),
+    };
+  });
+}
+
+function buildCandidateColumns(
+  leagueId: string,
+  renderAction: (c: HiringCandidateSummary) => React.ReactNode,
+): ColumnDef<CandidateRow>[] {
+  return [
+    {
+      accessorKey: "fullName",
+      header: ({ column }) => (
+        <SortableHeader column={column}>Name</SortableHeader>
+      ),
+      cell: ({ row }) => (
+        <Link
+          to="/leagues/$leagueId/hiring/$candidateId"
+          params={{ leagueId, candidateId: row.original.id }}
+          className="font-medium underline-offset-2 hover:underline"
+          data-testid={`candidate-link-${row.original.id}`}
+        >
+          {row.original.fullName}
+        </Link>
+      ),
+    },
+    {
+      accessorKey: "displayRole",
+      header: ({ column }) => (
+        <SortableHeader column={column}>Role</SortableHeader>
+      ),
+      cell: ({ row }) => row.original.displayRole,
+    },
+    {
+      accessorKey: "medianSalary",
+      header: ({ column }) => (
+        <SortableHeader column={column}>Expected Salary</SortableHeader>
+      ),
+      cell: ({ row }) => formatMoney(row.original.medianSalary),
+    },
+    {
+      id: "band",
+      header: "Market Band",
+      cell: ({ row }) => (
+        <span className="text-muted-foreground">
+          {formatMoney(row.original.bandMin)} –{" "}
+          {formatMoney(row.original.bandMax)}
+        </span>
+      ),
+    },
+    {
+      id: "action",
+      header: () => <span className="sr-only">Action</span>,
+      cell: ({ row }) => (
+        <div className="text-right">{renderAction(row.original)}</div>
+      ),
+    },
+  ];
+}
+
+function CandidateDataTable(
+  { candidates, renderAction, leagueId, testId, toolbarEnd, searchable = true }:
+    {
+      candidates: HiringCandidateSummary[];
+      renderAction: (c: HiringCandidateSummary) => React.ReactNode;
+      leagueId: string;
+      testId?: string;
+      toolbarEnd?: React.ReactNode;
+      searchable?: boolean;
+    },
+) {
+  const rows = useMemo(() => toRows(candidates), [candidates]);
+  const columns = useMemo(
+    () => buildCandidateColumns(leagueId, renderAction),
+    [leagueId, renderAction],
+  );
+
+  const toolbar = (!searchable && !toolbarEnd)
+    ? undefined
+    : (table: import("@tanstack/react-table").Table<CandidateRow>) => (
+      <div className="flex flex-wrap items-center justify-between gap-2">
+        {searchable
+          ? (
+            <Input
+              aria-label="Search candidates"
+              placeholder="Search by name or role…"
+              value={(table.getState().globalFilter as string) ?? ""}
+              onChange={(e) => table.setGlobalFilter(e.target.value)}
+              className="max-w-sm"
+            />
+          )
+          : <span />}
+        {toolbarEnd}
+      </div>
+    );
+
+  return (
+    <div data-testid={testId}>
+      <DataTable
+        columns={columns}
+        data={rows}
+        getRowTestId={(row) => `candidate-row-${row.id}`}
+        toolbar={toolbar}
+      />
+    </div>
   );
 }

--- a/client/src/features/league/layout.tsx
+++ b/client/src/features/league/layout.tsx
@@ -129,7 +129,7 @@ export function LeagueLayout() {
         </SidebarFooter>
       </Sidebar>
       <SidebarInset>
-        <header className="flex items-center gap-2 border-b px-4 py-2">
+        <header className="sticky top-0 z-10 flex items-center gap-2 border-b bg-background px-4 py-2">
           <SidebarTrigger className="-ml-1" />
           {leagueId && (
             <LeagueClockDisplay

--- a/client/src/features/league/nav-config.test.ts
+++ b/client/src/features/league/nav-config.test.ts
@@ -149,7 +149,7 @@ describe("navGroups", () => {
     it.each<[LeaguePhase, string[]]>([
       [
         "initial_staff_hiring",
-        ["Home", "Coaches", "Scouts", "Media"],
+        ["Home", "Coaches", "Scouts", "Hiring", "Media"],
       ],
       [
         "initial_draft",
@@ -252,10 +252,11 @@ describe("navGroups", () => {
 });
 
 describe("Hiring nav item", () => {
-  it("is visible only in coaching_carousel phase", () => {
+  it("is visible in initial_staff_hiring and coaching_carousel phases", () => {
+    const hiringPhases = new Set(["initial_staff_hiring", "coaching_carousel"]);
     for (const phase of LEAGUE_PHASES) {
       const visible = visibleLabels(phase).includes("Hiring");
-      expect(visible).toBe(phase === "coaching_carousel");
+      expect(visible).toBe(hiringPhases.has(phase));
     }
   });
 });

--- a/client/src/features/league/nav-config.ts
+++ b/client/src/features/league/nav-config.ts
@@ -71,7 +71,7 @@ const freeAgencyPhases = inPhases(
 
 const initialPool = inPhases("initial_pool");
 const initialDraft = inPhases("initial_draft");
-const coachingCarousel = inPhases("coaching_carousel");
+const hiringPhases = inPhases("initial_staff_hiring", "coaching_carousel");
 
 export const navGroups: NavGroup[] = [
   {
@@ -164,7 +164,7 @@ export const navGroups: NavGroup[] = [
         label: "Hiring",
         path: "hiring",
         Icon: BriefcaseIcon,
-        visibleInPhases: coachingCarousel,
+        visibleInPhases: hiringPhases,
       },
       {
         label: "Media",

--- a/client/src/features/league/role-labels.test.ts
+++ b/client/src/features/league/role-labels.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+import { roleLabel } from "./role-labels.ts";
+
+describe("roleLabel", () => {
+  it("returns the coach label for known coach roles", () => {
+    expect(roleLabel("coach", "HC")).toBe("Head Coach");
+  });
+
+  it("falls back to the raw role when the coach role is unknown", () => {
+    expect(roleLabel("coach", "UNKNOWN")).toBe("UNKNOWN");
+  });
+
+  it("returns the scout label for known scout roles", () => {
+    expect(roleLabel("scout", "AREA_SCOUT")).toBe("Area Scout");
+  });
+
+  it("falls back to the raw role when the scout role is unknown", () => {
+    expect(roleLabel("scout", "UNKNOWN")).toBe("UNKNOWN");
+  });
+});

--- a/client/src/features/league/role-labels.ts
+++ b/client/src/features/league/role-labels.ts
@@ -1,0 +1,33 @@
+import type { CoachRole, ScoutRole } from "@zone-blitz/shared";
+
+export const COACH_ROLE_LABELS: Record<CoachRole, string> = {
+  HC: "Head Coach",
+  OC: "Offensive Coordinator",
+  DC: "Defensive Coordinator",
+  STC: "Special Teams Coordinator",
+  QB: "Quarterbacks Coach",
+  RB: "Running Backs Coach",
+  WR: "Wide Receivers Coach",
+  TE: "Tight Ends Coach",
+  OL: "Offensive Line Coach",
+  DL: "Defensive Line Coach",
+  LB: "Linebackers Coach",
+  DB: "Defensive Backs Coach",
+  ST_ASSISTANT: "Special Teams Assistant",
+};
+
+export const SCOUT_ROLE_LABELS: Record<ScoutRole, string> = {
+  DIRECTOR: "Director of Scouting",
+  NATIONAL_CROSS_CHECKER: "National Cross-Checker",
+  AREA_SCOUT: "Area Scout",
+};
+
+export function roleLabel(
+  staffType: "coach" | "scout",
+  role: string,
+): string {
+  if (staffType === "coach") {
+    return COACH_ROLE_LABELS[role as CoachRole] ?? role;
+  }
+  return SCOUT_ROLE_LABELS[role as ScoutRole] ?? role;
+}

--- a/client/src/features/league/scouts/build-tree.test.ts
+++ b/client/src/features/league/scouts/build-tree.test.ts
@@ -67,6 +67,40 @@ describe("buildStaffTree", () => {
     expect(rootIds).toEqual(["dir", "orphan"]);
   });
 
+  it("falls back to last-name ordering when two scouts share a role", () => {
+    const tree = buildStaffTree([
+      node({ id: "dir", role: "DIRECTOR" }),
+      node({
+        id: "a2",
+        role: "AREA_SCOUT",
+        lastName: "Zebra",
+        reportsToId: "dir",
+      }),
+      node({
+        id: "a1",
+        role: "AREA_SCOUT",
+        lastName: "Adams",
+        reportsToId: "dir",
+      }),
+    ]);
+
+    expect(tree[0].reports.map((r) => r.id)).toEqual(["a1", "a2"]);
+  });
+
+  it("places scouts with unknown roles after canonical roles", () => {
+    const tree = buildStaffTree([
+      node({ id: "dir", role: "DIRECTOR" }),
+      node({
+        id: "unknown",
+        role: "MYSTERY" as ScoutRole,
+        reportsToId: "dir",
+      }),
+      node({ id: "cc", role: "NATIONAL_CROSS_CHECKER", reportsToId: "dir" }),
+    ]);
+
+    expect(tree[0].reports.map((r) => r.id)).toEqual(["cc", "unknown"]);
+  });
+
   it("sorts direct reports by canonical role order", () => {
     const tree = buildStaffTree([
       node({ id: "dir", role: "DIRECTOR" }),

--- a/client/src/hooks/use-leagues.ts
+++ b/client/src/hooks/use-leagues.ts
@@ -70,11 +70,11 @@ export function useGenerateLeague() {
   const queryClient = useQueryClient();
   return useMutation({
     mutationFn: async (leagueId: string) => {
-      const res = await api.api.leagues[":id"].found.$post({
+      const res = await api.api.leagues[":id"].generate.$post({
         param: { id: leagueId },
       });
       if (!res.ok) {
-        throw new Error(`Failed to found league (${res.status})`);
+        throw new Error(`Failed to generate league (${res.status})`);
       }
       return res.json();
     },


### PR DESCRIPTION
## Summary
- Rework the hiring page around shadcn `DataTable` with Coach/Scout tabs, human-readable role labels (HC → Head Coach, QB → Quarterbacks Coach, etc.), and prominent cap counters for interests, interviews, and offers.
- Disable Express Interest / Request Interview / Submit Offer once each cap is hit, so the UI matches the server-side caps.
- Sticky league header stays visible while scrolling long candidate lists.
- Drop the "What this candidate wants" preferences card — numeric preference scores shouldn't be exposed as if candidates announce them publicly.
- Handle empty interview-reveal fields instead of rendering literal `null` in a `<pre>` block.
- Show the Hiring nav item during `initial_staff_hiring` (not only `coaching_carousel`) so it's reachable during setup.
- Fix the generate-league hook to call `/generate` — the endpoint was renamed from `/found` in #458 but the client still pointed at the old path, surfacing as "Failed to found league".
- Salary input formats with thousands separators and a leading `$` so multi-million-dollar values are readable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)