### PR TITLE
feat(calibration): add per-TE-bucket calibration harness (#496, TE slice)

### DIFF
--- a/data/R/bands/per-position-te.R
+++ b/data/R/bands/per-position-te.R
@@ -1,0 +1,146 @@
+#!/usr/bin/env Rscript
+# per-position-te.R — NFL TE percentile-band reference.
+#
+# Pulls weekly TE stats from load_player_stats, aggregates to per-TE-season
+# lines, filters to starters (season targets >= 30), ranks by receiving
+# EPA/target, and carves the population into five percentile bands (elite /
+# good / average / weak / replacement). For each band, reports mean + sd + n
+# on the headline TE receiving metrics tracked by the sim.
+#
+# Output: data/bands/per-position/te.json
+#
+# Usage:
+#   Rscript data/R/bands/per-position-te.R [--seasons 2020:2024]
+
+suppressPackageStartupMessages({
+  library(nflreadr)
+  library(dplyr)
+})
+
+script_file <- (function() {
+  args <- commandArgs(trailingOnly = FALSE)
+  f <- grep("^--file=", args, value = TRUE)
+  if (length(f) > 0) normalizePath(sub("^--file=", "", f[1]), mustWork = FALSE) else NULL
+})()
+source(file.path(dirname(script_file), "..", "lib.R"))
+
+args <- commandArgs(trailingOnly = TRUE)
+seasons <- parse_seasons(args)
+
+cat("Loading weekly player stats for seasons:",
+    paste(range(seasons), collapse = "-"), "\n")
+
+weekly <- nflreadr::load_player_stats(seasons, stat_type = "offense")
+
+te_weekly <- weekly |>
+  filter(season_type == "REG", position == "TE", targets > 0)
+
+# Aggregate weekly rows into per-TE-season totals. Starter threshold is
+# 30 targets over a season — roughly two targets per game at the low
+# end, which excludes rotational blocking TEs who don't factor into
+# the receiving calibration we're measuring.
+te_season <- te_weekly |>
+  group_by(player_id, player_display_name, season) |>
+  summarise(
+    games         = n(),
+    targets       = sum(targets, na.rm = TRUE),
+    receptions    = sum(receptions, na.rm = TRUE),
+    rec_yards     = sum(receiving_yards, na.rm = TRUE),
+    rec_tds       = sum(receiving_tds, na.rm = TRUE),
+    epa_total     = sum(receiving_epa, na.rm = TRUE),
+    .groups       = "drop"
+  ) |>
+  mutate(
+    catch_rate          = ifelse(targets > 0, receptions / targets, NA_real_),
+    yards_per_reception = ifelse(receptions > 0,
+                                 rec_yards / receptions, NA_real_),
+    yards_per_target    = ifelse(targets > 0,
+                                 rec_yards / targets, NA_real_),
+    td_rate             = ifelse(targets > 0, rec_tds / targets, NA_real_),
+    yards_per_game      = ifelse(games > 0, rec_yards / games, NA_real_),
+    epa_per_target      = ifelse(targets > 0,
+                                 epa_total / targets, NA_real_)
+  ) |>
+  filter(targets >= 30) # starter threshold: ~2 targets/game over 17 weeks
+
+cat("TE-seasons after starter filter:", nrow(te_season), "\n")
+
+# Rank by receiving EPA/target and assign percentile bands on the
+# filtered starter population. Bands follow the scheme from issue #496:
+# top 10% elite, next 20% good, middle 40% average, next 20% weak,
+# bottom 10% replacement.
+te_ranked <- te_season |>
+  arrange(desc(epa_per_target)) |>
+  mutate(
+    pct = (row_number() - 0.5) / n(),
+    band = case_when(
+      pct <= 0.10 ~ "elite",
+      pct <= 0.30 ~ "good",
+      pct <= 0.70 ~ "average",
+      pct <= 0.90 ~ "weak",
+      TRUE        ~ "replacement"
+    )
+  )
+
+metric_keys <- c(
+  "catch_rate",
+  "yards_per_reception",
+  "yards_per_target",
+  "td_rate",
+  "yards_per_game"
+)
+
+band_order <- c("elite", "good", "average", "weak", "replacement")
+
+band_summary <- function(rows) {
+  metrics <- list()
+  for (key in metric_keys) {
+    vals <- rows[[key]]
+    vals <- vals[!is.na(vals)]
+    metrics[[key]] <- list(
+      n = length(vals),
+      mean = mean(vals),
+      sd = stats::sd(vals)
+    )
+  }
+  list(
+    n = nrow(rows),
+    metrics = metrics
+  )
+}
+
+bands <- list()
+for (band_name in band_order) {
+  rows <- te_ranked |> filter(band == band_name)
+  bands[[band_name]] <- band_summary(rows)
+}
+
+out <- list(
+  generated_at = format(Sys.time(), "%Y-%m-%dT%H:%M:%SZ", tz = "UTC"),
+  seasons = as.integer(seasons),
+  position = "TE",
+  qualifier = "regular-season TE-seasons with >=30 targets",
+  ranking_stat = "epa_per_target (receiving EPA / targets)",
+  notes = paste0(
+    "Starter TE-seasons 2020-2024, ranked by receiving EPA/target then ",
+    "carved into percentile bands (elite: top 10%, good: 10-30%, average: ",
+    "30-70%, weak: 70-90%, replacement: bottom 10%). Each band reports ",
+    "mean+sd per metric across the TE-seasons in that band. catch_rate, ",
+    "yards_per_target, and td_rate use targets as denominator; ",
+    "yards_per_reception uses receptions; yards_per_game uses games ",
+    "played. Rushing/blocking production is intentionally excluded from ",
+    "the ranking stat — the sim's TE attribution covers receiving only."
+  ),
+  bands = bands
+)
+
+out_path <- file.path(
+  repo_root(), "data", "bands", "per-position", "te.json"
+)
+dir.create(dirname(out_path), recursive = TRUE, showWarnings = FALSE)
+writeLines(
+  jsonlite::toJSON(out, auto_unbox = TRUE, pretty = TRUE, digits = 4,
+                   null = "null"),
+  out_path
+)
+cat("Wrote", out_path, "\n")

--- a/data/bands/per-position/te.json
+++ b/data/bands/per-position/te.json
@@ -1,0 +1,160 @@
+{
+  "generated_at": "2026-04-17T12:28:57Z",
+  "seasons": [2020, 2021, 2022, 2023, 2024],
+  "position": "TE",
+  "qualifier": "regular-season TE-seasons with >=30 targets",
+  "ranking_stat": "epa_per_target (receiving EPA / targets)",
+  "notes": "Starter TE-seasons 2020-2024, ranked by receiving EPA/target then carved into percentile bands (elite: top 10%, good: 10-30%, average: 30-70%, weak: 70-90%, replacement: bottom 10%). Each band reports mean+sd per metric across the TE-seasons in that band. catch_rate, yards_per_target, and td_rate use targets as denominator; yards_per_reception uses receptions; yards_per_game uses games played. Rushing/blocking production is intentionally excluded from the ranking stat — the sim's TE attribution covers receiving only.",
+  "bands": {
+    "elite": {
+      "n": 22,
+      "metrics": {
+        "catch_rate": {
+          "n": 22,
+          "mean": 0.7737,
+          "sd": 0.0597
+        },
+        "yards_per_reception": {
+          "n": 22,
+          "mean": 12.6136,
+          "sd": 1.7131
+        },
+        "yards_per_target": {
+          "n": 22,
+          "mean": 9.6966,
+          "sd": 1.0326
+        },
+        "td_rate": {
+          "n": 22,
+          "mean": 0.0799,
+          "sd": 0.0414
+        },
+        "yards_per_game": {
+          "n": 22,
+          "mean": 44.6672,
+          "sd": 19.6583
+        }
+      }
+    },
+    "good": {
+      "n": 45,
+      "metrics": {
+        "catch_rate": {
+          "n": 45,
+          "mean": 0.7318,
+          "sd": 0.0593
+        },
+        "yards_per_reception": {
+          "n": 45,
+          "mean": 11.1308,
+          "sd": 1.3195
+        },
+        "yards_per_target": {
+          "n": 45,
+          "mean": 8.1129,
+          "sd": 0.8792
+        },
+        "td_rate": {
+          "n": 45,
+          "mean": 0.0661,
+          "sd": 0.0331
+        },
+        "yards_per_game": {
+          "n": 45,
+          "mean": 40.0004,
+          "sd": 16.9485
+        }
+      }
+    },
+    "average": {
+      "n": 90,
+      "metrics": {
+        "catch_rate": {
+          "n": 90,
+          "mean": 0.6961,
+          "sd": 0.066
+        },
+        "yards_per_reception": {
+          "n": 90,
+          "mean": 10.5169,
+          "sd": 1.5726
+        },
+        "yards_per_target": {
+          "n": 90,
+          "mean": 7.2712,
+          "sd": 0.9505
+        },
+        "td_rate": {
+          "n": 90,
+          "mean": 0.0447,
+          "sd": 0.0275
+        },
+        "yards_per_game": {
+          "n": 90,
+          "mean": 34.0073,
+          "sd": 12.4518
+        }
+      }
+    },
+    "weak": {
+      "n": 45,
+      "metrics": {
+        "catch_rate": {
+          "n": 45,
+          "mean": 0.6626,
+          "sd": 0.0676
+        },
+        "yards_per_reception": {
+          "n": 45,
+          "mean": 9.5816,
+          "sd": 1.2393
+        },
+        "yards_per_target": {
+          "n": 45,
+          "mean": 6.3116,
+          "sd": 0.7598
+        },
+        "td_rate": {
+          "n": 45,
+          "mean": 0.0424,
+          "sd": 0.0262
+        },
+        "yards_per_game": {
+          "n": 45,
+          "mean": 29.5649,
+          "sd": 11.5604
+        }
+      }
+    },
+    "replacement": {
+      "n": 22,
+      "metrics": {
+        "catch_rate": {
+          "n": 22,
+          "mean": 0.6204,
+          "sd": 0.0701
+        },
+        "yards_per_reception": {
+          "n": 22,
+          "mean": 9.0394,
+          "sd": 1.4223
+        },
+        "yards_per_target": {
+          "n": 22,
+          "mean": 5.5513,
+          "sd": 0.7018
+        },
+        "td_rate": {
+          "n": 22,
+          "mean": 0.0241,
+          "sd": 0.0226
+        },
+        "yards_per_game": {
+          "n": 22,
+          "mean": 22.4744,
+          "sd": 7.4219
+        }
+      }
+    }
+  }
+}

--- a/deno.json
+++ b/deno.json
@@ -36,6 +36,7 @@
     "sim:calibrate": "deno run --allow-read server/features/simulation/calibration/run-calibration.ts",
     "sim:calibrate:qb": "deno run --allow-read server/features/simulation/calibration/per-position/run-qb-calibration.ts",
     "sim:calibrate:rb": "deno run --allow-read server/features/simulation/calibration/per-position/run-rb-calibration.ts",
+    "sim:calibrate:te": "deno run --allow-read server/features/simulation/calibration/per-position/run-te-calibration.ts",
     "build": "cd client && deno task build",
     "start": "cd server && deno run --env=../.env --allow-net --allow-env --allow-read --allow-sys main.ts"
   },

