### PR TITLE
feat(league-dashboard): accent dashboard with user team colors

### DIFF
--- a/client/src/features/league/layout.test.tsx
+++ b/client/src/features/league/layout.test.tsx
@@ -53,6 +53,8 @@ const mockTouch = vi.fn().mockResolvedValue({
 
 let mockPhase = "offseason_review";
 const mockClockGet = vi.fn();
+const mockLeagueGet = vi.fn();
+const mockTeamsGet = vi.fn();
 
 vi.mock("../../api.ts", () => ({
   api: {
@@ -64,16 +66,16 @@ vi.mock("../../api.ts", () => ({
       },
       leagues: {
         [":id"]: {
-          $get: vi.fn().mockResolvedValue({
-            json: () =>
-              Promise.resolve({
-                id: 1,
-                name: "My League",
-                userTeamId: "team-1",
-              }),
-          }),
+          $get: (...args: unknown[]) => mockLeagueGet(...args),
           touch: {
             $post: (...args: unknown[]) => mockTouch(...args),
+          },
+        },
+      },
+      teams: {
+        league: {
+          [":leagueId"]: {
+            $get: (...args: unknown[]) => mockTeamsGet(...args),
           },
         },
       },
@@ -105,6 +107,29 @@ function renderWithProviders() {
 
 beforeEach(() => {
   mockPhase = "offseason_review";
+  mockLeagueGet.mockResolvedValue({
+    json: () =>
+      Promise.resolve({
+        id: 1,
+        name: "My League",
+        userTeamId: "team-1",
+      }),
+  });
+  mockTeamsGet.mockResolvedValue({
+    ok: true,
+    json: () =>
+      Promise.resolve([
+        {
+          id: "team-1",
+          name: "Alphas",
+          city: "Alpha City",
+          abbreviation: "ALP",
+          primaryColor: "#112233",
+          secondaryColor: "#445566",
+          accentColor: "#ffcc00",
+        },
+      ]),
+  });
   mockClockGet.mockImplementation(() =>
     Promise.resolve({
       ok: true,
@@ -360,6 +385,61 @@ describe("LeagueLayout", () => {
     expect(screen.getByRole("link", { name: "Roster" })).toBeDefined();
     expect(screen.getByRole("link", { name: "Draft" })).toBeDefined();
     expect(screen.getByRole("link", { name: "Standings" })).toBeDefined();
+  });
+
+  it("applies the user team's primary color as the top header accent border", async () => {
+    renderWithProviders();
+    const header = await screen.findByTestId("league-header");
+    await waitFor(() => {
+      expect(
+        (header as HTMLElement).style.borderBottomColor,
+      ).not.toBe("");
+    });
+    expect((header as HTMLElement).style.borderBottomColor).toMatch(
+      /rgb\(17,\s*34,\s*51\)|#112233/,
+    );
+  });
+
+  it("exposes user team colors as CSS variables on the sidebar wrapper", async () => {
+    renderWithProviders();
+    await waitFor(() => {
+      const wrapper = document.querySelector(
+        '[data-slot="sidebar-wrapper"]',
+      ) as HTMLElement | null;
+      expect(wrapper?.style.getPropertyValue("--team-primary")).toBe(
+        "#112233",
+      );
+    });
+    const wrapper = document.querySelector(
+      '[data-slot="sidebar-wrapper"]',
+    ) as HTMLElement;
+    expect(wrapper.style.getPropertyValue("--team-secondary")).toBe("#445566");
+    expect(wrapper.style.getPropertyValue("--team-accent")).toBe("#ffcc00");
+  });
+
+  it("shows the user team's city and name in the sidebar header once loaded", async () => {
+    renderWithProviders();
+    await waitFor(() => {
+      expect(screen.getByText("Alpha City")).toBeDefined();
+    });
+    expect(screen.getByText("Alphas")).toBeDefined();
+  });
+
+  it("omits team-color styles when the league has no userTeamId", async () => {
+    mockLeagueGet.mockResolvedValue({
+      json: () =>
+        Promise.resolve({ id: 1, name: "My League", userTeamId: null }),
+    });
+    renderWithProviders();
+    await waitFor(() => {
+      expect(screen.getByText("My League")).toBeDefined();
+    });
+    const header = screen.getByTestId("league-header") as HTMLElement;
+    expect(header.style.borderBottomColor).toBe("");
+    const wrapper = document.querySelector(
+      '[data-slot="sidebar-wrapper"]',
+    ) as HTMLElement;
+    expect(wrapper.style.getPropertyValue("--team-primary")).toBe("");
   });
 
   it("collapses empty nav groups in early initial phases", async () => {

--- a/client/src/features/league/layout.tsx
+++ b/client/src/features/league/layout.tsx
@@ -17,10 +17,12 @@ import {
   SidebarTrigger,
   useSidebar,
 } from "@/components/ui/sidebar";
+import { TeamLogo } from "../../components/team-logo.tsx";
 import { UserMenu } from "../../components/user-menu.tsx";
 import { useLeague } from "../../hooks/use-league.ts";
 import { useLeagueClock } from "../../hooks/use-league-clock.ts";
 import { useTouchLeague } from "../../hooks/use-leagues.ts";
+import { type UserTeam, useUserTeam } from "../../hooks/use-user-team.ts";
 import type { LeaguePhase } from "../../types/league-phase.ts";
 import { LeagueClockDisplay } from "./league-clock-display.tsx";
 import { navGroups } from "./nav-config.ts";
@@ -43,6 +45,7 @@ export function LeagueLayout() {
   const { leagueId } = useParams({ strict: false });
   const { data: league } = useLeague(leagueId ?? "");
   const { data: clock } = useLeagueClock(leagueId ?? "");
+  const userTeam = useUserTeam(leagueId ?? "");
   const touchLeague = useTouchLeague();
 
   useEffect(() => {
@@ -58,11 +61,21 @@ export function LeagueLayout() {
   );
 
   const basePath = `/leagues/${leagueId}`;
+  const teamStyle = userTeam
+    ? ({
+      "--team-primary": userTeam.primaryColor,
+      "--team-secondary": userTeam.secondaryColor,
+      "--team-accent": userTeam.accentColor,
+    } as React.CSSProperties)
+    : undefined;
 
   return (
-    <SidebarProvider>
+    <SidebarProvider
+      style={teamStyle}
+      data-team-themed={userTeam ? "" : undefined}
+    >
       <Sidebar collapsible="icon">
-        <LeagueSidebarHeader name={league?.name} />
+        <LeagueSidebarHeader name={league?.name} team={userTeam} />
         <SidebarContent>
           {filteredGroups.map((group) => (
             <SidebarGroup key={group.label}>
@@ -129,7 +142,13 @@ export function LeagueLayout() {
         </SidebarFooter>
       </Sidebar>
       <SidebarInset>
-        <header className="sticky top-0 z-10 flex items-center gap-2 border-b bg-background px-4 py-2">
+        <header
+          className="sticky top-0 z-10 flex items-center gap-2 border-b-2 bg-background px-4 py-2"
+          style={userTeam
+            ? { borderBottomColor: userTeam.primaryColor }
+            : undefined}
+          data-testid="league-header"
+        >
           <SidebarTrigger className="-ml-1" />
           {leagueId && (
             <LeagueClockDisplay
@@ -144,7 +163,9 @@ export function LeagueLayout() {
   );
 }
 
-function LeagueSidebarHeader({ name }: { name?: string }) {
+function LeagueSidebarHeader(
+  { name, team }: { name?: string; team?: UserTeam },
+) {
   const { state } = useSidebar();
   const isCollapsed = state === "collapsed";
 
@@ -153,12 +174,41 @@ function LeagueSidebarHeader({ name }: { name?: string }) {
   }
 
   return (
-    <SidebarHeader>
-      <div className="flex items-center gap-2 px-2 py-1">
-        <span className="truncate text-sm font-semibold">
-          {name ?? "League"}
-        </span>
+    <SidebarHeader
+      className="gap-0 p-0"
+      style={team
+        ? {
+          background:
+            `linear-gradient(135deg, ${team.primaryColor}, ${team.secondaryColor})`,
+          color: team.accentColor,
+        }
+        : undefined}
+      data-testid="league-sidebar-header"
+    >
+      <div className="flex items-center gap-3 px-3 py-3">
+        {team && <TeamLogo team={team} className="size-9 text-xs" decorative />}
+        <div className="min-w-0 flex flex-col">
+          {team
+            ? (
+              <>
+                <span className="truncate text-xs opacity-90">{team.city}</span>
+                <span className="truncate text-sm font-bold leading-tight">
+                  {team.name}
+                </span>
+              </>
+            )
+            : (
+              <span className="truncate text-sm font-semibold">
+                {name ?? "League"}
+              </span>
+            )}
+        </div>
       </div>
+      {team && name && (
+        <div className="truncate border-t border-white/15 bg-black/20 px-3 py-1 text-[10px] uppercase tracking-wide opacity-90">
+          {name}
+        </div>
+      )}
     </SidebarHeader>
   );
 }

--- a/client/src/hooks/use-user-team.test.ts
+++ b/client/src/hooks/use-user-team.test.ts
@@ -1,0 +1,104 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { renderHook, waitFor } from "@testing-library/react";
+import { createElement, type ReactNode } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useUserTeam } from "./use-user-team.ts";
+
+const mockLeagueGet = vi.fn();
+const mockTeamsGet = vi.fn();
+
+vi.mock("../api.ts", () => ({
+  api: {
+    api: {
+      leagues: {
+        ":id": {
+          $get: (...args: unknown[]) => mockLeagueGet(...args),
+        },
+      },
+      teams: {
+        league: {
+          ":leagueId": {
+            $get: (...args: unknown[]) => mockTeamsGet(...args),
+          },
+        },
+      },
+    },
+  },
+}));
+
+function createWrapper() {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return ({ children }: { children: ReactNode }) =>
+    createElement(QueryClientProvider, { client }, children);
+}
+
+beforeEach(() => {
+  mockLeagueGet.mockResolvedValue({
+    ok: true,
+    json: () => Promise.resolve({ id: "1", name: "L", userTeamId: "team-a" }),
+  });
+  mockTeamsGet.mockResolvedValue({
+    ok: true,
+    json: () =>
+      Promise.resolve([
+        {
+          id: "team-a",
+          name: "Alphas",
+          city: "Alpha City",
+          abbreviation: "ALP",
+          primaryColor: "#112233",
+          secondaryColor: "#445566",
+          accentColor: "#778899",
+        },
+        {
+          id: "team-b",
+          name: "Betas",
+          city: "Beta",
+          abbreviation: "BET",
+          primaryColor: "#000000",
+          secondaryColor: "#ffffff",
+          accentColor: "#ff0000",
+        },
+      ]),
+  });
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("useUserTeam", () => {
+  it("returns the team matching the league's userTeamId", async () => {
+    const { result } = renderHook(() => useUserTeam("1"), {
+      wrapper: createWrapper(),
+    });
+    await waitFor(() => expect(result.current).toBeDefined());
+    expect(result.current?.id).toBe("team-a");
+    expect(result.current?.primaryColor).toBe("#112233");
+    expect(result.current?.secondaryColor).toBe("#445566");
+    expect(result.current?.accentColor).toBe("#778899");
+  });
+
+  it("returns undefined when the league has no userTeamId", async () => {
+    mockLeagueGet.mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ id: "1", name: "L", userTeamId: null }),
+    });
+    const { result } = renderHook(() => useUserTeam("1"), {
+      wrapper: createWrapper(),
+    });
+    await waitFor(() => {
+      expect(mockTeamsGet).toHaveBeenCalled();
+    });
+    expect(result.current).toBeUndefined();
+  });
+
+  it("returns undefined when leagueId is empty", () => {
+    const { result } = renderHook(() => useUserTeam(""), {
+      wrapper: createWrapper(),
+    });
+    expect(result.current).toBeUndefined();
+  });
+});

--- a/client/src/hooks/use-user-team.ts
+++ b/client/src/hooks/use-user-team.ts
@@ -1,0 +1,20 @@
+import { useLeague } from "./use-league.ts";
+import { useLeagueTeams } from "./use-teams.ts";
+
+export interface UserTeam {
+  id: string;
+  name: string;
+  city: string;
+  abbreviation: string;
+  primaryColor: string;
+  secondaryColor: string;
+  accentColor: string;
+}
+
+export function useUserTeam(leagueId: string): UserTeam | undefined {
+  const { data: league } = useLeague(leagueId);
+  const { data: teams } = useLeagueTeams(leagueId);
+  const userTeamId = league?.userTeamId;
+  if (!userTeamId || !teams) return undefined;
+  return (teams as UserTeam[]).find((team) => team.id === userTeamId);
+}


### PR DESCRIPTION
## Summary

- Sidebar header becomes a team primary→secondary gradient with the team logo, city, and name; the league name moves to a secondary strip beneath it.
- Top dashboard header gains a primary-color accent border, and `--team-primary` / `--team-secondary` / `--team-accent` are published as CSS variables on the sidebar wrapper for future dashboard surfaces to consume.
- New `useUserTeam` hook resolves the full franchise record (colors + identity) for the league's `userTeamId`; when no team is chosen the layout falls back to the plain league name.

🤖 Generated with [Claude Code](https://claude.com/claude-code)