### PR TITLE
feat(calibration): add per-QB-bucket calibration harness (#496, QB slice)

### DIFF
--- a/data/R/bands/per-position-qb.R
+++ b/data/R/bands/per-position-qb.R
@@ -1,0 +1,148 @@
+#!/usr/bin/env Rscript
+# per-position-qb.R — NFL QB percentile-band reference.
+#
+# Pulls weekly QB stats from load_player_stats, aggregates to per-QB-season
+# lines, filters to starters (season attempts >= 200), ranks by qb_epa/play,
+# and carves the population into five percentile bands (elite / good /
+# average / weak / replacement). For each band, reports mean + sd + n on the
+# metrics we can stably measure for QB performance at the season level.
+#
+# Output: data/bands/per-position/qb.json
+#
+# Usage:
+#   Rscript data/R/bands/per-position-qb.R [--seasons 2020:2024]
+
+suppressPackageStartupMessages({
+  library(nflreadr)
+  library(dplyr)
+})
+
+script_file <- (function() {
+  args <- commandArgs(trailingOnly = FALSE)
+  f <- grep("^--file=", args, value = TRUE)
+  if (length(f) > 0) normalizePath(sub("^--file=", "", f[1]), mustWork = FALSE) else NULL
+})()
+source(file.path(dirname(script_file), "..", "lib.R"))
+
+args <- commandArgs(trailingOnly = TRUE)
+seasons <- parse_seasons(args)
+
+cat("Loading weekly player stats for seasons:",
+    paste(range(seasons), collapse = "-"), "\n")
+
+weekly <- nflreadr::load_player_stats(seasons, stat_type = "offense")
+
+qb_weekly <- weekly |>
+  filter(season_type == "REG", position == "QB", attempts > 0)
+
+# Aggregate weekly rows into per-QB-season totals. We want season-level
+# rate stats (completion %, YPA, TD%, INT%, sack%) because the sim
+# emits per-game samples that we then bucket -- season rates have enough
+# denominator to rank QBs cleanly against each other.
+qb_season <- qb_weekly |>
+  group_by(player_id, player_display_name, season) |>
+  summarise(
+    games       = n(),
+    attempts    = sum(attempts, na.rm = TRUE),
+    completions = sum(completions, na.rm = TRUE),
+    pass_yards  = sum(passing_yards, na.rm = TRUE),
+    pass_tds    = sum(passing_tds, na.rm = TRUE),
+    ints        = sum(passing_interceptions, na.rm = TRUE),
+    sacks       = sum(sacks_suffered, na.rm = TRUE),
+    sack_yards  = sum(sack_yards_lost, na.rm = TRUE),
+    epa_total   = sum(passing_epa, na.rm = TRUE),
+    .groups     = "drop"
+  ) |>
+  mutate(
+    # Denominator for completion%/YPA/TD%/INT% is attempts (excludes sacks),
+    # matching how the sim's existing team-game calibration computes them.
+    completion_pct = ifelse(attempts > 0, completions / attempts, NA_real_),
+    yards_per_attempt = ifelse(attempts > 0, pass_yards / attempts, NA_real_),
+    td_rate  = ifelse(attempts > 0, pass_tds / attempts, NA_real_),
+    int_rate = ifelse(attempts > 0, ints / attempts, NA_real_),
+    # Sack rate uses dropbacks (attempts + sacks) as denominator, which is
+    # the standard definition and avoids crediting sacks to attempts.
+    sack_rate = ifelse((attempts + sacks) > 0,
+                       sacks / (attempts + sacks), NA_real_),
+    epa_per_play = ifelse((attempts + sacks) > 0,
+                          epa_total / (attempts + sacks), NA_real_)
+  ) |>
+  filter(attempts >= 200) # starter threshold
+
+cat("QB-seasons after starter filter:", nrow(qb_season), "\n")
+
+# Rank by EPA/play and assign percentile bands on the filtered starter
+# population. Bands follow the scheme from issue #496: top 10% elite,
+# next 20% good, middle 40% average, next 20% weak, bottom 10% replacement.
+qb_ranked <- qb_season |>
+  arrange(desc(epa_per_play)) |>
+  mutate(
+    pct = (row_number() - 0.5) / n(),
+    band = case_when(
+      pct <= 0.10 ~ "elite",
+      pct <= 0.30 ~ "good",
+      pct <= 0.70 ~ "average",
+      pct <= 0.90 ~ "weak",
+      TRUE        ~ "replacement"
+    )
+  )
+
+metric_keys <- c(
+  "completion_pct",
+  "yards_per_attempt",
+  "td_rate",
+  "int_rate",
+  "sack_rate"
+)
+
+band_order <- c("elite", "good", "average", "weak", "replacement")
+
+band_summary <- function(rows) {
+  metrics <- list()
+  for (key in metric_keys) {
+    vals <- rows[[key]]
+    vals <- vals[!is.na(vals)]
+    metrics[[key]] <- list(
+      n = length(vals),
+      mean = mean(vals),
+      sd = stats::sd(vals)
+    )
+  }
+  list(
+    n = nrow(rows),
+    metrics = metrics
+  )
+}
+
+bands <- list()
+for (band_name in band_order) {
+  rows <- qb_ranked |> filter(band == band_name)
+  bands[[band_name]] <- band_summary(rows)
+}
+
+out <- list(
+  generated_at = format(Sys.time(), "%Y-%m-%dT%H:%M:%SZ", tz = "UTC"),
+  seasons = as.integer(seasons),
+  position = "QB",
+  qualifier = "regular-season QB-seasons with >=200 attempts",
+  ranking_stat = "epa_per_play (dropback EPA / (attempts + sacks))",
+  notes = paste0(
+    "Starter QB-seasons 2020-2024, ranked by EPA/play then carved into ",
+    "percentile bands (elite: top 10%, good: 10-30%, average: 30-70%, ",
+    "weak: 70-90%, replacement: bottom 10%). Each band reports mean+sd ",
+    "per metric across the QB-seasons in that band. Completion%, YPA, ",
+    "TD%, INT% use attempts as denominator; sack_rate uses dropbacks."
+  ),
+  bands = bands
+)
+
+out_path <- file.path(
+  repo_root(), "data", "bands", "per-position", "qb.json"
+)
+dir.create(dirname(out_path), recursive = TRUE, showWarnings = FALSE)
+writeLines(
+  jsonlite::toJSON(out, auto_unbox = TRUE, pretty = TRUE, digits = 4,
+                   null = "null"),
+  out_path
+)
+cat("Wrote", out_path, "\n")

--- a/data/bands/per-position/qb.json
+++ b/data/bands/per-position/qb.json
@@ -1,0 +1,160 @@
+{
+  "generated_at": "2026-04-17T11:46:54Z",
+  "seasons": [2020, 2021, 2022, 2023, 2024],
+  "position": "QB",
+  "qualifier": "regular-season QB-seasons with >=200 attempts",
+  "ranking_stat": "epa_per_play (dropback EPA / (attempts + sacks))",
+  "notes": "Starter QB-seasons 2020-2024, ranked by EPA/play then carved into percentile bands (elite: top 10%, good: 10-30%, average: 30-70%, weak: 70-90%, replacement: bottom 10%). Each band reports mean+sd per metric across the QB-seasons in that band. Completion%, YPA, TD%, INT% use attempts as denominator; sack_rate uses dropbacks.",
+  "bands": {
+    "elite": {
+      "n": 18,
+      "metrics": {
+        "completion_pct": {
+          "n": 18,
+          "mean": 0.6802,
+          "sd": 0.0257
+        },
+        "yards_per_attempt": {
+          "n": 18,
+          "mean": 8.189,
+          "sd": 0.6163
+        },
+        "td_rate": {
+          "n": 18,
+          "mean": 0.0637,
+          "sd": 0.0118
+        },
+        "int_rate": {
+          "n": 18,
+          "mean": 0.0167,
+          "sd": 0.006
+        },
+        "sack_rate": {
+          "n": 18,
+          "mean": 0.0481,
+          "sd": 0.0126
+        }
+      }
+    },
+    "good": {
+      "n": 35,
+      "metrics": {
+        "completion_pct": {
+          "n": 35,
+          "mean": 0.671,
+          "sd": 0.0223
+        },
+        "yards_per_attempt": {
+          "n": 35,
+          "mean": 7.6587,
+          "sd": 0.423
+        },
+        "td_rate": {
+          "n": 35,
+          "mean": 0.0557,
+          "sd": 0.0088
+        },
+        "int_rate": {
+          "n": 35,
+          "mean": 0.0198,
+          "sd": 0.0058
+        },
+        "sack_rate": {
+          "n": 35,
+          "mean": 0.055,
+          "sd": 0.0169
+        }
+      }
+    },
+    "average": {
+      "n": 70,
+      "metrics": {
+        "completion_pct": {
+          "n": 70,
+          "mean": 0.6548,
+          "sd": 0.0241
+        },
+        "yards_per_attempt": {
+          "n": 70,
+          "mean": 7.1505,
+          "sd": 0.4561
+        },
+        "td_rate": {
+          "n": 70,
+          "mean": 0.0431,
+          "sd": 0.0092
+        },
+        "int_rate": {
+          "n": 70,
+          "mean": 0.022,
+          "sd": 0.0068
+        },
+        "sack_rate": {
+          "n": 70,
+          "mean": 0.063,
+          "sd": 0.016
+        }
+      }
+    },
+    "weak": {
+      "n": 35,
+      "metrics": {
+        "completion_pct": {
+          "n": 35,
+          "mean": 0.6315,
+          "sd": 0.0306
+        },
+        "yards_per_attempt": {
+          "n": 35,
+          "mean": 6.5688,
+          "sd": 0.4137
+        },
+        "td_rate": {
+          "n": 35,
+          "mean": 0.0331,
+          "sd": 0.0076
+        },
+        "int_rate": {
+          "n": 35,
+          "mean": 0.0245,
+          "sd": 0.0072
+        },
+        "sack_rate": {
+          "n": 35,
+          "mean": 0.0765,
+          "sd": 0.0184
+        }
+      }
+    },
+    "replacement": {
+      "n": 18,
+      "metrics": {
+        "completion_pct": {
+          "n": 18,
+          "mean": 0.598,
+          "sd": 0.0387
+        },
+        "yards_per_attempt": {
+          "n": 18,
+          "mean": 6.2154,
+          "sd": 0.4956
+        },
+        "td_rate": {
+          "n": 18,
+          "mean": 0.029,
+          "sd": 0.009
+        },
+        "int_rate": {
+          "n": 18,
+          "mean": 0.0307,
+          "sd": 0.0085
+        },
+        "sack_rate": {
+          "n": 18,
+          "mean": 0.0951,
+          "sd": 0.0263
+        }
+      }
+    }
+  }
+}

--- a/deno.json
+++ b/deno.json
@@ -34,6 +34,7 @@
     "test:coverage": "./bin/check-coverage",
     "test:e2e": "./bin/test-e2e",
     "sim:calibrate": "deno run --allow-read server/features/simulation/calibration/run-calibration.ts",
+    "sim:calibrate:qb": "deno run --allow-read server/features/simulation/calibration/per-position/run-qb-calibration.ts",
     "build": "cd client && deno task build",
     "start": "cd server && deno run --env=../.env --allow-net --allow-env --allow-read --allow-sys main.ts"
   },

