### PR TITLE
refactor(chunked-insert,attributes): relax row types to drop `as unknown as` casts

### DIFF
--- a/server/db/chunked-insert.ts
+++ b/server/db/chunked-insert.ts
@@ -3,8 +3,8 @@ import type { Executor } from "./connection.ts";
 export const DEFAULT_CHUNK_SIZE = 100;
 export const MAX_PARAMETERS_PER_BATCH = 5_000;
 
-function effectiveChunkSize(
-  rows: readonly Record<string, unknown>[],
+function effectiveChunkSize<Row extends object>(
+  rows: readonly Row[],
   chunkSize: number,
 ): number {
   if (rows.length === 0) return chunkSize;
@@ -17,11 +17,11 @@ function effectiveChunkSize(
   return Math.min(chunkSize, maxByParams);
 }
 
-export async function chunkedInsert(
+export async function chunkedInsert<Row extends object>(
   exec: Executor,
   // deno-lint-ignore no-explicit-any
   table: any,
-  rows: readonly Record<string, unknown>[],
+  rows: readonly Row[],
   chunkSize: number = DEFAULT_CHUNK_SIZE,
 ): Promise<void> {
   const size = effectiveChunkSize(rows, chunkSize);
@@ -31,11 +31,11 @@ export async function chunkedInsert(
   }
 }
 
-export async function chunkedInsertReturning<R>(
+export async function chunkedInsertReturning<R, Row extends object = object>(
   exec: Executor,
   // deno-lint-ignore no-explicit-any
   table: any,
-  rows: readonly Record<string, unknown>[],
+  rows: readonly Row[],
   returning: Record<string, unknown>,
   chunkSize: number = DEFAULT_CHUNK_SIZE,
 ): Promise<R[]> {

--- a/server/features/depth-chart/depth-chart.publisher.ts
+++ b/server/features/depth-chart/depth-chart.publisher.ts
@@ -127,9 +127,7 @@ export function createDepthChartPublisher(deps: {
 
         const playersForAssignment: PlayerForAssignment[] = playerRows.map(
           (row) => {
-            const attributes = pickAttributes(
-              row as unknown as Record<string, unknown>,
-            );
+            const attributes = pickAttributes(row);
             const bucket = neutralBucket({
               attributes,
               heightInches: row.heightInches,

--- a/server/features/players/attributes.schema.ts
+++ b/server/features/players/attributes.schema.ts
@@ -20,13 +20,12 @@ export function attributeColumns() {
   return columns;
 }
 
-export function pickAttributes(
-  row: Record<string, unknown>,
-): PlayerAttributes {
+export function pickAttributes(row: object): PlayerAttributes {
+  const indexed = row as Record<string, unknown>;
   const attrs: Record<string, number> = {};
   for (const key of PLAYER_ATTRIBUTE_KEYS) {
-    attrs[key] = row[key] as number;
-    attrs[`${key}Potential`] = row[`${key}Potential`] as number;
+    attrs[key] = indexed[key] as number;
+    attrs[`${key}Potential`] = indexed[`${key}Potential`] as number;
   }
   return attrs as PlayerAttributes;
 }

--- a/server/features/players/players.repository.ts
+++ b/server/features/players/players.repository.ts
@@ -239,9 +239,7 @@ export function createPlayersRepository(deps: {
 
       if (!row) return undefined;
 
-      const attributes: PlayerAttributes = pickAttributes(
-        row as unknown as Record<string, unknown>,
-      );
+      const attributes: PlayerAttributes = pickAttributes(row);
       const bucket = neutralBucket({
         attributes,
         heightInches: row.heightInches,
@@ -486,7 +484,7 @@ export function createPlayersRepository(deps: {
         firstName: row.firstName,
         lastName: row.lastName,
         neutralBucket: neutralBucket({
-          attributes: pickAttributes(row as unknown as Record<string, unknown>),
+          attributes: pickAttributes(row),
           heightInches: row.heightInches,
           weightPounds: row.weightPounds,
         }),

--- a/server/features/players/players.service.ts
+++ b/server/features/players/players.service.ts
@@ -195,9 +195,7 @@ export function createPlayersService(deps: {
       });
 
       if (contractBundles.length > 0) {
-        const contractRows = contractBundles.map(
-          (b) => b.contract as unknown as Record<string, unknown>,
-        );
+        const contractRows = contractBundles.map((b) => b.contract);
         const insertedContracts = await chunkedInsertReturning<{
           id: string;
           playerId: string;

--- a/server/features/roster/roster.repository.ts
+++ b/server/features/roster/roster.repository.ts
@@ -181,9 +181,7 @@ export function createRosterRepository(deps: {
 
       const today = now();
       const rosterPlayers: RosterPlayer[] = rows.map((row) => {
-        const attributes: PlayerAttributes = pickAttributes(
-          row as unknown as Record<string, unknown>,
-        );
+        const attributes: PlayerAttributes = pickAttributes(row);
         const bucket = neutralBucket({
           attributes,
           heightInches: row.heightInches,


### PR DESCRIPTION
## Summary

Four call sites were laundering typed Drizzle row objects through `as unknown as Record<string, unknown>` to satisfy parameter signatures:

- `players.service.ts` passing typed `GeneratedContract[]` to `chunkedInsertReturning`
- `players.repository.ts`, `roster.repository.ts`, `depth-chart.publisher.ts` passing Drizzle row objects to `pickAttributes()`

Double-casts defeat type safety and tell future readers \"trust me\" when nothing at runtime required it.

Widen the parameter types so callers don't cast:

- `chunkedInsert` / `chunkedInsertReturning` now take `readonly Row[]` with `Row extends object` instead of `Record<string, unknown>[]`. Drizzle already accepts any shape at runtime; this lets typed interfaces like `GeneratedContract` flow through directly.
- `pickAttributes` now takes `row: object` and narrows to `Record<string, unknown>` once internally for the dynamic lookup.

All 695 server tests still pass.