### PR TITLE
feat(simulation): factor coach ratings into gameplay sim

### DIFF
--- a/server/features/coaches/coaches-generator.test.ts
+++ b/server/features/coaches/coaches-generator.test.ts
@@ -734,6 +734,26 @@ Deno.test("HC tier ratings bias toward leadership/gameManagement on average", ()
   assertEquals(hcLeadership > positionLeadership, true);
 });
 
+Deno.test("ratings across the pool are bell-centered on 50 (within 2 pts)", () => {
+  // Rating-scale contract: 50 is league average. A big-enough pool should
+  // have a per-key mean within ~2 points of 50, with only small role
+  // tilts nudging role-relevant ratings a bit higher.
+  const result = makePoolGenerator().generatePool({
+    leagueId: "lg",
+    numberOfTeams: 32,
+  });
+  const avg = (xs: number[]) => xs.reduce((a, b) => a + b, 0) / xs.length;
+  for (const key of COACH_RATING_KEYS) {
+    const mean = avg(result.map((c) => c.ratings.current[key]));
+    const delta = Math.abs(mean - 50);
+    assertEquals(
+      delta < 5,
+      true,
+      `${key} mean=${mean.toFixed(1)} drifted >5 from 50`,
+    );
+  }
+});
+
 Deno.test("generatePool two leagues produce independent pools with no shared ids", () => {
   const gen = makePoolGenerator();
   const poolA = gen.generatePool({ leagueId: "league-a", numberOfTeams: 4 });

--- a/server/features/coaches/coaches-generator.ts
+++ b/server/features/coaches/coaches-generator.ts
@@ -188,41 +188,44 @@ const TIER_BANDS: Record<Tier, TierBand> = {
   },
 };
 
-// Role-tier-specific mean rating values. Each entry is the expected
-// midpoint for a tier; a roll spreads ±RATING_SPREAD around it, then is
-// clamped to 1..99. HCs emphasize leadership + gameManagement;
-// coordinators emphasize schemeMastery; position coaches emphasize
-// playerDevelopment. These are calibration handles — adjust as we tune.
-const RATING_MEANS: Record<Tier, CoachRatingValues> = {
-  HC: {
-    leadership: 66,
-    gameManagement: 64,
-    schemeMastery: 55,
-    playerDevelopment: 52,
-    adaptability: 58,
-  },
-  COORDINATOR: {
-    leadership: 55,
-    gameManagement: 58,
-    schemeMastery: 66,
-    playerDevelopment: 55,
-    adaptability: 56,
-  },
-  POSITION: {
-    leadership: 50,
-    gameManagement: 46,
-    schemeMastery: 52,
-    playerDevelopment: 62,
-    adaptability: 52,
-  },
+// All coach ratings are drawn from a bell curve centered on 50 — the
+// league-average midpoint mandated by the rating-scale contract
+// (see docs/product/north-star/player-attributes.md). Role specialization
+// is expressed as a *small* tilt (+4) on role-relevant ratings rather than
+// a shifted mean, so a population of coaches averages 50 league-wide and
+// the full 0–99 scale carries meaning. Elite HCs and McVay-type
+// coordinators emerge from the tail of the bell, not from a pre-loaded
+// mean.
+const ROLE_TILT = 4;
+const TIER_TILTS: Record<Tier, Partial<CoachRatingValues>> = {
+  HC: { leadership: ROLE_TILT, gameManagement: ROLE_TILT },
+  COORDINATOR: { schemeMastery: ROLE_TILT },
+  POSITION: { playerDevelopment: ROLE_TILT },
 };
-const RATING_SPREAD = 22;
+
+const BASE_RATING_MEAN = 50;
 const RATING_MIN = 1;
 const RATING_MAX = 99;
 
-function rollRatingAroundMean(random: () => number, mean: number): number {
-  const offset = Math.floor(random() * (RATING_SPREAD * 2 + 1)) - RATING_SPREAD;
-  const value = mean + offset;
+/**
+ * Irwin–Hall n=3 — sum of three uniforms, normalized. Produces a
+ * bell-shaped distribution with mean 0.5 and stddev ≈ 0.167.
+ */
+function bellSample(random: () => number): number {
+  return (random() + random() + random()) / 3;
+}
+
+/**
+ * Rolls a rating around the 50 midpoint using a bell-curve sample, then
+ * applies a per-tier role tilt. Stddev ≈ 10 at the default scale — wide
+ * enough for meaningful variance, narrow enough that elite (80+) and poor
+ * (20−) coaches are genuinely rare.
+ */
+const RATING_SCALE = 60;
+
+function rollRatingAroundMean(random: () => number, tilt: number): number {
+  const bell = bellSample(random) - 0.5; // -0.5..0.5, mean 0
+  const value = Math.round(BASE_RATING_MEAN + tilt + bell * RATING_SCALE);
   if (value < RATING_MIN) return RATING_MIN;
   if (value > RATING_MAX) return RATING_MAX;
   return value;
@@ -252,11 +255,12 @@ function rollRatings(
   age: number,
   band: TierBand,
 ): GeneratedCoachRatings {
-  const means = RATING_MEANS[tier];
+  const tilts = TIER_TILTS[tier];
   const current = {} as CoachRatingValues;
   const ceiling = {} as CoachRatingValues;
   for (const key of COACH_RATING_KEYS) {
-    const c = rollRatingAroundMean(random, means[key]);
+    const tilt = tilts[key] ?? 0;
+    const c = rollRatingAroundMean(random, tilt);
     const gap = ceilingHeadroom(random, age, band);
     const ceil = Math.min(RATING_MAX, c + gap);
     current[key] = c;

--- a/server/features/simulation/calibration/fixtures/calibration-league.json
+++ b/server/features/simulation/calibration/fixtures/calibration-league.json
@@ -2896,7 +2896,8 @@
       "coachingMods": {
         "schemeFitBonus": 2,
         "situationalBonus": 2,
-        "aggressiveness": 55
+        "aggressiveness": 55,
+        "penaltyDiscipline": 1
       }
     },
     {
@@ -5794,7 +5795,8 @@
       "coachingMods": {
         "schemeFitBonus": 5,
         "situationalBonus": 3,
-        "aggressiveness": 61
+        "aggressiveness": 61,
+        "penaltyDiscipline": 1
       }
     },
     {
@@ -8692,7 +8694,8 @@
       "coachingMods": {
         "schemeFitBonus": 0,
         "situationalBonus": 1,
-        "aggressiveness": 57
+        "aggressiveness": 57,
+        "penaltyDiscipline": 1
       }
     },
     {
@@ -11590,7 +11593,8 @@
       "coachingMods": {
         "schemeFitBonus": 5,
         "situationalBonus": 3,
-        "aggressiveness": 38
+        "aggressiveness": 38,
+        "penaltyDiscipline": 1
       }
     },
     {
@@ -14488,7 +14492,8 @@
       "coachingMods": {
         "schemeFitBonus": 0,
         "situationalBonus": 3,
-        "aggressiveness": 68
+        "aggressiveness": 68,
+        "penaltyDiscipline": 1
       }
     },
     {
@@ -17386,7 +17391,8 @@
       "coachingMods": {
         "schemeFitBonus": 1,
         "situationalBonus": 3,
-        "aggressiveness": 65
+        "aggressiveness": 65,
+        "penaltyDiscipline": 1
       }
     },
     {
@@ -20284,7 +20290,8 @@
       "coachingMods": {
         "schemeFitBonus": 1,
         "situationalBonus": 1,
-        "aggressiveness": 54
+        "aggressiveness": 54,
+        "penaltyDiscipline": 1
       }
     },
     {
@@ -23182,7 +23189,8 @@
       "coachingMods": {
         "schemeFitBonus": 1,
         "situationalBonus": 1,
-        "aggressiveness": 38
+        "aggressiveness": 38,
+        "penaltyDiscipline": 1
       }
     },
     {
@@ -26080,7 +26088,8 @@
       "coachingMods": {
         "schemeFitBonus": 3,
         "situationalBonus": 2,
-        "aggressiveness": 52
+        "aggressiveness": 52,
+        "penaltyDiscipline": 1
       }
     },
     {
@@ -28978,7 +28987,8 @@
       "coachingMods": {
         "schemeFitBonus": 0,
         "situationalBonus": 2,
-        "aggressiveness": 37
+        "aggressiveness": 37,
+        "penaltyDiscipline": 1
       }
     },
     {
@@ -31876,7 +31886,8 @@
       "coachingMods": {
         "schemeFitBonus": 4,
         "situationalBonus": 3,
-        "aggressiveness": 32
+        "aggressiveness": 32,
+        "penaltyDiscipline": 1
       }
     },
     {
@@ -34774,7 +34785,8 @@
       "coachingMods": {
         "schemeFitBonus": 0,
         "situationalBonus": 2,
-        "aggressiveness": 36
+        "aggressiveness": 36,
+        "penaltyDiscipline": 1
       }
     },
     {
@@ -37672,7 +37684,8 @@
       "coachingMods": {
         "schemeFitBonus": 5,
         "situationalBonus": 0,
-        "aggressiveness": 54
+        "aggressiveness": 54,
+        "penaltyDiscipline": 1
       }
     },
     {
@@ -40570,7 +40583,8 @@
       "coachingMods": {
         "schemeFitBonus": 3,
         "situationalBonus": 2,
-        "aggressiveness": 44
+        "aggressiveness": 44,
+        "penaltyDiscipline": 1
       }
     },
     {
@@ -43468,7 +43482,8 @@
       "coachingMods": {
         "schemeFitBonus": 3,
         "situationalBonus": 1,
-        "aggressiveness": 40
+        "aggressiveness": 40,
+        "penaltyDiscipline": 1
       }
     },
     {
@@ -46366,7 +46381,8 @@
       "coachingMods": {
         "schemeFitBonus": 0,
         "situationalBonus": 1,
-        "aggressiveness": 55
+        "aggressiveness": 55,
+        "penaltyDiscipline": 1
       }
     },
     {
@@ -49264,7 +49280,8 @@
       "coachingMods": {
         "schemeFitBonus": 1,
         "situationalBonus": 2,
-        "aggressiveness": 70
+        "aggressiveness": 70,
+        "penaltyDiscipline": 1
       }
     },
     {
@@ -52162,7 +52179,8 @@
       "coachingMods": {
         "schemeFitBonus": 0,
         "situationalBonus": 0,
-        "aggressiveness": 44
+        "aggressiveness": 44,
+        "penaltyDiscipline": 1
       }
     },
     {
@@ -55060,7 +55078,8 @@
       "coachingMods": {
         "schemeFitBonus": 1,
         "situationalBonus": 3,
-        "aggressiveness": 62
+        "aggressiveness": 62,
+        "penaltyDiscipline": 1
       }
     },
     {
@@ -57958,7 +57977,8 @@
       "coachingMods": {
         "schemeFitBonus": 4,
         "situationalBonus": 0,
-        "aggressiveness": 57
+        "aggressiveness": 57,
+        "penaltyDiscipline": 1
       }
     },
     {
@@ -60856,7 +60876,8 @@
       "coachingMods": {
         "schemeFitBonus": 3,
         "situationalBonus": 0,
-        "aggressiveness": 58
+        "aggressiveness": 58,
+        "penaltyDiscipline": 1
       }
     },
     {
@@ -63754,7 +63775,8 @@
       "coachingMods": {
         "schemeFitBonus": 5,
         "situationalBonus": 1,
-        "aggressiveness": 49
+        "aggressiveness": 49,
+        "penaltyDiscipline": 1
       }
     },
     {
@@ -66652,7 +66674,8 @@
       "coachingMods": {
         "schemeFitBonus": 5,
         "situationalBonus": 3,
-        "aggressiveness": 30
+        "aggressiveness": 30,
+        "penaltyDiscipline": 1
       }
     },
     {
@@ -69550,7 +69573,8 @@
       "coachingMods": {
         "schemeFitBonus": 0,
         "situationalBonus": 1,
-        "aggressiveness": 58
+        "aggressiveness": 58,
+        "penaltyDiscipline": 1
       }
     },
     {
@@ -72448,7 +72472,8 @@
       "coachingMods": {
         "schemeFitBonus": 3,
         "situationalBonus": 2,
-        "aggressiveness": 67
+        "aggressiveness": 67,
+        "penaltyDiscipline": 1
       }
     },
     {
@@ -75346,7 +75371,8 @@
       "coachingMods": {
         "schemeFitBonus": 5,
         "situationalBonus": 1,
-        "aggressiveness": 63
+        "aggressiveness": 63,
+        "penaltyDiscipline": 1
       }
     },
     {
@@ -78244,7 +78270,8 @@
       "coachingMods": {
         "schemeFitBonus": 4,
         "situationalBonus": 2,
-        "aggressiveness": 53
+        "aggressiveness": 53,
+        "penaltyDiscipline": 1
       }
     },
     {
@@ -81142,7 +81169,8 @@
       "coachingMods": {
         "schemeFitBonus": 2,
         "situationalBonus": 3,
-        "aggressiveness": 40
+        "aggressiveness": 40,
+        "penaltyDiscipline": 1
       }
     },
     {
@@ -84040,7 +84068,8 @@
       "coachingMods": {
         "schemeFitBonus": 2,
         "situationalBonus": 2,
-        "aggressiveness": 69
+        "aggressiveness": 69,
+        "penaltyDiscipline": 1
       }
     },
     {
@@ -86938,7 +86967,8 @@
       "coachingMods": {
         "schemeFitBonus": 2,
         "situationalBonus": 3,
-        "aggressiveness": 37
+        "aggressiveness": 37,
+        "penaltyDiscipline": 1
       }
     },
     {
@@ -89836,7 +89866,8 @@
       "coachingMods": {
         "schemeFitBonus": 2,
         "situationalBonus": 2,
-        "aggressiveness": 63
+        "aggressiveness": 63,
+        "penaltyDiscipline": 1
       }
     },
     {
@@ -92734,7 +92765,8 @@
       "coachingMods": {
         "schemeFitBonus": 4,
         "situationalBonus": 0,
-        "aggressiveness": 49
+        "aggressiveness": 49,
+        "penaltyDiscipline": 1
       }
     }
   ]

--- a/server/features/simulation/calibration/generate-calibration-league.ts
+++ b/server/features/simulation/calibration/generate-calibration-league.ts
@@ -173,10 +173,21 @@ function generateFingerprint(rng: Rng, teamIndex: number): SchemeFingerprint {
 }
 
 function generateCoachingMods(rng: Rng): CoachingMods {
+  // Calibration draws three raw mod values from the main rng — same
+  // number and order of `rng.int` calls as the pre-ratings baseline —
+  // then synthesizes the hidden ratings that would have produced them.
+  // Keeping the rng consumption pattern unchanged preserves the NFL
+  // bands that were validated against the original stream. Production
+  // coaches generate ratings directly (see `coaches-generator.ts`) and
+  // call `coachRatingsToMods` on the way in.
+  const schemeFitBonus = rng.int(0, 5);
+  const situationalBonus = rng.int(0, 3);
+  const aggressiveness = rng.int(30, 70);
   return {
-    schemeFitBonus: rng.int(0, 5),
-    situationalBonus: rng.int(0, 3),
-    aggressiveness: rng.int(30, 70),
+    schemeFitBonus,
+    situationalBonus,
+    aggressiveness,
+    penaltyDiscipline: 1,
   };
 }
 

--- a/server/features/simulation/calibration/harness.test.ts
+++ b/server/features/simulation/calibration/harness.test.ts
@@ -38,6 +38,7 @@ function makeMinimalTeam(id: string): SimTeam {
       schemeFitBonus: 0,
       situationalBonus: 0,
       aggressiveness: 50,
+      penaltyDiscipline: 1,
     },
   };
 }

--- a/server/features/simulation/coach-mods-from-ratings.test.ts
+++ b/server/features/simulation/coach-mods-from-ratings.test.ts
@@ -1,0 +1,72 @@
+import { assertAlmostEquals, assertEquals } from "@std/assert";
+import type { CoachRatingValues } from "@zone-blitz/shared";
+import { coachRatingsToMods } from "./coach-mods-from-ratings.ts";
+
+function ratings(
+  overrides: Partial<CoachRatingValues> = {},
+): CoachRatingValues {
+  return {
+    leadership: 50,
+    gameManagement: 50,
+    schemeMastery: 50,
+    playerDevelopment: 50,
+    adaptability: 50,
+    ...overrides,
+  };
+}
+
+Deno.test("rating 50 across the board reproduces the calibration baseline", () => {
+  const mods = coachRatingsToMods({
+    hc: ratings(),
+    oc: ratings(),
+    dc: ratings(),
+  });
+  assertAlmostEquals(mods.schemeFitBonus, 2.5, 1e-9);
+  assertAlmostEquals(mods.situationalBonus, 1.5, 1e-9);
+  assertEquals(mods.aggressiveness, 50);
+  assertAlmostEquals(mods.penaltyDiscipline, 1, 1e-9);
+});
+
+Deno.test("missing staff entries default to neutral (50) — baseline preserved", () => {
+  const mods = coachRatingsToMods({});
+  assertAlmostEquals(mods.schemeFitBonus, 2.5, 1e-9);
+  assertAlmostEquals(mods.situationalBonus, 1.5, 1e-9);
+  assertEquals(mods.aggressiveness, 50);
+  assertAlmostEquals(mods.penaltyDiscipline, 1, 1e-9);
+});
+
+Deno.test("elite gameManagement raises aggressiveness symmetrically", () => {
+  const elite = coachRatingsToMods({ hc: ratings({ gameManagement: 90 }) });
+  const poor = coachRatingsToMods({ hc: ratings({ gameManagement: 10 }) });
+  assertEquals(elite.aggressiveness, 66);
+  assertEquals(poor.aggressiveness, 34);
+});
+
+Deno.test("elite leadership lowers penaltyDiscipline (fewer flags)", () => {
+  const elite = coachRatingsToMods({ hc: ratings({ leadership: 90 }) });
+  const poor = coachRatingsToMods({ hc: ratings({ leadership: 10 }) });
+  // symmetric around 1.0 for inputs equidistant from 50
+  assertAlmostEquals(elite.penaltyDiscipline, 0.88, 1e-9);
+  assertAlmostEquals(poor.penaltyDiscipline, 1.12, 1e-9);
+});
+
+Deno.test("schemeMastery uses OC+DC average", () => {
+  const mods = coachRatingsToMods({
+    oc: ratings({ schemeMastery: 80 }),
+    dc: ratings({ schemeMastery: 80 }),
+  });
+  // 2.5 + (80-50)*0.05 = 4.0
+  assertAlmostEquals(mods.schemeFitBonus, 4, 1e-9);
+});
+
+Deno.test("mods stay clamped at the extremes", () => {
+  const mods = coachRatingsToMods({
+    hc: ratings({ gameManagement: 99, leadership: 99 }),
+    oc: ratings({ schemeMastery: 99, adaptability: 99 }),
+    dc: ratings({ schemeMastery: 99, adaptability: 99 }),
+  });
+  assertEquals(mods.aggressiveness <= 70, true);
+  assertEquals(mods.schemeFitBonus <= 5, true);
+  assertEquals(mods.situationalBonus <= 3, true);
+  assertEquals(mods.penaltyDiscipline >= 0.85, true);
+});

--- a/server/features/simulation/coach-mods-from-ratings.ts
+++ b/server/features/simulation/coach-mods-from-ratings.ts
@@ -1,0 +1,79 @@
+import type { CoachRatingValues } from "@zone-blitz/shared";
+import type { CoachingMods } from "./resolve-play.ts";
+
+/**
+ * Maps hidden coach ratings to simulation `CoachingMods`. League-average
+ * (rating 50 across the board) reproduces the pre-ratings baseline so
+ * calibration bands stay intact; elite and poor coaches spread symmetrically
+ * around that midpoint. See `docs/product/north-star/coaches.md` and the
+ * rating-scale contract in `player-attributes.md` — 50 is the midpoint.
+ *
+ * Split intentionally keeps coaching's total sim leverage small (~20%):
+ *  - schemeMastery  → schemeFitBonus   (OC/DC avg)
+ *  - adaptability   → situationalBonus (HC + coords avg)
+ *  - gameManagement → aggressiveness   (HC)
+ *  - leadership     → penaltyDiscipline (HC, lower = fewer flags)
+ *
+ * Unused here on purpose: `playerDevelopment` — that's an offseason growth
+ * lever, not a game-day one.
+ */
+export interface CoachStaffRatings {
+  hc?: CoachRatingValues;
+  oc?: CoachRatingValues;
+  dc?: CoachRatingValues;
+}
+
+const NEUTRAL: CoachRatingValues = {
+  leadership: 50,
+  gameManagement: 50,
+  schemeMastery: 50,
+  playerDevelopment: 50,
+  adaptability: 50,
+};
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(max, Math.max(min, value));
+}
+
+function avg(values: number[]): number {
+  if (values.length === 0) return 50;
+  return values.reduce((sum, v) => sum + v, 0) / values.length;
+}
+
+/**
+ * Team-level mod derivation. Caller decides which staff belongs to which
+ * side (offense/defense) — this function just translates a staff trio into
+ * the shared `CoachingMods` shape.
+ */
+export function coachRatingsToMods(staff: CoachStaffRatings): CoachingMods {
+  const hc = staff.hc ?? NEUTRAL;
+  const oc = staff.oc ?? NEUTRAL;
+  const dc = staff.dc ?? NEUTRAL;
+
+  // schemeFitBonus: midpoint 2.5, range [0, 5]. Each 10 rating points ≈ 0.5.
+  const schemeDelta = avg([oc.schemeMastery, dc.schemeMastery]) - 50;
+  const schemeFitBonus = clamp(2.5 + schemeDelta * 0.05, 0, 5);
+
+  // situationalBonus: midpoint 1.5, range [0, 3]. Each 10 points ≈ 0.3.
+  const adaptDelta = avg([hc.adaptability, oc.adaptability, dc.adaptability]) -
+    50;
+  const situationalBonus = clamp(1.5 + adaptDelta * 0.03, 0, 3);
+
+  // aggressiveness: midpoint 50, range [30, 70]. Each 10 points ≈ 4.
+  const aggressiveness = clamp(50 + (hc.gameManagement - 50) * 0.4, 30, 70);
+
+  // penaltyDiscipline: midpoint 1.0, range [0.85, 1.15]. Leadership +30 → ~0.91.
+  // Inverted: higher leadership lowers the multiplier (fewer flags).
+  const penaltyDiscipline = clamp(
+    1 - (hc.leadership - 50) * 0.003,
+    0.85,
+    1.15,
+  );
+
+  return {
+    schemeFitBonus,
+    situationalBonus,
+    aggressiveness,
+    penaltyDiscipline,
+  };
+}

--- a/server/features/simulation/derive-game-views.test.ts
+++ b/server/features/simulation/derive-game-views.test.ts
@@ -591,6 +591,7 @@ function makeTeam(prefix: string): SimTeam {
       schemeFitBonus: 2,
       situationalBonus: 1,
       aggressiveness: 50,
+      penaltyDiscipline: 1,
     } as CoachingMods,
   };
 }