--- a/server/features/simulation/calibration/per-position/band-check.test.ts
+++ b/server/features/simulation/calibration/per-position/band-check.test.ts
@@ -1,0 +1,114 @@
+import { assertEquals, assertThrows } from "@std/assert";
+import { checkBand, expectedBandFor } from "./band-check.ts";
+import type { PositionBands } from "./band-loader.ts";
+
+function bandsFixture(): PositionBands {
+  return {
+    position: "QB",
+    seasons: [2020, 2021, 2022, 2023, 2024],
+    rankingStat: "epa_per_play",
+    bands: {
+      elite: {
+        n: 18,
+        metrics: { ypa: { n: 18, mean: 8.2, sd: 0.6 } },
+      },
+      good: {
+        n: 35,
+        metrics: { ypa: { n: 35, mean: 7.6, sd: 0.4 } },
+      },
+      average: {
+        n: 70,
+        metrics: { ypa: { n: 70, mean: 7.1, sd: 0.45 } },
+      },
+      weak: {
+        n: 35,
+        metrics: { ypa: { n: 35, mean: 6.5, sd: 0.4 } },
+      },
+      replacement: {
+        n: 18,
+        metrics: { ypa: { n: 18, mean: 6.2, sd: 0.5 } },
+      },
+    },
+  };
+}
+
+Deno.test("expectedBandFor defaults map 50→average, 70→elite, 40→weak, 30→replacement", () => {
+  assertEquals(expectedBandFor("50"), "average");
+  assertEquals(expectedBandFor("40"), "weak");
+  assertEquals(expectedBandFor("60"), "good");
+  assertEquals(expectedBandFor("70"), "elite");
+  assertEquals(expectedBandFor("80"), "elite");
+  assertEquals(expectedBandFor("30"), "replacement");
+});
+
+Deno.test("expectedBandFor honors overrides", () => {
+  assertEquals(expectedBandFor("50", { "50": "good" }), "good");
+});
+
+Deno.test("expectedBandFor throws on unknown bucket label", () => {
+  assertThrows(() => expectedBandFor("99"), Error, "No expected band");
+});
+
+Deno.test("checkBand passes when sim mean is closest to the expected band", () => {
+  const result = checkBand({
+    bucketLabel: "50",
+    metricName: "ypa",
+    simSummary: { n: 500, mean: 7.1, sd: 0.4 },
+    bands: bandsFixture(),
+  });
+  assertEquals(result.expectedBand, "average");
+  assertEquals(result.actualBand, "average");
+  assertEquals(result.passed, true);
+  assertEquals(result.direction, "on_target");
+});
+
+Deno.test("checkBand fails with 'too_high' when sim mean lands in a better band", () => {
+  const result = checkBand({
+    bucketLabel: "50",
+    metricName: "ypa",
+    simSummary: { n: 500, mean: 7.6, sd: 0.4 },
+    bands: bandsFixture(),
+  });
+  assertEquals(result.expectedBand, "average");
+  assertEquals(result.actualBand, "good");
+  assertEquals(result.passed, false);
+  assertEquals(result.direction, "too_high");
+});
+
+Deno.test("checkBand fails with 'too_low' when sim mean drops below expected", () => {
+  const result = checkBand({
+    bucketLabel: "70",
+    metricName: "ypa",
+    simSummary: { n: 500, mean: 7.1, sd: 0.4 },
+    bands: bandsFixture(),
+  });
+  assertEquals(result.expectedBand, "elite");
+  assertEquals(result.actualBand, "average");
+  assertEquals(result.passed, false);
+  assertEquals(result.direction, "too_low");
+});
+
+Deno.test("checkBand reports a z-score expressing distance from band mean", () => {
+  const result = checkBand({
+    bucketLabel: "50",
+    metricName: "ypa",
+    simSummary: { n: 500, mean: 7.55, sd: 0.4 },
+    bands: bandsFixture(),
+  });
+  // band average ypa is 7.1, sd 0.45 → z = (7.55 - 7.1)/0.45 = 1.0
+  assertEquals(Math.round(result.zScore * 10) / 10, 1.0);
+});
+
+Deno.test("checkBand throws if the band is missing the requested metric", () => {
+  assertThrows(
+    () =>
+      checkBand({
+        bucketLabel: "50",
+        metricName: "missing",
+        simSummary: { n: 1, mean: 0, sd: 0 },
+        bands: bandsFixture(),
+      }),
+    Error,
+    'missing metric "missing"',
+  );
+});

