### PR TITLE
feat(hiring): widen coach + scout age distribution to NFL shape

### DIFF
--- a/packages/shared/mod.ts
+++ b/packages/shared/mod.ts
@@ -294,6 +294,7 @@ export {
   createSeededRng,
   deriveGameSeed,
   mulberry32,
+  triangularInt,
 } from "./rng/mod.ts";
 export type { SeededRng } from "./rng/mod.ts";
 

--- a/packages/shared/rng/mod.ts
+++ b/packages/shared/rng/mod.ts
@@ -3,5 +3,6 @@ export {
   createSeededRng,
   deriveGameSeed,
   mulberry32,
+  triangularInt,
 } from "./rng.ts";
 export type { SeededRng } from "./rng.ts";

--- a/packages/shared/rng/rng.test.ts
+++ b/packages/shared/rng/rng.test.ts
@@ -4,6 +4,7 @@ import {
   createSeededRng,
   deriveGameSeed,
   mulberry32,
+  triangularInt,
 } from "./rng.ts";
 import type { SeededRng } from "./rng.ts";
 
@@ -114,6 +115,62 @@ Deno.test("createSeededRng", async (t) => {
     assertEquals(typeof rng.int, "function");
     assertEquals(typeof rng.pick, "function");
     assertEquals(typeof rng.gaussian, "function");
+  });
+});
+
+Deno.test("triangularInt", async (t) => {
+  await t.step("stays within [min, max]", () => {
+    const rng = mulberry32(42);
+    for (let i = 0; i < 1000; i++) {
+      const val = triangularInt(rng, 10, 30, 50);
+      assertEquals(val >= 10 && val <= 50, true);
+      assertEquals(Number.isInteger(val), true);
+    }
+  });
+
+  await t.step(
+    "mean of a large sample approximates (min + mode + max) / 3",
+    () => {
+      const rng = mulberry32(123);
+      const samples: number[] = [];
+      for (let i = 0; i < 10_000; i++) {
+        samples.push(triangularInt(rng, 0, 20, 100));
+      }
+      const mean = samples.reduce((a, b) => a + b, 0) / samples.length;
+      const expected = (0 + 20 + 100) / 3;
+      assertEquals(
+        Math.abs(mean - expected) < 1,
+        true,
+        `mean=${mean} expected≈${expected}`,
+      );
+    },
+  );
+
+  await t.step(
+    "is skewed: left-mode produces smaller mean than right-mode",
+    () => {
+      const leftRng = mulberry32(7);
+      const rightRng = mulberry32(7);
+      let leftSum = 0;
+      let rightSum = 0;
+      const n = 5000;
+      for (let i = 0; i < n; i++) {
+        leftSum += triangularInt(leftRng, 0, 10, 100);
+        rightSum += triangularInt(rightRng, 0, 90, 100);
+      }
+      assertEquals(leftSum / n < rightSum / n, true);
+    },
+  );
+
+  await t.step("is deterministic with a seeded rng", () => {
+    const rng1 = mulberry32(999);
+    const rng2 = mulberry32(999);
+    for (let i = 0; i < 50; i++) {
+      assertEquals(
+        triangularInt(rng1, 10, 25, 60),
+        triangularInt(rng2, 10, 25, 60),
+      );
+    }
   });
 });
 

--- a/packages/shared/rng/rng.ts
+++ b/packages/shared/rng/rng.ts
@@ -39,6 +39,29 @@ export function createSeededRng(seed: number): SeededRng {
   return createRng(mulberry32(seed));
 }
 
