### PR TITLE
feat(scouts): give every scout a real position-group focus

### DIFF
--- a/server/features/scouts/scouts-generator.test.ts
+++ b/server/features/scouts/scouts-generator.test.ts
@@ -355,3 +355,29 @@ Deno.test("generate leaves preference columns null for assigned scouts", () => {
     assertEquals(scout.minimumThreshold, null);
   }
 });
+
+Deno.test("generatePool rolls directors across the full position-focus pool", () => {
+  const result = makeGenerator(7777).generatePool({
+    leagueId: "league-1",
+    numberOfTeams: 40,
+  });
+  const directors = result.filter((s) => s.role === "DIRECTOR");
+  const focusCounts = new Map<string, number>();
+  for (const d of directors) {
+    const focus = d.positionFocus ?? "GENERALIST";
+    focusCounts.set(focus, (focusCounts.get(focus) ?? 0) + 1);
+  }
+
+  assertEquals(
+    focusCounts.size >= 6,
+    true,
+    `expected ≥6 distinct director position focuses, got ${focusCounts.size}`,
+  );
+
+  const generalists = focusCounts.get("GENERALIST") ?? 0;
+  assertEquals(
+    generalists < directors.length * 0.5,
+    true,
+    `expected <50% generalist directors, got ${generalists}/${directors.length}`,
+  );
+});

--- a/server/features/scouts/scouts-generator.ts
+++ b/server/features/scouts/scouts-generator.ts
@@ -231,14 +231,14 @@ const NULL_PREFERENCES = {
 };
 
 /**
- * Position-group options for an area scout or cross-checker. Real
- * front offices heavily skew toward generalists — an area scout
- * typically evaluates every position in their region — so we weight
- * `GENERALIST` more heavily than any single group.
+ * Position-group options for any scout — area scout, cross-checker, or
+ * director. Most scouts build up deeper reps on a specific position group
+ * over their career (an area scout who spent years on Big Ten OL, a
+ * director who rose through DB evaluation), so each of the eight groups
+ * gets an equal shot alongside a single `GENERALIST` bucket for the true
+ * all-position evaluators and pure board-builders.
  */
 const POSITION_FOCUS_POOL: ReadonlyArray<PositionGroup> = [
-  "GENERALIST",
-  "GENERALIST",
   "GENERALIST",
   "QB",
   "RB",
@@ -264,24 +264,17 @@ function pickFromArray<T>(random: () => number, values: ReadonlyArray<T>): T {
 }
 
 /**
- * Rolls the position-focus value a scout is hireable on. Directors
- * almost always read as `GENERALIST` — their value is board-building
- * and management — but we allow a small chance of a position-focused
- * director (e.g. a former DB coach who runs a DB-centric board).
+ * Rolls the position-focus value a scout is hireable on. All scouts —
+ * including directors, who are former area scouts who built their way up —
+ * draw from the same pool: one generalist slot and eight position-group
+ * slots with equal weight. This gives hiring managers a meaningful fit
+ * decision (a DB-focus director builds a different board than a QB-focus
+ * one) instead of every director reading as an interchangeable generalist.
  */
 function rollPositionFocus(
-  role: ScoutRole,
+  _role: ScoutRole,
   random: () => number,
 ): PositionGroup {
-  if (role === "DIRECTOR") {
-    return random() < 0.2
-      ? pickFromArray(random, [
-        "QB" as const,
-        "DL" as const,
-        "DB" as const,
-      ])
-      : "GENERALIST";
-  }
   return pickFromArray(random, POSITION_FOCUS_POOL);
 }
 


### PR DESCRIPTION
## Summary

- Directors were hardcoded to roll `GENERALIST` ~80% of the time (with the remaining 20% artificially locked to only QB/DL/DB), and area scouts / cross-checkers drew from a pool where `GENERALIST` was 3x weighted. Result: a sea of interchangeable "Generalist" director cards with nothing to differentiate them in the hiring UI.
- Unified every scout role onto a single position-focus pool: one `GENERALIST` slot + eight position-group slots of equal weight. A director is now a former area scout who carries forward the positional expertise they built — a DB-focus director is a real archetype distinct from a QB-focus one, giving hiring managers a meaningful fit decision.
- Empirical distribution across 500 simulated leagues x 8 teams: all nine focuses land within 10.6-11.5% for every scout tier.
- Bonus check (requested inline): simulated HC specialty distribution across 32,000 HCs lands at 40.42% offense / 39.86% defense / 19.73% CEO — matches the 40/40/20 spec with no bias. The small-sample skew noticed in the original hiring screenshot was variance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)