### PR TITLE
refactor: extract shared coach-tendency and age-from-birth helpers

### DIFF
--- a/server/features/coaches/coach-tendencies.repository.ts
+++ b/server/features/coaches/coach-tendencies.repository.ts
@@ -1,49 +1,13 @@
 import { eq } from "drizzle-orm";
 import type pino from "pino";
-import type {
-  CoachTendencies,
-  DefensiveTendencies,
-  OffensiveTendencies,
-} from "@zone-blitz/shared";
 import {
   DEFENSIVE_TENDENCY_KEYS,
   OFFENSIVE_TENDENCY_KEYS,
 } from "@zone-blitz/shared";
 import type { Database } from "../../db/connection.ts";
 import { coachTendencies } from "./coach-tendencies.schema.ts";
+import { toCoachTendencies } from "./tendency-row.ts";
 import type { CoachTendenciesRepository } from "./coach-tendencies.repository.interface.ts";
-
-type CoachTendencyRow = typeof coachTendencies.$inferSelect;
-
-function pickOffense(row: CoachTendencyRow): OffensiveTendencies | null {
-  const values = OFFENSIVE_TENDENCY_KEYS.map((key) => row[key]);
-  if (values.every((v) => v === null)) return null;
-  const out = {} as OffensiveTendencies;
-  for (const key of OFFENSIVE_TENDENCY_KEYS) {
-    out[key] = (row[key] ?? 0) as number;
-  }
-  return out;
-}
-
-function pickDefense(row: CoachTendencyRow): DefensiveTendencies | null {
-  const values = DEFENSIVE_TENDENCY_KEYS.map((key) => row[key]);
-  if (values.every((v) => v === null)) return null;
-  const out = {} as DefensiveTendencies;
-  for (const key of DEFENSIVE_TENDENCY_KEYS) {
-    out[key] = (row[key] ?? 0) as number;
-  }
-  return out;
-}
-
-function toCoachTendencies(row: CoachTendencyRow): CoachTendencies {
-  return {
-    coachId: row.coachId,
-    offense: pickOffense(row),
-    defense: pickDefense(row),
-    createdAt: row.createdAt,
-    updatedAt: row.updatedAt,
-  };
-}
 
 export function createCoachTendenciesRepository(deps: {
   db: Database;

--- a/server/features/coaches/tendency-row.ts
+++ b/server/features/coaches/tendency-row.ts
@@ -1,0 +1,39 @@
+import type {
+  CoachTendencies,
+  DefensiveTendencies,
+  OffensiveTendencies,
+} from "@zone-blitz/shared";
+import {
+  DEFENSIVE_TENDENCY_KEYS,
+  OFFENSIVE_TENDENCY_KEYS,
+} from "@zone-blitz/shared";
+import type { coachTendencies } from "./coach-tendencies.schema.ts";
+
+export type CoachTendencyRow = typeof coachTendencies.$inferSelect;
+
+// A fully-null offense/defense block is how the schema represents
+// "coach has not set their tendencies yet" — return null so callers
+// can distinguish that from "set, but every value is zero".
+export function pickOffense(row: CoachTendencyRow): OffensiveTendencies | null {
+  if (OFFENSIVE_TENDENCY_KEYS.every((k) => row[k] === null)) return null;
+  const out = {} as OffensiveTendencies;
+  for (const k of OFFENSIVE_TENDENCY_KEYS) out[k] = (row[k] ?? 0) as number;
+  return out;
+}
+
+export function pickDefense(row: CoachTendencyRow): DefensiveTendencies | null {
+  if (DEFENSIVE_TENDENCY_KEYS.every((k) => row[k] === null)) return null;
+  const out = {} as DefensiveTendencies;
+  for (const k of DEFENSIVE_TENDENCY_KEYS) out[k] = (row[k] ?? 0) as number;
+  return out;
+}
+
+export function toCoachTendencies(row: CoachTendencyRow): CoachTendencies {
+  return {
+    coachId: row.coachId,
+    offense: pickOffense(row),
+    defense: pickDefense(row),
+    createdAt: row.createdAt,
+    updatedAt: row.updatedAt,
+  };
+}

--- a/server/features/depth-chart/depth-chart.publisher.ts
+++ b/server/features/depth-chart/depth-chart.publisher.ts
@@ -3,12 +3,8 @@ import type pino from "pino";
 import {
   assignDepthChart,
   type CoachTendencies,
-  DEFENSIVE_TENDENCY_KEYS,
-  type DefensiveTendencies,
   depthChartVocabulary,
   neutralBucket,
-  OFFENSIVE_TENDENCY_KEYS,
-  type OffensiveTendencies,
   type PlayerForAssignment,
 } from "@zone-blitz/shared";
 import type { Database } from "../../db/connection.ts";
@@ -21,34 +17,9 @@ import {
 import { depthChartEntries } from "../players/depth-chart.schema.ts";
 import { coaches } from "../coaches/coach.schema.ts";
 import { coachTendencies } from "../coaches/coach-tendencies.schema.ts";
+import { toCoachTendencies } from "../coaches/tendency-row.ts";
 import { computeFingerprint, computeSchemeScore } from "../schemes/mod.ts";
 import type { DepthChartPublisher } from "./depth-chart.publisher.interface.ts";
-
-type TendencyRow = typeof coachTendencies.$inferSelect;
-
-function pickOffense(row: TendencyRow): OffensiveTendencies | null {
-  if (OFFENSIVE_TENDENCY_KEYS.every((k) => row[k] === null)) return null;
-  const out = {} as OffensiveTendencies;
-  for (const k of OFFENSIVE_TENDENCY_KEYS) out[k] = (row[k] ?? 0) as number;
-  return out;
-}
-
-function pickDefense(row: TendencyRow): DefensiveTendencies | null {
-  if (DEFENSIVE_TENDENCY_KEYS.every((k) => row[k] === null)) return null;
-  const out = {} as DefensiveTendencies;
-  for (const k of DEFENSIVE_TENDENCY_KEYS) out[k] = (row[k] ?? 0) as number;
-  return out;
-}
-
-function toCoachTendencies(row: TendencyRow): CoachTendencies {
-  return {
-    coachId: row.coachId,
-    offense: pickOffense(row),
-    defense: pickDefense(row),
-    createdAt: row.createdAt,
-    updatedAt: row.updatedAt,
-  };
-}
 
 export function createDepthChartPublisher(deps: {
   db: Database;

--- a/server/features/players/age.ts
+++ b/server/features/players/age.ts
@@ -1,0 +1,12 @@
+export function ageFromBirthDate(birthDate: string, today: Date): number {
+  const birth = new Date(birthDate);
+  let age = today.getUTCFullYear() - birth.getUTCFullYear();
+  const monthDelta = today.getUTCMonth() - birth.getUTCMonth();
+  if (
+    monthDelta < 0 ||
+    (monthDelta === 0 && today.getUTCDate() < birth.getUTCDate())
+  ) {
+    age -= 1;
+  }
+  return Math.max(0, age);
+}

--- a/server/features/players/players.repository.ts
+++ b/server/features/players/players.repository.ts
@@ -20,6 +20,7 @@ import {
   pickAttributes,
   playerAttributes,
 } from "./attributes.schema.ts";
+import { ageFromBirthDate } from "./age.ts";
 import { contracts } from "../contracts/contract.schema.ts";
 import { contractHistory } from "../contracts/contract-history.schema.ts";
 import { playerTransactions } from "../contracts/player-transaction.schema.ts";
@@ -30,19 +31,6 @@ import { teams } from "../team/team.schema.ts";
 import { cities } from "../cities/city.schema.ts";
 import { alias } from "drizzle-orm/pg-core";
 import type { PlayersRepository } from "./players.repository.interface.ts";
-
-function ageFromBirthDate(birthDate: string, today: Date): number {
-  const birth = new Date(birthDate);
-  let age = today.getUTCFullYear() - birth.getUTCFullYear();
-  const monthDelta = today.getUTCMonth() - birth.getUTCMonth();
-  if (
-    monthDelta < 0 ||
-    (monthDelta === 0 && today.getUTCDate() < birth.getUTCDate())
-  ) {
-    age -= 1;
-  }
-  return Math.max(0, age);
-}
 
 export function createPlayersRepository(deps: {
   db: Database;

--- a/server/features/roster/roster.repository.ts
+++ b/server/features/roster/roster.repository.ts
@@ -2,8 +2,6 @@ import { and, desc, eq, inArray } from "drizzle-orm";
 import type pino from "pino";
 import {
   type CoachTendencies,
-  DEFENSIVE_TENDENCY_KEYS,
-  type DefensiveTendencies,
   type DepthChartInactive,
   type DepthChartSlot,
   depthChartVocabulary,
@@ -11,8 +9,6 @@ import {
   neutralBucket,
   type NeutralBucketGroup,
   neutralBucketGroupOf,
-  OFFENSIVE_TENDENCY_KEYS,
-  type OffensiveTendencies,
   type PlayerAttributes,
   type RosterPlayer,
   type RosterPositionGroupSummary,
@@ -26,56 +22,19 @@ import {
   pickAttributes,
   playerAttributes,
 } from "../players/attributes.schema.ts";
+import { ageFromBirthDate } from "../players/age.ts";
 import { contracts } from "../contracts/contract.schema.ts";
 import { depthChartEntries } from "../players/depth-chart.schema.ts";
 import { leagues } from "../league/league.schema.ts";
 import { coaches } from "../coaches/coach.schema.ts";
 import { coachTendencies } from "../coaches/coach-tendencies.schema.ts";
+import { toCoachTendencies } from "../coaches/tendency-row.ts";
 import {
   computeFingerprint,
   computeSchemeFit,
   schemeLens,
 } from "../schemes/mod.ts";
 import type { RosterRepository } from "./roster.repository.interface.ts";
-
-type TendencyRow = typeof coachTendencies.$inferSelect;
-
-function pickOffense(row: TendencyRow): OffensiveTendencies | null {
-  if (OFFENSIVE_TENDENCY_KEYS.every((k) => row[k] === null)) return null;
-  const out = {} as OffensiveTendencies;
-  for (const k of OFFENSIVE_TENDENCY_KEYS) out[k] = (row[k] ?? 0) as number;
-  return out;
-}
-
-function pickDefense(row: TendencyRow): DefensiveTendencies | null {
-  if (DEFENSIVE_TENDENCY_KEYS.every((k) => row[k] === null)) return null;
-  const out = {} as DefensiveTendencies;
-  for (const k of DEFENSIVE_TENDENCY_KEYS) out[k] = (row[k] ?? 0) as number;
-  return out;
-}
-
-function toCoachTendencies(row: TendencyRow): CoachTendencies {
-  return {
-    coachId: row.coachId,
-    offense: pickOffense(row),
-    defense: pickDefense(row),
-    createdAt: row.createdAt,
-    updatedAt: row.updatedAt,
-  };
-}
-
-function ageFromBirthDate(birthDate: string, today: Date): number {
-  const birth = new Date(birthDate);
-  let age = today.getUTCFullYear() - birth.getUTCFullYear();
-  const monthDelta = today.getUTCMonth() - birth.getUTCMonth();
-  if (
-    monthDelta < 0 ||
-    (monthDelta === 0 && today.getUTCDate() < birth.getUTCDate())
-  ) {
-    age -= 1;
-  }
-  return Math.max(0, age);
-}
 
 function summarizeGroups(
   rosterPlayers: RosterPlayer[],


### PR DESCRIPTION
## Summary

Pure copy-paste dedupe. Three files had an identical 22-line `pickOffense` / `pickDefense` / `toCoachTendencies` block (`roster.repository`, `depth-chart.publisher`, `coach-tendencies.repository`), and two files had an identical `ageFromBirthDate` (`players.repository`, `roster.repository`).

Extracted into:

- `server/features/coaches/tendency-row.ts` — `pickOffense`, `pickDefense`, `toCoachTendencies`, `CoachTendencyRow` type.
- `server/features/players/age.ts` — `ageFromBirthDate`.

Net: −67 lines, and changing either concept (tendency null-semantics, leap-year handling) is now a one-file edit instead of three.