### PR TITLE
fix(team-select): allow franchise backstory to wrap inside card

### DIFF
--- a/client/src/features/team-select/index.test.tsx
+++ b/client/src/features/team-select/index.test.tsx
@@ -217,6 +217,21 @@ describe("TeamSelect", () => {
     }
   });
 
+  it("allows backstory text to wrap rather than truncating to a single line", async () => {
+    mockFranchisesGet.mockReturnValue(
+      Promise.resolve({ json: () => Promise.resolve(MOCK_FRANCHISES) }),
+    );
+    renderWithProviders();
+    await waitFor(() => {
+      expect(screen.getByText("Aces")).toBeDefined();
+    });
+    for (const franchise of MOCK_FRANCHISES) {
+      const backstory = screen.getByText(franchise.backstory);
+      const card = backstory.closest("button");
+      expect(card?.className).toContain("whitespace-normal");
+    }
+  });
+
   it("groups teams into Pacific and Mountain conference cards", async () => {
     mockFranchisesGet.mockReturnValue(
       Promise.resolve({ json: () => Promise.resolve(MOCK_FRANCHISES) }),

--- a/client/src/features/team-select/index.tsx
+++ b/client/src/features/team-select/index.tsx
@@ -55,7 +55,7 @@ function FranchiseCard({
     <Button
       variant="ghost"
       onClick={() => onSelect(team)}
-      className="h-auto p-0 w-full"
+      className="h-auto p-0 w-full whitespace-normal"
     >
       <Card className="w-full overflow-hidden transition-shadow hover:shadow-lg">
         <div


### PR DESCRIPTION
## Summary

- The franchise card's outer click target is shadcn's `Button`, whose base class set includes `whitespace-nowrap`. The backstory paragraph rendered on one line and got clipped by the card's width.
- Add `whitespace-normal` to the `Button`'s `className` so tailwind-merge overrides the base, letting the backstory wrap. Cover the behavior with a regression test asserting the wrapping class is present on the button surrounding each backstory.