### PR TITLE
feat(hiring): spreadsheet-style column filter widgets on the Hiring page

### DIFF
--- a/client/src/components/ui/checkbox.tsx
+++ b/client/src/components/ui/checkbox.tsx
@@ -1,0 +1,28 @@
+"use client";
+
+import { Checkbox as CheckboxPrimitive } from "@base-ui/react/checkbox";
+
+import { cn } from "@/lib/utils";
+import { CheckIcon } from "lucide-react";
+
+function Checkbox({ className, ...props }: CheckboxPrimitive.Root.Props) {
+  return (
+    <CheckboxPrimitive.Root
+      data-slot="checkbox"
+      className={cn(
+        "peer relative flex size-4 shrink-0 items-center justify-center rounded-[4px] border border-input transition-colors outline-none group-has-disabled/field:opacity-50 after:absolute after:-inset-x-3 after:-inset-y-2 focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 aria-invalid:aria-checked:border-primary dark:bg-input/30 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 data-checked:border-primary data-checked:bg-primary data-checked:text-primary-foreground dark:data-checked:bg-primary",
+        className,
+      )}
+      {...props}
+    >
+      <CheckboxPrimitive.Indicator
+        data-slot="checkbox-indicator"
+        className="grid place-content-center text-current transition-none [&>svg]:size-3.5"
+      >
+        <CheckIcon />
+      </CheckboxPrimitive.Indicator>
+    </CheckboxPrimitive.Root>
+  );
+}
+
+export { Checkbox };

--- a/client/src/components/ui/data-table.test.tsx
+++ b/client/src/components/ui/data-table.test.tsx
@@ -3,13 +3,19 @@ import {
   fireEvent,
   render,
   screen,
+  waitFor,
   within,
 } from "@testing-library/react";
 import type { ColumnDef } from "@tanstack/react-table";
 import { afterEach, describe, expect, it } from "vitest";
-import { DataTable, SortableHeader } from "./data-table.tsx";
+import {
+  DataTable,
+  multiSelectFilterFn,
+  rangeFilterFn,
+  SortableHeader,
+} from "./data-table.tsx";
 
