### PR TITLE
refactor(depth-chart): move schema to its owning feature folder

### DIFF
--- a/server/db/schema.ts
+++ b/server/db/schema.ts
@@ -60,7 +60,7 @@ export {
   players,
   playerStatusEnum,
 } from "../features/players/player.schema.ts";
-export { depthChartEntries } from "../features/players/depth-chart.schema.ts";
+export { depthChartEntries } from "../features/depth-chart/depth-chart.schema.ts";
 export { playerAttributes } from "../features/players/attributes.schema.ts";
 export { playerDraftProfile } from "../features/players/player-draft-profile.schema.ts";
 export { playerSeasonRatings } from "../features/players/player-season-ratings.schema.ts";

--- a/server/features/depth-chart/depth-chart.publisher.test.ts
+++ b/server/features/depth-chart/depth-chart.publisher.test.ts
@@ -7,7 +7,7 @@ import { type NeutralBucket, PLAYER_ATTRIBUTE_KEYS } from "@zone-blitz/shared";
 import * as schema from "../../db/schema.ts";
 import { players } from "../players/player.schema.ts";
 import { playerAttributes } from "../players/attributes.schema.ts";
-import { depthChartEntries } from "../players/depth-chart.schema.ts";
+import { depthChartEntries } from "./depth-chart.schema.ts";
 import {
   BUCKET_PROFILES,
   stubAttributesFor,

--- a/server/features/depth-chart/depth-chart.publisher.ts
+++ b/server/features/depth-chart/depth-chart.publisher.ts
@@ -14,7 +14,7 @@ import {
   pickAttributes,
   playerAttributes,
 } from "../players/attributes.schema.ts";
-import { depthChartEntries } from "../players/depth-chart.schema.ts";
+import { depthChartEntries } from "./depth-chart.schema.ts";
 import { coaches } from "../coaches/coach.schema.ts";
 import { coachTendencies } from "../coaches/coach-tendencies.schema.ts";
 import { toCoachTendencies } from "../coaches/tendency-row.ts";

--- a/server/features/depth-chart/depth-chart.schema.ts
+++ b/server/features/depth-chart/depth-chart.schema.ts
@@ -9,7 +9,7 @@ import {
 } from "drizzle-orm/pg-core";
 import { teams } from "../team/team.schema.ts";
 import { coaches } from "../coaches/coach.schema.ts";
-import { players } from "./player.schema.ts";
+import { players } from "../players/player.schema.ts";
 
 export const depthChartEntries = pgTable(
   "depth_chart_entries",

--- a/server/features/roster-transaction/roster-transaction.service.test.ts
+++ b/server/features/roster-transaction/roster-transaction.service.test.ts
@@ -7,7 +7,7 @@ import { type NeutralBucket, PLAYER_ATTRIBUTE_KEYS } from "@zone-blitz/shared";
 import * as schema from "../../db/schema.ts";
 import { players } from "../players/player.schema.ts";
 import { playerAttributes } from "../players/attributes.schema.ts";
-import { depthChartEntries } from "../players/depth-chart.schema.ts";
+import { depthChartEntries } from "../depth-chart/depth-chart.schema.ts";
 import { playerTransactions } from "../contracts/player-transaction.schema.ts";
 import {
   BUCKET_PROFILES,

--- a/server/features/roster/roster.repository.test.ts
+++ b/server/features/roster/roster.repository.test.ts
@@ -12,7 +12,7 @@ import * as schema from "../../db/schema.ts";
 import { players } from "../players/player.schema.ts";
 import { playerAttributes } from "../players/attributes.schema.ts";
 import { contracts } from "../contracts/contract.schema.ts";
-import { depthChartEntries } from "../players/depth-chart.schema.ts";
+import { depthChartEntries } from "../depth-chart/depth-chart.schema.ts";
 import {
   BUCKET_PROFILES,
   stubAttributesFor,

--- a/server/features/roster/roster.repository.ts
+++ b/server/features/roster/roster.repository.ts
@@ -24,7 +24,7 @@ import {
 } from "../players/attributes.schema.ts";
 import { ageFromBirthDate } from "../players/age.ts";
 import { contracts } from "../contracts/contract.schema.ts";
-import { depthChartEntries } from "../players/depth-chart.schema.ts";
+import { depthChartEntries } from "../depth-chart/depth-chart.schema.ts";
 import { leagues } from "../league/league.schema.ts";
 import { coaches } from "../coaches/coach.schema.ts";
 import { coachTendencies } from "../coaches/coach-tendencies.schema.ts";


### PR DESCRIPTION
## Summary

\`depth-chart.schema.ts\` lived in \`server/features/players/\` but was consumed primarily by \`depth-chart.publisher\`, \`roster.repository\`, and \`roster-transaction\` — not by players. Location didn't match ownership.

Move:

- \`server/features/players/depth-chart.schema.ts\` → \`server/features/depth-chart/depth-chart.schema.ts\`
- Update 5 import sites (\`db/schema.ts\`, \`depth-chart.publisher\` + test, \`roster.repository\` + test, \`roster-transaction\` test).

Cross-feature joins that reference \`depthChartEntries\` inside larger Drizzle queries (the active-roster query, for instance) are left as-is. Schema location signals ownership; it doesn't forbid joins.

No behavior change. All 708 server tests pass.