### PR TITLE
feat(calibration): add per-RB-bucket calibration harness (#496, RB slice)

### DIFF
--- a/data/R/bands/per-position-rb.R
+++ b/data/R/bands/per-position-rb.R
@@ -1,0 +1,139 @@
+#!/usr/bin/env Rscript
+# per-position-rb.R — NFL RB percentile-band reference.
+#
+# Pulls weekly RB stats from load_player_stats, aggregates to per-RB-season
+# lines, filters to starters (season carries >= 100), ranks by rushing
+# EPA/play, and carves the population into five percentile bands (elite /
+# good / average / weak / replacement). For each band, reports mean + sd + n
+# on the headline RB metrics tracked by the sim.
+#
+# Output: data/bands/per-position/rb.json
+#
+# Usage:
+#   Rscript data/R/bands/per-position-rb.R [--seasons 2020:2024]
+
+suppressPackageStartupMessages({
+  library(nflreadr)
+  library(dplyr)
+})
+
+script_file <- (function() {
+  args <- commandArgs(trailingOnly = FALSE)
+  f <- grep("^--file=", args, value = TRUE)
+  if (length(f) > 0) normalizePath(sub("^--file=", "", f[1]), mustWork = FALSE) else NULL
+})()
+source(file.path(dirname(script_file), "..", "lib.R"))
+
+args <- commandArgs(trailingOnly = TRUE)
+seasons <- parse_seasons(args)
+
+cat("Loading weekly player stats for seasons:",
+    paste(range(seasons), collapse = "-"), "\n")
+
+weekly <- nflreadr::load_player_stats(seasons, stat_type = "offense")
+
+rb_weekly <- weekly |>
+  filter(season_type == "REG", position == "RB", carries > 0)
+
+# Aggregate weekly rows into per-RB-season totals. The sim samples on a
+# per-game cadence and then rolls up to per-bucket means, so the NFL
+# reference also lives at the per-season grain: season rates + per-game
+# averages are stable enough to rank RBs cleanly against each other.
+rb_season <- rb_weekly |>
+  group_by(player_id, player_display_name, season) |>
+  summarise(
+    games       = n(),
+    carries     = sum(carries, na.rm = TRUE),
+    rush_yards  = sum(rushing_yards, na.rm = TRUE),
+    rush_tds    = sum(rushing_tds, na.rm = TRUE),
+    fumbles     = sum(rushing_fumbles_lost, na.rm = TRUE),
+    epa_total   = sum(rushing_epa, na.rm = TRUE),
+    .groups     = "drop"
+  ) |>
+  mutate(
+    yards_per_carry = ifelse(carries > 0, rush_yards / carries, NA_real_),
+    rush_td_rate    = ifelse(carries > 0, rush_tds / carries, NA_real_),
+    yards_per_game  = ifelse(games > 0, rush_yards / games, NA_real_),
+    fumble_rate     = ifelse(carries > 0, fumbles / carries, NA_real_),
+    epa_per_play    = ifelse(carries > 0, epa_total / carries, NA_real_)
+  ) |>
+  filter(carries >= 100) # starter threshold: ~6 carries/game over 17 weeks
+
+cat("RB-seasons after starter filter:", nrow(rb_season), "\n")
+
+# Rank by EPA/play and assign percentile bands on the filtered starter
+# population. Bands follow the scheme from issue #496: top 10% elite,
+# next 20% good, middle 40% average, next 20% weak, bottom 10% replacement.
+rb_ranked <- rb_season |>
+  arrange(desc(epa_per_play)) |>
+  mutate(
+    pct = (row_number() - 0.5) / n(),
+    band = case_when(
+      pct <= 0.10 ~ "elite",
+      pct <= 0.30 ~ "good",
+      pct <= 0.70 ~ "average",
+      pct <= 0.90 ~ "weak",
+      TRUE        ~ "replacement"
+    )
+  )
+
+metric_keys <- c(
+  "yards_per_carry",
+  "rush_td_rate",
+  "yards_per_game",
+  "fumble_rate"
+)
+
+band_order <- c("elite", "good", "average", "weak", "replacement")
+
+band_summary <- function(rows) {
+  metrics <- list()
+  for (key in metric_keys) {
+    vals <- rows[[key]]
+    vals <- vals[!is.na(vals)]
+    metrics[[key]] <- list(
+      n = length(vals),
+      mean = mean(vals),
+      sd = stats::sd(vals)
+    )
+  }
+  list(
+    n = nrow(rows),
+    metrics = metrics
+  )
+}
+
+bands <- list()
+for (band_name in band_order) {
+  rows <- rb_ranked |> filter(band == band_name)
+  bands[[band_name]] <- band_summary(rows)
+}
+
+out <- list(
+  generated_at = format(Sys.time(), "%Y-%m-%dT%H:%M:%SZ", tz = "UTC"),
+  seasons = as.integer(seasons),
+  position = "RB",
+  qualifier = "regular-season RB-seasons with >=100 carries",
+  ranking_stat = "epa_per_play (rushing EPA / carries)",
+  notes = paste0(
+    "Starter RB-seasons 2020-2024, ranked by rushing EPA/play then carved ",
+    "into percentile bands (elite: top 10%, good: 10-30%, average: 30-70%, ",
+    "weak: 70-90%, replacement: bottom 10%). Each band reports mean+sd per ",
+    "metric across the RB-seasons in that band. YPC, rush_td_rate, and ",
+    "fumble_rate use carries as denominator; yards_per_game uses games ",
+    "played. Receiving production is intentionally excluded from the ",
+    "ranking stat — the sim's RB attribution covers rush attempts only."
+  ),
+  bands = bands
+)
+
+out_path <- file.path(
+  repo_root(), "data", "bands", "per-position", "rb.json"
+)
+dir.create(dirname(out_path), recursive = TRUE, showWarnings = FALSE)
+writeLines(
+  jsonlite::toJSON(out, auto_unbox = TRUE, pretty = TRUE, digits = 4,
+                   null = "null"),
+  out_path
+)
+cat("Wrote", out_path, "\n")

--- a/data/bands/per-position/rb.json
+++ b/data/bands/per-position/rb.json
@@ -1,0 +1,135 @@
+{
+  "generated_at": "2026-04-17T12:12:14Z",
+  "seasons": [2020, 2021, 2022, 2023, 2024],
+  "position": "RB",
+  "qualifier": "regular-season RB-seasons with >=100 carries",
+  "ranking_stat": "epa_per_play (rushing EPA / carries)",
+  "notes": "Starter RB-seasons 2020-2024, ranked by rushing EPA/play then carved into percentile bands (elite: top 10%, good: 10-30%, average: 30-70%, weak: 70-90%, replacement: bottom 10%). Each band reports mean+sd per metric across the RB-seasons in that band. YPC, rush_td_rate, and fumble_rate use carries as denominator; yards_per_game uses games played. Receiving production is intentionally excluded from the ranking stat — the sim's RB attribution covers rush attempts only.",
+  "bands": {
+    "elite": {
+      "n": 23,
+      "metrics": {
+        "yards_per_carry": {
+          "n": 23,
+          "mean": 5.4537,
+          "sd": 0.6484
+        },
+        "rush_td_rate": {
+          "n": 23,
+          "mean": 0.0455,
+          "sd": 0.0186
+        },
+        "yards_per_game": {
+          "n": 23,
+          "mean": 75.444,
+          "sd": 25.9033
+        },
+        "fumble_rate": {
+          "n": 23,
+          "mean": 0.0027,
+          "sd": 0.0029
+        }
+      }
+    },
+    "good": {
+      "n": 47,
+      "metrics": {
+        "yards_per_carry": {
+          "n": 47,
+          "mean": 4.7262,
+          "sd": 0.4273
+        },
+        "rush_td_rate": {
+          "n": 47,
+          "mean": 0.037,
+          "sd": 0.0172
+        },
+        "yards_per_game": {
+          "n": 47,
+          "mean": 60.3748,
+          "sd": 16.9955
+        },
+        "fumble_rate": {
+          "n": 47,
+          "mean": 0.0022,
+          "sd": 0.0033
+        }
+      }
+    },
+    "average": {
+      "n": 94,
+      "metrics": {
+        "yards_per_carry": {
+          "n": 94,
+          "mean": 4.2986,
+          "sd": 0.3675
+        },
+        "rush_td_rate": {
+          "n": 94,
+          "mean": 0.0338,
+          "sd": 0.015
+        },
+        "yards_per_game": {
+          "n": 94,
+          "mean": 56.55,
+          "sd": 16.7054
+        },
+        "fumble_rate": {
+          "n": 94,
+          "mean": 0.004,
+          "sd": 0.0053
+        }
+      }
+    },
+    "weak": {
+      "n": 47,
+      "metrics": {
+        "yards_per_carry": {
+          "n": 47,
+          "mean": 3.9522,
+          "sd": 0.357
+        },
+        "rush_td_rate": {
+          "n": 47,
+          "mean": 0.0232,
+          "sd": 0.0111
+        },
+        "yards_per_game": {
+          "n": 47,
+          "mean": 47.8297,
+          "sd": 13.8238
+        },
+        "fumble_rate": {
+          "n": 47,
+          "mean": 0.0058,
+          "sd": 0.0051
+        }
+      }
+    },
+    "replacement": {
+      "n": 23,
+      "metrics": {
+        "yards_per_carry": {
+          "n": 23,
+          "mean": 3.6072,
+          "sd": 0.4261
+        },
+        "rush_td_rate": {
+          "n": 23,
+          "mean": 0.0215,
+          "sd": 0.0088
+        },
+        "yards_per_game": {
+          "n": 23,
+          "mean": 42.6217,
+          "sd": 15.8636
+        },
+        "fumble_rate": {
+          "n": 23,
+          "mean": 0.0078,
+          "sd": 0.0048
+        }
+      }
+    }
+  }
+}

--- a/deno.json
+++ b/deno.json
@@ -35,6 +35,7 @@
     "test:e2e": "./bin/test-e2e",
     "sim:calibrate": "deno run --allow-read server/features/simulation/calibration/run-calibration.ts",
     "sim:calibrate:qb": "deno run --allow-read server/features/simulation/calibration/per-position/run-qb-calibration.ts",
+    "sim:calibrate:rb": "deno run --allow-read server/features/simulation/calibration/per-position/run-rb-calibration.ts",
     "build": "cd client && deno task build",
     "start": "cd server && deno run --env=../.env --allow-net --allow-env --allow-read --allow-sys main.ts"
   },