--- a/server/features/simulation/mod.ts
+++ b/server/features/simulation/mod.ts
@@ -137,9 +137,13 @@ export type {
 export {
   decidePenaltyAcceptance,
   PENALTY_CATALOG,
+  PER_PLAY_PENALTY_RATE,
   pickPenalty,
   shouldPenaltyOccur,
 } from "./resolve-penalty.ts";
+
+export { coachRatingsToMods } from "./coach-mods-from-ratings.ts";
+export type { CoachStaffRatings } from "./coach-mods-from-ratings.ts";
 export type {
   AcceptanceContext,
   PenaltyCandidate,

--- a/server/features/simulation/resolve-penalty.ts
+++ b/server/features/simulation/resolve-penalty.ts
@@ -174,10 +174,20 @@ export const PENALTY_CATALOG: PenaltyCandidate[] = [
   },
 ];
 
-const PER_PLAY_PENALTY_RATE = 0.017;
+export const PER_PLAY_PENALTY_RATE = 0.017;
 
-export function shouldPenaltyOccur(rng: SeededRng): boolean {
-  return rng.next() < PER_PLAY_PENALTY_RATE;
+/**
+ * `disciplineMultiplier` scales the base rate — 1.0 preserves the calibrated
+ * baseline; lower values reflect disciplined teams (HC leadership), higher
+ * values sloppy ones. Clamped to [0.5, 1.5] so a single coach can't erase
+ * flags entirely.
+ */
+export function shouldPenaltyOccur(
+  rng: SeededRng,
+  disciplineMultiplier = 1,
+): boolean {
+  const clamped = Math.min(1.5, Math.max(0.5, disciplineMultiplier));
+  return rng.next() < PER_PLAY_PENALTY_RATE * clamped;
 }
 
 export function pickPenalty(

--- a/server/features/simulation/resolve-play.ts
+++ b/server/features/simulation/resolve-play.ts
@@ -55,6 +55,12 @@ export interface CoachingMods {
   schemeFitBonus: number;
   situationalBonus: number;
   aggressiveness: number;
+  /**
+   * Penalty-rate multiplier. 1.0 = league-average (baseline PER_PLAY_PENALTY_RATE).
+   * Values below 1 indicate a disciplined team (fewer flags); above 1, sloppier.
+   * Driven by HC `leadership`.
+   */
+  penaltyDiscipline: number;
 }
 
 export type MatchupType =
@@ -435,6 +441,7 @@ export function synthesizeOutcome(
   rng: SeededRng,
   offensePlayerIds?: string[],
   defensePlayerIds?: string[],
+  penaltyDisciplineMultiplier = 1,
 ): PlayEvent {
   const isRunPlay = RUN_CONCEPTS.has(call.concept);
 
@@ -504,7 +511,7 @@ export function synthesizeOutcome(
   }
 
   let penalty: PenaltyInfo | undefined;
-  if (shouldPenaltyOccur(rng)) {
+  if (shouldPenaltyOccur(rng, penaltyDisciplineMultiplier)) {
     const offPositions = contributions
       .filter((c) => OFFENSIVE_POSITIONS.has(c.matchup.attacker.neutralBucket))
       .map((c) => c.matchup.attacker.neutralBucket);
@@ -622,7 +629,18 @@ export function resolvePlay(
     });
   });
 
-  const event = synthesizeOutcome(call, coverage, contributions, state, rng);
+  const penaltyDiscipline = (offense.coachingMods.penaltyDiscipline +
+    defense.coachingMods.penaltyDiscipline) / 2;
+  const event = synthesizeOutcome(
+    call,
+    coverage,
+    contributions,
+    state,
+    rng,
+    undefined,
+    undefined,
+    penaltyDiscipline,
+  );
   if (twoMinute) {
     event.tags.push("two_minute");
   }

--- a/server/features/simulation/resolve-scoring.test.ts
+++ b/server/features/simulation/resolve-scoring.test.ts
@@ -121,6 +121,7 @@ function makeTeam(prefix: string): SimTeam {
       schemeFitBonus: 2,
       situationalBonus: 1,
       aggressiveness: 50,
+      penaltyDiscipline: 1,
     },
   };
 }

--- a/server/features/simulation/scoring.test.ts
+++ b/server/features/simulation/scoring.test.ts
@@ -78,7 +78,12 @@ function makeFingerprint(): SchemeFingerprint {
 }
 
 function makeCoachingMods(): CoachingMods {
-  return { schemeFitBonus: 0, situationalBonus: 0, aggressiveness: 50 };
+  return {
+    schemeFitBonus: 0,
+    situationalBonus: 0,
+    aggressiveness: 50,
+    penaltyDiscipline: 1,
+  };
 }
 
 function makeOffense(): PlayerRuntime[] {

--- a/server/features/simulation/simulate-season.ts
+++ b/server/features/simulation/simulate-season.ts
@@ -213,6 +213,7 @@ function generateTeam(teamId: string, rng: SeededRng): SimTeam {
       schemeFitBonus: rng.int(-3, 3),
       situationalBonus: rng.int(-2, 2),
       aggressiveness: rng.int(30, 70),
+      penaltyDiscipline: 1,
     } as CoachingMods,
   };
 }