--- a/server/features/simulation/calibration/per-position/band-check.ts
+++ b/server/features/simulation/calibration/per-position/band-check.ts
@@ -1,0 +1,134 @@
+import type { MetricSummary } from "./bucket-by-attr.ts";
+import type { BandData, PercentileBand, PositionBands } from "./band-loader.ts";
+
+// Maps each rating-bucket label to the NFL percentile band we expect
+// that bucket's sim output to resemble. The 50 bucket anchors to the
+// NFL median starter (average band); ratings above/below step the
+// expected band one rank each way. 30 falls off the bottom, so pair
+// it with replacement — same as 40 — since our NFL fixture only has
+// five bands.
+const DEFAULT_EXPECTED_BAND: Record<string, PercentileBand> = {
+  "30": "replacement",
+  "40": "weak",
+  "50": "average",
+  "60": "good",
+  "70": "elite",
+  "80": "elite",
+};
+
+export interface BandCheckArgs {
+  bucketLabel: string;
+  metricName: string;
+  simSummary: MetricSummary;
+  bands: PositionBands;
+  // Override expected-band mapping per bucket; defaults to the
+  // 30↔replacement, 40↔weak, 50↔average, 60↔good, 70/80↔elite mapping.
+  expectedBand?: Record<string, PercentileBand>;
+  // Some metrics (int_rate, sack_rate) are *better* when lower. We
+  // still expect a 70 QB to land in the elite band — which for those
+  // metrics means a lower mean. This only flips the direction of the
+  // "missed high / missed low" verdict in the result.
+  lowerIsBetter?: boolean;
+}
+
+export interface BandCheckResult {
+  bucketLabel: string;
+  metricName: string;
+  expectedBand: PercentileBand;
+  actualBand: PercentileBand | "none";
+  simMean: number;
+  simN: number;
+  bandMean: number;
+  bandSd: number;
+  // Signed distance in band standard deviations. 0 = on the band's mean;
+  // +1 = one sd above; negative = below.
+  zScore: number;
+  passed: boolean;
+  direction: "on_target" | "too_high" | "too_low";
+}
+
+function classifyActualBand(
+  simMean: number,
+  bands: PositionBands,
+  metricName: string,
+): PercentileBand | "none" {
+  // Walk bands in rating order from elite (highest mean on a
+  // lower-is-better stat is flipped; but we always classify by which
+  // band's mean this sim value is closest to). Bands aren't guaranteed
+  // to be monotonic on every metric so "closest mean" is the honest
+  // classification rather than threshold-walking.
+  const order: PercentileBand[] = [
+    "elite",
+    "good",
+    "average",
+    "weak",
+    "replacement",
+  ];
+  let best: { band: PercentileBand | "none"; distance: number } = {
+    band: "none",
+    distance: Infinity,
+  };
+  for (const name of order) {
+    const m = bands.bands[name].metrics[metricName];
+    if (!m) continue;
+    const distance = Math.abs(simMean - m.mean);
+    if (distance < best.distance) {
+      best = { band: name, distance };
+    }
+  }
+  return best.band;
+}
+
+export function expectedBandFor(
+  bucketLabel: string,
+  overrides?: Record<string, PercentileBand>,
+): PercentileBand {
+  const map = { ...DEFAULT_EXPECTED_BAND, ...(overrides ?? {}) };
+  const expected = map[bucketLabel];
+  if (!expected) {
+    throw new Error(
+      `No expected band mapping for bucket "${bucketLabel}". ` +
+        `Provide an override via expectedBand.`,
+    );
+  }
+  return expected;
+}
+
+export function checkBand(args: BandCheckArgs): BandCheckResult {
+  const { bucketLabel, metricName, simSummary, bands } = args;
+  const expected = expectedBandFor(bucketLabel, args.expectedBand);
+
+  const band: BandData = bands.bands[expected];
+  const bandMetric = band.metrics[metricName];
+  if (!bandMetric) {
+    throw new Error(
+      `Band "${expected}" is missing metric "${metricName}"`,
+    );
+  }
+
+  const actualBand = classifyActualBand(simSummary.mean, bands, metricName);
+
+  const zScore = bandMetric.sd > 0
+    ? (simSummary.mean - bandMetric.mean) / bandMetric.sd
+    : 0;
+
+  const direction: BandCheckResult["direction"] = actualBand === expected
+    ? "on_target"
+    : zScore > 0
+    ? "too_high"
+    : "too_low";
+
+  return {
+    bucketLabel,
+    metricName,
+    expectedBand: expected,
+    actualBand,
+    simMean: simSummary.mean,
+    simN: simSummary.n,
+    bandMean: bandMetric.mean,
+    bandSd: bandMetric.sd,
+    zScore,
+    passed: actualBand === expected,
+    direction,
+  };
+}

--- a/server/features/simulation/calibration/per-position/band-loader.test.ts
+++ b/server/features/simulation/calibration/per-position/band-loader.test.ts
@@ -1,0 +1,78 @@
+import { assertEquals, assertThrows } from "@std/assert";
+import { loadPositionBands, PERCENTILE_BANDS } from "./band-loader.ts";
+
+function buildValidJson(overrides: Record<string, unknown> = {}): string {
+  const band = () => ({
+    n: 10,
+    metrics: {
+      completion_pct: { n: 10, mean: 0.6, sd: 0.03 },
+    },
+  });
+  return JSON.stringify({
+    position: "QB",
+    seasons: [2020, 2021, 2022, 2023, 2024],
+    ranking_stat: "epa_per_play",
+    bands: {
+      elite: band(),
+      good: band(),
+      average: band(),
+      weak: band(),
+      replacement: band(),
+    },
+    ...overrides,
+  });
+}
+
+Deno.test("loadPositionBands parses position, seasons, and all five bands", () => {
+  const bands = loadPositionBands(buildValidJson());
+  assertEquals(bands.position, "QB");
+  assertEquals(bands.seasons, [2020, 2021, 2022, 2023, 2024]);
+  assertEquals(bands.rankingStat, "epa_per_play");
+  for (const name of PERCENTILE_BANDS) {
+    assertEquals(bands.bands[name].n, 10);
+    assertEquals(bands.bands[name].metrics.completion_pct.mean, 0.6);
+  }
+});
+
+Deno.test("loadPositionBands throws on missing position", () => {
+  const json = JSON.stringify({
+    seasons: [],
+    bands: {
+      elite: { n: 1, metrics: {} },
+      good: { n: 1, metrics: {} },
+      average: { n: 1, metrics: {} },
+      weak: { n: 1, metrics: {} },
+      replacement: { n: 1, metrics: {} },
+    },
+  });
+  assertThrows(() => loadPositionBands(json), Error, "position");
+});
+
+Deno.test("loadPositionBands throws when a band is missing", () => {
+  const full = JSON.parse(buildValidJson());
+  delete full.bands.good;
+  assertThrows(
+    () => loadPositionBands(JSON.stringify(full)),
+    Error,
+    'missing band "good"',
+  );
+});
+
+Deno.test("loadPositionBands throws when a metric is missing required fields", () => {
+  const full = JSON.parse(buildValidJson());
+  full.bands.elite.metrics.completion_pct = { mean: 0.6 };
+  assertThrows(
+    () => loadPositionBands(JSON.stringify(full)),
+    Error,
+    "n/mean/sd",
+  );
+});
+
+Deno.test("loadPositionBands tolerates missing seasons + ranking_stat", () => {
+  const full = JSON.parse(buildValidJson());
+  delete full.seasons;
+  delete full.ranking_stat;
+  const bands = loadPositionBands(JSON.stringify(full));
+  assertEquals(bands.seasons, []);
+  assertEquals(bands.rankingStat, "");
+});

--- a/server/features/simulation/calibration/per-position/band-loader.ts
+++ b/server/features/simulation/calibration/per-position/band-loader.ts
@@ -1,0 +1,95 @@
+export const PERCENTILE_BANDS = [
+  "elite",
+  "good",
+  "average",
+  "weak",
+  "replacement",
+] as const;
+
+export type PercentileBand = typeof PERCENTILE_BANDS[number];
+
+export interface BandMetric {
+  n: number;
+  mean: number;
+  sd: number;
+}
+
+export interface BandData {
+  n: number;
+  metrics: Record<string, BandMetric>;
+}
+
+export interface PositionBands {
+  position: string;
+  seasons: number[];
+  rankingStat: string;
+  bands: Record<PercentileBand, BandData>;
+}
+
+function isBandMetric(value: unknown): value is BandMetric {
+  if (typeof value !== "object" || value === null) return false;
+  const obj = value as Record<string, unknown>;
+  return typeof obj.n === "number" &&
+    typeof obj.mean === "number" &&
+    typeof obj.sd === "number";
+}
+
+function parseBand(value: unknown, bandName: string): BandData {
+  if (typeof value !== "object" || value === null) {
+    throw new Error(`Band "${bandName}" is not an object`);
+  }
+  const obj = value as Record<string, unknown>;
+  if (typeof obj.n !== "number") {
+    throw new Error(`Band "${bandName}" is missing numeric field "n"`);
+  }
+  const metricsRaw = obj.metrics;
+  if (typeof metricsRaw !== "object" || metricsRaw === null) {
+    throw new Error(`Band "${bandName}" is missing metrics object`);
+  }
+  const metrics: Record<string, BandMetric> = {};
+  for (const [name, m] of Object.entries(metricsRaw)) {
+    if (!isBandMetric(m)) {
+      throw new Error(
+        `Band "${bandName}" metric "${name}" is missing n/mean/sd`,
+      );
+    }
+    metrics[name] = m;
+  }
+  return { n: obj.n, metrics };
+}
+
+export function loadPositionBands(jsonString: string): PositionBands {
+  const parsed = JSON.parse(jsonString);
+
+  if (typeof parsed.position !== "string") {
+    throw new Error("Position band JSON missing 'position' key");
+  }
+  if (!parsed.bands || typeof parsed.bands !== "object") {
+    throw new Error("Position band JSON missing 'bands' key");
+  }
+
+  const bands = {} as Record<PercentileBand, BandData>;
+  for (const bandName of PERCENTILE_BANDS) {
+    const raw = parsed.bands[bandName];
+    if (raw === undefined) {
+      throw new Error(
+        `Position band JSON is missing band "${bandName}"`,
+      );
+    }
+    bands[bandName] = parseBand(raw, bandName);
+  }
+
+  const seasonsRaw = parsed.seasons;
+  const seasons = Array.isArray(seasonsRaw)
+    ? seasonsRaw.filter((s): s is number => typeof s === "number")
+    : [];
+
+  return {
+    position: parsed.position,
+    seasons,
+    rankingStat: typeof parsed.ranking_stat === "string"
+      ? parsed.ranking_stat
+      : "",
+    bands,
+  };
+}