--- a/server/features/simulation/calibration/per-position/rb-harness.test.ts
+++ b/server/features/simulation/calibration/per-position/rb-harness.test.ts
@@ -1,0 +1,303 @@
+import { assertEquals, assertStringIncludes } from "@std/assert";
+import type { PlayerAttributes } from "@zone-blitz/shared";
+import { formatRbCalibrationReport, runRbCalibration } from "./rb-harness.ts";
+import type { GameResult, PlayEvent } from "../../events.ts";
+import type { SimTeam } from "../../simulate-game.ts";
+import type { PlayerRuntime } from "../../resolve-play.ts";
+import type { CalibrationLeague } from "../generate-calibration-league.ts";
+
+function attrs(overrides: Partial<PlayerAttributes> = {}): PlayerAttributes {
+  const base: Record<string, number> = {};
+  const keys = [
+    "speed",
+    "acceleration",
+    "agility",
+    "strength",
+    "jumping",
+    "stamina",
+    "durability",
+    "armStrength",
+    "accuracyShort",
+    "accuracyMedium",
+    "accuracyDeep",
+    "accuracyOnTheRun",
+    "touch",
+    "release",
+    "ballCarrying",
+    "elusiveness",
+    "routeRunning",
+    "catching",
+    "contestedCatching",
+    "runAfterCatch",
+    "passBlocking",
+    "runBlocking",
+    "blockShedding",
+    "tackling",
+    "manCoverage",
+    "zoneCoverage",
+    "passRushing",
+    "runDefense",
+    "kickingPower",
+    "kickingAccuracy",
+    "puntingPower",
+    "puntingAccuracy",
+    "snapAccuracy",
+    "footballIq",
+    "decisionMaking",
+    "anticipation",
+    "composure",
+    "clutch",
+    "consistency",
+    "workEthic",
+    "coachability",
+    "leadership",
+    "greed",
+    "loyalty",
+    "ambition",
+    "vanity",
+    "schemeAttachment",
+    "mediaSensitivity",
+  ];
+  for (const k of keys) {
+    base[k] = 50;
+    base[`${k}Potential`] = 50;
+  }
+  return { ...(base as unknown as PlayerAttributes), ...overrides };
+}
+
+function rbRuntime(id: string, overall: number): PlayerRuntime {
+  return {
+    playerId: id,
+    neutralBucket: "RB",
+    attributes: attrs({
+      ballCarrying: overall,
+      elusiveness: overall,
+      acceleration: overall,
+      speed: overall,
+    }),
+  };
+}
+
+function team(teamId: string, starterRb: PlayerRuntime): SimTeam {
+  return {
+    teamId,
+    starters: [starterRb],
+    bench: [],
+    fingerprint: { offense: null, defense: null, overrides: {} },
+    coachingMods: {
+      schemeFitBonus: 0,
+      situationalBonus: 0,
+      aggressiveness: 50,
+      penaltyDiscipline: 1,
+    },
+  };
+}
+
+function bandJson(): string {
+  const band = (ypc: number) => ({
+    n: 20,
+    metrics: {
+      yards_per_carry: { n: 20, mean: ypc, sd: 0.4 },
+      rush_td_rate: { n: 20, mean: 0.035, sd: 0.015 },
+      yards_per_game: { n: 20, mean: ypc * 13, sd: 15 },
+      fumble_rate: { n: 20, mean: 0.004, sd: 0.003 },
+    },
+  });
+  return JSON.stringify({
+    position: "RB",
+    seasons: [2020, 2021, 2022, 2023, 2024],
+    ranking_stat: "epa_per_play",
+    bands: {
+      elite: band(5.4),
+      good: band(4.7),
+      average: band(4.3),
+      weak: band(4.0),
+      replacement: band(3.6),
+    },
+  });
+}
+
+function makeGame(
+  gameId: string,
+  homeTeamId: string,
+  awayTeamId: string,
+  ypcByTeam: Record<string, number>,
+): GameResult {
+  const events: PlayEvent[] = [];
+  for (const [offenseTeamId, ypc] of Object.entries(ypcByTeam)) {
+    const defenseTeamId = offenseTeamId === homeTeamId
+      ? awayTeamId
+      : homeTeamId;
+    const carries = 25;
+    for (let i = 0; i < carries; i++) {
+      events.push({
+        gameId,
+        driveIndex: 0,
+        playIndex: events.length,
+        quarter: 1,
+        clock: "15:00",
+        situation: { down: 1, distance: 10, yardLine: 25 },
+        offenseTeamId,
+        defenseTeamId,
+        call: {
+          concept: "inside_zone",
+          personnel: "11",
+          formation: "singleback",
+          motion: "none",
+        },
+        coverage: { front: "4-3", coverage: "cover_2", pressure: "four_man" },
+        participants: [],
+        outcome: "rush",
+        yardage: ypc,
+        tags: [],
+      });
+    }
+  }
+  return {
+    gameId,
+    seed: 1,
+    finalScore: { home: 0, away: 0 },
+    events,
+    boxScore: {
+      home: {
+        totalYards: 0,
+        passingYards: 0,
+        rushingYards: 0,
+        turnovers: 0,
+        sacks: 0,
+        penalties: 0,
+      },
+      away: {
+        totalYards: 0,
+        passingYards: 0,
+        rushingYards: 0,
+        turnovers: 0,
+        sacks: 0,
+        penalties: 0,
+      },
+    },
+    driveLog: [],
+    injuryReport: [],
+  };
+}
+
+Deno.test("runRbCalibration runs the sim, buckets RBs, and returns a populated report", () => {
+  // Build a league where each team's starter RB is at a different
+  // overall, giving us one team per bucket. The stub simulate maps
+  // each team's YPC directly to its RB overall so every bucket lands
+  // in its target band.
+  const overallByTeam: Record<string, number> = {
+    "t30": 30,
+    "t40": 40,
+    "t50": 50,
+    "t60": 60,
+    "t70": 70,
+    "t80": 80,
+  };
+  const ypcByOverall: Record<number, number> = {
+    30: 3.6,
+    40: 4.0,
+    50: 4.3,
+    60: 4.7,
+    70: 5.4,
+    80: 5.4,
+  };
+
+  const teams: SimTeam[] = Object.entries(overallByTeam).map(([id, o]) =>
+    team(id, rbRuntime(`${id}-rb`, o))
+  );
+  const league: CalibrationLeague = { calibrationSeed: 1, teams };
+
+  let gameCount = 0;
+  const simulate = ({ home, away, gameId }: {
+    home: SimTeam;
+    away: SimTeam;
+    seed: number;
+    gameId: string;
+  }): GameResult => {
+    gameCount++;
+    return makeGame(gameId, home.teamId, away.teamId, {
+      [home.teamId]: ypcByOverall[overallByTeam[home.teamId]],
+      [away.teamId]: ypcByOverall[overallByTeam[away.teamId]],
+    });
+  };
+
+  const report = runRbCalibration({
+    bandJson: bandJson(),
+    league,
+    simulate,
+    gameCount: teams.length * 12,
+    minSamplesPerBucket: 5,
+  });
+
+  assertEquals(report.totalGames, teams.length * 12);
+  // Each matchup produces 2 samples (home + away RB).
+  assertEquals(report.totalSamples, gameCount * 2);
+
+  const fifty = report.buckets.find((b) => b.bucketLabel === "50")!;
+  assertEquals(fifty.samples > 0, true);
+  assertEquals(fifty.underSampled, false);
+  assertEquals(fifty.checks.length > 0, true);
+  const ypcCheck = fifty.checks.find((c) =>
+    c.metricName === "yards_per_carry"
+  )!;
+  assertEquals(ypcCheck.passed, true);
+});
+
+Deno.test("runRbCalibration marks a bucket under-sampled when below min threshold", () => {
+  const teams: SimTeam[] = [team("t50", rbRuntime("t50-rb", 50))];
+  const league: CalibrationLeague = { calibrationSeed: 1, teams };
+  const simulate = (
+    { home, away, gameId }: {
+      home: SimTeam;
+      away: SimTeam;
+      seed: number;
+      gameId: string;
+    },
+  ) =>
+    makeGame(gameId, home.teamId, away.teamId, {
+      [home.teamId]: 4.3,
+      [away.teamId]: 4.3,
+    });
+
+  const report = runRbCalibration({
+    bandJson: bandJson(),
+    league,
+    simulate,
+    gameCount: 1,
+    minSamplesPerBucket: 100,
+  });
+
+  const fifty = report.buckets.find((b) => b.bucketLabel === "50")!;
+  assertEquals(fifty.underSampled, true);
+  assertEquals(fifty.checks.length, 0);
+});
+
+Deno.test("formatRbCalibrationReport renders a human-readable summary", () => {
+  const teams: SimTeam[] = [team("t50", rbRuntime("t50-rb", 50))];
+  const league: CalibrationLeague = { calibrationSeed: 1, teams };
+  const simulate = (
+    { home, away, gameId }: {
+      home: SimTeam;
+      away: SimTeam;
+      seed: number;
+      gameId: string;
+    },
+  ) =>
+    makeGame(gameId, home.teamId, away.teamId, {
+      [home.teamId]: 4.3,
+      [away.teamId]: 4.3,
+    });
+
+  const report = runRbCalibration({
+    bandJson: bandJson(),
+    league,
+    simulate,
+    gameCount: 100,
+    minSamplesPerBucket: 1,
+  });
+  const output = formatRbCalibrationReport(report);
+  assertStringIncludes(output, "RB calibration");
+  assertStringIncludes(output, "bucket 50");
+  assertStringIncludes(output, "yards_per_carry");
+});

