### PR TITLE
refactor(league-clock): decouple from hiring via phase-step listener fanout

### DIFF
--- a/server/features/hiring/hiring-step-effects.ts
+++ b/server/features/hiring/hiring-step-effects.ts
@@ -1,14 +1,12 @@
 import type pino from "pino";
+import type { PhaseStepListener } from "../league-clock/phase-step-listener.ts";
 import type { HiringService } from "./hiring.service.ts";
 import type { NpcHiringAi } from "./npc-hiring-ai.ts";
 
-export interface HiringStepEffects {
-  onTransition(input: {
-    leagueId: string;
-    prevStepSlug: string;
-    nextStepSlug: string;
-  }): Promise<void>;
-}
+// Retained for public API compatibility — HiringStepEffects is just a
+// PhaseStepListener, so new features can implement the same contract
+// without depending on the hiring module.
+export type HiringStepEffects = PhaseStepListener;
 
 type HiringServiceSubset = Pick<
   HiringService,

--- a/server/features/league-clock/league-clock.service.ts
+++ b/server/features/league-clock/league-clock.service.ts
@@ -12,6 +12,12 @@ import {
 } from "./gates.ts";
 import { DEFAULT_PHASE_STEPS } from "./default-phase-steps.ts";
 import { leaguePhaseEnum } from "./league-clock.schema.ts";
+import type { PhaseStepListener } from "./phase-step-listener.ts";
+
+// The first phase of a Year-1 league. Exported so other features can
+// seed the clock at this phase without hardcoding the string.
+export const FIRST_INITIAL_PHASE: typeof leaguePhaseEnum.enumValues[number] =
+  "initial_staff_hiring";
 
 export interface Actor {
   userId: string;
@@ -72,14 +78,6 @@ export interface LeagueClockService {
     leagueId: string,
     teamId: string,
   ): Promise<VoteResult>;
-}
-
-export interface StepTransitionEffects {
-  onTransition(input: {
-    leagueId: string;
-    prevStepSlug: string;
-    nextStepSlug: string;
-  }): Promise<void>;
 }
 
 interface TargetStep {
@@ -236,7 +234,7 @@ export function createLeagueClockService(deps: {
   txRunner: TransactionRunner;
   leagueClockRepo: LeagueClockRepository;
   log: pino.Logger;
-  stepEffects?: StepTransitionEffects;
+  stepEffects?: PhaseStepListener;
 }): LeagueClockService {
   const log = deps.log.child({ module: "league-clock.service" });
   const phases = leaguePhaseEnum.enumValues;

--- a/server/features/league-clock/mod.ts
+++ b/server/features/league-clock/mod.ts
@@ -1,7 +1,10 @@
 export { createLeagueClockRepository } from "./league-clock.repository.ts";
 export type { LeagueClockRepository } from "./league-clock.repository.ts";
 export { createLeagueClockRouter } from "./league-clock.router.ts";
-export { createLeagueClockService } from "./league-clock.service.ts";
+export {
+  createLeagueClockService,
+  FIRST_INITIAL_PHASE,
+} from "./league-clock.service.ts";
 export type {
   Actor,
   AdvanceResult,
@@ -10,6 +13,8 @@ export type {
   ReadyCheckState,
   VoteResult,
 } from "./league-clock.service.ts";
+export { createPhaseStepListenerFanout } from "./phase-step-listener.ts";
+export type { PhaseStepListener } from "./phase-step-listener.ts";
 export type {
   Blocker,
   GateFn,

--- a/server/features/league-clock/phase-step-listener.ts
+++ b/server/features/league-clock/phase-step-listener.ts
@@ -1,0 +1,29 @@
+// Features subscribe to clock-step transitions by providing a
+// PhaseStepListener. The clock itself is phase-agnostic: it does not
+// know which features care about which step, only that it fires a
+// transition callback. New features (draft, trades, salary cap) plug
+// in by appending another listener to the registry in the composition
+// root — the clock does not change.
+export interface PhaseStepListener {
+  onTransition(input: {
+    leagueId: string;
+    prevStepSlug: string;
+    nextStepSlug: string;
+  }): Promise<void>;
+}
+
+// Composes multiple listeners into one. Listeners run sequentially in
+// the order supplied. A listener's rejection aborts the chain — the
+// clock treats that as a failed advance and rolls the transaction back,
+// so later listeners are not silently skipped.
+export function createPhaseStepListenerFanout(
+  listeners: readonly PhaseStepListener[],
+): PhaseStepListener {
+  return {
+    async onTransition(input) {
+      for (const listener of listeners) {
+        await listener.onTransition(input);
+      }
+    },
+  };
+}

--- a/server/features/league/league.service.ts
+++ b/server/features/league/league.service.ts
@@ -9,9 +9,9 @@ import type { FranchiseService } from "../franchise/franchise.service.interface.
 import type { PersonnelService } from "../personnel/personnel.service.interface.ts";
 import type { ScheduleService } from "../schedule/schedule.service.interface.ts";
 import type { LeagueClockRepository } from "../league-clock/league-clock.repository.ts";
+import { FIRST_INITIAL_PHASE } from "../league-clock/mod.ts";
 
 const INITIAL_TEAM_COUNT = 8;
-const FIRST_INITIAL_PHASE = "initial_staff_hiring";
 
 export function createLeagueService(deps: {
   txRunner: TransactionRunner;

--- a/server/features/mod.ts
+++ b/server/features/mod.ts
@@ -57,6 +57,8 @@ import {
   createLeagueClockRepository,
   createLeagueClockRouter,
   createLeagueClockService,
+  createPhaseStepListenerFanout,
+  type PhaseStepListener,
 } from "./league-clock/mod.ts";
 import {
   createFranchiseRepository,
@@ -208,12 +210,15 @@ export function createFeatureRouters(
     log,
   });
 
-  // League Clock service
+  // Phase-step listener registry. Features subscribe here to react to
+  // clock transitions; the clock itself stays agnostic. Add new
+  // listeners (draft, trades, etc.) to this array as they arrive.
+  const phaseStepListeners: PhaseStepListener[] = [hiringStepEffects];
   const leagueClockService = createLeagueClockService({
     txRunner,
     leagueClockRepo,
     log,
-    stepEffects: hiringStepEffects,
+    stepEffects: createPhaseStepListenerFanout(phaseStepListeners),
   });
   const leagueClockRouter = createLeagueClockRouter(leagueClockService, {
     teamService,


### PR DESCRIPTION
## Summary

The clock's \`stepEffects\` hook was technically generic but only hiring could plug in. Adding another feature (draft, trades, salary cap) would have meant either folding that feature's logic into \`hiring-step-effects.ts\` or hand-rolling a composite.

Promote the contract and add a fanout:

- New \`server/features/league-clock/phase-step-listener.ts\` exports \`PhaseStepListener\` (formerly the ad-hoc \`StepTransitionEffects\`) and \`createPhaseStepListenerFanout(listeners[])\`.
- \`hiring-step-effects.ts\` no longer re-declares the contract — \`HiringStepEffects\` is now a type alias of \`PhaseStepListener\`.
- \`server/features/mod.ts\` builds a \`phaseStepListeners\` array and passes the fanout to the clock. Adding a listener = appending to the array.
- Export \`FIRST_INITIAL_PHASE\` from league-clock; \`league.service.ts\` imports it instead of hardcoding \`"initial_staff_hiring"\`.

No behavior change. All 695 server tests pass.