--- a/server/features/simulation/calibration/per-position/bucket-by-attr.test.ts
+++ b/server/features/simulation/calibration/per-position/bucket-by-attr.test.ts
@@ -1,0 +1,86 @@
+import { assertAlmostEquals, assertEquals } from "@std/assert";
+import { bucketByAttr, DEFAULT_ATTR_BUCKETS } from "./bucket-by-attr.ts";
+
+interface Sample {
+  overall: number;
+  ypa: number;
+  completion_pct: number;
+}
+
+Deno.test("bucketByAttr groups samples by attribute into the default 10-point bands", () => {
+  const samples: Sample[] = [
+    { overall: 40, ypa: 6, completion_pct: 0.55 },
+    { overall: 41, ypa: 6.2, completion_pct: 0.6 },
+    { overall: 50, ypa: 7, completion_pct: 0.62 },
+    { overall: 55, ypa: 7.5, completion_pct: 0.63 },
+    { overall: 71, ypa: 8.2, completion_pct: 0.69 },
+  ];
+  const report = bucketByAttr({
+    samples,
+    attr: (s) => s.overall,
+    metrics: {
+      ypa: (s) => s.ypa,
+      completion_pct: (s) => s.completion_pct,
+    },
+  });
+  assertEquals(report.length, DEFAULT_ATTR_BUCKETS.length);
+  const fortyBucket = report.find((r) => r.bucket.label === "40")!;
+  assertEquals(fortyBucket.samples.length, 2);
+  const fiftyBucket = report.find((r) => r.bucket.label === "50")!;
+  assertEquals(fiftyBucket.samples.length, 1); // 50 is in [45,55); 55 is not
+  const sixtyBucket = report.find((r) => r.bucket.label === "60")!;
+  assertEquals(sixtyBucket.samples.length, 1); // 55 lands here
+  const seventyBucket = report.find((r) => r.bucket.label === "70")!;
+  assertEquals(seventyBucket.samples.length, 1);
+});
+
+Deno.test("bucketByAttr computes mean and sd per metric per bucket", () => {
+  const samples: Sample[] = [
+    { overall: 50, ypa: 6, completion_pct: 0.6 },
+    { overall: 52, ypa: 8, completion_pct: 0.7 },
+  ];
+  const report = bucketByAttr({
+    samples,
+    attr: (s) => s.overall,
+    metrics: {
+      ypa: (s) => s.ypa,
+      completion_pct: (s) => s.completion_pct,
+    },
+  });
+  const fiftyBucket = report.find((r) => r.bucket.label === "50")!;
+  assertEquals(fiftyBucket.metrics.ypa.n, 2);
+  assertAlmostEquals(fiftyBucket.metrics.ypa.mean, 7);
+  assertAlmostEquals(fiftyBucket.metrics.ypa.sd, 1); // population sd of [6,8]
+  assertAlmostEquals(fiftyBucket.metrics.completion_pct.mean, 0.65);
+});
+
+Deno.test("bucketByAttr returns zeroed metrics for empty buckets", () => {
+  const samples: Sample[] = [
+    { overall: 50, ypa: 7, completion_pct: 0.62 },
+  ];
+  const report = bucketByAttr({
+    samples,
+    attr: (s) => s.overall,
+    metrics: { ypa: (s) => s.ypa, completion_pct: (s) => s.completion_pct },
+  });
+  const thirtyBucket = report.find((r) => r.bucket.label === "30")!;
+  assertEquals(thirtyBucket.samples.length, 0);
+  assertEquals(thirtyBucket.metrics.ypa.n, 0);
+  assertEquals(thirtyBucket.metrics.ypa.mean, 0);
+  assertEquals(thirtyBucket.metrics.ypa.sd, 0);
+});
+
+Deno.test("bucketByAttr supports custom bucket definitions", () => {
+  const report = bucketByAttr({
+    samples: [{ overall: 42, ypa: 6, completion_pct: 0.55 }] as Sample[],
+    attr: (s: Sample) => s.overall,
+    metrics: { ypa: (s: Sample) => s.ypa },
+    buckets: [
+      { label: "low", center: 35, min: 0, max: 45 },
+      { label: "high", center: 65, min: 45, max: 100 },
+    ],
+  });
+  assertEquals(report.length, 2);
+  assertEquals(report[0].samples.length, 1);
+  assertEquals(report[1].samples.length, 0);
+});

--- a/server/features/simulation/calibration/per-position/bucket-by-attr.ts
+++ b/server/features/simulation/calibration/per-position/bucket-by-attr.ts
@@ -1,0 +1,67 @@
+export interface AttrBucket {
+  readonly label: string; // e.g. "50" — the bucket center
+  readonly center: number;
+  readonly min: number; // inclusive
+  readonly max: number; // exclusive
+}
+
+// Five equal-width buckets spanning the 0-100 rating scale centered on
+// 50. Calibration sanity check: the midpoint bucket (45-55) should
+// produce NFL median-starter numbers — that directly tests the
+// "rating midpoint is 50" contract.
+export const DEFAULT_ATTR_BUCKETS: readonly AttrBucket[] = [
+  { label: "30", center: 30, min: 25, max: 35 },
+  { label: "40", center: 40, min: 35, max: 45 },
+  { label: "50", center: 50, min: 45, max: 55 },
+  { label: "60", center: 60, min: 55, max: 65 },
+  { label: "70", center: 70, min: 65, max: 75 },
+  { label: "80", center: 80, min: 75, max: 85 },
+];
+
+export interface MetricSummary {
+  n: number;
+  mean: number;
+  sd: number;
+}
+
+export interface BucketReport<S> {
+  bucket: AttrBucket;
+  samples: S[];
+  metrics: Record<string, MetricSummary>;
+}
+
+function meanAndSd(values: number[]): MetricSummary {
+  const n = values.length;
+  if (n === 0) return { n: 0, mean: 0, sd: 0 };
+  const mean = values.reduce((a, b) => a + b, 0) / n;
+  const variance = values.reduce((s, v) => s + (v - mean) ** 2, 0) / n;
+  return { n, mean, sd: Math.sqrt(variance) };
+}
+
+export interface BucketByAttrOptions<S> {
+  samples: readonly S[];
+  // Extracts the attribute value each sample should be bucketed on.
+  attr: (sample: S) => number;
+  metrics: Record<string, (sample: S) => number>;
+  buckets?: readonly AttrBucket[];
+}
+
+export function bucketByAttr<S>(
+  options: BucketByAttrOptions<S>,
+): BucketReport<S>[] {
+  const buckets = options.buckets ?? DEFAULT_ATTR_BUCKETS;
+
+  return buckets.map((bucket) => {
+    const samples = options.samples.filter((s) => {
+      const value = options.attr(s);
+      return value >= bucket.min && value < bucket.max;
+    });
+
+    const metrics: Record<string, MetricSummary> = {};
+    for (const [name, extract] of Object.entries(options.metrics)) {
+      metrics[name] = meanAndSd(samples.map(extract));
+    }
+
+    return { bucket, samples, metrics };
+  });
+}