--- a/server/features/simulation/calibration/per-position/rb-harness.ts
+++ b/server/features/simulation/calibration/per-position/rb-harness.ts
@@ -1,0 +1,171 @@
+import { deriveGameSeed } from "../../rng.ts";
+import { CALIBRATION_GAME_COUNT } from "../constants.ts";
+import { generateMatchups } from "../harness.ts";
+import type { SimulateFn } from "../harness.ts";
+import type { CalibrationLeague } from "../generate-calibration-league.ts";
+import { collectRbSamples, type RbGameSample } from "./rb-sample.ts";
+import { bucketByAttr, type BucketReport } from "./bucket-by-attr.ts";
+import { type BandCheckResult, checkBand } from "./band-check.ts";
+import { loadPositionBands, type PositionBands } from "./band-loader.ts";
+
+// Headline RB metrics. YPC + per-game yardage cover the bulk of NFL
+// RB production, TD rate captures the red-zone finishing piece, and
+// fumble rate surfaces ball-security regressions. Receiving production
+// is intentionally left out of this slice — the sim attributes catches
+// to WR/TE, not RB, so it belongs in the WR harness.
+export const RB_METRICS = [
+  "yards_per_carry",
+  "rush_td_rate",
+  "yards_per_game",
+  "fumble_rate",
+] as const;
+
+export type RbMetric = typeof RB_METRICS[number];
+
+const METRIC_EXTRACTORS: Record<RbMetric, (s: RbGameSample) => number> = {
+  yards_per_carry: (s) => s.yards_per_carry,
+  rush_td_rate: (s) => s.rush_td_rate,
+  yards_per_game: (s) => s.yards_per_game,
+  fumble_rate: (s) => s.fumble_rate,
+};
+
+export interface RbCalibrationOptions {
+  bandJson: string;
+  league: CalibrationLeague;
+  simulate: SimulateFn;
+  gameCount?: number;
+  // Minimum samples per bucket before we trust a band check. Under
+  // this count we still emit the summary but flag it as under-sampled
+  // so the report distinguishes "bucket is empty/noisy" from "bucket
+  // is calibrated wrong".
+  minSamplesPerBucket?: number;
+}
+
+export interface RbBucketReport {
+  bucketLabel: string;
+  bucketCenter: number;
+  samples: number;
+  underSampled: boolean;
+  checks: BandCheckResult[];
+}
+
+export interface RbCalibrationReport {
+  totalGames: number;
+  totalSamples: number;
+  bands: PositionBands;
+  buckets: RbBucketReport[];
+  failures: BandCheckResult[];
+  passed: boolean;
+}
+
+const DEFAULT_MIN_SAMPLES = 50;
+
+export function runRbCalibration(
+  options: RbCalibrationOptions,
+): RbCalibrationReport {
+  const {
+    bandJson,
+    league,
+    simulate,
+    gameCount = CALIBRATION_GAME_COUNT,
+    minSamplesPerBucket = DEFAULT_MIN_SAMPLES,
+  } = options;
+
+  const bands = loadPositionBands(bandJson);
+  const teamById = new Map(league.teams.map((t) => [t.teamId, t]));
+  const matchups = generateMatchups(league.teams, gameCount);
+
+  const samples: RbGameSample[] = [];
+
+  for (let i = 0; i < matchups.length; i++) {
+    const { home, away } = matchups[i];
+    const gameId = `rb-calibration-game-${i}`;
+    const seed = deriveGameSeed(league.calibrationSeed, gameId);
+
+    const result = simulate({ home, away, seed, gameId });
+    const gameSamples = collectRbSamples({
+      game: result,
+      home: teamById.get(home.teamId) ?? home,
+      away: teamById.get(away.teamId) ?? away,
+    });
+    samples.push(...gameSamples);
+  }
+
+  const bucketReports: BucketReport<RbGameSample>[] = bucketByAttr({
+    samples,
+    attr: (s) => s.rbOverall,
+    metrics: METRIC_EXTRACTORS,
+  });
+
+  const buckets: RbBucketReport[] = bucketReports.map((report) => {
+    const underSampled = report.samples.length < minSamplesPerBucket;
+    const checks: BandCheckResult[] = RB_METRICS.flatMap((metric) => {
+      // Don't emit band checks on under-sampled buckets — the NFL band
+      // comparison would be dominated by sampling noise and drown out
+      // the real failures from the populated buckets.
+      if (underSampled) return [];
+      return [
+        checkBand({
+          bucketLabel: report.bucket.label,
+          metricName: metric,
+          simSummary: report.metrics[metric],
+          bands,
+        }),
+      ];
+    });
+    return {
+      bucketLabel: report.bucket.label,
+      bucketCenter: report.bucket.center,
+      samples: report.samples.length,
+      underSampled,
+      checks,
+    };
+  });
+
+  const failures = buckets.flatMap((b) => b.checks.filter((c) => !c.passed));
+
+  return {
+    totalGames: matchups.length,
+    totalSamples: samples.length,
+    bands,
+    buckets,
+    failures,
+    passed: failures.length === 0,
+  };
+}
+
+export function formatRbCalibrationReport(report: RbCalibrationReport): string {
+  const lines: string[] = [];
+  lines.push(
+    `RB calibration — ${report.totalGames} games, ${report.totalSamples} RB-games`,
+  );
+  lines.push(
+    `Bands: ${report.bands.position} / ${
+      report.bands.seasons.join("-")
+    } / ranked by ${report.bands.rankingStat}`,
+  );
+  lines.push("");
+  for (const bucket of report.buckets) {
+    const header = `[bucket ${bucket.bucketLabel}] n=${bucket.samples}` +
+      (bucket.underSampled ? " (under-sampled, skipping band checks)" : "");
+    lines.push(header);
+    for (const check of bucket.checks) {
+      const verdict = check.passed ? "PASS" : "FAIL";
+      const dir = check.passed ? "" : ` (${check.direction})`;
+      lines.push(
+        `  ${verdict} ${check.metricName.padEnd(20)} ` +
+          `sim=${check.simMean.toFixed(4)}  ` +
+          `band(${check.expectedBand})=${check.bandMean.toFixed(4)}±${
+            check.bandSd.toFixed(4)
+          }  ` +
+          `z=${check.zScore.toFixed(2)}  actual=${check.actualBand}${dir}`,
+      );
+    }
+    lines.push("");
+  }
+  const passed = report.passed ? "PASS" : "FAIL";
+  lines.push(
+    `${passed}: ${report.failures.length} band check(s) missed expected band`,
+  );
+  return lines.join("\n");
+}

