### PR TITLE
fix(league): extend contrast fix to league-name strip

### DIFF
--- a/client/src/features/league/layout.test.tsx
+++ b/client/src/features/league/layout.test.tsx
@@ -436,6 +436,16 @@ describe("LeagueLayout", () => {
     expect(color).not.toMatch(/rgb\(255,\s*204,\s*0\)|#ffcc00/);
   });
 
+  it("uses a high-contrast text color on the league-name strip over the darkened gradient", async () => {
+    renderWithProviders();
+    const strip = await screen.findByTestId("league-sidebar-name-strip");
+    await waitFor(() => {
+      expect((strip as HTMLElement).style.color).not.toBe("");
+    });
+    const color = (strip as HTMLElement).style.color;
+    expect(color).toMatch(/rgb\(255,\s*255,\s*255\)|#ffffff/);
+  });
+
   it("omits team-color styles when the league has no userTeamId", async () => {
     mockLeagueGet.mockResolvedValue({
       json: () =>

--- a/client/src/features/league/layout.tsx
+++ b/client/src/features/league/layout.tsx
@@ -19,7 +19,7 @@ import {
 } from "@/components/ui/sidebar";
 import { TeamLogo } from "../../components/team-logo.tsx";
 import { UserMenu } from "../../components/user-menu.tsx";
-import { readableTextColor } from "../../lib/readable-text-color.ts";
+import { blendHex, readableTextColor } from "../../lib/readable-text-color.ts";
 import { useLeague } from "../../hooks/use-league.ts";
 import { useLeagueClock } from "../../hooks/use-league-clock.ts";
 import { useTouchLeague } from "../../hooks/use-leagues.ts";
@@ -206,7 +206,16 @@ function LeagueSidebarHeader(
         </div>
       </div>
       {team && name && (
-        <div className="truncate border-t border-white/15 bg-black/20 px-3 py-1 text-[10px] uppercase tracking-wide opacity-90">
+        <div
+          className="truncate border-t border-white/15 bg-black/20 px-3 py-1 text-[10px] uppercase tracking-wide opacity-90"
+          style={{
+            color: readableTextColor(
+              blendHex(team.primaryColor, "#000000", 0.2),
+              blendHex(team.secondaryColor, "#000000", 0.2),
+            ),
+          }}
+          data-testid="league-sidebar-name-strip"
+        >
           {name}
         </div>
       )}

--- a/client/src/lib/readable-text-color.test.ts
+++ b/client/src/lib/readable-text-color.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { readableTextColor } from "./readable-text-color.ts";
+import { blendHex, readableTextColor } from "./readable-text-color.ts";
 
 describe("readableTextColor", () => {
   it("returns white text on a dark gradient", () => {
@@ -27,5 +27,28 @@ describe("readableTextColor", () => {
 
   it("is case-insensitive for hex input", () => {
     expect(readableTextColor("#3D0F0A", "#A12A12")).toBe("#ffffff");
+  });
+});
+
+describe("blendHex", () => {
+  it("returns the base color when overlay alpha is 0", () => {
+    expect(blendHex("#ff8800", "#000000", 0)).toBe("#ff8800");
+  });
+
+  it("returns the overlay color when alpha is 1", () => {
+    expect(blendHex("#ff8800", "#000000", 1)).toBe("#000000");
+  });
+
+  it("darkens a base color when blended with black at 20% alpha", () => {
+    expect(blendHex("#ffffff", "#000000", 0.2)).toBe("#cccccc");
+  });
+
+  it("clamps alpha to the [0, 1] range", () => {
+    expect(blendHex("#ffffff", "#000000", -1)).toBe("#ffffff");
+    expect(blendHex("#ffffff", "#000000", 2)).toBe("#000000");
+  });
+
+  it("accepts shorthand hex for base and overlay", () => {
+    expect(blendHex("#fff", "#000", 0.5)).toBe("#808080");
   });
 });

--- a/client/src/lib/readable-text-color.ts
+++ b/client/src/lib/readable-text-color.ts
@@ -6,16 +6,45 @@ function expandHex(hex: string): string {
   return stripped;
 }
 
+function toRgb(hex: string): [number, number, number] {
+  const expanded = expandHex(hex);
+  return [
+    parseInt(expanded.slice(0, 2), 16),
+    parseInt(expanded.slice(2, 4), 16),
+    parseInt(expanded.slice(4, 6), 16),
+  ];
+}
+
+function toHex(r: number, g: number, b: number): string {
+  const h = (n: number) =>
+    Math.round(Math.max(0, Math.min(255, n)))
+      .toString(16)
+      .padStart(2, "0");
+  return `#${h(r)}${h(g)}${h(b)}`;
+}
+
+export function blendHex(
+  base: string,
+  overlay: string,
+  overlayAlpha: number,
+): string {
+  const [br, bg, bb] = toRgb(base);
+  const [or, og, ob] = toRgb(overlay);
+  const a = Math.max(0, Math.min(1, overlayAlpha));
+  return toHex(
+    or * a + br * (1 - a),
+    og * a + bg * (1 - a),
+    ob * a + bb * (1 - a),
+  );
+}
+
 function channelLuminance(channel: number): number {
   const srgb = channel / 255;
   return srgb <= 0.03928 ? srgb / 12.92 : Math.pow((srgb + 0.055) / 1.055, 2.4);
 }
 
 function relativeLuminance(hex: string): number {
-  const expanded = expandHex(hex);
-  const r = parseInt(expanded.slice(0, 2), 16);
-  const g = parseInt(expanded.slice(2, 4), 16);
-  const b = parseInt(expanded.slice(4, 6), 16);
+  const [r, g, b] = toRgb(hex);
   return (
     0.2126 * channelLuminance(r) +
     0.7152 * channelLuminance(g) +


### PR DESCRIPTION
## Summary

- Stacks on top of #478. The league-name strip inside the sidebar header sits on the team gradient with a `bg-black/20` overlay, so its effective background differs from the parent header. Inheriting the parent's text color still produced unreadable names on some teams.
- Computes a separate readable black/white color by first blending each gradient endpoint with 20% black (matching the strip's real background) and then running the same WCAG min-contrast picker.
- Exports a `blendHex` helper next to `readableTextColor`, with unit tests for both, plus a regression assertion on the league layout strip.