-type Row = { id: string; name: string; value: number };
+type Row = { id: string; name: string; value: number; color: string };
 
 const columns: ColumnDef<Row>[] = [
   { accessorKey: "name", header: "Name" },
@@ -17,8 +23,8 @@ const columns: ColumnDef<Row>[] = [
 ];
 
 const data: Row[] = [
-  { id: "a", name: "Alpha", value: 2 },
-  { id: "b", name: "Beta", value: 1 },
+  { id: "a", name: "Alpha", value: 2, color: "red" },
+  { id: "b", name: "Beta", value: 1, color: "blue" },
 ];
 
 afterEach(cleanup);
@@ -39,6 +45,17 @@ describe("DataTable", () => {
   it("shows an empty-state row when data is empty", () => {
     render(<DataTable columns={columns} data={[]} />);
     expect(screen.getByText(/no results/i)).toBeDefined();
+  });
+
+  it("renders a custom emptyMessage when provided", () => {
+    render(
+      <DataTable
+        columns={columns}
+        data={[]}
+        emptyMessage="Nothing here yet."
+      />,
+    );
+    expect(screen.getByText("Nothing here yet.")).toBeDefined();
   });
 
   it("applies a row data-testid from the getRowTestId prop", () => {
@@ -81,7 +98,7 @@ describe("DataTable", () => {
     expect(orderedIds()).toEqual(["row-a", "row-b"]);
   });
 
-  it("renders a toolbar and filters rows via the global filter", () => {
+  it("renders a custom toolbar and filters rows via the global filter", () => {
     render(
       <DataTable
         columns={columns}
@@ -103,5 +120,322 @@ describe("DataTable", () => {
     });
     expect(screen.getByTestId("row-a")).toBeDefined();
     expect(screen.queryByTestId("row-b")).toBeNull();
+  });
+
+  it("filters rows via the built-in global search input", () => {
+    render(
+      <DataTable
+        columns={columns}
+        data={data}
+        getRowTestId={(row) => `row-${row.id}`}
+        enableGlobalFilter
+        testIdPrefix="grid"
+      />,
+    );
+    fireEvent.change(screen.getByTestId("grid-search"), {
+      target: { value: "Beta" },
+    });
+    expect(screen.queryByTestId("row-a")).toBeNull();
+    expect(screen.getByTestId("row-b")).toBeDefined();
+    expect(screen.getByTestId("grid-result-count").textContent).toContain(
+      "1 of 2",
+    );
+  });
+
+  it("toggles the column-filter row when the Filters button is clicked", () => {
+    const cols: ColumnDef<Row>[] = [
+      {
+        accessorKey: "name",
+        header: "Name",
+        meta: { filterVariant: "text" },
+      },
+      { accessorKey: "value", header: "Value" },
+    ];
+    render(
+      <DataTable
+        columns={cols}
+        data={data}
+        enableColumnFilters
+        testIdPrefix="grid"
+      />,
+    );
+    expect(screen.queryByTestId("grid-filter-row")).toBeNull();
+    fireEvent.click(screen.getByTestId("grid-toggle-filters"));
+    expect(screen.getByTestId("grid-filter-row")).toBeDefined();
+  });
+
+  it("filters rows via a per-column text filter", () => {
+    const cols: ColumnDef<Row>[] = [
+      {
+        accessorKey: "name",
+        header: "Name",
+        meta: { filterVariant: "text", filterPlaceholder: "Search name" },
+      },
+      { accessorKey: "value", header: "Value" },
+    ];
+    render(
+      <DataTable
+        columns={cols}
+        data={data}
+        getRowTestId={(row) => `row-${row.id}`}
+        enableColumnFilters
+        initiallyShowColumnFilters
+        testIdPrefix="grid"
+      />,
+    );
+    fireEvent.change(screen.getByTestId("grid-filter-name"), {
+      target: { value: "Alp" },
+    });
+    expect(screen.getByTestId("row-a")).toBeDefined();
+    expect(screen.queryByTestId("row-b")).toBeNull();
+    fireEvent.change(screen.getByTestId("grid-filter-name"), {
+      target: { value: "" },
+    });
+    expect(screen.getByTestId("row-b")).toBeDefined();
+  });
+
+  it("filters rows via a per-column range filter (min and max)", () => {
+    const cols: ColumnDef<Row>[] = [
+      { accessorKey: "name", header: "Name" },
+      {
+        accessorKey: "value",
+        header: "Value",
+        meta: { filterVariant: "range" },
+      },
+    ];
+    render(
+      <DataTable
+        columns={cols}
+        data={data}
+        getRowTestId={(row) => `row-${row.id}`}
+        enableColumnFilters
+        initiallyShowColumnFilters
+        testIdPrefix="grid"
+      />,
+    );
+    fireEvent.change(screen.getByTestId("grid-filter-value-min"), {
+      target: { value: "2" },
+    });
+    expect(screen.queryByTestId("row-b")).toBeNull();
+    expect(screen.getByTestId("row-a")).toBeDefined();
+    fireEvent.change(screen.getByTestId("grid-filter-value-min"), {
+      target: { value: "" },
+    });
+    fireEvent.change(screen.getByTestId("grid-filter-value-max"), {
+      target: { value: "1" },
+    });
+    expect(screen.queryByTestId("row-a")).toBeNull();
+    expect(screen.getByTestId("row-b")).toBeDefined();
+  });
+
+  it("filters rows via a per-column multi-select filter", async () => {
+    const cols: ColumnDef<Row>[] = [
+      { accessorKey: "name", header: "Name" },
+      {
+        accessorKey: "color",
+        header: "Color",
+        meta: {
+          filterVariant: "multi-select",
+          filterFormatLabel: (v) => v.toUpperCase(),
+        },
+      },
+    ];
+    render(
+      <DataTable
+        columns={cols}
+        data={data}
+        getRowTestId={(row) => `row-${row.id}`}
+        enableColumnFilters
+        initiallyShowColumnFilters
+        testIdPrefix="grid"
+      />,
+    );
+    fireEvent.click(screen.getByTestId("grid-filter-color"));
+    fireEvent.click(
+      await screen.findByTestId("grid-filter-color-option-red"),
+    );
+    await waitFor(() => {
+      expect(screen.queryByTestId("row-b")).toBeNull();
+      expect(screen.getByTestId("row-a")).toBeDefined();
+    });
+    // Toggling the same option clears the selection
+    fireEvent.click(
+      await screen.findByTestId("grid-filter-color-option-red"),
+    );
+    await waitFor(() => {
+      expect(screen.getByTestId("row-b")).toBeDefined();
+    });
+  });
+
+  it("uses fixed filterOptions when provided instead of faceted values", async () => {
+    const cols: ColumnDef<Row>[] = [
+      { accessorKey: "name", header: "Name" },
+      {
+        accessorKey: "color",
+        header: "Color",
+        meta: {
+          filterVariant: "select",
+          filterOptions: [
+            { value: "red", label: "Red" },
+            { value: "green", label: "Green (no rows)" },
+          ],
+        },
+      },
+    ];
+    render(
+      <DataTable
+        columns={cols}
+        data={data}
+        getRowTestId={(row) => `row-${row.id}`}
+        enableColumnFilters
+        initiallyShowColumnFilters
+        testIdPrefix="grid"
+      />,
+    );
+    fireEvent.click(screen.getByTestId("grid-filter-color"));
+    expect(
+      await screen.findByTestId("grid-filter-color-option-green"),
+    ).toBeDefined();
+    fireEvent.click(
+      screen.getByTestId("grid-filter-color-option-red"),
+    );
+    await waitFor(() => {
+      expect(screen.getByTestId("row-a")).toBeDefined();
+      expect(screen.queryByTestId("row-b")).toBeNull();
+    });
+  });
+
+  it("clears all column filters via the toolbar Clear filters button", async () => {
+    const cols: ColumnDef<Row>[] = [
+      { accessorKey: "name", header: "Name" },
+      {
+        accessorKey: "color",
+        header: "Color",
+        meta: { filterVariant: "multi-select" },
+      },
+    ];
+    render(
+      <DataTable
+        columns={cols}
+        data={data}
+        getRowTestId={(row) => `row-${row.id}`}
+        enableColumnFilters
+        initiallyShowColumnFilters
+        testIdPrefix="grid"
+      />,
+    );
+    fireEvent.click(screen.getByTestId("grid-filter-color"));
+    fireEvent.click(
+      await screen.findByTestId("grid-filter-color-option-red"),
+    );
+    await waitFor(() => {
+      expect(screen.queryByTestId("row-b")).toBeNull();
+    });
+    expect(screen.getByTestId("grid-active-filter-count").textContent).toBe(
+      "1",
+    );
+    fireEvent.click(screen.getByTestId("grid-clear-filters"));
+    await waitFor(() => {
+      expect(screen.getByTestId("row-b")).toBeDefined();
+    });
+  });
+
+  it("toggles between comfortable and compact density", () => {
+    render(
+      <DataTable
+        columns={columns}
+        data={data}
+        getRowTestId={(row) => `row-${row.id}`}
+        enableDensityToggle
+        testIdPrefix="grid"
+      />,
+    );
+    const button = screen.getByTestId("grid-density-toggle");
+    expect(button.textContent).toContain("Comfortable");
+    fireEvent.click(button);
+    expect(button.textContent).toContain("Compact");
+  });
+
+  it("renders a sticky header when stickyHeader is enabled", () => {
+    render(
+      <DataTable
+        columns={columns}
+        data={data}
+        stickyHeader
+      />,
+    );
+    const header = document.querySelector("thead");
+    expect(header?.className).toContain("sticky");
+  });
+
+  it("shows an empty popover hint when a multi-select column has no faceted values", async () => {
+    const cols: ColumnDef<Row>[] = [
+      {
+        id: "missing",
+        accessorFn: () => "",
+        header: "Missing",
+        meta: { filterVariant: "multi-select" },
+      },
+    ];
+    render(
+      <DataTable
+        columns={cols}
+        data={data}
+        enableColumnFilters
+        initiallyShowColumnFilters
+        testIdPrefix="grid"
+      />,
+    );
+    fireEvent.click(screen.getByTestId("grid-filter-missing"));
+    expect(await screen.findByText(/no values to filter/i)).toBeDefined();
+  });
+});
+
+describe("multiSelectFilterFn", () => {
+  const fakeRow = (
+    value: unknown,
+  ) => ({ getValue: () => value } as unknown as Parameters<
+    typeof multiSelectFilterFn
+  >[0]);
+
+  it("includes everything when no filter values are selected", () => {
+    expect(multiSelectFilterFn(fakeRow("red"), "color", undefined)).toBe(true);
+    expect(multiSelectFilterFn(fakeRow("red"), "color", [])).toBe(true);
+  });
+
+  it("includes only rows whose stringified value matches", () => {
+    expect(multiSelectFilterFn(fakeRow("red"), "color", ["red"])).toBe(true);
+    expect(multiSelectFilterFn(fakeRow("blue"), "color", ["red"])).toBe(false);
+  });
+
+  it("rejects rows with a null/undefined value", () => {
+    expect(multiSelectFilterFn(fakeRow(null), "color", ["red"])).toBe(false);
+  });
+});
+
+describe("rangeFilterFn", () => {
+  const fakeRow = (
+    value: unknown,
+  ) => ({ getValue: () => value } as unknown as Parameters<
+    typeof rangeFilterFn
+  >[0]);
+
+  it("includes rows with no min/max constraints", () => {
+    expect(rangeFilterFn(fakeRow(5), "v", undefined)).toBe(true);
+    expect(rangeFilterFn(fakeRow(5), "v", [null, null])).toBe(true);
+  });
+
+  it("excludes rows below the min", () => {
+    expect(rangeFilterFn(fakeRow(2), "v", [3, null])).toBe(false);
+    expect(rangeFilterFn(fakeRow(3), "v", [3, null])).toBe(true);
+  });
+
+  it("excludes rows above the max", () => {
+    expect(rangeFilterFn(fakeRow(10), "v", [null, 5])).toBe(false);
+    expect(rangeFilterFn(fakeRow(5), "v", [null, 5])).toBe(true);
+  });
+
+  it("rejects non-numeric cell values", () => {
+    expect(rangeFilterFn(fakeRow("abc"), "v", [0, 10])).toBe(false);
   });
 });

--- a/client/src/components/ui/data-table.tsx
+++ b/client/src/components/ui/data-table.tsx
@@ -1,21 +1,39 @@
-import { type ReactNode, useState } from "react";
+import { type ReactNode, useMemo, useState } from "react";
 import {
   type Column,
   type ColumnDef,
   type ColumnFiltersState,
+  type FilterFn,
   flexRender,
   getCoreRowModel,
+  getFacetedMinMaxValues,
   getFacetedRowModel,
   getFacetedUniqueValues,
   getFilteredRowModel,
   getSortedRowModel,
+  type RowData,
   type SortingState,
   type Table as ReactTable,
   useReactTable,
 } from "@tanstack/react-table";
-import { ArrowDown, ArrowUp, ArrowUpDown } from "lucide-react";
+import {
+  ArrowDown,
+  ArrowUp,
+  ArrowUpDown,
+  Filter as FilterIcon,
+  Rows3,
+  Rows4,
+  Search as SearchIcon,
+} from "lucide-react";
 
 import { Button } from "@/components/ui/button";
+import { Checkbox } from "@/components/ui/checkbox";
+import { Input } from "@/components/ui/input";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
 import {
   Table,
   TableBody,
@@ -24,12 +42,45 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/table";
+import { cn } from "@/lib/utils";
+
+declare module "@tanstack/react-table" {
+  interface ColumnMeta<TData extends RowData, TValue> {
+    filterVariant?: "text" | "select" | "multi-select" | "range";
+    filterOptions?: { value: string; label: string }[];
+    filterFormatLabel?: (value: string) => string;
+    filterPlaceholder?: string;
+    filterTestId?: string;
+    filterLabel?: string;
+  }
+}
+
+type Density = "comfortable" | "compact";
 
 interface DataTableProps<TData, TValue> {
   columns: ColumnDef<TData, TValue>[];
   data: TData[];
   getRowTestId?: (row: TData) => string;
+  /** Custom toolbar; rendered to the right of built-in toolbar controls. */
   toolbar?: (table: ReactTable<TData>) => ReactNode;
+  /** Show built-in global search input. */
+  enableGlobalFilter?: boolean;
+  /** Show built-in "Filters" toggle that reveals a per-column filter row. */
+  enableColumnFilters?: boolean;
+  /** Show built-in density toggle. */
+  enableDensityToggle?: boolean;
+  /** Make the header row sticky. Caller should constrain table height. */
+  stickyHeader?: boolean;
+  /** Initial table density. */
+  initialDensity?: Density;
+  /** Whether the column-filter row is open initially. */
+  initiallyShowColumnFilters?: boolean;
+  /** Placeholder for the global search input. */
+  searchPlaceholder?: string;
+  /** Prefix for auto-generated test ids on toolbar/filter widgets. */
+  testIdPrefix?: string;
+  /** Render-prop body for the empty state row. */
+  emptyMessage?: ReactNode;
 }
 
 export function DataTable<TData, TValue>({
@@ -37,14 +88,32 @@ export function DataTable<TData, TValue>({
   data,
   getRowTestId,
   toolbar,
+  enableGlobalFilter = false,
+  enableColumnFilters = false,
+  enableDensityToggle = false,
+  stickyHeader = false,
+  initialDensity = "comfortable",
+  initiallyShowColumnFilters = false,
+  searchPlaceholder = "Search…",
+  testIdPrefix,
+  emptyMessage = "No results.",
 }: DataTableProps<TData, TValue>) {
   const [sorting, setSorting] = useState<SortingState>([]);
   const [columnFilters, setColumnFilters] = useState<ColumnFiltersState>([]);
   const [globalFilter, setGlobalFilter] = useState("");
+  const [density, setDensity] = useState<Density>(initialDensity);
+  const [showColumnFilters, setShowColumnFilters] = useState(
+    initiallyShowColumnFilters,
+  );
+
+  const decoratedColumns = useMemo(
+    () => decorateColumns(columns),
+    [columns],
+  );
 
   const table = useReactTable({
     data,
-    columns,
+    columns: decoratedColumns,
     state: { sorting, columnFilters, globalFilter },
     onSortingChange: setSorting,
     onColumnFiltersChange: setColumnFilters,
@@ -54,16 +123,127 @@ export function DataTable<TData, TValue>({
     getFilteredRowModel: getFilteredRowModel(),
     getFacetedRowModel: getFacetedRowModel(),
     getFacetedUniqueValues: getFacetedUniqueValues(),
+    getFacetedMinMaxValues: getFacetedMinMaxValues(),
   });
 
   const rows = table.getRowModel().rows;
+  const totalRows = data.length;
+  const filteredRows = rows.length;
+  const activeFilters = columnFilters.length;
+
+  const builtInToolbar = enableGlobalFilter || enableColumnFilters ||
+    enableDensityToggle;
+
+  const cellPaddingClass = density === "compact" ? "py-1.5" : "py-3";
+  const cellTextClass = density === "compact" ? "text-xs" : "text-sm";
 
   return (
-    <div className="flex flex-col gap-3">
-      {toolbar ? toolbar(table) : null}
-      <div className="overflow-hidden rounded-md border">
+    <div className="flex flex-col gap-3" data-testid={testIdPrefix}>
+      {(builtInToolbar || toolbar) && (
+        <div
+          className="flex flex-wrap items-center gap-2"
+          data-testid={testIdPrefix ? `${testIdPrefix}-toolbar` : undefined}
+        >
+          {enableGlobalFilter && (
+            <div className="relative">
+              <SearchIcon className="pointer-events-none absolute left-2.5 top-1/2 size-3.5 -translate-y-1/2 text-muted-foreground" />
+              <Input
+                value={globalFilter}
+                onChange={(e) => setGlobalFilter(e.target.value)}
+                placeholder={searchPlaceholder}
+                className="h-8 w-56 pl-8 text-sm"
+                data-testid={testIdPrefix
+                  ? `${testIdPrefix}-search`
+                  : undefined}
+                aria-label="Search"
+              />
+            </div>
+          )}
+          {enableColumnFilters && (
+            <Button
+              variant={showColumnFilters ? "secondary" : "outline"}
+              size="sm"
+              className="h-8 gap-1.5"
+              onClick={() => setShowColumnFilters((v) => !v)}
+              data-testid={testIdPrefix
+                ? `${testIdPrefix}-toggle-filters`
+                : undefined}
+              aria-pressed={showColumnFilters}
+            >
+              <FilterIcon className="size-3.5" />
+              Filters
+              {activeFilters > 0 && (
+                <span
+                  className="ml-0.5 rounded-full bg-primary px-1.5 py-0.5 text-[10px] font-semibold leading-none text-primary-foreground"
+                  data-testid={testIdPrefix
+                    ? `${testIdPrefix}-active-filter-count`
+                    : undefined}
+                >
+                  {activeFilters}
+                </span>
+              )}
+            </Button>
+          )}
+          {enableColumnFilters && activeFilters > 0 && (
+            <Button
+              variant="ghost"
+              size="sm"
+              className="h-8"
+              onClick={() => setColumnFilters([])}
+              data-testid={testIdPrefix
+                ? `${testIdPrefix}-clear-filters`
+                : undefined}
+            >
+              Clear filters
+            </Button>
+          )}
+          {enableDensityToggle && (
+            <Button
+              variant="outline"
+              size="sm"
+              className="h-8 gap-1.5"
+              onClick={() =>
+                setDensity((d) =>
+                  d === "comfortable" ? "compact" : "comfortable"
+                )}
+              data-testid={testIdPrefix
+                ? `${testIdPrefix}-density-toggle`
+                : undefined}
+              aria-label={`Switch to ${
+                density === "comfortable" ? "compact" : "comfortable"
+              } density`}
+            >
+              {density === "comfortable"
+                ? <Rows3 className="size-3.5" />
+                : <Rows4 className="size-3.5" />}
+              {density === "comfortable" ? "Comfortable" : "Compact"}
+            </Button>
+          )}
+          {toolbar?.(table)}
+          {enableGlobalFilter && globalFilter && (
+            <span
+              className="ml-auto text-xs text-muted-foreground tabular-nums"
+              data-testid={testIdPrefix
+                ? `${testIdPrefix}-result-count`
+                : undefined}
+            >
+              {filteredRows} of {totalRows}
+            </span>
+          )}
+        </div>
+      )}
+      <div
+        className={cn(
+          "rounded-md border",
+          stickyHeader ? "overflow-auto" : "overflow-hidden",
+        )}
+      >
         <Table>
-          <TableHeader>
+          <TableHeader
+            className={cn(
+              stickyHeader && "sticky top-0 z-10 bg-background shadow-sm",
+            )}
+          >
             {table.getHeaderGroups().map((headerGroup) => (
               <TableRow key={headerGroup.id}>
                 {headerGroup.headers.map((header) => (
@@ -76,6 +256,34 @@ export function DataTable<TData, TValue>({
                 ))}
               </TableRow>
             ))}
+            {enableColumnFilters && showColumnFilters && (
+              <TableRow
+                data-testid={testIdPrefix
+                  ? `${testIdPrefix}-filter-row`
+                  : undefined}
+              >
+                {table.getHeaderGroups()[0]?.headers.map((header) => {
+                  const variant = header.column.columnDef.meta?.filterVariant;
+                  const canFilter = header.column.getCanFilter() &&
+                    variant != null;
+                  return (
+                    <TableHead
+                      key={`${header.id}-filter`}
+                      className="py-1.5 align-top"
+                    >
+                      {canFilter
+                        ? (
+                          <DataTableColumnFilter
+                            column={header.column}
+                            testIdPrefix={testIdPrefix}
+                          />
+                        )
+                        : null}
+                    </TableHead>
+                  );
+                })}
+              </TableRow>
+            )}
           </TableHeader>
           <TableBody>
             {rows.length
@@ -86,7 +294,10 @@ export function DataTable<TData, TValue>({
                   data-testid={getRowTestId?.(row.original)}
                 >
                   {row.getVisibleCells().map((cell) => (
-                    <TableCell key={cell.id}>
+                    <TableCell
+                      key={cell.id}
+                      className={cn(cellPaddingClass, cellTextClass)}
+                    >
                       {flexRender(
                         cell.column.columnDef.cell,
                         cell.getContext(),
@@ -101,7 +312,7 @@ export function DataTable<TData, TValue>({
                     colSpan={columns.length}
                     className="h-24 text-center"
                   >
-                    No results.
+                    {emptyMessage}
                   </TableCell>
                 </TableRow>
               )}
@@ -135,5 +346,249 @@ export function SortableHeader<TData, TValue>({
       {children}
       <Icon className="ml-1 size-3.5 opacity-70" />
     </Button>
+  );
+}
+
+export const multiSelectFilterFn: FilterFn<unknown> = (
+  row,
+  columnId,
+  filterValue: unknown,
+) => {
+  const values = filterValue as string[] | undefined;
+  if (!values || values.length === 0) return true;
+  const cellValue = row.getValue(columnId);
+  if (cellValue == null) return false;
+  return values.includes(String(cellValue));
+};
+
+export const rangeFilterFn: FilterFn<unknown> = (
+  row,
+  columnId,
+  filterValue: unknown,
+) => {
+  const [min, max] = (filterValue as [number | null, number | null]) ??
+    [null, null];
+  const cellValue = row.getValue(columnId);
+  const numeric = typeof cellValue === "number" ? cellValue : Number(cellValue);
+  if (Number.isNaN(numeric)) return false;
+  if (min != null && numeric < min) return false;
+  if (max != null && numeric > max) return false;
+  return true;
+};
+
+function decorateColumns<TData, TValue>(
+  columns: ColumnDef<TData, TValue>[],
+): ColumnDef<TData, TValue>[] {
+  return columns.map((col) => {
+    const variant = col.meta?.filterVariant;
+    if (col.filterFn != null || variant == null) return col;
+    if (variant === "select" || variant === "multi-select") {
+      return { ...col, filterFn: multiSelectFilterFn };
+    }
+    if (variant === "range") {
+      return { ...col, filterFn: rangeFilterFn };
+    }
+    return col;
+  });
+}
+
+function DataTableColumnFilter<TData, TValue>(
+  { column, testIdPrefix }: {
+    column: Column<TData, TValue>;
+    testIdPrefix: string | undefined;
+  },
+) {
+  const meta = column.columnDef.meta;
+  const variant = meta?.filterVariant;
+  const filterTestId = meta?.filterTestId ??
+    (testIdPrefix ? `${testIdPrefix}-filter-${column.id}` : undefined);
+
+  if (variant === "text") {
+    return (
+      <Input
+        value={(column.getFilterValue() as string | undefined) ?? ""}
+        onChange={(e) => column.setFilterValue(e.target.value || undefined)}
+        placeholder={meta?.filterPlaceholder ?? "Filter…"}
+        className="h-7 text-xs"
+        data-testid={filterTestId}
+        aria-label={`Filter ${column.id}`}
+      />
+    );
+  }
+
+  if (variant === "range") {
+    return <RangeFilter column={column} testId={filterTestId} />;
+  }
+
+  if (variant === "select" || variant === "multi-select") {
+    return (
+      <MultiSelectFilter
+        column={column}
+        testId={filterTestId}
+        single={variant === "select"}
+      />
+    );
+  }
+
+  return null;
+}
+
+function RangeFilter<TData, TValue>(
+  { column, testId }: {
+    column: Column<TData, TValue>;
+    testId: string | undefined;
+  },
+) {
+  const [min, max] = (column.getFilterValue() as
+    | [number | null, number | null]
+    | undefined) ?? [null, null];
+  const update = (next: [number | null, number | null]) => {
+    if (next[0] == null && next[1] == null) {
+      column.setFilterValue(undefined);
+    } else {
+      column.setFilterValue(next);
+    }
+  };
+  return (
+    <div className="flex items-center gap-1" data-testid={testId}>
+      <Input
+        type="number"
+        value={min ?? ""}
+        onChange={(e) =>
+          update([e.target.value === "" ? null : Number(e.target.value), max])}
+        placeholder="Min"
+        className="h-7 w-16 text-xs"
+        data-testid={testId ? `${testId}-min` : undefined}
+        aria-label={`${column.id} minimum`}
+      />
+      <span className="text-muted-foreground">–</span>
+      <Input
+        type="number"
+        value={max ?? ""}
+        onChange={(e) =>
+          update([min, e.target.value === "" ? null : Number(e.target.value)])}
+        placeholder="Max"
+        className="h-7 w-16 text-xs"
+        data-testid={testId ? `${testId}-max` : undefined}
+        aria-label={`${column.id} maximum`}
+      />
+    </div>
+  );
+}
+
+function MultiSelectFilter<TData, TValue>(
+  { column, testId, single }: {
+    column: Column<TData, TValue>;
+    testId: string | undefined;
+    single: boolean;
+  },
+) {
+  const meta = column.columnDef.meta;
+  const formatLabel = meta?.filterFormatLabel ?? ((v: string) => v);
+  const options = useMemo(() => {
+    if (meta?.filterOptions) return meta.filterOptions;
+    return Array.from(column.getFacetedUniqueValues().keys())
+      .filter((v): v is string => typeof v === "string" && v.length > 0)
+      .sort((a, b) => formatLabel(a).localeCompare(formatLabel(b)))
+      .map((value) => ({ value, label: formatLabel(value) }));
+    // re-evaluate when facets change
+  }, [column.getFacetedUniqueValues(), meta?.filterOptions, formatLabel]);
+
+  const selected = (column.getFilterValue() as string[] | undefined) ?? [];
+  const summary = selected.length === 0
+    ? "All"
+    : selected.length === 1
+    ? formatLabel(selected[0])
+    : `${selected.length} selected`;
+
+  const toggle = (value: string) => {
+    if (single) {
+      column.setFilterValue(selected[0] === value ? undefined : [value]);
+      return;
+    }
+    const next = selected.includes(value)
+      ? selected.filter((v) => v !== value)
+      : [...selected, value];
+    column.setFilterValue(next.length === 0 ? undefined : next);
+  };
+
+  return (
+    <Popover>
+      <PopoverTrigger
+        render={
+          <Button
+            variant="outline"
+            size="sm"
+            className="h-7 w-full justify-between gap-1 px-2 text-xs font-normal"
+            data-testid={testId}
+            aria-label={`Filter ${column.id}`}
+          >
+            <span
+              className={cn(
+                "truncate",
+                selected.length === 0 && "text-muted-foreground",
+              )}
+            >
+              {summary}
+            </span>
+            <FilterIcon className="size-3 opacity-60" />
+          </Button>
+        }
+      />
+      <PopoverContent
+        align="start"
+        className="w-56 max-h-72 overflow-auto p-1.5"
+      >
+        {options.length === 0
+          ? (
+            <p className="px-2 py-1 text-xs text-muted-foreground">
+              No values to filter.
+            </p>
+          )
+          : (
+            <ul
+              className="flex flex-col gap-0.5"
+              data-testid={testId ? `${testId}-options` : undefined}
+            >
+              {options.map((opt) => {
+                const isSelected = selected.includes(opt.value);
+                return (
+                  <li key={opt.value}>
+                    <button
+                      type="button"
+                      role="option"
+                      aria-selected={isSelected}
+                      onClick={() => toggle(opt.value)}
+                      data-testid={testId
+                        ? `${testId}-option-${opt.value}`
+                        : undefined}
+                      className="flex w-full cursor-pointer items-center gap-2 rounded-sm px-2 py-1 text-left text-xs hover:bg-accent hover:text-accent-foreground"
+                    >
+                      <Checkbox
+                        checked={isSelected}
+                        tabIndex={-1}
+                        aria-hidden="true"
+                        className="pointer-events-none"
+                      />
+                      <span className="flex-1 truncate">{opt.label}</span>
+                    </button>
+                  </li>
+                );
+              })}
+            </ul>
+          )}
+        {selected.length > 0 && (
+          <Button
+            variant="ghost"
+            size="sm"
+            className="mt-1 h-7 w-full text-xs"
+            onClick={() => column.setFilterValue(undefined)}
+            data-testid={testId ? `${testId}-clear` : undefined}
+          >
+            Clear
+          </Button>
+        )}
+      </PopoverContent>
+    </Popover>
   );
 }

--- a/client/src/components/ui/popover.tsx
+++ b/client/src/components/ui/popover.tsx
@@ -1,0 +1,89 @@
+import type * as React from "react";
+import { Popover as PopoverPrimitive } from "@base-ui/react/popover";
+
+import { cn } from "@/lib/utils";
+
+function Popover({ ...props }: PopoverPrimitive.Root.Props) {
+  return <PopoverPrimitive.Root data-slot="popover" {...props} />;
+}
+
+function PopoverTrigger({ ...props }: PopoverPrimitive.Trigger.Props) {
+  return <PopoverPrimitive.Trigger data-slot="popover-trigger" {...props} />;
+}
+
+function PopoverContent({
+  className,
+  align = "center",
+  alignOffset = 0,
+  side = "bottom",
+  sideOffset = 4,
+  ...props
+}:
+  & PopoverPrimitive.Popup.Props
+  & Pick<
+    PopoverPrimitive.Positioner.Props,
+    "align" | "alignOffset" | "side" | "sideOffset"
+  >) {
+  return (
+    <PopoverPrimitive.Portal>
+      <PopoverPrimitive.Positioner
+        align={align}
+        alignOffset={alignOffset}
+        side={side}
+        sideOffset={sideOffset}
+        className="isolate z-50"
+      >
+        <PopoverPrimitive.Popup
+          data-slot="popover-content"
+          className={cn(
+            "z-50 flex w-72 origin-(--transform-origin) flex-col gap-2.5 rounded-lg bg-popover p-2.5 text-sm text-popover-foreground shadow-md ring-1 ring-foreground/10 outline-hidden duration-100 data-[side=bottom]:slide-in-from-top-2 data-[side=inline-end]:slide-in-from-left-2 data-[side=inline-start]:slide-in-from-right-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95",
+            className,
+          )}
+          {...props}
+        />
+      </PopoverPrimitive.Positioner>
+    </PopoverPrimitive.Portal>
+  );
+}
+
+function PopoverHeader({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="popover-header"
+      className={cn("flex flex-col gap-0.5 text-sm", className)}
+      {...props}
+    />
+  );
+}
+
+function PopoverTitle({ className, ...props }: PopoverPrimitive.Title.Props) {
+  return (
+    <PopoverPrimitive.Title
+      data-slot="popover-title"
+      className={cn("font-medium", className)}
+      {...props}
+    />
+  );
+}
+
+function PopoverDescription({
+  className,
+  ...props
+}: PopoverPrimitive.Description.Props) {
+  return (
+    <PopoverPrimitive.Description
+      data-slot="popover-description"
+      className={cn("text-muted-foreground", className)}
+      {...props}
+    />
+  );
+}
+
+export {
+  Popover,
+  PopoverContent,
+  PopoverDescription,
+  PopoverHeader,
+  PopoverTitle,
+  PopoverTrigger,
+};

--- a/client/src/features/league/hiring/index.test.tsx
+++ b/client/src/features/league/hiring/index.test.tsx
@@ -355,11 +355,15 @@ describe("Market survey view", () => {
     ).toBeTruthy();
   });
 
-  it("filters coach candidates by archetype", async () => {
+  it("filters coach candidates by archetype via the multi-select column filter", async () => {
     renderPage();
-    fireEvent.change(
+    fireEvent.click(
       screen.getByTestId("market-coach-table-filter-archetype"),
-      { target: { value: "defense" } },
+    );
+    fireEvent.click(
+      await screen.findByTestId(
+        "market-coach-table-filter-archetype-option-defense",
+      ),
     );
     await waitFor(() => {
       expect(screen.queryByTestId("candidate-row-c1")).toBeNull();
@@ -367,11 +371,15 @@ describe("Market survey view", () => {
     });
   });
 
-  it("filters coach candidates by scheme", async () => {
+  it("filters coach candidates by scheme via the multi-select column filter", async () => {
     renderPage();
-    fireEvent.change(
+    fireEvent.click(
       screen.getByTestId("market-coach-table-filter-scheme"),
-      { target: { value: "shanahan_wide_zone" } },
+    );
+    fireEvent.click(
+      await screen.findByTestId(
+        "market-coach-table-filter-scheme-option-shanahan_wide_zone",
+      ),
     );
     await waitFor(() => {
       expect(screen.queryByTestId("candidate-row-c1")).toBeNull();
@@ -379,11 +387,15 @@ describe("Market survey view", () => {
     });
   });
 
-  it("filters coach candidates by position specialty", async () => {
+  it("filters coach candidates by position specialty via the multi-select column filter", async () => {
     renderPage();
-    fireEvent.change(
+    fireEvent.click(
       screen.getByTestId("market-coach-table-filter-position"),
-      { target: { value: "DB" } },
+    );
+    fireEvent.click(
+      await screen.findByTestId(
+        "market-coach-table-filter-position-option-DB",
+      ),
     );
     await waitFor(() => {
       expect(screen.getByTestId("candidate-row-c3")).toBeTruthy();
@@ -391,11 +403,15 @@ describe("Market survey view", () => {
     });
   });
 
-  it("filters coach candidates by CEO scheme bucket", async () => {
+  it("filters coach candidates by CEO scheme bucket via the multi-select column filter", async () => {
     renderPage();
-    fireEvent.change(
+    fireEvent.click(
       screen.getByTestId("market-coach-table-filter-scheme"),
-      { target: { value: "ceo" } },
+    );
+    fireEvent.click(
+      await screen.findByTestId(
+        "market-coach-table-filter-scheme-option-ceo",
+      ),
     );
     await waitFor(() => {
       expect(screen.getByTestId("candidate-row-c4")).toBeTruthy();
@@ -403,18 +419,23 @@ describe("Market survey view", () => {
     });
   });
 
-  it("clears a filter back to all candidates when 'All' is selected", async () => {
+  it("clears a column filter back to all candidates via the Clear button", async () => {
     renderPage();
-    fireEvent.change(
+    fireEvent.click(
       screen.getByTestId("market-coach-table-filter-archetype"),
-      { target: { value: "defense" } },
+    );
+    fireEvent.click(
+      await screen.findByTestId(
+        "market-coach-table-filter-archetype-option-defense",
+      ),
     );
     await waitFor(() => {
       expect(screen.queryByTestId("candidate-row-c1")).toBeNull();
     });
-    fireEvent.change(
-      screen.getByTestId("market-coach-table-filter-archetype"),
-      { target: { value: "all" } },
+    fireEvent.click(
+      await screen.findByTestId(
+        "market-coach-table-filter-archetype-clear",
+      ),
     );
     await waitFor(() => {
       expect(screen.getByTestId("candidate-row-c1")).toBeTruthy();
@@ -493,9 +514,13 @@ describe("Market survey view", () => {
     });
     renderPage();
     fireEvent.click(screen.getByTestId("market-tab-scout"));
-    fireEvent.change(
+    fireEvent.click(
       screen.getByTestId("market-scout-table-filter-region"),
-      { target: { value: "MIDWEST" } },
+    );
+    fireEvent.click(
+      await screen.findByTestId(
+        "market-scout-table-filter-region-option-MIDWEST",
+      ),
     );
     await waitFor(() => {
       expect(screen.queryByTestId("candidate-row-s1")).toBeNull();

--- a/client/src/features/league/hiring/index.tsx
+++ b/client/src/features/league/hiring/index.tsx
@@ -1,11 +1,7 @@
 import { useMemo, useState } from "react";
 import { Link, useParams } from "@tanstack/react-router";
 import { toast } from "sonner";
-import type {
-  Column,
-  ColumnDef,
-  Table as ReactTable,
-} from "@tanstack/react-table";
+import type { ColumnDef } from "@tanstack/react-table";
 import type {
   HiringCandidateSummary,
   HiringDecisionView,
@@ -911,6 +907,7 @@ function buildCandidateColumns(
           {row.original.fullName}
         </Link>
       ),
+      meta: { filterVariant: "text", filterPlaceholder: "Name…" },
     },
     {
       accessorKey: "age",
@@ -925,6 +922,7 @@ function buildCandidateColumns(
           {row.original.age}
         </span>
       ),
+      meta: { filterVariant: "range" },
     },
     {
       accessorKey: "yearsExperience",
@@ -940,6 +938,7 @@ function buildCandidateColumns(
           {row.original.yearsExperience === 1 ? "" : "s"}
         </span>
       ),
+      meta: { filterVariant: "range" },
     },
   ];
 
@@ -954,7 +953,10 @@ function buildCandidateColumns(
             {coachArchetypeLabel(row.original.specialty)}
           </span>
         ),
-        filterFn: "equals",
+        meta: {
+          filterVariant: "multi-select",
+          filterFormatLabel: coachArchetypeLabel,
+        },
       },
       {
         id: "position",
@@ -965,7 +967,10 @@ function buildCandidateColumns(
             {positionGroupLabel(row.original.positionBackground) ?? "—"}
           </span>
         ),
-        filterFn: "equals",
+        meta: {
+          filterVariant: "multi-select",
+          filterFormatLabel: positionFilterLabel,
+        },
       },
       {
         id: "scheme",
@@ -976,7 +981,10 @@ function buildCandidateColumns(
             {coachSchemeLabel(row.original)}
           </span>
         ),
-        filterFn: "equals",
+        meta: {
+          filterVariant: "multi-select",
+          filterFormatLabel: schemeOptionLabel,
+        },
       },
     );
   }
@@ -992,7 +1000,10 @@ function buildCandidateColumns(
             {scoutRegionLabel(row.original.regionFocus) ?? "—"}
           </span>
         ),
-        filterFn: "equals",
+        meta: {
+          filterVariant: "multi-select",
+          filterFormatLabel: regionFilterLabel,
+        },
       },
       {
         id: "position",
@@ -1003,7 +1014,10 @@ function buildCandidateColumns(
             {positionGroupLabel(row.original.positionFocus) ?? "—"}
           </span>
         ),
-        filterFn: "equals",
+        meta: {
+          filterVariant: "multi-select",
+          filterFormatLabel: positionFilterLabel,
+        },
       },
     );
   }
@@ -1015,6 +1029,7 @@ function buildCandidateColumns(
         <SortableHeader column={column}>Expected Salary</SortableHeader>
       ),
       cell: ({ row }) => formatMoney(row.original.medianSalary),
+      meta: { filterVariant: "range" },
     },
     {
       id: "band",
@@ -1041,105 +1056,6 @@ function buildCandidateColumns(
 function coachSchemeKey(c: HiringCandidateSummary): string {
   if (c.role === "HC" && c.specialty === "ceo") return "ceo";
   return c.offensiveArchetype ?? c.defensiveArchetype ?? "";
-}
-
-function CandidateFilter(
-  {
-    column,
-    label,
-    formatLabel,
-    testId,
-  }: {
-    column: Column<CandidateRow, unknown> | undefined;
-    label: string;
-    formatLabel: (value: string) => string;
-    testId: string;
-  },
-) {
-  if (!column) return null;
-  const options = Array.from(column.getFacetedUniqueValues().keys())
-    .filter((v): v is string => typeof v === "string" && v.length > 0)
-    .sort((a, b) => formatLabel(a).localeCompare(formatLabel(b)));
-  const current = (column.getFilterValue() as string | undefined) ?? "all";
-  return (
-    <label className="flex items-center gap-2 text-sm">
-      <span className="text-muted-foreground">{label}</span>
-      <select
-        data-testid={testId}
-        value={current}
-        onChange={(event) => {
-          const next = event.target.value;
-          column.setFilterValue(next === "all" ? undefined : next);
-        }}
-        className="h-8 min-w-40 rounded-lg border border-input bg-transparent px-2 text-sm text-foreground focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 outline-none"
-      >
-        <option value="all">All {label}</option>
-        {options.map((value) => (
-          <option key={value} value={value}>
-            {formatLabel(value)}
-          </option>
-        ))}
-      </select>
-    </label>
-  );
-}
-
-function CandidateFilters(
-  {
-    table,
-    staffType,
-    testIdPrefix,
-  }: {
-    table: ReactTable<CandidateRow>;
-    staffType: "coach" | "scout";
-    testIdPrefix: string;
-  },
-) {
-  return (
-    <div
-      className="flex flex-wrap items-center gap-2"
-      data-testid={`${testIdPrefix}-filters`}
-    >
-      {staffType === "coach" && (
-        <>
-          <CandidateFilter
-            column={table.getColumn("archetype")}
-            label="Archetype"
-            formatLabel={coachArchetypeLabel}
-            testId={`${testIdPrefix}-filter-archetype`}
-          />
-          <CandidateFilter
-            column={table.getColumn("position")}
-            label="Position Specialty"
-            formatLabel={positionFilterLabel}
-            testId={`${testIdPrefix}-filter-position`}
-          />
-          <CandidateFilter
-            column={table.getColumn("scheme")}
-            label="Scheme"
-            formatLabel={schemeOptionLabel}
-            testId={`${testIdPrefix}-filter-scheme`}
-          />
-        </>
-      )}
-      {staffType === "scout" && (
-        <>
-          <CandidateFilter
-            column={table.getColumn("region")}
-            label="Region"
-            formatLabel={regionFilterLabel}
-            testId={`${testIdPrefix}-filter-region`}
-          />
-          <CandidateFilter
-            column={table.getColumn("position")}
-            label="Position Specialty"
-            formatLabel={positionFilterLabel}
-            testId={`${testIdPrefix}-filter-position`}
-          />
-        </>
-      )}
-    </div>
-  );
 }
 
 export function positionFilterLabel(value: string): string {
@@ -1186,19 +1102,18 @@ function CandidateDataTable(
   );
 
   return (
-    <div data-testid={testId}>
-      <DataTable
-        columns={columns}
-        data={rows}
-        getRowTestId={(row) => `candidate-row-${row.id}`}
-        toolbar={(table) => (
-          <CandidateFilters
-            table={table}
-            staffType={staffType}
-            testIdPrefix={testId}
-          />
-        )}
-      />
-    </div>
+    <DataTable
+      columns={columns}
+      data={rows}
+      getRowTestId={(row) => `candidate-row-${row.id}`}
+      enableGlobalFilter
+      enableColumnFilters
+      enableDensityToggle
+      initiallyShowColumnFilters
+      searchPlaceholder={staffType === "coach"
+        ? "Search coaches…"
+        : "Search scouts…"}
+      testIdPrefix={testId}
+    />
   );
 }


### PR DESCRIPTION
## Summary

The Hiring page filtered candidates with three native `<select>` dropdowns wired into a hand-rolled `CandidateFilters` toolbar. It only supported equality filters on a few categorical columns and felt clunky compared to the per-column filter UX in tools like Mantine React Table.

This PR rebuilds the shared `DataTable` component to support a Mantine-style **column filter row** driven entirely by `column.meta.filterVariant`, then migrates the Hiring page to use it.

### New `DataTable` capabilities (all opt-in)

- **Per-column filter widgets** declared via `column.meta.filterVariant`:
  - `text` — inline filter input
  - `range` — paired min/max number inputs
  - `select` / `multi-select` — popover with checkbox options pulled from faceted unique values (or fixed `filterOptions`)
- **Built-in toolbar features** so consumers don't have to hand-roll one:
  - Global search input with live `N of M` result count
  - "Filters" toggle that reveals/hides the per-column filter row, with an active-filter badge and a one-click "Clear filters" shortcut
  - Comfortable / Compact density toggle
  - Optional sticky header
- Existing consumers (`salary-cap`, `roster`, `opponents/detail`) keep working unchanged — the new toolbar is opt-in and the legacy `toolbar` render prop is preserved.

### Hiring page migration

- Removed `CandidateFilter` / `CandidateFilters` and the custom select dropdowns.
- Coach tab now has multi-select filters on Archetype, Position Specialty, and Scheme.
- Scout tab now has multi-select filters on Region and Position Specialty.
- Added range filters on Age, Experience, and Expected Salary, plus a text filter on Name — none of which existed before.
- Added a global search input and density toggle.

Filter widgets use shadcn primitives (`Popover`, `Checkbox`, `Input`, `Button`) over `@base-ui/react`, so we stay shadcn-first instead of pulling in Mantine just for tables.

### Tests

- 24 unit tests on `DataTable` covering each filter variant, the toolbar toggles, density, sticky header, and the new `multiSelectFilterFn` / `rangeFilterFn` helpers.
- Hiring page tests rewritten to drive the new popover + checkbox interaction; all 57 tests still pass.
- Full client suite: 60 files / 574 tests pass; coverage 99.75% (above the 95% threshold).

🤖 Generated with [Claude Code](https://claude.com/claude-code)