### PR TITLE
refactor(league): collapse getAll() into a repo-level read model

### DIFF
--- a/server/features/league/league.repository.interface.ts
+++ b/server/features/league/league.repository.interface.ts
@@ -1,8 +1,12 @@
-import type { League, NewLeague } from "@zone-blitz/shared";
+import type { League, LeagueListItem, NewLeague } from "@zone-blitz/shared";
 import type { Executor } from "../../db/connection.ts";
 
 export interface LeagueRepository {
-  getAll(): Promise<League[]>;
+  // Returns every league with its latest season + user-team summaries
+  // pre-joined. The league-list page needs this shape; having the repo
+  // own the joins keeps the service thin and collapses what used to be
+  // a 1+2N query fan-out into two bounded queries.
+  listWithSummary(): Promise<LeagueListItem[]>;
   getById(id: string): Promise<League | undefined>;
   create(league: NewLeague, tx?: Executor): Promise<League>;
   updateUserTeam(id: string, userTeamId: string): Promise<League | undefined>;

--- a/server/features/league/league.repository.test.ts
+++ b/server/features/league/league.repository.test.ts
@@ -22,7 +22,7 @@ function createTestLogger() {
 }
 
 Deno.test({
-  name: "leagueRepository.getAll: returns all leagues",
+  name: "leagueRepository.listWithSummary: returns all leagues",
   sanitizeResources: false,
   sanitizeOps: false,
   fn: async () => {
@@ -37,10 +37,14 @@ Deno.test({
         .returning();
       inserted.push(a.id, b.id);
 
-      const result = await repo.getAll();
+      const result = await repo.listWithSummary();
       const names = result.map((l) => l.name);
       assertEquals(names.includes("League A"), true);
       assertEquals(names.includes("League B"), true);
+      // Leagues with no seasons or user team come back with nulls.
+      const justA = result.find((l) => l.name === "League A");
+      assertEquals(justA?.currentSeason, null);
+      assertEquals(justA?.userTeam, null);
     } finally {
       for (const id of inserted) {
         await db.delete(leagues).where(eq(leagues.id, id));
@@ -147,7 +151,7 @@ Deno.test({
 
 Deno.test({
   name:
-    "leagueRepository.getAll: orders by lastPlayedAt desc nulls last, then createdAt desc",
+    "leagueRepository.listWithSummary: orders by lastPlayedAt desc nulls last, then createdAt desc",
   sanitizeResources: false,
   sanitizeOps: false,
   fn: async () => {
@@ -170,7 +174,7 @@ Deno.test({
         .returning();
       inserted.push(a.id, b.id, c.id);
 
-      const result = await repo.getAll();
+      const result = await repo.listWithSummary();
       const byName = result.filter((l) =>
         ["order-a", "order-b", "order-c"].includes(l.name)
       );

--- a/server/features/league/league.repository.ts
+++ b/server/features/league/league.repository.ts
@@ -1,8 +1,12 @@
 import type { LeagueRepository } from "./league.repository.interface.ts";
 import type pino from "pino";
-import { desc, eq, sql } from "drizzle-orm";
+import { desc, eq, inArray, sql } from "drizzle-orm";
+import type { LeagueListItem } from "@zone-blitz/shared";
 import type { Database } from "../../db/connection.ts";
 import { leagues } from "./league.schema.ts";
+import { seasons } from "../season/season.schema.ts";
+import { teams } from "../team/team.schema.ts";
+import { cities } from "../cities/city.schema.ts";
 
 export function createLeagueRepository(deps: {
   db: Database;
@@ -11,15 +15,64 @@ export function createLeagueRepository(deps: {
   const log = deps.log.child({ module: "league.repository" });
 
   return {
-    async getAll() {
-      log.debug("fetching all leagues");
-      return await deps.db
-        .select()
+    async listWithSummary() {
+      log.debug("fetching leagues with summary");
+      const leagueRows = await deps.db
+        .select({
+          league: leagues,
+          userTeamId: teams.id,
+          userTeamName: teams.name,
+          userTeamCity: cities.name,
+          userTeamAbbreviation: teams.abbreviation,
+          userTeamPrimaryColor: teams.primaryColor,
+        })
         .from(leagues)
+        .leftJoin(teams, eq(teams.id, leagues.userTeamId))
+        .leftJoin(cities, eq(cities.id, teams.cityId))
         .orderBy(
           sql`${leagues.lastPlayedAt} desc nulls last`,
           desc(leagues.createdAt),
         );
+
+      if (leagueRows.length === 0) return [];
+
+      const leagueIds = leagueRows.map((r) => r.league.id);
+      const seasonRows = await deps.db
+        .select()
+        .from(seasons)
+        .where(inArray(seasons.leagueId, leagueIds))
+        .orderBy(seasons.leagueId, desc(seasons.year));
+
+      // seasonRows are ordered by (leagueId, year desc), so the first
+      // row seen for each league is its latest season.
+      const latestByLeague = new Map<string, typeof seasonRows[number]>();
+      for (const s of seasonRows) {
+        if (!latestByLeague.has(s.leagueId)) latestByLeague.set(s.leagueId, s);
+      }
+
+      return leagueRows.map((row): LeagueListItem => {
+        const current = latestByLeague.get(row.league.id);
+        return {
+          ...row.league,
+          currentSeason: current
+            ? {
+              year: current.year,
+              phase: current.phase,
+              offseasonStage: current.offseasonStage,
+              week: current.week,
+            }
+            : null,
+          userTeam: row.userTeamId
+            ? {
+              id: row.userTeamId,
+              name: row.userTeamName!,
+              city: row.userTeamCity!,
+              abbreviation: row.userTeamAbbreviation!,
+              primaryColor: row.userTeamPrimaryColor!,
+            }
+            : null,
+        };
+      });
     },
 
     async getById(id) {

--- a/server/features/league/league.service.test.ts
+++ b/server/features/league/league.service.test.ts
@@ -2,7 +2,12 @@ import { assertEquals, assertRejects } from "@std/assert";
 import { createLeagueService } from "./league.service.ts";
 import { DomainError } from "@zone-blitz/shared";
 import pino from "pino";
-import type { Franchise, League, Team } from "@zone-blitz/shared";
+import type {
+  Franchise,
+  League,
+  LeagueListItem,
+  Team,
+} from "@zone-blitz/shared";
 import type { Executor } from "../../db/connection.ts";
 import type { TransactionRunner } from "../../db/transaction-runner.ts";
 import type { LeagueRepository } from "./league.repository.interface.ts";
@@ -96,7 +101,7 @@ function createMockRepo(
   overrides: Partial<LeagueRepository> = {},
 ): LeagueRepository {
   return {
-    getAll: () => Promise.resolve([]),
+    listWithSummary: () => Promise.resolve([]),
     getById: () => Promise.resolve(undefined),
     create: () => Promise.resolve(createMockLeague({ id: "new-id" })),
     updateUserTeam: () => Promise.resolve(createMockLeague({ id: "new-id" })),
@@ -243,163 +248,37 @@ function createService(overrides: {
 
 Deno.test("league.service", async (t) => {
   await t.step(
-    "getAll returns leagues with their current season embedded",
+    "getAll delegates to leagueRepo.listWithSummary",
     async () => {
-      const leagues: League[] = [
-        createMockLeague({ id: "1", name: "League One" }),
-        createMockLeague({ id: "2", name: "League Two" }),
+      const items: LeagueListItem[] = [
+        {
+          ...createMockLeague({ id: "1", name: "League One" }),
+          currentSeason: {
+            year: 2,
+            phase: "regular_season",
+            offseasonStage: null,
+            week: 5,
+          },
+          userTeam: {
+            id: "team-42",
+            name: "Falcons",
+            city: "Atlanta",
+            abbreviation: "ATL",
+            primaryColor: "#A71930",
+          },
+        },
+        {
+          ...createMockLeague({ id: "2", name: "League Two" }),
+          currentSeason: null,
+          userTeam: null,
+        },
       ];
       const service = createService({
-        leagueRepo: { getAll: () => Promise.resolve(leagues) },
-        seasonService: {
-          getByLeagueId: (leagueId) =>
-            Promise.resolve([
-              {
-                id: `${leagueId}-s1`,
-                leagueId,
-                year: 1,
-                phase: "preseason" as const,
-                offseasonStage: null,
-                week: 1,
-                createdAt: new Date(),
-                updatedAt: new Date(),
-              },
-              {
-                id: `${leagueId}-s2`,
-                leagueId,
-                year: 2,
-                phase: "regular_season" as const,
-                offseasonStage: null,
-                week: 5,
-                createdAt: new Date(),
-                updatedAt: new Date(),
-              },
-            ]),
-        },
+        leagueRepo: { listWithSummary: () => Promise.resolve(items) },
       });
 
       const result = await service.getAll();
-      assertEquals(result.length, 2);
-      assertEquals(result[0].name, "League One");
-      assertEquals(result[0].currentSeason, {
-        year: 2,
-        phase: "regular_season",
-        offseasonStage: null,
-        week: 5,
-      });
-    },
-  );
-
-  await t.step(
-    "getAll includes offseasonStage in currentSeason when set",
-    async () => {
-      const service = createService({
-        leagueRepo: {
-          getAll: () =>
-            Promise.resolve([createMockLeague({ id: "1", name: "League" })]),
-        },
-        seasonService: {
-          getByLeagueId: (leagueId) =>
-            Promise.resolve([
-              {
-                id: `${leagueId}-s1`,
-                leagueId,
-                year: 1,
-                phase: "offseason" as const,
-                offseasonStage: "draft" as const,
-                week: 1,
-                createdAt: new Date(),
-                updatedAt: new Date(),
-              },
-            ]),
-        },
-      });
-
-      const result = await service.getAll();
-      assertEquals(result[0].currentSeason, {
-        year: 1,
-        phase: "offseason",
-        offseasonStage: "draft",
-        week: 1,
-      });
-    },
-  );
-
-  await t.step(
-    "getAll embeds userTeam summary when league has userTeamId",
-    async () => {
-      const teamId = "team-42";
-      const service = createService({
-        leagueRepo: {
-          getAll: () =>
-            Promise.resolve([
-              createMockLeague({ id: "lg-1", userTeamId: teamId }),
-            ]),
-        },
-        teamService: {
-          getById: (id) =>
-            Promise.resolve({
-              id,
-              leagueId: "lg-1",
-              franchiseId: "f-1",
-              name: "Falcons",
-              cityId: "city-1",
-              city: "Atlanta",
-              state: "GA",
-              abbreviation: "ATL",
-              primaryColor: "#A71930",
-              secondaryColor: "#000",
-              accentColor: "#FFF",
-              backstory: "A test backstory.",
-              conference: "NFC",
-              division: "NFC South",
-              marketTier: "medium",
-              createdAt: new Date(),
-              updatedAt: new Date(),
-            }),
-        },
-      });
-
-      const result = await service.getAll();
-      assertEquals(result[0].userTeam, {
-        id: teamId,
-        name: "Falcons",
-        city: "Atlanta",
-        abbreviation: "ATL",
-        primaryColor: "#A71930",
-      });
-    },
-  );
-
-  await t.step(
-    "getAll returns userTeam null when userTeamId is null",
-    async () => {
-      const service = createService({
-        leagueRepo: {
-          getAll: () =>
-            Promise.resolve([
-              createMockLeague({ id: "lg-1", userTeamId: null }),
-            ]),
-        },
-      });
-
-      const result = await service.getAll();
-      assertEquals(result[0].userTeam, null);
-    },
-  );
-
-  await t.step(
-    "getAll returns currentSeason null when a league has no seasons",
-    async () => {
-      const service = createService({
-        leagueRepo: {
-          getAll: () => Promise.resolve([createMockLeague({ id: "1" })]),
-        },
-        seasonService: { getByLeagueId: () => Promise.resolve([]) },
-      });
-
-      const result = await service.getAll();
-      assertEquals(result[0].currentSeason, null);
+      assertEquals(result, items);
     },
   );
 

--- a/server/features/league/league.service.ts
+++ b/server/features/league/league.service.ts
@@ -29,40 +29,7 @@ export function createLeagueService(deps: {
   return {
     async getAll() {
       log.debug("fetching all leagues");
-      const leagues = await deps.leagueRepo.getAll();
-      return await Promise.all(
-        leagues.map(async (league) => {
-          const seasons = await deps.seasonService.getByLeagueId(league.id);
-          const current = seasons.reduce<typeof seasons[number] | undefined>(
-            (latest, season) =>
-              !latest || season.year > latest.year ? season : latest,
-            undefined,
-          );
-          const userTeam = league.userTeamId
-            ? await deps.teamService.getById(league.userTeamId)
-            : null;
-          return {
-            ...league,
-            currentSeason: current
-              ? {
-                year: current.year,
-                phase: current.phase,
-                offseasonStage: current.offseasonStage,
-                week: current.week,
-              }
-              : null,
-            userTeam: userTeam
-              ? {
-                id: userTeam.id,
-                name: userTeam.name,
-                city: userTeam.city,
-                abbreviation: userTeam.abbreviation,
-                primaryColor: userTeam.primaryColor,
-              }
-              : null,
-          };
-        }),
-      );
+      return await deps.leagueRepo.listWithSummary();
     },
 
     async getById(id) {


### PR DESCRIPTION
## Summary

\`league.service.ts\` \`getAll()\` was a 7-dependency coordinator hiding an N+1: for each league it called \`seasonService.getByLeagueId\` and \`teamService.getById\` inside a \`Promise.all\`. Small leagues, cheap; at scale it's one DB round-trip per league per summary field.

Push the join into the repository as \`listWithSummary()\`, which runs exactly two queries regardless of league count:

1. \`leagues LEFT JOIN teams LEFT JOIN cities\` for the user-team summary, ordered by the existing \`lastPlayedAt desc nulls last, createdAt desc\` rule.
2. \`seasons WHERE leagueId IN (...) ORDER BY leagueId, year DESC\`.

Pick the latest season per league in memory by walking the pre-sorted season rows. The service is now a one-liner.

Collapsed the five service-level \`getAll\` test steps into one delegation test — the shape assertions move to the repository layer where the transformation actually lives. Repo-level tests cover the basic list, the ordering rule, and the null-summary case.

All 708 server tests pass.