### PR TITLE
feat(hiring): make leadership candidate columns filterable

### DIFF
--- a/client/src/features/league/hiring/index.test.tsx
+++ b/client/src/features/league/hiring/index.test.tsx
@@ -1,8 +1,19 @@
-import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { toast } from "sonner";
-import { Hiring } from "./index.tsx";
+import {
+  Hiring,
+  positionFilterLabel,
+  regionFilterLabel,
+  schemeOptionLabel,
+} from "./index.tsx";
 
 const mockUseParams = vi.fn();
 const mockUseLeagueClock = vi.fn();
@@ -111,6 +122,51 @@ beforeEach(() => {
 afterEach(() => {
   cleanup();
   vi.clearAllMocks();
+});
+
+describe("positionFilterLabel", () => {
+  it("polishes a known position group", () => {
+    expect(positionFilterLabel("QB")).toBe("Quarterbacks");
+  });
+
+  it("echoes back unknown position keys so missing labels surface", () => {
+    expect(positionFilterLabel("MASCOT")).toBe("MASCOT");
+  });
+
+  it("falls back to the raw value when the shared label resolver returns null", () => {
+    // positionGroupLabel returns null for an empty string — the wrapper's
+    // `?? value` keeps the dropdown rendering something instead of "null".
+    expect(positionFilterLabel("")).toBe("");
+  });
+});
+
+describe("regionFilterLabel", () => {
+  it("polishes a known region", () => {
+    expect(regionFilterLabel("MIDWEST")).toBe("Midwest");
+  });
+
+  it("echoes back unknown region keys", () => {
+    expect(regionFilterLabel("MARS")).toBe("MARS");
+  });
+
+  it("falls back to the raw value when the shared label resolver returns null", () => {
+    expect(regionFilterLabel("")).toBe("");
+  });
+});
+
+describe("schemeOptionLabel", () => {
+  it("labels the CEO bucket distinctly", () => {
+    expect(schemeOptionLabel("ceo")).toBe("Defers to coordinators");
+  });
+
+  it("returns a polished label for known offensive and defensive schemes", () => {
+    expect(schemeOptionLabel("shanahan_wide_zone")).toBe("Wide Zone");
+    expect(schemeOptionLabel("fangio_two_high")).toBe("Fangio Two-High");
+  });
+
+  it("echoes back unknown scheme keys so missing labels surface visibly", () => {
+    expect(schemeOptionLabel("smashmouth_2026")).toBe("smashmouth_2026");
+  });
 });
 
 describe("Hiring page", () => {
@@ -285,6 +341,86 @@ describe("Market survey view", () => {
     ).toBe("Generalist");
   });
 
+  it("does not render a Role column — every leadership candidate is HC or DIRECTOR", () => {
+    renderPage();
+    expect(
+      screen.queryByRole("columnheader", { name: /^Role$/ }),
+    ).toBeNull();
+  });
+
+  it("labels the position column 'Position Specialty' on the coach tab", () => {
+    renderPage();
+    expect(
+      screen.getByRole("columnheader", { name: /Position Specialty/i }),
+    ).toBeTruthy();
+  });
+
+  it("filters coach candidates by background", async () => {
+    renderPage();
+    fireEvent.change(
+      screen.getByTestId("market-coach-table-filter-background"),
+      { target: { value: "defense" } },
+    );
+    await waitFor(() => {
+      expect(screen.queryByTestId("candidate-row-c1")).toBeNull();
+      expect(screen.getByTestId("candidate-row-c3")).toBeTruthy();
+    });
+  });
+
+  it("filters coach candidates by scheme", async () => {
+    renderPage();
+    fireEvent.change(
+      screen.getByTestId("market-coach-table-filter-scheme"),
+      { target: { value: "shanahan_wide_zone" } },
+    );
+    await waitFor(() => {
+      expect(screen.queryByTestId("candidate-row-c1")).toBeNull();
+      expect(screen.getByTestId("candidate-row-c2")).toBeTruthy();
+    });
+  });
+
+  it("filters coach candidates by position specialty", async () => {
+    renderPage();
+    fireEvent.change(
+      screen.getByTestId("market-coach-table-filter-position"),
+      { target: { value: "DB" } },
+    );
+    await waitFor(() => {
+      expect(screen.getByTestId("candidate-row-c3")).toBeTruthy();
+      expect(screen.queryByTestId("candidate-row-c1")).toBeNull();
+    });
+  });
+
+  it("filters coach candidates by CEO scheme bucket", async () => {
+    renderPage();
+    fireEvent.change(
+      screen.getByTestId("market-coach-table-filter-scheme"),
+      { target: { value: "ceo" } },
+    );
+    await waitFor(() => {
+      expect(screen.getByTestId("candidate-row-c4")).toBeTruthy();
+      expect(screen.queryByTestId("candidate-row-c1")).toBeNull();
+    });
+  });
+
+  it("clears a filter back to all candidates when 'All' is selected", async () => {
+    renderPage();
+    fireEvent.change(
+      screen.getByTestId("market-coach-table-filter-background"),
+      { target: { value: "defense" } },
+    );
+    await waitFor(() => {
+      expect(screen.queryByTestId("candidate-row-c1")).toBeNull();
+    });
+    fireEvent.change(
+      screen.getByTestId("market-coach-table-filter-background"),
+      { target: { value: "all" } },
+    );
+    await waitFor(() => {
+      expect(screen.getByTestId("candidate-row-c1")).toBeTruthy();
+    });
+  });
+
   it("shows a scouting director's region and position focus on the scout tab", () => {
     mockUseHiringCandidates.mockReturnValue({
       data: [
@@ -315,6 +451,56 @@ describe("Market survey view", () => {
     expect(
       screen.getByTestId("candidate-position-s1").textContent,
     ).toBe("Generalist");
+  });
+
+  it("filters scout candidates by region", async () => {
+    mockUseHiringCandidates.mockReturnValue({
+      data: [
+        {
+          id: "s1",
+          leagueId: "lg",
+          staffType: "scout",
+          firstName: "Ron",
+          lastName: "Wolf",
+          role: "DIRECTOR",
+          specialty: null,
+          offensiveArchetype: null,
+          defensiveArchetype: null,
+          age: 58,
+          yearsExperience: 30,
+          positionBackground: null,
+          positionFocus: "GENERALIST",
+          regionFocus: "SOUTHEAST",
+        },
+        {
+          id: "s2",
+          leagueId: "lg",
+          staffType: "scout",
+          firstName: "Bill",
+          lastName: "Polian",
+          role: "DIRECTOR",
+          specialty: null,
+          offensiveArchetype: null,
+          defensiveArchetype: null,
+          age: 60,
+          yearsExperience: 32,
+          positionBackground: null,
+          positionFocus: "QB",
+          regionFocus: "MIDWEST",
+        },
+      ],
+      isLoading: false,
+    });
+    renderPage();
+    fireEvent.click(screen.getByTestId("market-tab-scout"));
+    fireEvent.change(
+      screen.getByTestId("market-scout-table-filter-region"),
+      { target: { value: "MIDWEST" } },
+    );
+    await waitFor(() => {
+      expect(screen.queryByTestId("candidate-row-s1")).toBeNull();
+      expect(screen.getByTestId("candidate-row-s2")).toBeTruthy();
+    });
   });
 
   it("invokes expressInterest on Express Interest click", () => {

--- a/client/src/features/league/hiring/index.tsx
+++ b/client/src/features/league/hiring/index.tsx
@@ -1,7 +1,11 @@
 import { useMemo, useState } from "react";
 import { Link, useParams } from "@tanstack/react-router";
 import { toast } from "sonner";
-import type { ColumnDef } from "@tanstack/react-table";
+import type {
+  Column,
+  ColumnDef,
+  Table as ReactTable,
+} from "@tanstack/react-table";
 import type {
   HiringCandidateSummary,
   HiringDecisionView,
@@ -45,7 +49,9 @@ import { useStaffTree } from "../../../hooks/use-staff-tree.ts";
 import { useScoutStaffTree } from "../../../hooks/use-scout-staff-tree.ts";
 import { coachBackgroundLabel, roleLabel } from "../role-labels.ts";
 import {
+  DEFENSIVE_ARCHETYPE_NAMES,
   defensiveArchetypeLabel,
+  OFFENSIVE_ARCHETYPE_NAMES,
   offensiveArchetypeLabel,
   positionGroupLabel,
   scoutRegionLabel,
@@ -857,7 +863,6 @@ function StaffTypeTabs(
 
 type CandidateRow = HiringCandidateSummary & {
   fullName: string;
-  displayRole: string;
   bandMin: number;
   bandMax: number;
   medianSalary: number;
@@ -878,7 +883,6 @@ function toRows(candidates: HiringCandidateSummary[]): CandidateRow[] {
     return {
       ...c,
       fullName: `${c.firstName} ${c.lastName}`,
-      displayRole: roleLabel(c.staffType, c.role),
       bandMin: band.min,
       bandMax: band.max,
       medianSalary: medianSalary(c.staffType, c.role),
@@ -907,13 +911,6 @@ function buildCandidateColumns(
           {row.original.fullName}
         </Link>
       ),
-    },
-    {
-      accessorKey: "displayRole",
-      header: ({ column }) => (
-        <SortableHeader column={column}>Role</SortableHeader>
-      ),
-      cell: ({ row }) => row.original.displayRole,
     },
     {
       accessorKey: "age",
@@ -950,30 +947,36 @@ function buildCandidateColumns(
     cols.push(
       {
         id: "background",
+        accessorFn: (row) => row.specialty ?? "",
         header: "Background",
         cell: ({ row }) => (
           <span data-testid={`candidate-background-${row.original.id}`}>
             {coachBackgroundLabel(row.original.specialty)}
           </span>
         ),
+        filterFn: "equals",
       },
       {
         id: "position",
-        header: "Position",
+        accessorFn: (row) => row.positionBackground ?? "",
+        header: "Position Specialty",
         cell: ({ row }) => (
           <span data-testid={`candidate-position-${row.original.id}`}>
             {positionGroupLabel(row.original.positionBackground) ?? "—"}
           </span>
         ),
+        filterFn: "equals",
       },
       {
         id: "scheme",
+        accessorFn: (row) => coachSchemeKey(row),
         header: "Scheme",
         cell: ({ row }) => (
           <span data-testid={`candidate-scheme-${row.original.id}`}>
             {coachSchemeLabel(row.original)}
           </span>
         ),
+        filterFn: "equals",
       },
     );
   }
@@ -982,21 +985,25 @@ function buildCandidateColumns(
     cols.push(
       {
         id: "region",
+        accessorFn: (row) => row.regionFocus ?? "",
         header: "Region",
         cell: ({ row }) => (
           <span data-testid={`candidate-region-${row.original.id}`}>
             {scoutRegionLabel(row.original.regionFocus) ?? "—"}
           </span>
         ),
+        filterFn: "equals",
       },
       {
         id: "position",
-        header: "Position",
+        accessorFn: (row) => row.positionFocus ?? "",
+        header: "Position Specialty",
         cell: ({ row }) => (
           <span data-testid={`candidate-position-${row.original.id}`}>
             {positionGroupLabel(row.original.positionFocus) ?? "—"}
           </span>
         ),
+        filterFn: "equals",
       },
     );
   }
@@ -1031,6 +1038,132 @@ function buildCandidateColumns(
   return cols;
 }
 
+function coachSchemeKey(c: HiringCandidateSummary): string {
+  if (c.role === "HC" && c.specialty === "ceo") return "ceo";
+  return c.offensiveArchetype ?? c.defensiveArchetype ?? "";
+}
+
+function CandidateFilter(
+  {
+    column,
+    label,
+    formatLabel,
+    testId,
+  }: {
+    column: Column<CandidateRow, unknown> | undefined;
+    label: string;
+    formatLabel: (value: string) => string;
+    testId: string;
+  },
+) {
+  if (!column) return null;
+  const options = Array.from(column.getFacetedUniqueValues().keys())
+    .filter((v): v is string => typeof v === "string" && v.length > 0)
+    .sort((a, b) => formatLabel(a).localeCompare(formatLabel(b)));
+  const current = (column.getFilterValue() as string | undefined) ?? "all";
+  return (
+    <label className="flex items-center gap-2 text-sm">
+      <span className="text-muted-foreground">{label}</span>
+      <select
+        data-testid={testId}
+        value={current}
+        onChange={(event) => {
+          const next = event.target.value;
+          column.setFilterValue(next === "all" ? undefined : next);
+        }}
+        className="h-8 min-w-40 rounded-lg border border-input bg-transparent px-2 text-sm text-foreground focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 outline-none"
+      >
+        <option value="all">All {label}</option>
+        {options.map((value) => (
+          <option key={value} value={value}>
+            {formatLabel(value)}
+          </option>
+        ))}
+      </select>
+    </label>
+  );
+}
+
+function CandidateFilters(
+  {
+    table,
+    staffType,
+    testIdPrefix,
+  }: {
+    table: ReactTable<CandidateRow>;
+    staffType: "coach" | "scout";
+    testIdPrefix: string;
+  },
+) {
+  return (
+    <div
+      className="flex flex-wrap items-center gap-2"
+      data-testid={`${testIdPrefix}-filters`}
+    >
+      {staffType === "coach" && (
+        <>
+          <CandidateFilter
+            column={table.getColumn("background")}
+            label="Background"
+            formatLabel={coachBackgroundLabel}
+            testId={`${testIdPrefix}-filter-background`}
+          />
+          <CandidateFilter
+            column={table.getColumn("position")}
+            label="Position Specialty"
+            formatLabel={positionFilterLabel}
+            testId={`${testIdPrefix}-filter-position`}
+          />
+          <CandidateFilter
+            column={table.getColumn("scheme")}
+            label="Scheme"
+            formatLabel={schemeOptionLabel}
+            testId={`${testIdPrefix}-filter-scheme`}
+          />
+        </>
+      )}
+      {staffType === "scout" && (
+        <>
+          <CandidateFilter
+            column={table.getColumn("region")}
+            label="Region"
+            formatLabel={regionFilterLabel}
+            testId={`${testIdPrefix}-filter-region`}
+          />
+          <CandidateFilter
+            column={table.getColumn("position")}
+            label="Position Specialty"
+            formatLabel={positionFilterLabel}
+            testId={`${testIdPrefix}-filter-position`}
+          />
+        </>
+      )}
+    </div>
+  );
+}
+
+export function positionFilterLabel(value: string): string {
+  return positionGroupLabel(value) ?? value;
+}
+
+export function regionFilterLabel(value: string): string {
+  return scoutRegionLabel(value) ?? value;
+}
+
+const SCHEME_OPTION_LABELS = new Map<string, string>([
+  ["ceo", "Defers to coordinators"],
+  ...OFFENSIVE_ARCHETYPE_NAMES.map(
+    (name) => [name, offensiveArchetypeLabel(name) ?? name] as const,
+  ),
+  ...DEFENSIVE_ARCHETYPE_NAMES.map(
+    (name) => [name, defensiveArchetypeLabel(name) ?? name] as const,
+  ),
+]);
+
+export function schemeOptionLabel(value: string): string {
+  return SCHEME_OPTION_LABELS.get(value) ?? value;
+}
+
 function CandidateDataTable(
   {
     candidates,
@@ -1043,7 +1176,7 @@ function CandidateDataTable(
     staffType: "coach" | "scout";
     renderAction: (c: HiringCandidateSummary) => React.ReactNode;
     leagueId: string;
-    testId?: string;
+    testId: string;
   },
 ) {
   const rows = useMemo(() => toRows(candidates), [candidates]);
@@ -1058,6 +1191,13 @@ function CandidateDataTable(
         columns={columns}
         data={rows}
         getRowTestId={(row) => `candidate-row-${row.id}`}
+        toolbar={(table) => (
+          <CandidateFilters
+            table={table}
+            staffType={staffType}
+            testIdPrefix={testId}
+          />
+        )}
       />
     </div>
   );


### PR DESCRIPTION
## Summary

- Adds Background / Position Specialty / Scheme dropdown filters on the coach hiring tab and Region / Position Specialty filters on the scout tab. Options are derived from the candidates currently in view, so a deep market is easy to slice.
- Drops the now-redundant Role column — the leadership pool only contains HCs and Directors of Scouting today.
- Renames the "Position" column header to "Position Specialty" so it reads correctly for both coaches' career anchor and scouts' evaluation focus.