### PR TITLE
feat(team-select): group franchises by conference

### DIFF
--- a/client/src/features/team-select/index.test.tsx
+++ b/client/src/features/team-select/index.test.tsx
@@ -50,6 +50,7 @@ const MOCK_FRANCHISES = [
     accentColor: "#E74C3C",
     backstory:
       "Born from the neon glow and high-stakes spirit of the Biggest Little City.",
+    conference: "Mountain",
   },
   {
     id: "f2",
@@ -61,6 +62,7 @@ const MOCK_FRANCHISES = [
     accentColor: "#F5F0E1",
     backstory:
       "Forged in Portland's shipyard heritage, the Riveters honor the workers who built the West.",
+    conference: "Pacific",
   },
   {
     id: "f3",
@@ -72,6 +74,7 @@ const MOCK_FRANCHISES = [
     accentColor: "#FFFFFF",
     backstory:
       "With a naval heritage stretching back generations, the Admirals command San Diego's waterfront.",
+    conference: "Pacific",
   },
 ];
 
@@ -212,6 +215,39 @@ describe("TeamSelect", () => {
     for (const franchise of MOCK_FRANCHISES) {
       expect(screen.getByText(franchise.backstory)).toBeDefined();
     }
+  });
+
+  it("groups teams into Pacific and Mountain conference cards", async () => {
+    mockFranchisesGet.mockReturnValue(
+      Promise.resolve({ json: () => Promise.resolve(MOCK_FRANCHISES) }),
+    );
+    renderWithProviders();
+    await waitFor(() => {
+      expect(screen.getByText("Aces")).toBeDefined();
+    });
+    expect(screen.getByText("Pacific")).toBeDefined();
+    expect(screen.getByText("Mountain")).toBeDefined();
+  });
+
+  it("renders conferences in Pacific-then-Mountain order with cities alphabetical within each", async () => {
+    mockFranchisesGet.mockReturnValue(
+      Promise.resolve({ json: () => Promise.resolve(MOCK_FRANCHISES) }),
+    );
+    renderWithProviders();
+    await waitFor(() => {
+      expect(screen.getByText("Aces")).toBeDefined();
+    });
+    const conferenceHeadings = [
+      ...document.querySelectorAll('[data-slot="card-title"]'),
+    ].map((el) => el.textContent);
+    expect(conferenceHeadings).toEqual(["Pacific", "Mountain"]);
+
+    const cityOrder = ["Portland", "San Diego", "Reno"];
+    const cityPositions = cityOrder.map((city) => {
+      const el = screen.getByText(city);
+      return Array.from(document.querySelectorAll("*")).indexOf(el);
+    });
+    expect(cityPositions).toEqual([...cityPositions].sort((a, b) => a - b));
   });
 
   it("does not expose identity-override controls", async () => {

--- a/client/src/features/team-select/index.tsx
+++ b/client/src/features/team-select/index.tsx
@@ -2,7 +2,7 @@ import { useNavigate, useParams } from "@tanstack/react-router";
 import { useAssignUserTeam } from "../../hooks/use-leagues.ts";
 import { useLeagueTeams } from "../../hooks/use-teams.ts";
 import { Button } from "@/components/ui/button";
-import { Card, CardContent } from "@/components/ui/card";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { TeamLogo } from "../../components/team-logo.tsx";
@@ -16,6 +16,32 @@ interface FranchiseTeam {
   secondaryColor: string;
   accentColor: string;
   backstory: string;
+  conference: string;
+}
+
+const CONFERENCE_ORDER = ["Pacific", "Mountain"] as const;
+
+function groupByConference(
+  teams: FranchiseTeam[],
+): [string, FranchiseTeam[]][] {
+  const groups = new Map<string, FranchiseTeam[]>();
+  for (const team of teams) {
+    const bucket = groups.get(team.conference) ?? [];
+    bucket.push(team);
+    groups.set(team.conference, bucket);
+  }
+  for (const bucket of groups.values()) {
+    bucket.sort((a, b) => a.city.localeCompare(b.city));
+  }
+  const known = CONFERENCE_ORDER
+    .filter((name) => groups.has(name))
+    .map((name) => [name, groups.get(name)!] as [string, FranchiseTeam[]]);
+  const extras = [...groups.entries()]
+    .filter(([name]) =>
+      !CONFERENCE_ORDER.includes(name as typeof CONFERENCE_ORDER[number])
+    )
+    .sort(([a], [b]) => a.localeCompare(b));
+  return [...known, ...extras];
 }
 
 function FranchiseCard({
@@ -142,10 +168,25 @@ export function TeamSelect() {
           </Alert>
         )}
 
-        <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
-          {(teams as FranchiseTeam[]).map((team) => (
-            <FranchiseCard key={team.id} team={team} onSelect={handleSelect} />
-          ))}
+        <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+          {groupByConference(teams as FranchiseTeam[]).map(
+            ([conference, conferenceTeams]) => (
+              <Card key={conference}>
+                <CardHeader>
+                  <CardTitle>{conference}</CardTitle>
+                </CardHeader>
+                <CardContent className="flex flex-col gap-4">
+                  {conferenceTeams.map((team) => (
+                    <FranchiseCard
+                      key={team.id}
+                      team={team}
+                      onSelect={handleSelect}
+                    />
+                  ))}
+                </CardContent>
+              </Card>
+            ),
+          )}
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- Replace flat 2-column grid on the league creation team-select view with a Pacific card and a Mountain card
- Sort franchises alphabetically by city within each conference so the order is deterministic across renders
- Pull `conference` through the existing `/teams/league/:leagueId` payload (already returned by the repository) into the client `FranchiseTeam` shape

🤖 Generated with [Claude Code](https://claude.com/claude-code)