--- a/server/features/simulation/calibration/per-position/rb-overall.ts
+++ b/server/features/simulation/calibration/per-position/rb-overall.ts
@@ -1,0 +1,20 @@
+import type { PlayerAttributes } from "@zone-blitz/shared";
+
+// The four signature attributes `neutralBucket` uses to classify a
+// player as RB. Averaging them gives a single 0-100 "RB overall" we
+// can bucket on for calibration: a 50-overall RB should land on the
+// NFL median starter's YPC / TD rate, 70+ is elite.
+export const RB_OVERALL_ATTRS = [
+  "ballCarrying",
+  "elusiveness",
+  "acceleration",
+  "speed",
+] as const satisfies ReadonlyArray<keyof PlayerAttributes>;
+
+export function rbOverall(attributes: PlayerAttributes): number {
+  let sum = 0;
+  for (const key of RB_OVERALL_ATTRS) {
+    sum += attributes[key];
+  }
+  return sum / RB_OVERALL_ATTRS.length;
+}

--- a/server/features/simulation/calibration/per-position/rb-sample.test.ts
+++ b/server/features/simulation/calibration/per-position/rb-sample.test.ts
@@ -1,0 +1,306 @@
+import { assertAlmostEquals, assertEquals } from "@std/assert";
+import type { PlayerAttributes } from "@zone-blitz/shared";
+import { collectRbSamples } from "./rb-sample.ts";
+import type { GameResult, PlayEvent } from "../../events.ts";
+import type { SimTeam } from "../../simulate-game.ts";
+import type { PlayerRuntime } from "../../resolve-play.ts";
+
+function attrs(overrides: Partial<PlayerAttributes> = {}): PlayerAttributes {
+  const base: Record<string, number> = {};
+  const keys = [
+    "speed",
+    "acceleration",
+    "agility",
+    "strength",
+    "jumping",
+    "stamina",
+    "durability",
+    "armStrength",
+    "accuracyShort",
+    "accuracyMedium",
+    "accuracyDeep",
+    "accuracyOnTheRun",
+    "touch",
+    "release",
+    "ballCarrying",
+    "elusiveness",
+    "routeRunning",
+    "catching",
+    "contestedCatching",
+    "runAfterCatch",
+    "passBlocking",
+    "runBlocking",
+    "blockShedding",
+    "tackling",
+    "manCoverage",
+    "zoneCoverage",
+    "passRushing",
+    "runDefense",
+    "kickingPower",
+    "kickingAccuracy",
+    "puntingPower",
+    "puntingAccuracy",
+    "snapAccuracy",
+    "footballIq",
+    "decisionMaking",
+    "anticipation",
+    "composure",
+    "clutch",
+    "consistency",
+    "workEthic",
+    "coachability",
+    "leadership",
+    "greed",
+    "loyalty",
+    "ambition",
+    "vanity",
+    "schemeAttachment",
+    "mediaSensitivity",
+  ];
+  for (const k of keys) {
+    base[k] = 50;
+    base[`${k}Potential`] = 50;
+  }
+  return { ...(base as unknown as PlayerAttributes), ...overrides };
+}
+
+function rb(id: string, overall: number): PlayerRuntime {
+  return {
+    playerId: id,
+    neutralBucket: "RB",
+    attributes: attrs({
+      ballCarrying: overall,
+      elusiveness: overall,
+      acceleration: overall,
+      speed: overall,
+    }),
+  };
+}
+
+function team(teamId: string, starterRb: PlayerRuntime): SimTeam {
+  return {
+    teamId,
+    starters: [starterRb],
+    bench: [],
+    fingerprint: { offense: null, defense: null, overrides: {} },
+    coachingMods: {
+      schemeFitBonus: 0,
+      situationalBonus: 0,
+      aggressiveness: 50,
+      penaltyDiscipline: 1,
+    },
+  };
+}
+
+function event(
+  overrides: Partial<PlayEvent> & {
+    outcome: PlayEvent["outcome"];
+    offenseTeamId: string;
+  },
+): PlayEvent {
+  return {
+    gameId: "g",
+    driveIndex: 0,
+    playIndex: 0,
+    quarter: 1,
+    clock: "15:00",
+    situation: { down: 1, distance: 10, yardLine: 25 },
+    defenseTeamId: overrides.offenseTeamId === "home" ? "away" : "home",
+    call: {
+      concept: "inside_zone",
+      personnel: "11",
+      formation: "singleback",
+      motion: "none",
+    },
+    coverage: { front: "4-3", coverage: "cover_2", pressure: "four_man" },
+    participants: [],
+    yardage: 0,
+    tags: [],
+    ...overrides,
+  };
+}
+
+function gameOf(events: PlayEvent[]): GameResult {
+  return {
+    gameId: "g",
+    seed: 1,
+    finalScore: { home: 0, away: 0 },
+    events,
+    boxScore: {
+      home: {
+        totalYards: 0,
+        passingYards: 0,
+        rushingYards: 0,
+        turnovers: 0,
+        sacks: 0,
+        penalties: 0,
+      },
+      away: {
+        totalYards: 0,
+        passingYards: 0,
+        rushingYards: 0,
+        turnovers: 0,
+        sacks: 0,
+        penalties: 0,
+      },
+    },
+    driveLog: [],
+    injuryReport: [],
+  };
+}
+
+Deno.test("collectRbSamples returns one sample per team with a starter RB", () => {
+  const home = team("home", rb("home-rb", 50));
+  const away = team("away", rb("away-rb", 50));
+  const samples = collectRbSamples({
+    game: gameOf([]),
+    home,
+    away,
+  });
+  assertEquals(samples.length, 2);
+  assertEquals(samples[0].teamId, "home");
+  assertEquals(samples[0].rbPlayerId, "home-rb");
+  assertEquals(samples[1].teamId, "away");
+});
+
+Deno.test("collectRbSamples skips a team with no starter RB", () => {
+  const home = team("home", rb("home-rb", 50));
+  const away: SimTeam = { ...team("away", rb("away-rb", 50)), starters: [] };
+  const samples = collectRbSamples({
+    game: gameOf([]),
+    home,
+    away,
+  });
+  assertEquals(samples.length, 1);
+  assertEquals(samples[0].teamId, "home");
+});
+
+Deno.test("collectRbSamples tags sample with RB overall (mean of four signature attrs)", () => {
+  const home = team(
+    "home",
+    {
+      playerId: "home-rb",
+      neutralBucket: "RB",
+      attributes: attrs({
+        ballCarrying: 60,
+        elusiveness: 70,
+        acceleration: 80,
+        speed: 50,
+      }),
+    },
+  );
+  const away = team("away", rb("away-rb", 50));
+  const [homeSample] = collectRbSamples({
+    game: gameOf([]),
+    home,
+    away,
+  });
+  // (60 + 70 + 80 + 50) / 4 = 65
+  assertAlmostEquals(homeSample.rbOverall, 65, 0.01);
+});
+
+Deno.test("collectRbSamples accumulates rush events into YPC, per-game yards, TD rate, fumble rate", () => {
+  const home = team("home", rb("home-rb", 50));
+  const away = team("away", rb("away-rb", 50));
+  const events: PlayEvent[] = [
+    event({ outcome: "rush", offenseTeamId: "home", yardage: 5 }),
+    event({ outcome: "rush", offenseTeamId: "home", yardage: 3 }),
+    event({ outcome: "rush", offenseTeamId: "home", yardage: -2 }),
+    event({
+      outcome: "touchdown",
+      offenseTeamId: "home",
+      yardage: 4,
+      call: {
+        concept: "inside_zone",
+        personnel: "11",
+        formation: "singleback",
+        motion: "none",
+      },
+    }),
+    event({ outcome: "fumble", offenseTeamId: "home", yardage: 2 }),
+  ];
+  const [homeSample] = collectRbSamples({
+    game: gameOf(events),
+    home,
+    away,
+  });
+  assertEquals(homeSample.carries, 5);
+  assertEquals(homeSample.rush_yards, 12);
+  assertEquals(homeSample.rush_tds, 1);
+  assertEquals(homeSample.fumbles_lost, 1);
+  assertAlmostEquals(homeSample.yards_per_carry, 12 / 5, 1e-6);
+  assertAlmostEquals(homeSample.rush_td_rate, 1 / 5, 1e-6);
+  assertAlmostEquals(homeSample.yards_per_game, 12);
+  assertAlmostEquals(homeSample.fumble_rate, 1 / 5, 1e-6);
+});
+
+Deno.test("collectRbSamples attributes run-concept TDs to the RB but skips pass-concept TDs", () => {
+  const home = team("home", rb("home-rb", 50));
+  const away = team("away", rb("away-rb", 50));
+  const events: PlayEvent[] = [
+    event({
+      outcome: "touchdown",
+      offenseTeamId: "home",
+      yardage: 2,
+      call: {
+        concept: "inside_zone",
+        personnel: "11",
+        formation: "singleback",
+        motion: "none",
+      },
+    }),
+    event({
+      outcome: "touchdown",
+      offenseTeamId: "home",
+      yardage: 20,
+      call: {
+        concept: "quick_pass",
+        personnel: "11",
+        formation: "shotgun",
+        motion: "none",
+      },
+    }),
+  ];
+  const [homeSample] = collectRbSamples({
+    game: gameOf(events),
+    home,
+    away,
+  });
+  assertEquals(homeSample.carries, 1);
+  assertEquals(homeSample.rush_tds, 1);
+  assertEquals(homeSample.rush_yards, 2);
+});
+
+Deno.test("collectRbSamples isolates offense by team", () => {
+  const home = team("home", rb("home-rb", 50));
+  const away = team("away", rb("away-rb", 50));
+  const events: PlayEvent[] = [
+    event({ outcome: "rush", offenseTeamId: "home", yardage: 4 }),
+    event({ outcome: "rush", offenseTeamId: "away", yardage: 8 }),
+    event({ outcome: "fumble", offenseTeamId: "away", yardage: 1 }),
+  ];
+  const [homeSample, awaySample] = collectRbSamples({
+    game: gameOf(events),
+    home,
+    away,
+  });
+  assertEquals(homeSample.carries, 1);
+  assertEquals(homeSample.fumbles_lost, 0);
+  assertEquals(awaySample.carries, 2);
+  assertEquals(awaySample.fumbles_lost, 1);
+});
+
+Deno.test("collectRbSamples handles zero-carry games without divide-by-zero", () => {
+  const home = team("home", rb("home-rb", 50));
+  const away = team("away", rb("away-rb", 50));
+  const [sample] = collectRbSamples({
+    game: gameOf([]),
+    home,
+    away,
+  });
+  assertEquals(sample.carries, 0);
+  assertEquals(sample.yards_per_carry, 0);
+  assertEquals(sample.rush_td_rate, 0);
+  assertEquals(sample.yards_per_game, 0);
+  assertEquals(sample.fumble_rate, 0);
+});