--- a/server/features/simulation/calibration/per-position/run-te-calibration.ts
+++ b/server/features/simulation/calibration/per-position/run-te-calibration.ts
@@ -1,0 +1,61 @@
+import { simulateGame } from "../../simulate-game.ts";
+import { generateCalibrationLeague } from "../generate-calibration-league.ts";
+import { CALIBRATION_SEEDS } from "../calibration-seeds.ts";
+import { formatTeCalibrationReport, runTeCalibration } from "./te-harness.ts";
+
+// Per-issue-#496: report-only across every calibration seed so a human
+// can read the per-bucket PASS/FAIL signal against NFL TE percentile
+// bands. Gating will come later once we understand per-bucket noise.
+const bandPath = new URL(
+  "../../../../../data/bands/per-position/te.json",
+  import.meta.url,
+);
+
+const bandJson = await Deno.readTextFile(bandPath);
+
+let allPassed = true;
+const summary: {
+  seed: number;
+  passed: number;
+  total: number;
+  underSampled: number;
+}[] = [];
+
+for (const seed of CALIBRATION_SEEDS) {
+  const league = generateCalibrationLeague({ seed });
+  const report = runTeCalibration({
+    bandJson,
+    league,
+    simulate: simulateGame,
+  });
+
+  console.log(`=== seed=0x${seed.toString(16)} ===`);
+  console.log(formatTeCalibrationReport(report));
+  console.log("");
+
+  const totalChecks = report.buckets.reduce(
+    (sum, b) => sum + b.checks.length,
+    0,
+  );
+  const passCount = totalChecks - report.failures.length;
+  const underSampled = report.buckets.filter((b) => b.underSampled).length;
+  summary.push({ seed, passed: passCount, total: totalChecks, underSampled });
+  if (!report.passed) allPassed = false;
+}
+
+console.log("=== Multi-seed summary ===");
+for (const row of summary) {
+  const status = row.passed === row.total ? "PASS" : "FAIL";
+  const underSampledNote = row.underSampled > 0
+    ? ` (${row.underSampled} bucket(s) under-sampled)`
+    : "";
+  console.log(
+    `${status} seed=0x${
+      row.seed.toString(16)
+    }: ${row.passed}/${row.total}${underSampledNote}`,
+  );
+}
+
+if (!allPassed) {
+  Deno.exit(1);
+}

