### PR TITLE
fix(league): ensure readable text over team accent gradient

### DIFF
--- a/client/src/features/league/layout.test.tsx
+++ b/client/src/features/league/layout.test.tsx
@@ -425,6 +425,17 @@ describe("LeagueLayout", () => {
     expect(screen.getByText("Alphas")).toBeDefined();
   });
 
+  it("uses a high-contrast text color over the team gradient, not the accent", async () => {
+    renderWithProviders();
+    const header = await screen.findByTestId("league-sidebar-header");
+    await waitFor(() => {
+      expect((header as HTMLElement).style.color).not.toBe("");
+    });
+    const color = (header as HTMLElement).style.color;
+    expect(color).toMatch(/rgb\(255,\s*255,\s*255\)|#ffffff/);
+    expect(color).not.toMatch(/rgb\(255,\s*204,\s*0\)|#ffcc00/);
+  });
+
   it("omits team-color styles when the league has no userTeamId", async () => {
     mockLeagueGet.mockResolvedValue({
       json: () =>

--- a/client/src/features/league/layout.tsx
+++ b/client/src/features/league/layout.tsx
@@ -19,6 +19,7 @@ import {
 } from "@/components/ui/sidebar";
 import { TeamLogo } from "../../components/team-logo.tsx";
 import { UserMenu } from "../../components/user-menu.tsx";
+import { readableTextColor } from "../../lib/readable-text-color.ts";
 import { useLeague } from "../../hooks/use-league.ts";
 import { useLeagueClock } from "../../hooks/use-league-clock.ts";
 import { useTouchLeague } from "../../hooks/use-leagues.ts";
@@ -180,7 +181,7 @@ function LeagueSidebarHeader(
         ? {
           background:
             `linear-gradient(135deg, ${team.primaryColor}, ${team.secondaryColor})`,
-          color: team.accentColor,
+          color: readableTextColor(team.primaryColor, team.secondaryColor),
         }
         : undefined}
       data-testid="league-sidebar-header"

--- a/client/src/lib/readable-text-color.test.ts
+++ b/client/src/lib/readable-text-color.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+import { readableTextColor } from "./readable-text-color.ts";
+
+describe("readableTextColor", () => {
+  it("returns white text on a dark gradient", () => {
+    expect(readableTextColor("#3a0f0f", "#7a1a1a")).toBe("#ffffff");
+  });
+
+  it("returns black text on a light gradient", () => {
+    expect(readableTextColor("#ffe082", "#fff59d")).toBe("#000000");
+  });
+
+  it("returns white text for the Honolulu Lava dark-red gradient", () => {
+    expect(readableTextColor("#3d0f0a", "#a12a12")).toBe("#ffffff");
+  });
+
+  it("accepts 3-digit hex shorthand", () => {
+    expect(readableTextColor("#000", "#111")).toBe("#ffffff");
+    expect(readableTextColor("#fff", "#eee")).toBe("#000000");
+  });
+
+  it("picks the color with the higher minimum contrast across both endpoints", () => {
+    expect(readableTextColor("#000000", "#ffffff")).toMatch(
+      /^#(000000|ffffff)$/,
+    );
+  });
+
+  it("is case-insensitive for hex input", () => {
+    expect(readableTextColor("#3D0F0A", "#A12A12")).toBe("#ffffff");
+  });
+});

--- a/client/src/lib/readable-text-color.ts
+++ b/client/src/lib/readable-text-color.ts
@@ -1,0 +1,47 @@
+function expandHex(hex: string): string {
+  const stripped = hex.replace(/^#/, "");
+  if (stripped.length === 3) {
+    return stripped.split("").map((c) => c + c).join("");
+  }
+  return stripped;
+}
+
+function channelLuminance(channel: number): number {
+  const srgb = channel / 255;
+  return srgb <= 0.03928 ? srgb / 12.92 : Math.pow((srgb + 0.055) / 1.055, 2.4);
+}
+
+function relativeLuminance(hex: string): number {
+  const expanded = expandHex(hex);
+  const r = parseInt(expanded.slice(0, 2), 16);
+  const g = parseInt(expanded.slice(2, 4), 16);
+  const b = parseInt(expanded.slice(4, 6), 16);
+  return (
+    0.2126 * channelLuminance(r) +
+    0.7152 * channelLuminance(g) +
+    0.0722 * channelLuminance(b)
+  );
+}
+
+function contrastRatio(l1: number, l2: number): number {
+  const [lighter, darker] = l1 > l2 ? [l1, l2] : [l2, l1];
+  return (lighter + 0.05) / (darker + 0.05);
+}
+
+export function readableTextColor(primary: string, secondary: string): string {
+  const primaryLum = relativeLuminance(primary);
+  const secondaryLum = relativeLuminance(secondary);
+  const whiteLum = 1;
+  const blackLum = 0;
+
+  const whiteMinContrast = Math.min(
+    contrastRatio(whiteLum, primaryLum),
+    contrastRatio(whiteLum, secondaryLum),
+  );
+  const blackMinContrast = Math.min(
+    contrastRatio(blackLum, primaryLum),
+    contrastRatio(blackLum, secondaryLum),
+  );
+
+  return whiteMinContrast >= blackMinContrast ? "#ffffff" : "#000000";
+}


### PR DESCRIPTION
## Summary

- The league sidebar header placed team city/name text over a `primary → secondary` gradient using each team's `accentColor` as the text color. For franchises with similar-hue accents (e.g. Honolulu Lava: orange accent on dark red gradient), the text failed contrast and was nearly unreadable.
- Replaces the hardcoded accent with a WCAG-based choice of `#ffffff` or `#000000`, picked by whichever has the higher minimum contrast ratio against both gradient endpoints.
- Adds a small `readableTextColor` utility in `client/src/lib/` with unit tests, and a regression test on the league layout asserting the sidebar header no longer uses the accent color.