--- a/server/features/simulation/calibration/per-position/rb-sample.ts
+++ b/server/features/simulation/calibration/per-position/rb-sample.ts
@@ -1,0 +1,112 @@
+import type { GameResult, PlayEvent } from "../../events.ts";
+import type { SimTeam } from "../../simulate-game.ts";
+import { rbOverall } from "./rb-overall.ts";
+
+export interface RbGameSample {
+  teamId: string;
+  rbPlayerId: string;
+  rbOverall: number;
+  carries: number;
+  rush_yards: number;
+  rush_tds: number;
+  fumbles_lost: number;
+  yards_per_carry: number;
+  rush_td_rate: number;
+  yards_per_game: number;
+  fumble_rate: number;
+}
+
+const RUN_CONCEPTS = new Set([
+  "inside_zone",
+  "outside_zone",
+  "power",
+  "counter",
+  "draw",
+  "rpo",
+]);
+
+function accumulate(events: PlayEvent[], teamId: string) {
+  let carries = 0;
+  let rushYards = 0;
+  let rushTds = 0;
+  let fumblesLost = 0;
+
+  for (const event of events) {
+    if (event.offenseTeamId !== teamId) continue;
+
+    switch (event.outcome) {
+      case "rush":
+        carries++;
+        rushYards += event.yardage;
+        break;
+      case "fumble":
+        // A fumble outcome in the engine is produced downstream of a
+        // rush (`synthesize-run-outcome.ts`), so it counts as a carry
+        // with whatever yardage the runner had gained before coughing
+        // the ball up.
+        carries++;
+        rushYards += event.yardage;
+        fumblesLost++;
+        break;
+      case "touchdown":
+        // Run-concept TDs get credited to the ball carrier. Pass-concept
+        // TDs belong to the QB/receiver and are skipped, mirroring how
+        // `team-game-stats.ts` splits TDs between the pass and rush
+        // sides.
+        if (RUN_CONCEPTS.has(event.call.concept)) {
+          carries++;
+          rushYards += event.yardage;
+          rushTds++;
+        }
+        break;
+    }
+  }
+
+  return {
+    carries,
+    rush_yards: rushYards,
+    rush_tds: rushTds,
+    fumbles_lost: fumblesLost,
+    yards_per_carry: carries > 0 ? rushYards / carries : 0,
+    rush_td_rate: carries > 0 ? rushTds / carries : 0,
+    // One sample spans a single game, so `yards_per_game` is just the
+    // rushing yardage. Keeping the name aligned with the NFL band
+    // fixture makes the bucket report directly comparable.
+    yards_per_game: rushYards,
+    fumble_rate: carries > 0 ? fumblesLost / carries : 0,
+  };
+}
+
+export interface RbSampleInput {
+  game: GameResult;
+  home: SimTeam;
+  away: SimTeam;
+}
+
+// Attribute a team-game's rush stats to the team's starter RB. The
+// engine's `resolve-matchups.ts` picks `rbs[0]` as the ball carrier on
+// every run play, so the starter carries the full workload until
+// injured — and calibration injuries are rare enough that backup
+// carries don't meaningfully shift per-bucket means. If that
+// assumption breaks we can switch to per-participant attribution via
+// the `ball_carrier` tag once the engine writes it consistently.
+export function collectRbSamples(
+  input: RbSampleInput,
+): RbGameSample[] {
+  const { game, home, away } = input;
+
+  const samples: RbGameSample[] = [];
+  for (const team of [home, away]) {
+    const rb = team.starters.find((p) => p.neutralBucket === "RB");
+    if (!rb) continue;
+
+    const stats = accumulate(game.events, team.teamId);
+    samples.push({
+      teamId: team.teamId,
+      rbPlayerId: rb.playerId,
+      rbOverall: rbOverall(rb.attributes),
+      ...stats,
+    });
+  }
+  return samples;
+}