--- a/server/features/simulation/calibration/per-position/qb-harness.test.ts
+++ b/server/features/simulation/calibration/per-position/qb-harness.test.ts
@@ -1,0 +1,310 @@
+import { assertEquals, assertStringIncludes } from "@std/assert";
+import type { PlayerAttributes } from "@zone-blitz/shared";
+import { formatQbCalibrationReport, runQbCalibration } from "./qb-harness.ts";
+import type { GameResult, PlayEvent } from "../../events.ts";
+import type { SimTeam } from "../../simulate-game.ts";
+import type { PlayerRuntime } from "../../resolve-play.ts";
+import type { CalibrationLeague } from "../generate-calibration-league.ts";
+
+function attrs(overrides: Partial<PlayerAttributes> = {}): PlayerAttributes {
+  const base: Record<string, number> = {};
+  const keys = [
+    "speed",
+    "acceleration",
+    "agility",
+    "strength",
+    "jumping",
+    "stamina",
+    "durability",
+    "armStrength",
+    "accuracyShort",
+    "accuracyMedium",
+    "accuracyDeep",
+    "accuracyOnTheRun",
+    "touch",
+    "release",
+    "ballCarrying",
+    "elusiveness",
+    "routeRunning",
+    "catching",
+    "contestedCatching",
+    "runAfterCatch",
+    "passBlocking",
+    "runBlocking",
+    "blockShedding",
+    "tackling",
+    "manCoverage",
+    "zoneCoverage",
+    "passRushing",
+    "runDefense",
+    "kickingPower",
+    "kickingAccuracy",
+    "puntingPower",
+    "puntingAccuracy",
+    "snapAccuracy",
+    "footballIq",
+    "decisionMaking",
+    "anticipation",
+    "composure",
+    "clutch",
+    "consistency",
+    "workEthic",
+    "coachability",
+    "leadership",
+    "greed",
+    "loyalty",
+    "ambition",
+    "vanity",
+    "schemeAttachment",
+    "mediaSensitivity",
+  ];
+  for (const k of keys) {
+    base[k] = 50;
+    base[`${k}Potential`] = 50;
+  }
+  return { ...(base as unknown as PlayerAttributes), ...overrides };
+}
+
+function qbRuntime(id: string, overall: number): PlayerRuntime {
+  return {
+    playerId: id,
+    neutralBucket: "QB",
+    attributes: attrs({
+      armStrength: overall,
+      accuracyShort: overall,
+      accuracyMedium: overall,
+      accuracyDeep: overall,
+      release: overall,
+      decisionMaking: overall,
+    }),
+  };
+}
+
+function team(teamId: string, starterQb: PlayerRuntime): SimTeam {
+  return {
+    teamId,
+    starters: [starterQb],
+    bench: [],
+    fingerprint: { offense: null, defense: null, overrides: {} },
+    coachingMods: {
+      schemeFitBonus: 0,
+      situationalBonus: 0,
+      aggressiveness: 50,
+      penaltyDiscipline: 1,
+    },
+  };
+}
+
+function bandJson(): string {
+  const band = (mean: number, sd: number) => ({
+    n: 20,
+    metrics: {
+      completion_pct: { n: 20, mean, sd },
+      yards_per_attempt: { n: 20, mean: mean * 12, sd: sd * 2 },
+      td_rate: { n: 20, mean: 0.04, sd: 0.01 },
+      int_rate: { n: 20, mean: 0.02, sd: 0.005 },
+      sack_rate: { n: 20, mean: 0.06, sd: 0.015 },
+    },
+  });
+  return JSON.stringify({
+    position: "QB",
+    seasons: [2020, 2021, 2022, 2023, 2024],
+    ranking_stat: "epa_per_play",
+    bands: {
+      elite: band(0.68, 0.025),
+      good: band(0.66, 0.022),
+      average: band(0.65, 0.024),
+      weak: band(0.63, 0.03),
+      replacement: band(0.6, 0.04),
+    },
+  });
+}
+
+function makeGame(
+  gameId: string,
+  homeTeamId: string,
+  awayTeamId: string,
+  completionByTeam: Record<string, number>,
+): GameResult {
+  const events: PlayEvent[] = [];
+  for (
+    const [offenseTeamId, completionPct] of Object.entries(completionByTeam)
+  ) {
+    const defenseTeamId = offenseTeamId === homeTeamId
+      ? awayTeamId
+      : homeTeamId;
+    const attempts = 100;
+    const completions = Math.round(attempts * completionPct);
+    for (let i = 0; i < attempts; i++) {
+      const isComplete = i < completions;
+      events.push({
+        gameId,
+        driveIndex: 0,
+        playIndex: events.length,
+        quarter: 1,
+        clock: "15:00",
+        situation: { down: 1, distance: 10, yardLine: 25 },
+        offenseTeamId,
+        defenseTeamId,
+        call: {
+          concept: "dropback",
+          personnel: "11",
+          formation: "shotgun",
+          motion: "none",
+        },
+        coverage: { front: "4-3", coverage: "cover_2", pressure: "four_man" },
+        participants: [],
+        outcome: isComplete ? "pass_complete" : "pass_incomplete",
+        yardage: isComplete ? 7 : 0,
+        tags: [],
+      });
+    }
+  }
+  return {
+    gameId,
+    seed: 1,
+    finalScore: { home: 0, away: 0 },
+    events,
+    boxScore: {
+      home: {
+        totalYards: 0,
+        passingYards: 0,
+        rushingYards: 0,
+        turnovers: 0,
+        sacks: 0,
+        penalties: 0,
+      },
+      away: {
+        totalYards: 0,
+        passingYards: 0,
+        rushingYards: 0,
+        turnovers: 0,
+        sacks: 0,
+        penalties: 0,
+      },
+    },
+    driveLog: [],
+    injuryReport: [],
+  };
+}
+
+Deno.test("runQbCalibration runs the sim, buckets QBs, and returns a populated report", () => {
+  // Build a league where each team's starter QB is at a different
+  // overall, giving us one team per bucket. The stub simulate maps
+  // each team's expected completion% directly to its QB overall so
+  // every bucket lands in its target band.
+  const overallByTeam: Record<string, number> = {
+    "t30": 30,
+    "t40": 40,
+    "t50": 50,
+    "t60": 60,
+    "t70": 70,
+    "t80": 80,
+  };
+  const completionByOverall: Record<number, number> = {
+    30: 0.6,
+    40: 0.63,
+    50: 0.65,
+    60: 0.66,
+    70: 0.68,
+    80: 0.68,
+  };
+
+  const teams: SimTeam[] = Object.entries(overallByTeam).map(([id, o]) =>
+    team(id, qbRuntime(`${id}-qb`, o))
+  );
+  const league: CalibrationLeague = { calibrationSeed: 1, teams };
+
+  let gameCount = 0;
+  const simulate = ({ home, away, gameId }: {
+    home: SimTeam;
+    away: SimTeam;
+    seed: number;
+    gameId: string;
+  }): GameResult => {
+    gameCount++;
+    return makeGame(gameId, home.teamId, away.teamId, {
+      [home.teamId]: completionByOverall[overallByTeam[home.teamId]],
+      [away.teamId]: completionByOverall[overallByTeam[away.teamId]],
+    });
+  };
+
+  const report = runQbCalibration({
+    bandJson: bandJson(),
+    league,
+    simulate,
+    gameCount: teams.length * 12,
+    minSamplesPerBucket: 5,
+  });
+
+  assertEquals(report.totalGames, teams.length * 12);
+  // Each matchup produces 2 samples (home + away QB).
+  assertEquals(report.totalSamples, gameCount * 2);
+
+  const fifty = report.buckets.find((b) => b.bucketLabel === "50")!;
+  assertEquals(fifty.samples > 0, true);
+  assertEquals(fifty.underSampled, false);
+  assertEquals(fifty.checks.length > 0, true);
+  const completionCheck = fifty.checks.find((c) =>
+    c.metricName === "completion_pct"
+  )!;
+  assertEquals(completionCheck.passed, true);
+});
+
+Deno.test("runQbCalibration marks a bucket under-sampled when below min threshold", () => {
+  const teams: SimTeam[] = [team("t50", qbRuntime("t50-qb", 50))];
+  const league: CalibrationLeague = { calibrationSeed: 1, teams };
+  const simulate = (
+    { home, away, gameId }: {
+      home: SimTeam;
+      away: SimTeam;
+      seed: number;
+      gameId: string;
+    },
+  ) =>
+    makeGame(gameId, home.teamId, away.teamId, {
+      [home.teamId]: 0.65,
+      [away.teamId]: 0.65,
+    });
+
+  const report = runQbCalibration({
+    bandJson: bandJson(),
+    league,
+    simulate,
+    gameCount: 1,
+    minSamplesPerBucket: 100,
+  });
+
+  const fifty = report.buckets.find((b) => b.bucketLabel === "50")!;
+  assertEquals(fifty.underSampled, true);
+  assertEquals(fifty.checks.length, 0);
+});
+
+Deno.test("formatQbCalibrationReport renders a human-readable summary", () => {
+  const teams: SimTeam[] = [team("t50", qbRuntime("t50-qb", 50))];
+  const league: CalibrationLeague = { calibrationSeed: 1, teams };
+  const simulate = (
+    { home, away, gameId }: {
+      home: SimTeam;
+      away: SimTeam;
+      seed: number;
+      gameId: string;
+    },
+  ) =>
+    makeGame(gameId, home.teamId, away.teamId, {
+      [home.teamId]: 0.65,
+      [away.teamId]: 0.65,
+    });
+
+  const report = runQbCalibration({
+    bandJson: bandJson(),
+    league,
+    simulate,
+    gameCount: 100,
+    minSamplesPerBucket: 1,
+  });
+  const output = formatQbCalibrationReport(report);
+  assertStringIncludes(output, "QB calibration");
+  assertStringIncludes(output, "bucket 50");
+  assertStringIncludes(output, "completion_pct");
+});

