### PR TITLE
feat(hiring): size staff pools by tier with NFL-weighted sub-roles

### DIFF
--- a/server/features/coaches/coaches-generator.test.ts
+++ b/server/features/coaches/coaches-generator.test.ts
@@ -502,10 +502,28 @@ Deno.test("generatePool creates coaches with null teamId", () => {
   }
 });
 
-Deno.test("generatePool creates surplus coaches beyond team need", () => {
+Deno.test("generatePool sizes each tier by per-team count", () => {
   const result = makePoolGenerator().generatePool(POOL_INPUT);
-  const minimumNeeded = POOL_INPUT.numberOfTeams * COACHES_PER_TEAM;
-  assertEquals(result.length > minimumNeeded, true);
+  const N = POOL_INPUT.numberOfTeams;
+  const hcs = result.filter((c) => c.role === "HC");
+  const coords = result.filter((c) =>
+    c.role === "OC" || c.role === "DC" || c.role === "STC"
+  );
+  const positionRoles = new Set([
+    "QB",
+    "RB",
+    "WR",
+    "TE",
+    "OL",
+    "DL",
+    "LB",
+    "DB",
+    "ST_ASSISTANT",
+  ]);
+  const positions = result.filter((c) => positionRoles.has(c.role));
+  assertEquals(hcs.length, 2 * N);
+  assertEquals(coords.length, 4 * N);
+  assertEquals(positions.length, 6 * N);
 });
 
 Deno.test("generatePool creates coaches for all role types", () => {
@@ -516,15 +534,20 @@ Deno.test("generatePool creates coaches for all role types", () => {
   }
 });
 
-Deno.test("generatePool creates multiple candidates per role", () => {
+Deno.test("generatePool position weights favor OL/LB/DB over single-coach rooms", () => {
   const result = makePoolGenerator().generatePool(POOL_INPUT);
-  for (const role of EXPECTED_ROLES) {
-    const count = result.filter((c) => c.role === role).length;
-    assertEquals(
-      count >= POOL_INPUT.numberOfTeams,
-      true,
-      `role ${role}: expected >= ${POOL_INPUT.numberOfTeams}, got ${count}`,
-    );
+  const countOf = (role: string) =>
+    result.filter((c) => c.role === role).length;
+  for (const heavy of ["OL", "LB", "DB"]) {
+    for (const light of ["QB", "RB", "WR", "TE", "DL", "ST_ASSISTANT"]) {
+      assertEquals(
+        countOf(heavy) > countOf(light),
+        true,
+        `${heavy} (${countOf(heavy)}) should exceed ${light} (${
+          countOf(light)
+        })`,
+      );
+    }
   }
 });
 

--- a/server/features/coaches/coaches-generator.ts
+++ b/server/features/coaches/coaches-generator.ts
@@ -255,9 +255,59 @@ function intInRange(random: () => number, min: number, max: number): number {
   return Math.floor(random() * (max - min + 1)) + min;
 }
 
-const POOL_MULTIPLIER = 1.5;
+// Pool sizing is driven by tier-level per-team counts rather than a flat
+// multiplier per blueprint role. The numbers reflect the initial staffing
+// phase the game presents at league creation — teams compete over roughly
+// this many candidates per team, with sub-roles within each tier distributed
+// by NFL-realistic weights (defined below).
+const HC_POOL_PER_TEAM = 2;
+const COORDINATOR_POOL_PER_TEAM = 4;
+const POSITION_POOL_PER_TEAM = 6;
 
 const COORDINATOR_ROLES = new Set<CoachRole>(["OC", "DC", "STC"]);
+
+const COORDINATOR_WEIGHTS: ReadonlyArray<{ role: CoachRole; weight: number }> =
+  [
+    { role: "OC", weight: 1 },
+    { role: "DC", weight: 1 },
+    { role: "STC", weight: 1 },
+  ];
+
+// Position-coach weights track real-NFL staff composition: OL, LB, and DB
+// rooms typically carry two coaches (head + assistant or inside/outside
+// split); other position groups run with a single coach.
+const POSITION_WEIGHTS: ReadonlyArray<{ role: CoachRole; weight: number }> = [
+  { role: "QB", weight: 1 },
+  { role: "RB", weight: 1 },
+  { role: "WR", weight: 1 },
+  { role: "TE", weight: 1 },
+  { role: "OL", weight: 2 },
+  { role: "DL", weight: 1 },
+  { role: "LB", weight: 2 },
+  { role: "DB", weight: 2 },
+  { role: "ST_ASSISTANT", weight: 1 },
+];
+
+// Largest-remainder apportionment: distribute `total` units across
+// `weights` so each role's share approximates total*weight/sumW, and the
+// rounding remainder goes to roles with the largest fractional part.
+function distributeByWeight(
+  total: number,
+  weights: ReadonlyArray<{ role: CoachRole; weight: number }>,
+): Map<CoachRole, number> {
+  const sumW = weights.reduce((a, w) => a + w.weight, 0);
+  const rows = weights.map((w) => {
+    const exact = (total * w.weight) / sumW;
+    const floor = Math.floor(exact);
+    return { role: w.role, floor, remainder: exact - floor };
+  });
+  const leftover = total - rows.reduce((a, r) => a + r.floor, 0);
+  rows.sort((a, b) => b.remainder - a.remainder);
+  for (let i = 0; i < leftover; i++) rows[i].floor++;
+  const out = new Map<CoachRole, number>();
+  for (const r of rows) out.set(r.role, r.floor);
+  return out;
+}
 
 interface CoachPreferences {
   marketTierPref: number;
@@ -465,12 +515,29 @@ export function createCoachesGenerator(
       const collegeIndex = { value: 0 };
       const collegeIds = input.collegeIds ?? [];
 
-      const countPerRole = Math.ceil(
-        input.numberOfTeams * POOL_MULTIPLIER,
-      );
+      const N = input.numberOfTeams;
+      const roleCounts = new Map<CoachRole, number>();
+      roleCounts.set("HC", HC_POOL_PER_TEAM * N);
+      for (
+        const [role, count] of distributeByWeight(
+          COORDINATOR_POOL_PER_TEAM * N,
+          COORDINATOR_WEIGHTS,
+        )
+      ) {
+        roleCounts.set(role, count);
+      }
+      for (
+        const [role, count] of distributeByWeight(
+          POSITION_POOL_PER_TEAM * N,
+          POSITION_WEIGHTS,
+        )
+      ) {
+        roleCounts.set(role, count);
+      }
 
       for (const spec of STAFF_BLUEPRINT) {
-        for (let i = 0; i < countPerRole; i++) {
+        const count = roleCounts.get(spec.role) ?? 0;
+        for (let i = 0; i < count; i++) {
           const coach = generateCoach(
             spec,
             input.leagueId,

--- a/server/features/scouts/scouts-generator.test.ts
+++ b/server/features/scouts/scouts-generator.test.ts
@@ -257,22 +257,24 @@ Deno.test("generatePool creates unassigned scouts with no teamId", () => {
   }
 });
 
-Deno.test("generatePool creates 1.5x scouts per role per team count", () => {
+Deno.test("generatePool sizes each tier by per-team count with NFL 1:3 CC-to-area split", () => {
+  const N = 4;
   const result = makeGenerator().generatePool({
     leagueId: "league-1",
-    numberOfTeams: 4,
+    numberOfTeams: N,
   });
 
-  const countPerRole = Math.ceil(4 * 1.5);
   const directors = result.filter((s) => s.role === "DIRECTOR");
   const crossCheckers = result.filter(
     (s) => s.role === "NATIONAL_CROSS_CHECKER",
   );
   const areaScouts = result.filter((s) => s.role === "AREA_SCOUT");
 
-  assertEquals(directors.length, countPerRole);
-  assertEquals(crossCheckers.length, countPerRole * 2); // 2 cross-checker slots
-  assertEquals(areaScouts.length, countPerRole * 4); // 4 area scout slots
+  assertEquals(directors.length, 2 * N);
+  assertEquals(crossCheckers.length + areaScouts.length, 4 * N);
+  // 1:3 cross-checker to area-scout ratio mirrors real NFL clubs.
+  assertEquals(crossCheckers.length, N);
+  assertEquals(areaScouts.length, 3 * N);
 });
 
 Deno.test("generatePool returns empty array when numberOfTeams is 0", () => {

--- a/server/features/scouts/scouts-generator.ts
+++ b/server/features/scouts/scouts-generator.ts
@@ -80,7 +80,41 @@ const STAFF_BLUEPRINT: RoleSpec[] = [
 
 export const SCOUTS_PER_TEAM = STAFF_BLUEPRINT.length;
 
-const POOL_MULTIPLIER = 1.5;
+// Pool sizing is tier-driven: directors vs. non-directors. Non-director
+// weights mirror NFL scouting staffs — roughly 1 cross-checker per 3 area
+// scouts — then split across East/West (cross-checkers) and the four
+// regions (area scouts) so league coverage is preserved in aggregate.
+const DIRECTOR_POOL_PER_TEAM = 2;
+const NON_DIRECTOR_POOL_PER_TEAM = 4;
+
+const NON_DIRECTOR_WEIGHTS: ReadonlyArray<
+  { key: BlueprintKey; weight: number }
+> = [
+  { key: "EAST_CC", weight: 0.5 },
+  { key: "WEST_CC", weight: 0.5 },
+  { key: "AREA_NE", weight: 0.75 },
+  { key: "AREA_SE", weight: 0.75 },
+  { key: "AREA_MW", weight: 0.75 },
+  { key: "AREA_W", weight: 0.75 },
+];
+
+function distributeByWeight(
+  total: number,
+  weights: ReadonlyArray<{ key: BlueprintKey; weight: number }>,
+): Map<BlueprintKey, number> {
+  const sumW = weights.reduce((a, w) => a + w.weight, 0);
+  const rows = weights.map((w) => {
+    const exact = (total * w.weight) / sumW;
+    const floor = Math.floor(exact);
+    return { key: w.key, floor, remainder: exact - floor };
+  });
+  const leftover = total - rows.reduce((a, r) => a + r.floor, 0);
+  rows.sort((a, b) => b.remainder - a.remainder);
+  for (let i = 0; i < leftover; i++) rows[i].floor++;
+  const out = new Map<BlueprintKey, number>();
+  for (const r of rows) out.set(r.key, r.floor);
+  return out;
+}
 
 interface RoleBand {
   ageMin: number;
@@ -290,10 +324,21 @@ export function createScoutsGenerator(
 
       const scouts: GeneratedScout[] = [];
       const anchor = now();
-      const countPerRole = Math.ceil(input.numberOfTeams * POOL_MULTIPLIER);
+      const N = input.numberOfTeams;
+      const keyCounts = new Map<BlueprintKey, number>();
+      keyCounts.set("DIRECTOR", DIRECTOR_POOL_PER_TEAM * N);
+      for (
+        const [key, count] of distributeByWeight(
+          NON_DIRECTOR_POOL_PER_TEAM * N,
+          NON_DIRECTOR_WEIGHTS,
+        )
+      ) {
+        keyCounts.set(key, count);
+      }
 
       for (const spec of STAFF_BLUEPRINT) {
-        for (let i = 0; i < countPerRole; i++) {
+        const count = keyCounts.get(spec.key) ?? 0;
+        for (let i = 0; i < count; i++) {
           const { firstName, lastName } = nameGenerator.next();
           const id = crypto.randomUUID();
 


### PR DESCRIPTION
## Summary

- Replaces the flat `1.5x per role` candidate pool sizing with tier-level per-team counts during league creation: **2 HCs, 4 coordinators, 6 position coaches, 2 scouting directors, 4 non-director scouts** per team.
- Within each tier, sub-roles are apportioned by NFL-realistic weights via largest-remainder distribution: OL/LB/DB position rooms are weighted 2x (real staffs carry a head + assistant or inside/outside split), and scouts follow a 1:3 cross-checker-to-area-scout ratio while preserving the existing East/West and NE/SE/MW/W coverage splits.
- Generator tests updated to assert the new tier counts and sub-role weighting (position weights favor OL/LB/DB; scouts split 1:3 CC:area).