--- a/server/features/simulation/calibration/per-position/run-rb-calibration.ts
+++ b/server/features/simulation/calibration/per-position/run-rb-calibration.ts
@@ -1,0 +1,61 @@
+import { simulateGame } from "../../simulate-game.ts";
+import { generateCalibrationLeague } from "../generate-calibration-league.ts";
+import { CALIBRATION_SEEDS } from "../calibration-seeds.ts";
+import { formatRbCalibrationReport, runRbCalibration } from "./rb-harness.ts";
+
+// Per-issue-#496: report-only across every calibration seed so a human
+// can read the per-bucket PASS/FAIL signal against NFL RB percentile
+// bands. Gating will come later once we understand per-bucket noise.
+const bandPath = new URL(
+  "../../../../../data/bands/per-position/rb.json",
+  import.meta.url,
+);
+
+const bandJson = await Deno.readTextFile(bandPath);
+
+let allPassed = true;
+const summary: {
+  seed: number;
+  passed: number;
+  total: number;
+  underSampled: number;
+}[] = [];
+
+for (const seed of CALIBRATION_SEEDS) {
+  const league = generateCalibrationLeague({ seed });
+  const report = runRbCalibration({
+    bandJson,
+    league,
+    simulate: simulateGame,
+  });
+
+  console.log(`=== seed=0x${seed.toString(16)} ===`);
+  console.log(formatRbCalibrationReport(report));
+  console.log("");
+
+  const totalChecks = report.buckets.reduce(
+    (sum, b) => sum + b.checks.length,
+    0,
+  );
+  const passCount = totalChecks - report.failures.length;
+  const underSampled = report.buckets.filter((b) => b.underSampled).length;
+  summary.push({ seed, passed: passCount, total: totalChecks, underSampled });
+  if (!report.passed) allPassed = false;
+}
+
+console.log("=== Multi-seed summary ===");
+for (const row of summary) {
+  const status = row.passed === row.total ? "PASS" : "FAIL";
+  const underSampledNote = row.underSampled > 0
+    ? ` (${row.underSampled} bucket(s) under-sampled)`
+    : "";
+  console.log(
+    `${status} seed=0x${
+      row.seed.toString(16)
+    }: ${row.passed}/${row.total}${underSampledNote}`,
+  );
+}
+
+if (!allPassed) {
+  Deno.exit(1);
+}