--- a/server/features/simulation/calibration/per-position/te-harness.test.ts
+++ b/server/features/simulation/calibration/per-position/te-harness.test.ts
@@ -1,0 +1,328 @@
+import { assertEquals, assertStringIncludes } from "@std/assert";
+import type { PlayerAttributes } from "@zone-blitz/shared";
+import { formatTeCalibrationReport, runTeCalibration } from "./te-harness.ts";
+import type { GameResult, PlayEvent } from "../../events.ts";
+import type { SimTeam } from "../../simulate-game.ts";
+import type { PlayerRuntime } from "../../resolve-play.ts";
+import type { CalibrationLeague } from "../generate-calibration-league.ts";
+
+function attrs(overrides: Partial<PlayerAttributes> = {}): PlayerAttributes {
+  const base: Record<string, number> = {};
+  const keys = [
+    "speed",
+    "acceleration",
+    "agility",
+    "strength",
+    "jumping",
+    "stamina",
+    "durability",
+    "armStrength",
+    "accuracyShort",
+    "accuracyMedium",
+    "accuracyDeep",
+    "accuracyOnTheRun",
+    "touch",
+    "release",
+    "ballCarrying",
+    "elusiveness",
+    "routeRunning",
+    "catching",
+    "contestedCatching",
+    "runAfterCatch",
+    "passBlocking",
+    "runBlocking",
+    "blockShedding",
+    "tackling",
+    "manCoverage",
+    "zoneCoverage",
+    "passRushing",
+    "runDefense",
+    "kickingPower",
+    "kickingAccuracy",
+    "puntingPower",
+    "puntingAccuracy",
+    "snapAccuracy",
+    "footballIq",
+    "decisionMaking",
+    "anticipation",
+    "composure",
+    "clutch",
+    "consistency",
+    "workEthic",
+    "coachability",
+    "leadership",
+    "greed",
+    "loyalty",
+    "ambition",
+    "vanity",
+    "schemeAttachment",
+    "mediaSensitivity",
+  ];
+  for (const k of keys) {
+    base[k] = 50;
+    base[`${k}Potential`] = 50;
+  }
+  return { ...(base as unknown as PlayerAttributes), ...overrides };
+}
+
+function teRuntime(id: string, overall: number): PlayerRuntime {
+  return {
+    playerId: id,
+    neutralBucket: "TE",
+    attributes: attrs({
+      routeRunning: overall,
+      catching: overall,
+      runBlocking: overall,
+      passBlocking: overall,
+      speed: overall,
+    }),
+  };
+}
+
+function team(teamId: string, starterTe: PlayerRuntime): SimTeam {
+  return {
+    teamId,
+    starters: [starterTe],
+    bench: [],
+    fingerprint: { offense: null, defense: null, overrides: {} },
+    coachingMods: {
+      schemeFitBonus: 0,
+      situationalBonus: 0,
+      aggressiveness: 50,
+      penaltyDiscipline: 1,
+    },
+  };
+}
+
+function bandJson(): string {
+  const band = (yptMean: number) => ({
+    n: 20,
+    metrics: {
+      catch_rate: { n: 20, mean: 0.70, sd: 0.06 },
+      yards_per_reception: { n: 20, mean: 10.5, sd: 1.5 },
+      yards_per_target: { n: 20, mean: yptMean, sd: 0.9 },
+      td_rate: { n: 20, mean: 0.05, sd: 0.03 },
+      yards_per_game: { n: 20, mean: yptMean * 5, sd: 12 },
+    },
+  });
+  return JSON.stringify({
+    position: "TE",
+    seasons: [2020, 2021, 2022, 2023, 2024],
+    ranking_stat: "epa_per_target",
+    bands: {
+      elite: band(9.7),
+      good: band(8.1),
+      average: band(7.3),
+      weak: band(6.3),
+      replacement: band(5.5),
+    },
+  });
+}
+
+function makeGame(
+  gameId: string,
+  homeTeamId: string,
+  awayTeamId: string,
+  teByTeam: Record<string, string>,
+  yptByTeam: Record<string, number>,
+): GameResult {
+  const events: PlayEvent[] = [];
+  for (const [offenseTeamId, ypt] of Object.entries(yptByTeam)) {
+    const defenseTeamId = offenseTeamId === homeTeamId
+      ? awayTeamId
+      : homeTeamId;
+    const tePlayerId = teByTeam[offenseTeamId];
+    const targets = 8;
+    for (let i = 0; i < targets; i++) {
+      events.push({
+        gameId,
+        driveIndex: 0,
+        playIndex: events.length,
+        quarter: 1,
+        clock: "15:00",
+        situation: { down: 1, distance: 10, yardLine: 25 },
+        offenseTeamId,
+        defenseTeamId,
+        call: {
+          concept: "dropback",
+          personnel: "11",
+          formation: "shotgun",
+          motion: "none",
+        },
+        coverage: { front: "4-3", coverage: "cover_2", pressure: "four_man" },
+        participants: [
+          {
+            role: "route_coverage",
+            playerId: tePlayerId,
+            tags: ["target", "reception"],
+          },
+        ],
+        outcome: "pass_complete",
+        // Every reception worth `ypt` yards — because reception rate
+        // is 100% in this stub, yards_per_target == yards_per_reception
+        // and the check against `yards_per_target` band lands cleanly.
+        yardage: ypt,
+        tags: [],
+      });
+    }
+  }
+  return {
+    gameId,
+    seed: 1,
+    finalScore: { home: 0, away: 0 },
+    events,
+    boxScore: {
+      home: {
+        totalYards: 0,
+        passingYards: 0,
+        rushingYards: 0,
+        turnovers: 0,
+        sacks: 0,
+        penalties: 0,
+      },
+      away: {
+        totalYards: 0,
+        passingYards: 0,
+        rushingYards: 0,
+        turnovers: 0,
+        sacks: 0,
+        penalties: 0,
+      },
+    },
+    driveLog: [],
+    injuryReport: [],
+  };
+}
+
+Deno.test("runTeCalibration runs the sim, buckets TEs, and returns a populated report", () => {
+  // Build a league where each team's starter TE is at a different
+  // overall, giving us one team per bucket. The stub simulate maps
+  // each team's yards-per-target directly to its TE overall so every
+  // bucket lands in its target band.
+  const overallByTeam: Record<string, number> = {
+    "t30": 30,
+    "t40": 40,
+    "t50": 50,
+    "t60": 60,
+    "t70": 70,
+    "t80": 80,
+  };
+  const yptByOverall: Record<number, number> = {
+    30: 5.5,
+    40: 6.3,
+    50: 7.3,
+    60: 8.1,
+    70: 9.7,
+    80: 9.7,
+  };
+
+  const teams: SimTeam[] = Object.entries(overallByTeam).map(([id, o]) =>
+    team(id, teRuntime(`${id}-te`, o))
+  );
+  const league: CalibrationLeague = { calibrationSeed: 1, teams };
+
+  let gameCount = 0;
+  const simulate = ({ home, away, gameId }: {
+    home: SimTeam;
+    away: SimTeam;
+    seed: number;
+    gameId: string;
+  }): GameResult => {
+    gameCount++;
+    return makeGame(
+      gameId,
+      home.teamId,
+      away.teamId,
+      { [home.teamId]: `${home.teamId}-te`, [away.teamId]: `${away.teamId}-te` },
+      {
+        [home.teamId]: yptByOverall[overallByTeam[home.teamId]],
+        [away.teamId]: yptByOverall[overallByTeam[away.teamId]],
+      },
+    );
+  };
+
+  const report = runTeCalibration({
+    bandJson: bandJson(),
+    league,
+    simulate,
+    gameCount: teams.length * 12,
+    minSamplesPerBucket: 5,
+  });
+
+  assertEquals(report.totalGames, teams.length * 12);
+  // Each matchup produces 2 samples (home + away TE).
+  assertEquals(report.totalSamples, gameCount * 2);
+
+  const fifty = report.buckets.find((b) => b.bucketLabel === "50")!;
+  assertEquals(fifty.samples > 0, true);
+  assertEquals(fifty.underSampled, false);
+  assertEquals(fifty.checks.length > 0, true);
+  const yptCheck = fifty.checks.find((c) =>
+    c.metricName === "yards_per_target"
+  )!;
+  assertEquals(yptCheck.passed, true);
+});
+
+Deno.test("runTeCalibration marks a bucket under-sampled when below min threshold", () => {
+  const teams: SimTeam[] = [team("t50", teRuntime("t50-te", 50))];
+  const league: CalibrationLeague = { calibrationSeed: 1, teams };
+  const simulate = (
+    { home, away, gameId }: {
+      home: SimTeam;
+      away: SimTeam;
+      seed: number;
+      gameId: string;
+    },
+  ) =>
+    makeGame(
+      gameId,
+      home.teamId,
+      away.teamId,
+      { [home.teamId]: "t50-te", [away.teamId]: "t50-te" },
+      { [home.teamId]: 7.3, [away.teamId]: 7.3 },
+    );
+
+  const report = runTeCalibration({
+    bandJson: bandJson(),
+    league,
+    simulate,
+    gameCount: 1,
+    minSamplesPerBucket: 100,
+  });
+
+  const fifty = report.buckets.find((b) => b.bucketLabel === "50")!;
+  assertEquals(fifty.underSampled, true);
+  assertEquals(fifty.checks.length, 0);
+});
+
+Deno.test("formatTeCalibrationReport renders a human-readable summary", () => {
+  const teams: SimTeam[] = [team("t50", teRuntime("t50-te", 50))];
+  const league: CalibrationLeague = { calibrationSeed: 1, teams };
+  const simulate = (
+    { home, away, gameId }: {
+      home: SimTeam;
+      away: SimTeam;
+      seed: number;
+      gameId: string;
+    },
+  ) =>
+    makeGame(
+      gameId,
+      home.teamId,
+      away.teamId,
+      { [home.teamId]: "t50-te", [away.teamId]: "t50-te" },
+      { [home.teamId]: 7.3, [away.teamId]: 7.3 },
+    );
+
+  const report = runTeCalibration({
+    bandJson: bandJson(),
+    league,
+    simulate,
+    gameCount: 100,
+    minSamplesPerBucket: 1,
+  });
+  const output = formatTeCalibrationReport(report);
+  assertStringIncludes(output, "TE calibration");
+  assertStringIncludes(output, "bucket 50");
+  assertStringIncludes(output, "yards_per_target");
+});