--- a/server/features/simulation/calibration/per-position/qb-harness.ts
+++ b/server/features/simulation/calibration/per-position/qb-harness.ts
@@ -1,0 +1,172 @@
+import { deriveGameSeed } from "../../rng.ts";
+import { CALIBRATION_GAME_COUNT } from "../constants.ts";
+import { generateMatchups } from "../harness.ts";
+import type { SimulateFn } from "../harness.ts";
+import type { CalibrationLeague } from "../generate-calibration-league.ts";
+import { collectQbSamples, type QbGameSample } from "./qb-sample.ts";
+import { bucketByAttr, type BucketReport } from "./bucket-by-attr.ts";
+import { type BandCheckResult, checkBand } from "./band-check.ts";
+import { loadPositionBands, type PositionBands } from "./band-loader.ts";
+
+// Metrics the QB slice reports on. Keeping this list small keeps the
+// report focused on the headline stats — completion rate, efficiency,
+// scoring, turnovers, and protection. Can grow once the engine emits
+// richer per-play logging (cpoe, air yards, designed-run rate, etc.).
+export const QB_METRICS = [
+  "completion_pct",
+  "yards_per_attempt",
+  "td_rate",
+  "int_rate",
+  "sack_rate",
+] as const;
+
+export type QbMetric = typeof QB_METRICS[number];
+
+const METRIC_EXTRACTORS: Record<QbMetric, (s: QbGameSample) => number> = {
+  completion_pct: (s) => s.completion_pct,
+  yards_per_attempt: (s) => s.yards_per_attempt,
+  td_rate: (s) => s.td_rate,
+  int_rate: (s) => s.int_rate,
+  sack_rate: (s) => s.sack_rate,
+};
+
+export interface QbCalibrationOptions {
+  bandJson: string;
+  league: CalibrationLeague;
+  simulate: SimulateFn;
+  gameCount?: number;
+  // Minimum samples per bucket before we trust a band check. Under
+  // this count we still emit the summary but flag it as under-sampled
+  // so the report distinguishes "bucket is empty/noisy" from "bucket
+  // is calibrated wrong".
+  minSamplesPerBucket?: number;
+}
+
+export interface QbBucketReport {
+  bucketLabel: string;
+  bucketCenter: number;
+  samples: number;
+  underSampled: boolean;
+  checks: BandCheckResult[];
+}
+
+export interface QbCalibrationReport {
+  totalGames: number;
+  totalSamples: number;
+  bands: PositionBands;
+  buckets: QbBucketReport[];
+  failures: BandCheckResult[];
+  passed: boolean;
+}
+
+const DEFAULT_MIN_SAMPLES = 50;
+
+export function runQbCalibration(
+  options: QbCalibrationOptions,
+): QbCalibrationReport {
+  const {
+    bandJson,
+    league,
+    simulate,
+    gameCount = CALIBRATION_GAME_COUNT,
+    minSamplesPerBucket = DEFAULT_MIN_SAMPLES,
+  } = options;
+
+  const bands = loadPositionBands(bandJson);
+  const teamById = new Map(league.teams.map((t) => [t.teamId, t]));
+  const matchups = generateMatchups(league.teams, gameCount);
+
+  const samples: QbGameSample[] = [];
+
+  for (let i = 0; i < matchups.length; i++) {
+    const { home, away } = matchups[i];
+    const gameId = `qb-calibration-game-${i}`;
+    const seed = deriveGameSeed(league.calibrationSeed, gameId);
+
+    const result = simulate({ home, away, seed, gameId });
+    const gameSamples = collectQbSamples({
+      game: result,
+      home: teamById.get(home.teamId) ?? home,
+      away: teamById.get(away.teamId) ?? away,
+    });
+    samples.push(...gameSamples);
+  }
+
+  const bucketReports: BucketReport<QbGameSample>[] = bucketByAttr({
+    samples,
+    attr: (s) => s.qbOverall,
+    metrics: METRIC_EXTRACTORS,
+  });
+
+  const buckets: QbBucketReport[] = bucketReports.map((report) => {
+    const underSampled = report.samples.length < minSamplesPerBucket;
+    const checks: BandCheckResult[] = QB_METRICS.flatMap((metric) => {
+      // Don't emit band checks on under-sampled buckets — the NFL band
+      // comparison would be dominated by sampling noise and drown out
+      // the real failures from the populated buckets.
+      if (underSampled) return [];
+      return [
+        checkBand({
+          bucketLabel: report.bucket.label,
+          metricName: metric,
+          simSummary: report.metrics[metric],
+          bands,
+        }),
+      ];
+    });
+    return {
+      bucketLabel: report.bucket.label,
+      bucketCenter: report.bucket.center,
+      samples: report.samples.length,
+      underSampled,
+      checks,
+    };
+  });
+
+  const failures = buckets.flatMap((b) => b.checks.filter((c) => !c.passed));
+
+  return {
+    totalGames: matchups.length,
+    totalSamples: samples.length,
+    bands,
+    buckets,
+    failures,
+    passed: failures.length === 0,
+  };
+}
+
+export function formatQbCalibrationReport(report: QbCalibrationReport): string {
+  const lines: string[] = [];
+  lines.push(
+    `QB calibration — ${report.totalGames} games, ${report.totalSamples} QB-games`,
+  );
+  lines.push(
+    `Bands: ${report.bands.position} / ${
+      report.bands.seasons.join("-")
+    } / ranked by ${report.bands.rankingStat}`,
+  );
+  lines.push("");
+  for (const bucket of report.buckets) {
+    const header = `[bucket ${bucket.bucketLabel}] n=${bucket.samples}` +
+      (bucket.underSampled ? " (under-sampled, skipping band checks)" : "");
+    lines.push(header);
+    for (const check of bucket.checks) {
+      const verdict = check.passed ? "PASS" : "FAIL";
+      const dir = check.passed ? "" : ` (${check.direction})`;
+      lines.push(
+        `  ${verdict} ${check.metricName.padEnd(20)} ` +
+          `sim=${check.simMean.toFixed(4)}  ` +
+          `band(${check.expectedBand})=${check.bandMean.toFixed(4)}±${
+            check.bandSd.toFixed(4)
+          }  ` +
+          `z=${check.zScore.toFixed(2)}  actual=${check.actualBand}${dir}`,
+      );
+    }
+    lines.push("");
+  }
+  const passed = report.passed ? "PASS" : "FAIL";
+  lines.push(
+    `${passed}: ${report.failures.length} band check(s) missed expected band`,
+  );
+  return lines.join("\n");
+}

--- a/server/features/simulation/calibration/per-position/qb-overall.ts
+++ b/server/features/simulation/calibration/per-position/qb-overall.ts
@@ -1,0 +1,22 @@
+import type { PlayerAttributes } from "@zone-blitz/shared";
+
+// The six signature attributes that `neutralBucket` uses to classify
+// a player as QB. Averaging them gives a single 0-100 "QB overall"
+// that we can bucket on for calibration: a 50-overall QB should
+// produce median NFL starter numbers, 70 should be elite, etc.
+export const QB_OVERALL_ATTRS = [
+  "armStrength",
+  "accuracyShort",
+  "accuracyMedium",
+  "accuracyDeep",
+  "release",
+  "decisionMaking",
+] as const satisfies ReadonlyArray<keyof PlayerAttributes>;
+
+export function qbOverall(attributes: PlayerAttributes): number {
+  let sum = 0;
+  for (const key of QB_OVERALL_ATTRS) {
+    sum += attributes[key];
+  }
+  return sum / QB_OVERALL_ATTRS.length;
+}