+/**
+ * Inverse-CDF sample from a triangular distribution with an explicit
+ * mode, rounded to an integer. Peaks at `mode` and tapers toward both
+ * tails — the right shape for quantities like ages in a professional
+ * staff, where most people cluster near a typical career-arc peak but
+ * rising stars and career lifers genuinely exist. A uniform roll over
+ * a narrow band clusters everyone at the midpoint; this does not.
+ */
+export function triangularInt(
+  random: () => number,
+  min: number,
+  mode: number,
+  max: number,
+): number {
+  const u = random();
+  const range = max - min;
+  const leftShare = (mode - min) / range;
+  const raw = u < leftShare
+    ? min + Math.sqrt(u * range * (mode - min))
+    : max - Math.sqrt((1 - u) * range * (max - mode));
+  return Math.min(max, Math.max(min, Math.round(raw)));
+}
+
 export function deriveGameSeed(
   leagueSeed: number,
   gameIdentifier: string,

--- a/server/features/coaches/coaches-generator.test.ts
+++ b/server/features/coaches/coaches-generator.test.ts
@@ -303,25 +303,25 @@ Deno.test("CEO HCs defer to coordinators (no tendencies)", () => {
 
 // ---- Graduated-behaviour assertions ----
 
-Deno.test("head coach ages span the HC tier band (~48-60)", () => {
+Deno.test("head coach ages span the HC tier band (~36-68)", () => {
   const result = makeGenerator().generate(INPUT);
   const hcs = result.filter((c) => c.role === "HC");
   for (const hc of hcs) {
-    assertEquals(hc.age >= 48 && hc.age <= 60, true);
+    assertEquals(hc.age >= 36 && hc.age <= 68, true);
   }
 });
 
-Deno.test("coordinator ages span the coordinator tier band (~40-55)", () => {
+Deno.test("coordinator ages span the coordinator tier band (~30-62)", () => {
   const result = makeGenerator().generate(INPUT);
   const coords = result.filter(
     (c) => c.role === "OC" || c.role === "DC" || c.role === "STC",
   );
   for (const coord of coords) {
-    assertEquals(coord.age >= 40 && coord.age <= 55, true);
+    assertEquals(coord.age >= 30 && coord.age <= 62, true);
   }
 });
 
-Deno.test("position coach ages span the position tier band (~32-50)", () => {
+Deno.test("position coach ages span the position tier band (~26-62)", () => {
   const result = makeGenerator().generate(INPUT);
   const positionRoles = new Set<CoachRole>([
     "QB",
@@ -336,8 +336,58 @@ Deno.test("position coach ages span the position tier band (~32-50)", () => {
   ]);
   const positions = result.filter((c) => positionRoles.has(c.role));
   for (const coach of positions) {
-    assertEquals(coach.age >= 32 && coach.age <= 50, true);
+    assertEquals(coach.age >= 26 && coach.age <= 62, true);
   }
+});
+
+Deno.test("coach age distribution peaks near tier mode, not stacked at the midpoint", () => {
+  // Regression guard against the old uniform-roll shape where every tier
+  // clustered near its band midpoint. A wide band + triangular roll should
+  // land each tier's mean within ~3 years of its mode across a big pool.
+  const result = makeGenerator(7).generatePool({
+    leagueId: "lg",
+    numberOfTeams: 32,
+  });
+  const avg = (xs: number[]) => xs.reduce((a, b) => a + b, 0) / xs.length;
+  const hcMean = avg(result.filter((c) => c.role === "HC").map((c) => c.age));
+  const coordMean = avg(
+    result
+      .filter((c) => c.role === "OC" || c.role === "DC" || c.role === "STC")
+      .map((c) => c.age),
+  );
+  const posMean = avg(
+    result.filter((c) => c.role === "QB" || c.role === "RB" || c.role === "WR")
+      .map((c) => c.age),
+  );
+  // Triangular expected mean = (min + mode + max) / 3.
+  assertEquals(
+    Math.abs(hcMean - (36 + 51 + 68) / 3) < 3,
+    true,
+    `HC mean=${hcMean}`,
+  );
+  assertEquals(
+    Math.abs(coordMean - (30 + 44 + 62) / 3) < 3,
+    true,
+    `coord mean=${coordMean}`,
+  );
+  assertEquals(
+    Math.abs(posMean - (26 + 40 + 62) / 3) < 3,
+    true,
+    `position mean=${posMean}`,
+  );
+});
+
+Deno.test("coach pool includes young coaches (<40) and veterans (>55)", () => {
+  // Real NFL staffs field McVay-types and Belichick-types; the tails of
+  // the distribution should produce both.
+  const result = makeGenerator(11).generatePool({
+    leagueId: "lg",
+    numberOfTeams: 32,
+  });
+  const young = result.filter((c) => c.age < 40).length;
+  const old = result.filter((c) => c.age > 55).length;
+  assertEquals(young > 0, true, "expected at least one coach under 40");
+  assertEquals(old > 0, true, "expected at least one coach over 55");
 });
 
 Deno.test("ages vary within a role across the league (not a single constant)", () => {

--- a/server/features/coaches/coaches-generator.ts
+++ b/server/features/coaches/coaches-generator.ts
@@ -5,7 +5,7 @@ import type {
   CoachSpecialty,
   PositionGroup,
 } from "@zone-blitz/shared";
-import { COACH_RATING_KEYS } from "@zone-blitz/shared";
+import { COACH_RATING_KEYS, triangularInt } from "@zone-blitz/shared";
 import {
   createNameGenerator,
   type NameGenerator,
@@ -425,28 +425,6 @@ export interface CoachesGeneratorOptions {
 
 function intInRange(random: () => number, min: number, max: number): number {
   return Math.floor(random() * (max - min + 1)) + min;
-}
-
-/**
- * Inverse-CDF sample from a triangular distribution with explicit mode.
- * Produces a population whose histogram peaks at `mode` and tapers toward
- * both tails — the right shape for ages in a professional league, where
- * most coaches cluster near a typical career-arc peak but rising stars
- * (young) and career lifers (old) genuinely exist.
- */
-function triangularInt(
-  random: () => number,
-  min: number,
-  mode: number,
-  max: number,
-): number {
-  const u = random();
-  const range = max - min;
-  const leftShare = (mode - min) / range;
-  const raw = u < leftShare
-    ? min + Math.sqrt(u * range * (mode - min))
-    : max - Math.sqrt((1 - u) * range * (max - mode));
-  return Math.min(max, Math.max(min, Math.round(raw)));
 }
 
 // Pool sizing is driven by tier-level per-team counts rather than a flat

--- a/server/features/coaches/coaches-generator.ts
+++ b/server/features/coaches/coaches-generator.ts
@@ -109,6 +109,12 @@ const STAFF_BLUEPRINT: RoleSpec[] = [
 interface TierBand {
   ageMin: number;
   ageMax: number;
+  /** Most-common age (mode) for the triangular age distribution. Keeps
+   * the population shaped like the real NFL — a peak around the mode
+   * with genuinely young and genuinely old coaches appearing in the
+   * tails, instead of a flat uniform roll that clusters every coach in
+   * the middle of a narrow band. */
+  ageMode: number;
   /** Salary band in whole dollars; annual. */
   salaryMin: number;
   salaryMax: number;
@@ -146,8 +152,9 @@ const ROLE_SALARY_OVERRIDES: Partial<
 
 const TIER_BANDS: Record<Tier, TierBand> = {
   HC: {
-    ageMin: 48,
-    ageMax: 60,
+    ageMin: 36,
+    ageMax: 68,
+    ageMode: 51,
     salaryMin: 6_000_000,
     salaryMax: 14_000_000,
     yearsMin: 3,
@@ -156,12 +163,13 @@ const TIER_BANDS: Record<Tier, TierBand> = {
     buyoutYearsMax: 2,
     tenureMin: 0,
     tenureMax: 4,
-    experienceMin: 20,
-    experienceMax: 35,
+    experienceMin: 8,
+    experienceMax: 40,
   },
   COORDINATOR: {
-    ageMin: 40,
-    ageMax: 55,
+    ageMin: 30,
+    ageMax: 62,
+    ageMode: 44,
     salaryMin: 1_000_000,
     salaryMax: 5_000_000,
     yearsMin: 2,
@@ -170,12 +178,13 @@ const TIER_BANDS: Record<Tier, TierBand> = {
     buyoutYearsMax: 2,
     tenureMin: 0,
     tenureMax: 3,
-    experienceMin: 12,
-    experienceMax: 28,
+    experienceMin: 4,
+    experienceMax: 32,
   },
   POSITION: {
-    ageMin: 32,
-    ageMax: 50,
+    ageMin: 26,
+    ageMax: 62,
+    ageMode: 40,
     salaryMin: 400_000,
     salaryMax: 1_400_000,
     yearsMin: 1,
@@ -184,8 +193,8 @@ const TIER_BANDS: Record<Tier, TierBand> = {
     buyoutYearsMax: 1,
     tenureMin: 0,
     tenureMax: 3,
-    experienceMin: 5,
-    experienceMax: 20,
+    experienceMin: 2,
+    experienceMax: 30,
   },
 };
 
@@ -418,6 +427,28 @@ function intInRange(random: () => number, min: number, max: number): number {
   return Math.floor(random() * (max - min + 1)) + min;
 }
 
+/**
+ * Inverse-CDF sample from a triangular distribution with explicit mode.
+ * Produces a population whose histogram peaks at `mode` and tapers toward
+ * both tails — the right shape for ages in a professional league, where
+ * most coaches cluster near a typical career-arc peak but rising stars
+ * (young) and career lifers (old) genuinely exist.
+ */
+function triangularInt(
+  random: () => number,
+  min: number,
+  mode: number,
+  max: number,
+): number {
+  const u = random();
+  const range = max - min;
+  const leftShare = (mode - min) / range;
+  const raw = u < leftShare
+    ? min + Math.sqrt(u * range * (mode - min))
+    : max - Math.sqrt((1 - u) * range * (max - mode));
+  return Math.min(max, Math.max(min, Math.round(raw)));
+}
+
 // Pool sizing is driven by tier-level per-team counts rather than a flat
 // multiplier per blueprint role. The numbers reflect the initial staffing
 // phase the game presents at league creation — teams compete over roughly
@@ -509,7 +540,7 @@ function generateCoach(
   const salaryMin = salaryOverride?.salaryMin ?? band.salaryMin;
   const salaryMax = salaryOverride?.salaryMax ?? band.salaryMax;
 
-  const age = intInRange(random, band.ageMin, band.ageMax);
+  const age = triangularInt(random, band.ageMin, band.ageMode, band.ageMax);
   const contractYears = intInRange(random, band.yearsMin, band.yearsMax);
   const salarySteps = Math.max(
     1,

--- a/server/features/scouts/scouts-generator.test.ts
+++ b/server/features/scouts/scouts-generator.test.ts
@@ -86,28 +86,75 @@ Deno.test("generates no scouts when no teams provided", () => {
 
 // ---- Graduated-behaviour assertions ----
 
-Deno.test("director ages span the director tier band (~50-65)", () => {
+Deno.test("director ages span the director tier band (~40-70)", () => {
   const result = makeGenerator().generate(INPUT);
   const directors = result.filter((s) => s.role === "DIRECTOR");
   for (const d of directors) {
-    assertEquals(d.age >= 50 && d.age <= 65, true);
+    assertEquals(d.age >= 40 && d.age <= 70, true);
   }
 });
 
-Deno.test("national cross-checker ages span the cross-checker tier band (~42-58)", () => {
+Deno.test("national cross-checker ages span the cross-checker tier band (~32-64)", () => {
   const result = makeGenerator().generate(INPUT);
   const ccs = result.filter((s) => s.role === "NATIONAL_CROSS_CHECKER");
   for (const cc of ccs) {
-    assertEquals(cc.age >= 42 && cc.age <= 58, true);
+    assertEquals(cc.age >= 32 && cc.age <= 64, true);
   }
 });
 
-Deno.test("area scout ages span the area scout tier band (~30-50)", () => {
+Deno.test("area scout ages span the area scout tier band (~25-58)", () => {
   const result = makeGenerator().generate(INPUT);
   const areas = result.filter((s) => s.role === "AREA_SCOUT");
   for (const a of areas) {
-    assertEquals(a.age >= 30 && a.age <= 50, true);
+    assertEquals(a.age >= 25 && a.age <= 58, true);
   }
+});
+
+Deno.test("scout age distribution peaks near tier mode, not stacked at the midpoint", () => {
+  // Regression guard against the old narrow uniform roll where directors
+  // all landed near 58 and area scouts near 40. A wide triangular roll
+  // should produce tier means within ~3 years of their intended modes.
+  const result = makeGenerator(7).generatePool({
+    leagueId: "lg",
+    numberOfTeams: 32,
+  });
+  const avg = (xs: number[]) => xs.reduce((a, b) => a + b, 0) / xs.length;
+  const dirMean = avg(
+    result.filter((s) => s.role === "DIRECTOR").map((s) => s.age),
+  );
+  const ccMean = avg(
+    result.filter((s) => s.role === "NATIONAL_CROSS_CHECKER").map((s) => s.age),
+  );
+  const areaMean = avg(
+    result.filter((s) => s.role === "AREA_SCOUT").map((s) => s.age),
+  );
+  // Triangular expected mean = (min + mode + max) / 3.
+  assertEquals(
+    Math.abs(dirMean - (40 + 54 + 70) / 3) < 3,
+    true,
+    `director mean=${dirMean}`,
+  );
+  assertEquals(
+    Math.abs(ccMean - (32 + 46 + 64) / 3) < 3,
+    true,
+    `cc mean=${ccMean}`,
+  );
+  assertEquals(
+    Math.abs(areaMean - (25 + 36 + 58) / 3) < 3,
+    true,
+    `area scout mean=${areaMean}`,
+  );
+});
+
+Deno.test("scout pool includes young scouts (<32) and veterans (>55)", () => {
+  const result = makeGenerator(11).generatePool({
+    leagueId: "lg",
+    numberOfTeams: 32,
+  });
+  const young = result.filter((s) => s.age < 32).length;
+  const old = result.filter((s) => s.age > 55).length;
+  assertEquals(young > 0, true, "expected at least one scout under 32");
+  assertEquals(old > 0, true, "expected at least one scout over 55");
 });
 
 Deno.test("contract years vary within a role tier across the league", () => {

--- a/server/features/scouts/scouts-generator.ts
+++ b/server/features/scouts/scouts-generator.ts
@@ -1,4 +1,5 @@
 import type { PositionGroup, ScoutRegion, ScoutRole } from "@zone-blitz/shared";
+import { triangularInt } from "@zone-blitz/shared";
 import {
   createNameGenerator,
   type NameGenerator,
@@ -210,27 +211,6 @@ export interface ScoutsGeneratorOptions {
 
 function intInRange(random: () => number, min: number, max: number): number {
   return Math.floor(random() * (max - min + 1)) + min;
-}
-
-/**
- * Inverse-CDF sample from a triangular distribution with explicit mode.
- * Peaks at `mode` and tapers toward both tails — right shape for ages
- * in a professional scouting department, where most staff cluster near
- * a typical career-arc peak but rising stars and career lifers exist.
- */
-function triangularInt(
-  random: () => number,
-  min: number,
-  mode: number,
-  max: number,
-): number {
-  const u = random();
-  const range = max - min;
-  const leftShare = (mode - min) / range;
-  const raw = u < leftShare
-    ? min + Math.sqrt(u * range * (mode - min))
-    : max - Math.sqrt((1 - u) * range * (max - mode));
-  return Math.min(max, Math.max(min, Math.round(raw)));
 }
 
 interface ScoutPreferences {

--- a/server/features/scouts/scouts-generator.ts
+++ b/server/features/scouts/scouts-generator.ts
@@ -119,6 +119,11 @@ function distributeByWeight(
 interface RoleBand {
   ageMin: number;
   ageMax: number;
+  /** Most-common age (mode) for the triangular age distribution. Keeps
+   * the pool NFL-shaped with real tails (young cross-checkers, career
+   * area scouts well into their 50s) instead of a flat uniform roll
+   * that clusters everyone near the band's midpoint. */
+  ageMode: number;
   salaryMin: number;
   salaryMax: number;
   yearsMin: number;
@@ -139,8 +144,9 @@ const CAREER_START_AGE = 22;
 
 const ROLE_BANDS: Record<ScoutRole, RoleBand> = {
   DIRECTOR: {
-    ageMin: 50,
-    ageMax: 65,
+    ageMin: 40,
+    ageMax: 70,
+    ageMode: 54,
     salaryMin: 250_000,
     salaryMax: 800_000,
     yearsMin: 3,
@@ -151,12 +157,13 @@ const ROLE_BANDS: Record<ScoutRole, RoleBand> = {
     workCapacityMax: 240,
     tenureMin: 0,
     tenureMax: 5,
-    experienceMin: 20,
-    experienceMax: 35,
+    experienceMin: 12,
+    experienceMax: 40,
   },
   NATIONAL_CROSS_CHECKER: {
-    ageMin: 42,
-    ageMax: 58,
+    ageMin: 32,
+    ageMax: 64,
+    ageMode: 46,
     salaryMin: 150_000,
     salaryMax: 400_000,
     yearsMin: 2,
@@ -167,12 +174,13 @@ const ROLE_BANDS: Record<ScoutRole, RoleBand> = {
     workCapacityMax: 220,
     tenureMin: 0,
     tenureMax: 4,
-    experienceMin: 12,
-    experienceMax: 25,
+    experienceMin: 6,
+    experienceMax: 30,
   },
   AREA_SCOUT: {
-    ageMin: 30,
-    ageMax: 50,
+    ageMin: 25,
+    ageMax: 58,
+    ageMode: 36,
     salaryMin: 80_000,
     salaryMax: 200_000,
     yearsMin: 1,
@@ -183,8 +191,8 @@ const ROLE_BANDS: Record<ScoutRole, RoleBand> = {
     workCapacityMax: 160,
     tenureMin: 0,
     tenureMax: 3,
-    experienceMin: 3,
-    experienceMax: 15,
+    experienceMin: 1,
+    experienceMax: 25,
   },
 };
 
@@ -202,6 +210,27 @@ export interface ScoutsGeneratorOptions {
 
 function intInRange(random: () => number, min: number, max: number): number {
   return Math.floor(random() * (max - min + 1)) + min;
+}
+
+/**
+ * Inverse-CDF sample from a triangular distribution with explicit mode.
+ * Peaks at `mode` and tapers toward both tails — right shape for ages
+ * in a professional scouting department, where most staff cluster near
+ * a typical career-arc peak but rising stars and career lifers exist.
+ */
+function triangularInt(
+  random: () => number,
+  min: number,
+  mode: number,
+  max: number,
+): number {
+  const u = random();
+  const range = max - min;
+  const leftShare = (mode - min) / range;
+  const raw = u < leftShare
+    ? min + Math.sqrt(u * range * (mode - min))
+    : max - Math.sqrt((1 - u) * range * (max - mode));
+  return Math.min(max, Math.max(min, Math.round(raw)));
 }
 
 interface ScoutPreferences {
@@ -349,7 +378,12 @@ export function createScoutsGenerator(
             : idsByKey.get(spec.reportsTo)!;
 
           const band = ROLE_BANDS[spec.role];
-          const age = intInRange(random, band.ageMin, band.ageMax);
+          const age = triangularInt(
+            random,
+            band.ageMin,
+            band.ageMode,
+            band.ageMax,
+          );
           const contractYears = intInRange(
             random,
             band.yearsMin,
@@ -445,7 +479,12 @@ export function createScoutsGenerator(
           const id = crypto.randomUUID();
 
           const band = ROLE_BANDS[spec.role];
-          const age = intInRange(random, band.ageMin, band.ageMax);
+          const age = triangularInt(
+            random,
+            band.ageMin,
+            band.ageMode,
+            band.ageMax,
+          );
           const contractYears = intInRange(
             random,
             band.yearsMin,


### PR DESCRIPTION
## Summary

- Coach and scout hiring pools were rolling ages uniformly inside narrow bands (HC 48–60, director 50–65, etc.), so nearly every candidate landed near ~50 and young/old profiles were absent.
- Switch the age roll to a **triangular distribution with an explicit mode per tier** and widen the bands: HC 36–68 (mode 51), coordinator 30–62 (mode 44), position coach 26–62 (mode 40); scouting director 40–70 (mode 54), national cross-checker 32–64 (mode 46), area scout 25–58 (mode 36).
- Lower the experience floors so a 36-year-old coordinator doesn't get clamped to a veteran-sized experience roll.
- Update existing band-bounds tests and add distribution-shape regression tests (mean near `(min+mode+max)/3`; both young-tail and veteran-tail populated in a 32-team pool).