--- a/server/features/simulation/calibration/per-position/te-harness.test.ts
+++ b/server/features/simulation/calibration/per-position/te-harness.test.ts
@@ -233,7 +233,10 @@ Deno.test("runTeCalibration runs the sim, buckets TEs, and returns a populated r
       gameId,
       home.teamId,
       away.teamId,
-      { [home.teamId]: `${home.teamId}-te`, [away.teamId]: `${away.teamId}-te` },
+      {
+        [home.teamId]: `${home.teamId}-te`,
+        [away.teamId]: `${away.teamId}-te`,
+      },
       {
         [home.teamId]: yptByOverall[overallByTeam[home.teamId]],
         [away.teamId]: yptByOverall[overallByTeam[away.teamId]],

--- a/server/features/simulation/calibration/per-position/te-harness.ts
+++ b/server/features/simulation/calibration/per-position/te-harness.ts
@@ -1,0 +1,174 @@
+import { deriveGameSeed } from "../../rng.ts";
+import { CALIBRATION_GAME_COUNT } from "../constants.ts";
+import { generateMatchups } from "../harness.ts";
+import type { SimulateFn } from "../harness.ts";
+import type { CalibrationLeague } from "../generate-calibration-league.ts";
+import { collectTeSamples, type TeGameSample } from "./te-sample.ts";
+import { bucketByAttr, type BucketReport } from "./bucket-by-attr.ts";
+import { type BandCheckResult, checkBand } from "./band-check.ts";
+import { loadPositionBands, type PositionBands } from "./band-loader.ts";
+
+// Headline TE receiving metrics. Catch rate + YPT are the efficiency
+// measures; YPR surfaces YAC / separation; TD rate captures red-zone
+// finishing; yards_per_game ties the per-bucket efficiency back to
+// volume-adjusted production. Rushing/blocking production is out of
+// scope for this slice — the sim attributes rush yards to the RB and
+// block grades aren't a measured NFL band today.
+export const TE_METRICS = [
+  "catch_rate",
+  "yards_per_reception",
+  "yards_per_target",
+  "td_rate",
+  "yards_per_game",
+] as const;
+
+export type TeMetric = typeof TE_METRICS[number];
+
+const METRIC_EXTRACTORS: Record<TeMetric, (s: TeGameSample) => number> = {
+  catch_rate: (s) => s.catch_rate,
+  yards_per_reception: (s) => s.yards_per_reception,
+  yards_per_target: (s) => s.yards_per_target,
+  td_rate: (s) => s.td_rate,
+  yards_per_game: (s) => s.yards_per_game,
+};
+
+export interface TeCalibrationOptions {
+  bandJson: string;
+  league: CalibrationLeague;
+  simulate: SimulateFn;
+  gameCount?: number;
+  // Minimum samples per bucket before we trust a band check. Under
+  // this count we still emit the summary but flag it as under-sampled
+  // so the report distinguishes "bucket is empty/noisy" from "bucket
+  // is calibrated wrong".
+  minSamplesPerBucket?: number;
+}
+
+export interface TeBucketReport {
+  bucketLabel: string;
+  bucketCenter: number;
+  samples: number;
+  underSampled: boolean;
+  checks: BandCheckResult[];
+}
+
+export interface TeCalibrationReport {
+  totalGames: number;
+  totalSamples: number;
+  bands: PositionBands;
+  buckets: TeBucketReport[];
+  failures: BandCheckResult[];
+  passed: boolean;
+}
+
+const DEFAULT_MIN_SAMPLES = 50;
+
+export function runTeCalibration(
+  options: TeCalibrationOptions,
+): TeCalibrationReport {
+  const {
+    bandJson,
+    league,
+    simulate,
+    gameCount = CALIBRATION_GAME_COUNT,
+    minSamplesPerBucket = DEFAULT_MIN_SAMPLES,
+  } = options;
+
+  const bands = loadPositionBands(bandJson);
+  const teamById = new Map(league.teams.map((t) => [t.teamId, t]));
+  const matchups = generateMatchups(league.teams, gameCount);
+
+  const samples: TeGameSample[] = [];
+
+  for (let i = 0; i < matchups.length; i++) {
+    const { home, away } = matchups[i];
+    const gameId = `te-calibration-game-${i}`;
+    const seed = deriveGameSeed(league.calibrationSeed, gameId);
+
+    const result = simulate({ home, away, seed, gameId });
+    const gameSamples = collectTeSamples({
+      game: result,
+      home: teamById.get(home.teamId) ?? home,
+      away: teamById.get(away.teamId) ?? away,
+    });
+    samples.push(...gameSamples);
+  }
+
+  const bucketReports: BucketReport<TeGameSample>[] = bucketByAttr({
+    samples,
+    attr: (s) => s.teOverall,
+    metrics: METRIC_EXTRACTORS,
+  });
+
+  const buckets: TeBucketReport[] = bucketReports.map((report) => {
+    const underSampled = report.samples.length < minSamplesPerBucket;
+    const checks: BandCheckResult[] = TE_METRICS.flatMap((metric) => {
+      // Don't emit band checks on under-sampled buckets — the NFL band
+      // comparison would be dominated by sampling noise and drown out
+      // the real failures from the populated buckets.
+      if (underSampled) return [];
+      return [
+        checkBand({
+          bucketLabel: report.bucket.label,
+          metricName: metric,
+          simSummary: report.metrics[metric],
+          bands,
+        }),
+      ];
+    });
+    return {
+      bucketLabel: report.bucket.label,
+      bucketCenter: report.bucket.center,
+      samples: report.samples.length,
+      underSampled,
+      checks,
+    };
+  });
+
+  const failures = buckets.flatMap((b) => b.checks.filter((c) => !c.passed));
+
+  return {
+    totalGames: matchups.length,
+    totalSamples: samples.length,
+    bands,
+    buckets,
+    failures,
+    passed: failures.length === 0,
+  };
+}
+
+export function formatTeCalibrationReport(report: TeCalibrationReport): string {
+  const lines: string[] = [];
+  lines.push(
+    `TE calibration — ${report.totalGames} games, ${report.totalSamples} TE-games`,
+  );
+  lines.push(
+    `Bands: ${report.bands.position} / ${
+      report.bands.seasons.join("-")
+    } / ranked by ${report.bands.rankingStat}`,
+  );
+  lines.push("");
+  for (const bucket of report.buckets) {
+    const header = `[bucket ${bucket.bucketLabel}] n=${bucket.samples}` +
+      (bucket.underSampled ? " (under-sampled, skipping band checks)" : "");
+    lines.push(header);
+    for (const check of bucket.checks) {
+      const verdict = check.passed ? "PASS" : "FAIL";
+      const dir = check.passed ? "" : ` (${check.direction})`;
+      lines.push(
+        `  ${verdict} ${check.metricName.padEnd(20)} ` +
+          `sim=${check.simMean.toFixed(4)}  ` +
+          `band(${check.expectedBand})=${check.bandMean.toFixed(4)}±${
+            check.bandSd.toFixed(4)
+          }  ` +
+          `z=${check.zScore.toFixed(2)}  actual=${check.actualBand}${dir}`,
+      );
+    }
+    lines.push("");
+  }
+  const passed = report.passed ? "PASS" : "FAIL";
+  lines.push(
+    `${passed}: ${report.failures.length} band check(s) missed expected band`,
+  );
+  return lines.join("\n");
+}

--- a/server/features/simulation/calibration/per-position/te-overall.ts
+++ b/server/features/simulation/calibration/per-position/te-overall.ts
@@ -1,0 +1,32 @@
+import type { PlayerAttributes } from "@zone-blitz/shared";
+
+// The five attributes we use to compute a single 0-100 "TE overall"
+// for calibration bucketing. The neutral-bucket classifier signature
+// is just `catching`, `runBlocking`, `passBlocking` (three attrs) —
+// enough to separate TEs from WRs/IOL at generation time, but too
+// narrow for calibration: two modern NFL TEs with the same catching
+// can still be leagues apart on separation/YAC.
+//
+// We add `routeRunning` (separation on routes) and `speed` (YAC and
+// vertical seam threat) so the overall tracks what actually drives
+// receiving production — the thing the NFL bands measure. Blocking is
+// kept in the mix because a pure receiver TE who can't block gets
+// scheme-limited in the real game, and the sim reflects that via
+// run_block matchups. `strength` was considered but it largely
+// duplicates the signal from runBlocking, so leaving it out keeps
+// the overall balanced 3:2 in favor of receiving.
+export const TE_OVERALL_ATTRS = [
+  "routeRunning",
+  "catching",
+  "runBlocking",
+  "passBlocking",
+  "speed",
+] as const satisfies ReadonlyArray<keyof PlayerAttributes>;
+
+export function teOverall(attributes: PlayerAttributes): number {
+  let sum = 0;
+  for (const key of TE_OVERALL_ATTRS) {
+    sum += attributes[key];
+  }
+  return sum / TE_OVERALL_ATTRS.length;
+}

--- a/server/features/simulation/calibration/per-position/te-sample.test.ts
+++ b/server/features/simulation/calibration/per-position/te-sample.test.ts
@@ -1,0 +1,409 @@
+import { assertAlmostEquals, assertEquals } from "@std/assert";
+import type { PlayerAttributes } from "@zone-blitz/shared";
+import { collectTeSamples } from "./te-sample.ts";
+import type { GameResult, PlayEvent } from "../../events.ts";
+import type { SimTeam } from "../../simulate-game.ts";
+import type { PlayerRuntime } from "../../resolve-play.ts";
+
+function attrs(overrides: Partial<PlayerAttributes> = {}): PlayerAttributes {
+  const base: Record<string, number> = {};
+  const keys = [
+    "speed",
+    "acceleration",
+    "agility",
+    "strength",
+    "jumping",
+    "stamina",
+    "durability",
+    "armStrength",
+    "accuracyShort",
+    "accuracyMedium",
+    "accuracyDeep",
+    "accuracyOnTheRun",
+    "touch",
+    "release",
+    "ballCarrying",
+    "elusiveness",
+    "routeRunning",
+    "catching",
+    "contestedCatching",
+    "runAfterCatch",
+    "passBlocking",
+    "runBlocking",
+    "blockShedding",
+    "tackling",
+    "manCoverage",
+    "zoneCoverage",
+    "passRushing",
+    "runDefense",
+    "kickingPower",
+    "kickingAccuracy",
+    "puntingPower",
+    "puntingAccuracy",
+    "snapAccuracy",
+    "footballIq",
+    "decisionMaking",
+    "anticipation",
+    "composure",
+    "clutch",
+    "consistency",
+    "workEthic",
+    "coachability",
+    "leadership",
+    "greed",
+    "loyalty",
+    "ambition",
+    "vanity",
+    "schemeAttachment",
+    "mediaSensitivity",
+  ];
+  for (const k of keys) {
+    base[k] = 50;
+    base[`${k}Potential`] = 50;
+  }
+  return { ...(base as unknown as PlayerAttributes), ...overrides };
+}
+
+function te(id: string, overall: number): PlayerRuntime {
+  return {
+    playerId: id,
+    neutralBucket: "TE",
+    attributes: attrs({
+      routeRunning: overall,
+      catching: overall,
+      runBlocking: overall,
+      passBlocking: overall,
+      speed: overall,
+    }),
+  };
+}
+
+function team(teamId: string, starterTe: PlayerRuntime): SimTeam {
+  return {
+    teamId,
+    starters: [starterTe],
+    bench: [],
+    fingerprint: { offense: null, defense: null, overrides: {} },
+    coachingMods: {
+      schemeFitBonus: 0,
+      situationalBonus: 0,
+      aggressiveness: 50,
+      penaltyDiscipline: 1,
+    },
+  };
+}
+
+function event(
+  overrides: Partial<PlayEvent> & {
+    outcome: PlayEvent["outcome"];
+    offenseTeamId: string;
+  },
+): PlayEvent {
+  return {
+    gameId: "g",
+    driveIndex: 0,
+    playIndex: 0,
+    quarter: 1,
+    clock: "15:00",
+    situation: { down: 1, distance: 10, yardLine: 25 },
+    defenseTeamId: overrides.offenseTeamId === "home" ? "away" : "home",
+    call: {
+      concept: "dropback",
+      personnel: "11",
+      formation: "shotgun",
+      motion: "none",
+    },
+    coverage: { front: "4-3", coverage: "cover_2", pressure: "four_man" },
+    participants: [],
+    yardage: 0,
+    tags: [],
+    ...overrides,
+  };
+}
+
+function gameOf(events: PlayEvent[]): GameResult {
+  return {
+    gameId: "g",
+    seed: 1,
+    finalScore: { home: 0, away: 0 },
+    events,
+    boxScore: {
+      home: {
+        totalYards: 0,
+        passingYards: 0,
+        rushingYards: 0,
+        turnovers: 0,
+        sacks: 0,
+        penalties: 0,
+      },
+      away: {
+        totalYards: 0,
+        passingYards: 0,
+        rushingYards: 0,
+        turnovers: 0,
+        sacks: 0,
+        penalties: 0,
+      },
+    },
+    driveLog: [],
+    injuryReport: [],
+  };
+}
+
+Deno.test("collectTeSamples returns one sample per team with a starter TE", () => {
+  const home = team("home", te("home-te", 50));
+  const away = team("away", te("away-te", 50));
+  const samples = collectTeSamples({
+    game: gameOf([]),
+    home,
+    away,
+  });
+  assertEquals(samples.length, 2);
+  assertEquals(samples[0].teamId, "home");
+  assertEquals(samples[0].tePlayerId, "home-te");
+  assertEquals(samples[1].teamId, "away");
+});
+
+Deno.test("collectTeSamples skips a team with no starter TE", () => {
+  const home = team("home", te("home-te", 50));
+  const away: SimTeam = { ...team("away", te("away-te", 50)), starters: [] };
+  const samples = collectTeSamples({
+    game: gameOf([]),
+    home,
+    away,
+  });
+  assertEquals(samples.length, 1);
+  assertEquals(samples[0].teamId, "home");
+});
+
+Deno.test("collectTeSamples tags sample with TE overall (mean of five signature attrs)", () => {
+  const home = team(
+    "home",
+    {
+      playerId: "home-te",
+      neutralBucket: "TE",
+      attributes: attrs({
+        routeRunning: 60,
+        catching: 70,
+        runBlocking: 80,
+        passBlocking: 50,
+        speed: 65,
+      }),
+    },
+  );
+  const away = team("away", te("away-te", 50));
+  const [homeSample] = collectTeSamples({
+    game: gameOf([]),
+    home,
+    away,
+  });
+  // (60 + 70 + 80 + 50 + 65) / 5 = 65
+  assertAlmostEquals(homeSample.teOverall, 65, 0.01);
+});
+
+Deno.test("collectTeSamples accumulates target/reception events tagged on the TE", () => {
+  const home = team("home", te("home-te", 50));
+  const away = team("away", te("away-te", 50));
+  const events: PlayEvent[] = [
+    // Reception #1 — 10 yd completion
+    event({
+      outcome: "pass_complete",
+      offenseTeamId: "home",
+      yardage: 10,
+      participants: [
+        { role: "route_coverage", playerId: "home-te", tags: ["target", "reception"] },
+      ],
+    }),
+    // Reception #2 — 15 yd completion
+    event({
+      outcome: "pass_complete",
+      offenseTeamId: "home",
+      yardage: 15,
+      participants: [
+        { role: "route_coverage", playerId: "home-te", tags: ["target", "reception"] },
+      ],
+    }),
+    // Pass to another receiver — TE not involved
+    event({
+      outcome: "pass_complete",
+      offenseTeamId: "home",
+      yardage: 20,
+      participants: [
+        { role: "route_coverage", playerId: "home-wr", tags: ["target", "reception"] },
+      ],
+    }),
+    // TD thrown to the TE — counts as target + reception + rec TD
+    event({
+      outcome: "touchdown",
+      offenseTeamId: "home",
+      yardage: 25,
+      call: {
+        concept: "deep_shot",
+        personnel: "11",
+        formation: "shotgun",
+        motion: "none",
+      },
+      participants: [
+        { role: "route_coverage", playerId: "home-te", tags: ["target", "reception"] },
+      ],
+    }),
+  ];
+  const [homeSample] = collectTeSamples({
+    game: gameOf(events),
+    home,
+    away,
+  });
+  assertEquals(homeSample.targets, 3);
+  assertEquals(homeSample.receptions, 3);
+  assertEquals(homeSample.rec_yards, 50);
+  assertEquals(homeSample.rec_tds, 1);
+  assertAlmostEquals(homeSample.catch_rate, 1);
+  assertAlmostEquals(homeSample.yards_per_reception, 50 / 3, 1e-6);
+  assertAlmostEquals(homeSample.yards_per_target, 50 / 3, 1e-6);
+  assertAlmostEquals(homeSample.td_rate, 1 / 3, 1e-6);
+  assertAlmostEquals(homeSample.yards_per_game, 50);
+});
+
+Deno.test("collectTeSamples skips run-concept TDs — they belong to the ball carrier, not the TE", () => {
+  const home = team("home", te("home-te", 50));
+  const away = team("away", te("away-te", 50));
+  const events: PlayEvent[] = [
+    event({
+      outcome: "touchdown",
+      offenseTeamId: "home",
+      yardage: 2,
+      call: {
+        concept: "inside_zone",
+        personnel: "11",
+        formation: "singleback",
+        motion: "none",
+      },
+      // Even if the TE is tagged on the play (they blocked), a run-
+      // concept TD must not be credited to the receiving line.
+      participants: [
+        { role: "run_block", playerId: "home-te", tags: ["target"] },
+      ],
+    }),
+  ];
+  const [homeSample] = collectTeSamples({
+    game: gameOf(events),
+    home,
+    away,
+  });
+  assertEquals(homeSample.targets, 0);
+  assertEquals(homeSample.receptions, 0);
+  assertEquals(homeSample.rec_tds, 0);
+});
+
+Deno.test("collectTeSamples counts incomplete + INT pass attempts as targets when tagged", () => {
+  const home = team("home", te("home-te", 50));
+  const away = team("away", te("away-te", 50));
+  const events: PlayEvent[] = [
+    event({
+      outcome: "pass_complete",
+      offenseTeamId: "home",
+      yardage: 12,
+      participants: [
+        { role: "route_coverage", playerId: "home-te", tags: ["target", "reception"] },
+      ],
+    }),
+    event({
+      outcome: "pass_incomplete",
+      offenseTeamId: "home",
+      yardage: 0,
+      participants: [
+        { role: "route_coverage", playerId: "home-te", tags: ["target"] },
+      ],
+    }),
+    event({
+      outcome: "interception",
+      offenseTeamId: "home",
+      yardage: 0,
+      participants: [
+        { role: "route_coverage", playerId: "home-te", tags: ["target"] },
+      ],
+    }),
+  ];
+  const [homeSample] = collectTeSamples({
+    game: gameOf(events),
+    home,
+    away,
+  });
+  assertEquals(homeSample.targets, 3);
+  assertEquals(homeSample.receptions, 1);
+  assertEquals(homeSample.rec_yards, 12);
+  assertAlmostEquals(homeSample.catch_rate, 1 / 3, 1e-6);
+  assertAlmostEquals(homeSample.yards_per_target, 12 / 3, 1e-6);
+});
+
+Deno.test("collectTeSamples isolates offense by team", () => {
+  const home = team("home", te("home-te", 50));
+  const away = team("away", te("away-te", 50));
+  const events: PlayEvent[] = [
+    event({
+      outcome: "pass_complete",
+      offenseTeamId: "home",
+      yardage: 8,
+      participants: [
+        { role: "route_coverage", playerId: "home-te", tags: ["target", "reception"] },
+      ],
+    }),
+    event({
+      outcome: "pass_complete",
+      offenseTeamId: "away",
+      yardage: 14,
+      participants: [
+        { role: "route_coverage", playerId: "away-te", tags: ["target", "reception"] },
+      ],
+    }),
+  ];
+  const [homeSample, awaySample] = collectTeSamples({
+    game: gameOf(events),
+    home,
+    away,
+  });
+  assertEquals(homeSample.rec_yards, 8);
+  assertEquals(awaySample.rec_yards, 14);
+});
+
+Deno.test("collectTeSamples ignores events where the TE is not the tagged target", () => {
+  const home = team("home", te("home-te", 50));
+  const away = team("away", te("away-te", 50));
+  const events: PlayEvent[] = [
+    // No participants at all — can't attribute.
+    event({ outcome: "pass_complete", offenseTeamId: "home", yardage: 30 }),
+    // TE is on the field (run block) but did NOT run the route.
+    event({
+      outcome: "pass_complete",
+      offenseTeamId: "home",
+      yardage: 12,
+      participants: [
+        { role: "route_coverage", playerId: "home-wr", tags: ["target", "reception"] },
+        { role: "pass_block", playerId: "home-te", tags: [] },
+      ],
+    }),
+  ];
+  const [homeSample] = collectTeSamples({
+    game: gameOf(events),
+    home,
+    away,
+  });
+  assertEquals(homeSample.targets, 0);
+  assertEquals(homeSample.receptions, 0);
+});
+
+Deno.test("collectTeSamples handles zero-target games without divide-by-zero", () => {
+  const home = team("home", te("home-te", 50));
+  const away = team("away", te("away-te", 50));
+  const [sample] = collectTeSamples({
+    game: gameOf([]),
+    home,
+    away,
+  });
+  assertEquals(sample.targets, 0);
+  assertEquals(sample.catch_rate, 0);
+  assertEquals(sample.yards_per_reception, 0);
+  assertEquals(sample.yards_per_target, 0);
+  assertEquals(sample.td_rate, 0);
+  assertEquals(sample.yards_per_game, 0);
+});

--- a/server/features/simulation/calibration/per-position/te-sample.test.ts
+++ b/server/features/simulation/calibration/per-position/te-sample.test.ts
@@ -211,7 +211,11 @@ Deno.test("collectTeSamples accumulates target/reception events tagged on the TE
       offenseTeamId: "home",
       yardage: 10,
       participants: [
-        { role: "route_coverage", playerId: "home-te", tags: ["target", "reception"] },
+        {
+          role: "route_coverage",
+          playerId: "home-te",
+          tags: ["target", "reception"],
+        },
       ],
     }),
     // Reception #2 — 15 yd completion
@@ -220,7 +224,11 @@ Deno.test("collectTeSamples accumulates target/reception events tagged on the TE
       offenseTeamId: "home",
       yardage: 15,
       participants: [
-        { role: "route_coverage", playerId: "home-te", tags: ["target", "reception"] },
+        {
+          role: "route_coverage",
+          playerId: "home-te",
+          tags: ["target", "reception"],
+        },
       ],
     }),
     // Pass to another receiver — TE not involved