### PR DESCRIPTION
## Summary

Implements the RB slice of #496 — mirrors the QB harness from #497 for running backs. Tags every sim RB-game with the starter's overall (mean of `ballCarrying`, `elusiveness`, `acceleration`, `speed`), buckets samples into 10-point bands (30/40/50/60/70/80), and compares each bucket's mean stat line (YPC, rush TD rate, yards per game, fumble rate) to NFL RB percentile bands.

- `data/R/bands/per-position-rb.R` pulls RB-season stats (2020-2024, carries ≥ 100) from `nflreadr`, ranks by rushing EPA/play, and carves the starter population into five percentile bands (elite / good / average / weak / replacement) with mean+sd per metric.
- `data/bands/per-position/rb.json` is the generated fixture.
- `server/features/simulation/calibration/per-position/` gains `rb-overall`, `rb-sample`, `rb-harness`, `run-rb-calibration`. Reuses the existing `bucket-by-attr`, `band-loader`, `band-check` modules. Unit-test coverage for sample attribution and harness bucketing.
- `deno task sim:calibrate:rb` runs the harness across every calibration seed.

Report-only for now per issue #496 — we want to read the per-bucket noise before layering on gating.

## Notes

A multi-seed run already surfaces real calibration gaps the team-game aggregates were hiding:
- **YPC separation is too tight at the top.** The 50-overall bucket lands on NFL average YPC (~4.27 vs. 4.30), but the 70/80 buckets only reach ~4.4–4.75 YPC vs. NFL elite's 5.45.
- **Per-game yardage is ~2x NFL.** Sim starter RBs hit ~115 yards/game vs. NFL average-band 57 — the engine's `rbs[0]` ball-carrier pick means the starter absorbs every carry, while real teams rotate backs. Deliberate simplification documented in the sample collector; worth a follow-up if we want to model committee splits.
- **Fumble rate runs ~5x NFL.** Sim fumble rate sits ~0.018–0.024/carry across every bucket vs. NFL average 0.004 — a real engine tuning gap.
- **30-overall bucket is empty across every seed.** The generator's RB overall distribution sits above 35, so the replacement-tier bucket never populates.

Those become tracked follow-ups as `gh issue create` once this slice merges. Subsequent slices (WR/CB route_coverage, OL/pass-rush, TE/S, matchup harness) will follow as separate PRs per the issue's rollout plan.