--- a/server/features/simulation/calibration/per-position/qb-sample.test.ts
+++ b/server/features/simulation/calibration/per-position/qb-sample.test.ts
@@ -1,0 +1,317 @@
+import { assertAlmostEquals, assertEquals } from "@std/assert";
+import type { PlayerAttributes } from "@zone-blitz/shared";
+import { collectQbSamples } from "./qb-sample.ts";
+import type { GameResult, PlayEvent } from "../../events.ts";
+import type { SimTeam } from "../../simulate-game.ts";
+import type { PlayerRuntime } from "../../resolve-play.ts";
+
+function attrs(overrides: Partial<PlayerAttributes> = {}): PlayerAttributes {
+  const base: Record<string, number> = {};
+  const keys = [
+    "speed",
+    "acceleration",
+    "agility",
+    "strength",
+    "jumping",
+    "stamina",
+    "durability",
+    "armStrength",
+    "accuracyShort",
+    "accuracyMedium",
+    "accuracyDeep",
+    "accuracyOnTheRun",
+    "touch",
+    "release",
+    "ballCarrying",
+    "elusiveness",
+    "routeRunning",
+    "catching",
+    "contestedCatching",
+    "runAfterCatch",
+    "passBlocking",
+    "runBlocking",
+    "blockShedding",
+    "tackling",
+    "manCoverage",
+    "zoneCoverage",
+    "passRushing",
+    "runDefense",
+    "kickingPower",
+    "kickingAccuracy",
+    "puntingPower",
+    "puntingAccuracy",
+    "snapAccuracy",
+    "footballIq",
+    "decisionMaking",
+    "anticipation",
+    "composure",
+    "clutch",
+    "consistency",
+    "workEthic",
+    "coachability",
+    "leadership",
+    "greed",
+    "loyalty",
+    "ambition",
+    "vanity",
+    "schemeAttachment",
+    "mediaSensitivity",
+  ];
+  for (const k of keys) {
+    base[k] = 50;
+    base[`${k}Potential`] = 50;
+  }
+  return { ...(base as unknown as PlayerAttributes), ...overrides };
+}
+
+function qb(id: string, overall: number): PlayerRuntime {
+  return {
+    playerId: id,
+    neutralBucket: "QB",
+    attributes: attrs({
+      armStrength: overall,
+      accuracyShort: overall,
+      accuracyMedium: overall,
+      accuracyDeep: overall,
+      release: overall,
+      decisionMaking: overall,
+    }),
+  };
+}
+
+function team(teamId: string, starterQb: PlayerRuntime): SimTeam {
+  return {
+    teamId,
+    starters: [starterQb],
+    bench: [],
+    fingerprint: { offense: null, defense: null, overrides: {} },
+    coachingMods: {
+      schemeFitBonus: 0,
+      situationalBonus: 0,
+      aggressiveness: 50,
+      penaltyDiscipline: 1,
+    },
+  };
+}
+
+function event(
+  overrides: Partial<PlayEvent> & {
+    outcome: PlayEvent["outcome"];
+    offenseTeamId: string;
+  },
+): PlayEvent {
+  return {
+    gameId: "g",
+    driveIndex: 0,
+    playIndex: 0,
+    quarter: 1,
+    clock: "15:00",
+    situation: { down: 1, distance: 10, yardLine: 25 },
+    defenseTeamId: overrides.offenseTeamId === "home" ? "away" : "home",
+    call: {
+      concept: "dropback",
+      personnel: "11",
+      formation: "shotgun",
+      motion: "none",
+    },
+    coverage: { front: "4-3", coverage: "cover_2", pressure: "four_man" },
+    participants: [],
+    yardage: 0,
+    tags: [],
+    ...overrides,
+  };
+}
+
+function gameOf(events: PlayEvent[]): GameResult {
+  return {
+    gameId: "g",
+    seed: 1,
+    finalScore: { home: 0, away: 0 },
+    events,
+    boxScore: {
+      home: {
+        totalYards: 0,
+        passingYards: 0,
+        rushingYards: 0,
+        turnovers: 0,
+        sacks: 0,
+        penalties: 0,
+      },
+      away: {
+        totalYards: 0,
+        passingYards: 0,
+        rushingYards: 0,
+        turnovers: 0,
+        sacks: 0,
+        penalties: 0,
+      },
+    },
+    driveLog: [],
+    injuryReport: [],
+  };
+}
+
+Deno.test("collectQbSamples returns one sample per team with a starter QB", () => {
+  const home = team("home", qb("home-qb", 50));
+  const away = team("away", qb("away-qb", 50));
+  const samples = collectQbSamples({
+    game: gameOf([]),
+    home,
+    away,
+  });
+  assertEquals(samples.length, 2);
+  assertEquals(samples[0].teamId, "home");
+  assertEquals(samples[0].qbPlayerId, "home-qb");
+  assertEquals(samples[1].teamId, "away");
+});
+
+Deno.test("collectQbSamples skips a team with no starter QB", () => {
+  const home = team("home", qb("home-qb", 50));
+  const away: SimTeam = { ...team("away", qb("away-qb", 50)), starters: [] };
+  const samples = collectQbSamples({
+    game: gameOf([]),
+    home,
+    away,
+  });
+  assertEquals(samples.length, 1);
+  assertEquals(samples[0].teamId, "home");
+});
+
+Deno.test("collectQbSamples tags sample with QB overall (mean of six signature attrs)", () => {
+  const home = team(
+    "home",
+    {
+      playerId: "home-qb",
+      neutralBucket: "QB",
+      attributes: attrs({
+        armStrength: 60,
+        accuracyShort: 70,
+        accuracyMedium: 80,
+        accuracyDeep: 50,
+        release: 65,
+        decisionMaking: 55,
+      }),
+    },
+  );
+  const away = team("away", qb("away-qb", 50));
+  const [homeSample] = collectQbSamples({
+    game: gameOf([]),
+    home,
+    away,
+  });
+  // (60 + 70 + 80 + 50 + 65 + 55) / 6 = 63.3333
+  assertAlmostEquals(homeSample.qbOverall, 63.3333, 0.01);
+});
+
+Deno.test("collectQbSamples accumulates pass events into completion%, YPA, TD%, INT%, sack%", () => {
+  const home = team("home", qb("home-qb", 50));
+  const away = team("away", qb("away-qb", 50));
+  const events: PlayEvent[] = [
+    event({ outcome: "pass_complete", offenseTeamId: "home", yardage: 10 }),
+    event({ outcome: "pass_complete", offenseTeamId: "home", yardage: 15 }),
+    event({ outcome: "pass_incomplete", offenseTeamId: "home", yardage: 0 }),
+    event({ outcome: "pass_incomplete", offenseTeamId: "home", yardage: 0 }),
+    event({
+      outcome: "touchdown",
+      offenseTeamId: "home",
+      yardage: 25,
+      call: {
+        concept: "deep_shot",
+        personnel: "11",
+        formation: "shotgun",
+        motion: "none",
+      },
+    }),
+    event({ outcome: "interception", offenseTeamId: "home", yardage: 0 }),
+    event({ outcome: "sack", offenseTeamId: "home", yardage: -7 }),
+  ];
+  const [homeSample] = collectQbSamples({
+    game: gameOf(events),
+    home,
+    away,
+  });
+  assertEquals(homeSample.attempts, 6); // 2 complete + 2 incomplete + 1 TD (pass) + 1 INT
+  assertEquals(homeSample.completions, 3);
+  assertEquals(homeSample.pass_yards, 50);
+  assertEquals(homeSample.pass_tds, 1);
+  assertEquals(homeSample.interceptions, 1);
+  assertEquals(homeSample.sacks, 1);
+  assertEquals(homeSample.dropbacks, 7);
+  assertAlmostEquals(homeSample.completion_pct, 0.5);
+  assertAlmostEquals(homeSample.yards_per_attempt, 50 / 6, 1e-6);
+  assertAlmostEquals(homeSample.td_rate, 1 / 6, 1e-6);
+  assertAlmostEquals(homeSample.int_rate, 1 / 6, 1e-6);
+  assertAlmostEquals(homeSample.sack_rate, 1 / 7, 1e-6);
+});
+
+Deno.test("collectQbSamples attributes pass-concept TDs to the QB but skips run-concept TDs", () => {
+  const home = team("home", qb("home-qb", 50));
+  const away = team("away", qb("away-qb", 50));
+  const events: PlayEvent[] = [
+    event({
+      outcome: "touchdown",
+      offenseTeamId: "home",
+      yardage: 2,
+      call: {
+        concept: "inside_zone",
+        personnel: "11",
+        formation: "singleback",
+        motion: "none",
+      },
+    }),
+    event({
+      outcome: "touchdown",
+      offenseTeamId: "home",
+      yardage: 20,
+      call: {
+        concept: "quick_pass",
+        personnel: "11",
+        formation: "shotgun",
+        motion: "none",
+      },
+    }),
+  ];
+  const [homeSample] = collectQbSamples({
+    game: gameOf(events),
+    home,
+    away,
+  });
+  assertEquals(homeSample.attempts, 1);
+  assertEquals(homeSample.pass_tds, 1);
+  assertEquals(homeSample.pass_yards, 20);
+});
+
+Deno.test("collectQbSamples isolates offense by team", () => {
+  const home = team("home", qb("home-qb", 50));
+  const away = team("away", qb("away-qb", 50));
+  const events: PlayEvent[] = [
+    event({ outcome: "pass_complete", offenseTeamId: "home", yardage: 10 }),
+    event({ outcome: "pass_incomplete", offenseTeamId: "away", yardage: 0 }),
+    event({ outcome: "sack", offenseTeamId: "away", yardage: -6 }),
+  ];
+  const [homeSample, awaySample] = collectQbSamples({
+    game: gameOf(events),
+    home,
+    away,
+  });
+  assertEquals(homeSample.attempts, 1);
+  assertEquals(homeSample.sacks, 0);
+  assertEquals(awaySample.attempts, 1);
+  assertEquals(awaySample.sacks, 1);
+});
+
+Deno.test("collectQbSamples handles zero-attempt games without divide-by-zero", () => {
+  const home = team("home", qb("home-qb", 50));
+  const away = team("away", qb("away-qb", 50));
+  const [sample] = collectQbSamples({
+    game: gameOf([]),
+    home,
+    away,
+  });
+  assertEquals(sample.attempts, 0);
+  assertEquals(sample.completion_pct, 0);
+  assertEquals(sample.yards_per_attempt, 0);
+  assertEquals(sample.td_rate, 0);
+  assertEquals(sample.int_rate, 0);
+  assertEquals(sample.sack_rate, 0);
+});