@@ -229,7 +237,11 @@ Deno.test("collectTeSamples accumulates target/reception events tagged on the TE
       offenseTeamId: "home",
       yardage: 20,
       participants: [
-        { role: "route_coverage", playerId: "home-wr", tags: ["target", "reception"] },
+        {
+          role: "route_coverage",
+          playerId: "home-wr",
+          tags: ["target", "reception"],
+        },
       ],
     }),
     // TD thrown to the TE — counts as target + reception + rec TD
@@ -244,7 +256,11 @@ Deno.test("collectTeSamples accumulates target/reception events tagged on the TE
         motion: "none",
       },
       participants: [
-        { role: "route_coverage", playerId: "home-te", tags: ["target", "reception"] },
+        {
+          role: "route_coverage",
+          playerId: "home-te",
+          tags: ["target", "reception"],
+        },
       ],
     }),
   ];
@@ -304,7 +320,11 @@ Deno.test("collectTeSamples counts incomplete + INT pass attempts as targets whe
       offenseTeamId: "home",
       yardage: 12,
       participants: [
-        { role: "route_coverage", playerId: "home-te", tags: ["target", "reception"] },
+        {
+          role: "route_coverage",
+          playerId: "home-te",
+          tags: ["target", "reception"],
+        },
       ],
     }),
     event({
@@ -345,7 +365,11 @@ Deno.test("collectTeSamples isolates offense by team", () => {
       offenseTeamId: "home",
       yardage: 8,
       participants: [
-        { role: "route_coverage", playerId: "home-te", tags: ["target", "reception"] },
+        {
+          role: "route_coverage",
+          playerId: "home-te",
+          tags: ["target", "reception"],
+        },
       ],
     }),
     event({
@@ -353,7 +377,11 @@ Deno.test("collectTeSamples isolates offense by team", () => {
       offenseTeamId: "away",
       yardage: 14,
       participants: [
-        { role: "route_coverage", playerId: "away-te", tags: ["target", "reception"] },
+        {
+          role: "route_coverage",
+          playerId: "away-te",
+          tags: ["target", "reception"],
+        },
       ],
     }),
   ];
@@ -378,7 +406,11 @@ Deno.test("collectTeSamples ignores events where the TE is not the tagged target
       offenseTeamId: "home",
       yardage: 12,
       participants: [
-        { role: "route_coverage", playerId: "home-wr", tags: ["target", "reception"] },
+        {
+          role: "route_coverage",
+          playerId: "home-wr",
+          tags: ["target", "reception"],
+        },
         { role: "pass_block", playerId: "home-te", tags: [] },
       ],
     }),

--- a/server/features/simulation/calibration/per-position/te-sample.ts
+++ b/server/features/simulation/calibration/per-position/te-sample.ts
@@ -1,0 +1,136 @@
+import type { GameResult, PlayEvent } from "../../events.ts";
+import type { SimTeam } from "../../simulate-game.ts";
+import { teOverall } from "./te-overall.ts";
+
+export interface TeGameSample {
+  teamId: string;
+  tePlayerId: string;
+  teOverall: number;
+  targets: number;
+  receptions: number;
+  rec_yards: number;
+  rec_tds: number;
+  catch_rate: number;
+  yards_per_reception: number;
+  yards_per_target: number;
+  td_rate: number;
+  yards_per_game: number;
+}
+
+const RUN_CONCEPTS = new Set([
+  "inside_zone",
+  "outside_zone",
+  "power",
+  "counter",
+  "draw",
+  "rpo",
+]);
+
+function accumulate(
+  events: PlayEvent[],
+  teamId: string,
+  tePlayerId: string,
+) {
+  let targets = 0;
+  let receptions = 0;
+  let recYards = 0;
+  let recTds = 0;
+
+  for (const event of events) {
+    if (event.offenseTeamId !== teamId) continue;
+    if (RUN_CONCEPTS.has(event.call.concept)) continue;
+
+    const participant = event.participants.find(
+      (p) => p.playerId === tePlayerId && p.tags.includes("target"),
+    );
+    if (!participant) continue;
+
+    switch (event.outcome) {
+      case "pass_complete":
+        targets++;
+        receptions++;
+        recYards += event.yardage;
+        break;
+      case "touchdown":
+        // A pass-concept TD's participant carries both "target" and
+        // "reception" tags (pass_complete gets upgraded to touchdown
+        // in `resolve-play.ts`). Count it as a target + reception
+        // worth the event yardage, with a receiving TD credited to
+        // the TE.
+        targets++;
+        receptions++;
+        recYards += event.yardage;
+        recTds++;
+        break;
+      case "pass_incomplete":
+        // Engine tags the intended target even on incompletions via
+        // the `target` tag at the pass-outcome layer; we still count
+        // it as a target, but no reception / yards.
+        targets++;
+        break;
+      case "interception":
+        // An INT on a pass aimed at the TE also counts as a target
+        // (it was their route) with zero yards — mirrors how NFL
+        // target counts work for receivers.
+        targets++;
+        break;
+    }
+  }
+
+  // NOTE / gap: the engine currently tags "target" on pass_complete
+  // and upgraded-to-touchdown outcomes (see `synthesize-pass-outcome.ts`).
+  // Pass_incomplete and interception outcomes do NOT carry a `target`
+  // tag today, so those branches above will almost never fire — the
+  // TE calibration effectively measures catch rate as ~100% on the
+  // subset of plays that were flagged as TE receptions. Fixing this
+  // without touching shared engine code is out of scope for this
+  // slice; the calibration report will surface the mismatch against
+  // NFL catch-rate bands (~0.62–0.77) and we'll file a follow-up to
+  // teach the engine to tag the intended target on every pass play.
+  return {
+    targets,
+    receptions,
+    rec_yards: recYards,
+    rec_tds: recTds,
+    catch_rate: targets > 0 ? receptions / targets : 0,
+    yards_per_reception: receptions > 0 ? recYards / receptions : 0,
+    yards_per_target: targets > 0 ? recYards / targets : 0,
+    td_rate: targets > 0 ? recTds / targets : 0,
+    // One sample covers a single game, so yards_per_game is simply
+    // the receiving yardage for this game — keeps the metric name
+    // aligned with the NFL band fixture so bucket means are
+    // directly comparable.
+    yards_per_game: recYards,
+  };
+}
+
+export interface TeSampleInput {
+  game: GameResult;
+  home: SimTeam;
+  away: SimTeam;
+}
+
+// Attribute a team-game's TE receiving stats to the team's starter
+// TE. Real offenses rotate multiple TEs in 12/13-personnel packages,
+// but the calibration league's starter TE takes every TE route of
+// consequence — and calibration injuries are rare enough that backups
+// don't meaningfully shift per-bucket means. If a team starts no TE
+// (nominally one-TE personnel only), we skip it.
+export function collectTeSamples(input: TeSampleInput): TeGameSample[] {
+  const { game, home, away } = input;
+
+  const samples: TeGameSample[] = [];
+  for (const team of [home, away]) {
+    const te = team.starters.find((p) => p.neutralBucket === "TE");
+    if (!te) continue;
+
+    const stats = accumulate(game.events, team.teamId, te.playerId);
+    samples.push({
+      teamId: team.teamId,
+      tePlayerId: te.playerId,
+      teOverall: teOverall(te.attributes),
+      ...stats,
+    });
+  }
+  return samples;
+}


### PR DESCRIPTION
## Summary

Mirrors the QB/RB slices (#497/#500) for tight ends. Tags every sim TE-game with the starter's "overall" (mean of `routeRunning`, `catching`, `runBlocking`, `passBlocking`, `speed`), buckets samples into 10-point bands, and compares each bucket's `catch_rate` / `yards_per_reception` / `yards_per_target` / `td_rate` / `yards_per_game` to NFL TE percentile bands derived from nflreadr (2020-2024 starter seasons, targets >= 30, ranked by receiving EPA/target).

- `data/R/bands/per-position-te.R` + `data/bands/per-position/te.json` generate and store the NFL reference bands.
- `server/features/simulation/calibration/per-position/` gains `te-overall`, `te-sample`, `te-harness`, `run-te-calibration` with unit tests. Shared `bucket-by-attr`, `band-loader`, `band-check` modules are reused unchanged.
- `deno task sim:calibrate:te` runs the harness across every calibration seed. Report-only per #496 — gating comes later once per-bucket noise is understood.

## Notes

Running the harness against the live engine surfaces real calibration gaps that team-game aggregates were hiding:

- **TE catch rate** runs **0.43-0.60** in the sim vs. NFL **0.62-0.77** across every band — the engine is badly under-completing to TEs.
- **YPT / YPR** trail NFL by 3-5 yards at every bucket (elite sim ~7-8 YPR vs. NFL elite ~12.6), suggesting TEs aren't being targeted in-rhythm and rarely pick up YAC.
- **Yards-per-game** lands at roughly **50%** of NFL across most buckets — TEs aren't absorbing enough of the passing workload.
- **30-overall bucket** is empty or under-sampled across every seed (the generator's TE overall distribution sits above 35); **80-bucket** volume is also thin.

Engine-side gap worth flagging: `synthesize-pass-outcome.ts` only tags the `target` participant on `pass_complete` and upgraded-to-touchdown outcomes. `pass_incomplete` and `interception` outcomes don't carry a target tag today, so TE target counts under-count attempts and catch-rate measurements are biased high on the tagged subset. Teaching the engine to tag the intended target on every pass play is a prerequisite for measuring true receiver catch rate — will file as a follow-up issue.