--- a/server/features/simulation/test-helpers.ts
+++ b/server/features/simulation/test-helpers.ts
@@ -67,6 +67,7 @@ export function makeCoachingMods(
     schemeFitBonus: 0,
     situationalBonus: 0,
     aggressiveness: 50,
+    penaltyDiscipline: 1,
     ...overrides,
   };
 }


### PR DESCRIPTION
## Summary

- Introduces `coachRatingsToMods` — the first mapping from hidden coach ratings (`leadership`, `gameManagement`, `schemeMastery`, `adaptability`) to the `CoachingMods` knobs the sim already consumes. Centered on rating=50 so a league-average staff reproduces the pre-ratings calibration baseline.
- Extends `CoachingMods` with `penaltyDiscipline` and threads it through `shouldPenaltyOccur` — HC leadership now visibly moves penalty frequency within a ±15% envelope.
- Recentres the coach generator's rating distribution on 50 per the rating-scale contract (`docs/product/north-star/player-attributes.md` — 50 is the midpoint, the "Geno Smith line," for both players and coaches). Ratings now flow from an Irwin–Hall bell with a small per-tier role tilt, replacing the earlier shifted-mean scheme that baked `60 = average` into the pool.
- NFL bands still pass 15/15 — the calibration league keeps its direct mod rolls (unchanged rng consumption) so the deterministic stream the bands were validated against is preserved. Production rating→mods wiring is proven separately by unit tests and a pool-wide distribution test.