--- a/server/features/simulation/calibration/per-position/qb-sample.ts
+++ b/server/features/simulation/calibration/per-position/qb-sample.ts
@@ -1,0 +1,127 @@
+import type { GameResult, PlayEvent } from "../../events.ts";
+import type { SimTeam } from "../../simulate-game.ts";
+import { qbOverall } from "./qb-overall.ts";
+
+export interface QbGameSample {
+  teamId: string;
+  qbPlayerId: string;
+  qbOverall: number;
+  attempts: number;
+  completions: number;
+  pass_yards: number;
+  pass_tds: number;
+  interceptions: number;
+  sacks: number;
+  dropbacks: number;
+  completion_pct: number;
+  yards_per_attempt: number;
+  td_rate: number;
+  int_rate: number;
+  sack_rate: number;
+}
+
+const RUN_CONCEPTS = new Set([
+  "inside_zone",
+  "outside_zone",
+  "power",
+  "counter",
+  "draw",
+  "rpo",
+]);
+
+function accumulate(events: PlayEvent[], teamId: string) {
+  let attempts = 0;
+  let completions = 0;
+  let passYards = 0;
+  let passTds = 0;
+  let ints = 0;
+  let sacks = 0;
+
+  for (const event of events) {
+    if (event.offenseTeamId !== teamId) continue;
+
+    switch (event.outcome) {
+      case "pass_complete":
+        attempts++;
+        completions++;
+        passYards += event.yardage;
+        break;
+      case "pass_incomplete":
+        attempts++;
+        break;
+      case "sack":
+        sacks++;
+        break;
+      case "interception":
+        attempts++;
+        ints++;
+        break;
+      case "touchdown":
+        // Run-concept TDs are credited to the ball-carrier, not the QB.
+        // Pass-concept TDs are completed passes that reached the endzone
+        // — count them as attempts + completions + a pass TD, mirroring
+        // how `team-game-stats.ts` attributes pass-concept touchdowns.
+        if (!RUN_CONCEPTS.has(event.call.concept)) {
+          attempts++;
+          completions++;
+          passYards += event.yardage;
+          passTds++;
+        }
+        break;
+      case "fumble":
+        // Sack-fumbles are the only fumble attributed to the QB, and
+        // they already count as sacks at the outcome level; this
+        // `fumble` outcome is downstream from a rush, so skip.
+        break;
+    }
+  }
+
+  const dropbacks = attempts + sacks;
+  return {
+    attempts,
+    completions,
+    pass_yards: passYards,
+    pass_tds: passTds,
+    interceptions: ints,
+    sacks,
+    dropbacks,
+    completion_pct: attempts > 0 ? completions / attempts : 0,
+    yards_per_attempt: attempts > 0 ? passYards / attempts : 0,
+    td_rate: attempts > 0 ? passTds / attempts : 0,
+    int_rate: attempts > 0 ? ints / attempts : 0,
+    sack_rate: dropbacks > 0 ? sacks / dropbacks : 0,
+  };
+}
+
+export interface QbSampleInput {
+  game: GameResult;
+  home: SimTeam;
+  away: SimTeam;
+}
+
+// Attribute a team-game's pass stats to the team's starter QB. Real
+// games have injury-forced QB changes, but in the calibration league
+// QB injuries are essentially non-existent (INJURY_ON_PLAY = 0.005 and
+// the QB isn't a logged participant), so the starter carries the full
+// workload. If that assumption breaks we can switch to per-event
+// attribution once the engine logs the passer as a participant.
+export function collectQbSamples(
+  input: QbSampleInput,
+): QbGameSample[] {
+  const { game, home, away } = input;
+
+  const samples: QbGameSample[] = [];
+  for (const team of [home, away]) {
+    const qb = team.starters.find((p) => p.neutralBucket === "QB");
+    if (!qb) continue;
+
+    const stats = accumulate(game.events, team.teamId);
+    samples.push({
+      teamId: team.teamId,
+      qbPlayerId: qb.playerId,
+      qbOverall: qbOverall(qb.attributes),
+      ...stats,
+    });
+  }
+  return samples;
+}

--- a/server/features/simulation/calibration/per-position/run-qb-calibration.ts
+++ b/server/features/simulation/calibration/per-position/run-qb-calibration.ts
@@ -1,0 +1,63 @@
+import { simulateGame } from "../../simulate-game.ts";
+import { generateCalibrationLeague } from "../generate-calibration-league.ts";
+import { CALIBRATION_SEEDS } from "../calibration-seeds.ts";
+import { formatQbCalibrationReport, runQbCalibration } from "./qb-harness.ts";
+
+// Per-issue-#496: this entry point is intentionally report-only at
+// first. We print per-bucket PASS/FAIL against NFL QB percentile
+// bands across every calibration seed so a human can eyeball the
+// signal — gating will come later once we understand noise
+// characteristics per bucket.
+const bandPath = new URL(
+  "../../../../../data/bands/per-position/qb.json",
+  import.meta.url,
+);
+
+const bandJson = await Deno.readTextFile(bandPath);
+
+let allPassed = true;
+const summary: {
+  seed: number;
+  passed: number;
+  total: number;
+  underSampled: number;
+}[] = [];
+
+for (const seed of CALIBRATION_SEEDS) {
+  const league = generateCalibrationLeague({ seed });
+  const report = runQbCalibration({
+    bandJson,
+    league,
+    simulate: simulateGame,
+  });
+
+  console.log(`=== seed=0x${seed.toString(16)} ===`);
+  console.log(formatQbCalibrationReport(report));
+  console.log("");
+
+  const totalChecks = report.buckets.reduce(
+    (sum, b) => sum + b.checks.length,
+    0,
+  );
+  const passCount = totalChecks - report.failures.length;
+  const underSampled = report.buckets.filter((b) => b.underSampled).length;
+  summary.push({ seed, passed: passCount, total: totalChecks, underSampled });
+  if (!report.passed) allPassed = false;
+}
+
+console.log("=== Multi-seed summary ===");
+for (const row of summary) {
+  const status = row.passed === row.total ? "PASS" : "FAIL";
+  const underSampledNote = row.underSampled > 0
+    ? ` (${row.underSampled} bucket(s) under-sampled)`
+    : "";
+  console.log(
+    `${status} seed=0x${
+      row.seed.toString(16)
+    }: ${row.passed}/${row.total}${underSampledNote}`,
+  );
+}
+
+if (!allPassed) {
+  Deno.exit(1);
+}


### PR DESCRIPTION
## Summary

Implements the QB slice of #496 — a per-position calibration harness that tags every sim QB-game with the starter's "overall" attribute, buckets samples into 10-point bands (30/40/50/60/70/80), and compares each bucket's mean stat line (completion_pct, YPA, TD%, INT%, sack_rate) to NFL QB percentile bands.

- `data/R/bands/per-position-qb.R` pulls QB-season stats (2020-2024, attempts ≥ 200) from `nflreadr`, ranks by EPA/play, and carves the starter population into five percentile bands (elite / good / average / weak / replacement) with mean+sd per metric.
- `data/bands/per-position/qb.json` is the generated fixture.
- `server/features/simulation/calibration/per-position/` is a new module with `qb-overall`, `qb-sample`, `bucket-by-attr`, `band-loader`, `band-check`, `qb-harness`, and `run-qb-calibration`. Full unit-test coverage.
- `deno task sim:calibrate:qb` runs the harness across every calibration seed.

Report-only for now — per issue #496 we want to read the noise profile per bucket before layering in gating.

Subsequent slices (WR/CB route_coverage, RB/LB run_block, OL/pass-rush, TE/S, K/P, matchup harness) will follow as separate PRs per the issue's rollout plan.

## Notes

A one-seed smoke run already surfaces real calibration gaps the team-game aggregates were hiding:
- 50-bucket QBs hit the NFL average-band completion_pct and YPA on the nose.
- Sack and INT rates run high across every bucket.
- The 80-bucket doesn't separate meaningfully from 70 on most metrics.

Those become tracked follow-ups once this slice merges.