### PR TITLE
feat(calibration): add per-WR-bucket calibration harness (#496, WR slice)

### DIFF
--- a/data/R/bands/per-position-wr.R
+++ b/data/R/bands/per-position-wr.R
@@ -1,0 +1,143 @@
+#!/usr/bin/env Rscript
+# per-position-wr.R — NFL WR percentile-band reference.
+#
+# Pulls weekly WR stats from load_player_stats, aggregates to per-WR-season
+# lines, filters to starters (season targets >= 60), ranks by receiving
+# EPA/play (receiving_epa / targets), and carves the population into five
+# percentile bands (elite / good / average / weak / replacement). For each
+# band, reports mean + sd + n on the headline WR metrics tracked by the
+# sim.
+#
+# Output: data/bands/per-position/wr.json
+#
+# Usage:
+#   Rscript data/R/bands/per-position-wr.R [--seasons 2020:2024]
+
+suppressPackageStartupMessages({
+  library(nflreadr)
+  library(dplyr)
+})
+
+script_file <- (function() {
+  args <- commandArgs(trailingOnly = FALSE)
+  f <- grep("^--file=", args, value = TRUE)
+  if (length(f) > 0) normalizePath(sub("^--file=", "", f[1]), mustWork = FALSE) else NULL
+})()
+source(file.path(dirname(script_file), "..", "lib.R"))
+
+args <- commandArgs(trailingOnly = TRUE)
+seasons <- parse_seasons(args)
+
+cat("Loading weekly player stats for seasons:",
+    paste(range(seasons), collapse = "-"), "\n")
+
+weekly <- nflreadr::load_player_stats(seasons, stat_type = "offense")
+
+wr_weekly <- weekly |>
+  filter(season_type == "REG", position == "WR", targets > 0)
+
+# Aggregate weekly rows into per-WR-season totals. The sim samples on a
+# per-game cadence and then rolls up to per-bucket means, so the NFL
+# reference also lives at the per-season grain: season rates + per-game
+# averages are stable enough to rank WRs cleanly against each other.
+wr_season <- wr_weekly |>
+  group_by(player_id, player_display_name, season) |>
+  summarise(
+    games       = n(),
+    targets     = sum(targets, na.rm = TRUE),
+    receptions  = sum(receptions, na.rm = TRUE),
+    rec_yards   = sum(receiving_yards, na.rm = TRUE),
+    rec_tds     = sum(receiving_tds, na.rm = TRUE),
+    epa_total   = sum(receiving_epa, na.rm = TRUE),
+    .groups     = "drop"
+  ) |>
+  mutate(
+    catch_rate         = ifelse(targets > 0, receptions / targets, NA_real_),
+    yards_per_reception = ifelse(receptions > 0, rec_yards / receptions, NA_real_),
+    yards_per_target   = ifelse(targets > 0, rec_yards / targets, NA_real_),
+    td_rate            = ifelse(targets > 0, rec_tds / targets, NA_real_),
+    yards_per_game     = ifelse(games > 0, rec_yards / games, NA_real_),
+    epa_per_play       = ifelse(targets > 0, epa_total / targets, NA_real_)
+  ) |>
+  filter(targets >= 60) # starter threshold: ~4 targets/game across the season
+
+cat("WR-seasons after starter filter:", nrow(wr_season), "\n")
+
+# Rank by EPA/play and assign percentile bands on the filtered starter
+# population. Bands follow the scheme from issue #496: top 10% elite,
+# next 20% good, middle 40% average, next 20% weak, bottom 10% replacement.
+wr_ranked <- wr_season |>
+  arrange(desc(epa_per_play)) |>
+  mutate(
+    pct = (row_number() - 0.5) / n(),
+    band = case_when(
+      pct <= 0.10 ~ "elite",
+      pct <= 0.30 ~ "good",
+      pct <= 0.70 ~ "average",
+      pct <= 0.90 ~ "weak",
+      TRUE        ~ "replacement"
+    )
+  )
+
+metric_keys <- c(
+  "catch_rate",
+  "yards_per_reception",
+  "yards_per_target",
+  "td_rate",
+  "yards_per_game"
+)
+
+band_order <- c("elite", "good", "average", "weak", "replacement")
+
+band_summary <- function(rows) {
+  metrics <- list()
+  for (key in metric_keys) {
+    vals <- rows[[key]]
+    vals <- vals[!is.na(vals)]
+    metrics[[key]] <- list(
+      n = length(vals),
+      mean = mean(vals),
+      sd = stats::sd(vals)
+    )
+  }
+  list(
+    n = nrow(rows),
+    metrics = metrics
+  )
+}
+
+bands <- list()
+for (band_name in band_order) {
+  rows <- wr_ranked |> filter(band == band_name)
+  bands[[band_name]] <- band_summary(rows)
+}
+
+out <- list(
+  generated_at = format(Sys.time(), "%Y-%m-%dT%H:%M:%SZ", tz = "UTC"),
+  seasons = as.integer(seasons),
+  position = "WR",
+  qualifier = "regular-season WR-seasons with >=60 targets",
+  ranking_stat = "epa_per_play (receiving EPA / targets)",
+  notes = paste0(
+    "Starter WR-seasons 2020-2024, ranked by receiving EPA/play then ",
+    "carved into percentile bands (elite: top 10%, good: 10-30%, average: ",
+    "30-70%, weak: 70-90%, replacement: bottom 10%). Each band reports ",
+    "mean+sd per metric across the WR-seasons in that band. catch_rate, ",
+    "yards_per_target, and td_rate use targets as denominator; ",
+    "yards_per_reception uses receptions; yards_per_game uses games ",
+    "played. Rushing production is intentionally excluded from the ",
+    "ranking stat -- the sim's WR attribution covers passing targets only."
+  ),
+  bands = bands
+)
+
+out_path <- file.path(
+  repo_root(), "data", "bands", "per-position", "wr.json"
+)
+dir.create(dirname(out_path), recursive = TRUE, showWarnings = FALSE)
+writeLines(
+  jsonlite::toJSON(out, auto_unbox = TRUE, pretty = TRUE, digits = 4,
+                   null = "null"),
+  out_path
+)
+cat("Wrote", out_path, "\n")

--- a/data/bands/per-position/wr.json
+++ b/data/bands/per-position/wr.json
@@ -1,0 +1,160 @@
+{
+  "generated_at": "2026-04-17T12:28:18Z",
+  "seasons": [2020, 2021, 2022, 2023, 2024],
+  "position": "WR",
+  "qualifier": "regular-season WR-seasons with >=60 targets",
+  "ranking_stat": "epa_per_play (receiving EPA / targets)",
+  "notes": "Starter WR-seasons 2020-2024, ranked by receiving EPA/play then carved into percentile bands (elite: top 10%, good: 10-30%, average: 30-70%, weak: 70-90%, replacement: bottom 10%). Each band reports mean+sd per metric across the WR-seasons in that band. catch_rate, yards_per_target, and td_rate use targets as denominator; yards_per_reception uses receptions; yards_per_game uses games played. Rushing production is intentionally excluded from the ranking stat -- the sim's WR attribution covers passing targets only.",
+  "bands": {
+    "elite": {
+      "n": 36,
+      "metrics": {
+        "catch_rate": {
+          "n": 36,
+          "mean": 0.7096,
+          "sd": 0.0597
+        },
+        "yards_per_reception": {
+          "n": 36,
+          "mean": 14.3568,
+          "sd": 2.2915
+        },
+        "yards_per_target": {
+          "n": 36,
+          "mean": 10.0977,
+          "sd": 1.1604
+        },
+        "td_rate": {
+          "n": 36,
+          "mean": 0.0836,
+          "sd": 0.0248
+        },
+        "yards_per_game": {
+          "n": 36,
+          "mean": 71.8916,
+          "sd": 19.5012
+        }
+      }
+    },
+    "good": {
+      "n": 73,
+      "metrics": {
+        "catch_rate": {
+          "n": 73,
+          "mean": 0.6752,
+          "sd": 0.0564
+        },
+        "yards_per_reception": {
+          "n": 73,
+          "mean": 13.7416,
+          "sd": 2.058
+        },
+        "yards_per_target": {
+          "n": 73,
+          "mean": 9.1934,
+          "sd": 0.9342
+        },
+        "td_rate": {
+          "n": 73,
+          "mean": 0.0614,
+          "sd": 0.0243
+        },
+        "yards_per_game": {
+          "n": 73,
+          "mean": 66.3304,
+          "sd": 18.7635
+        }
+      }
+    },
+    "average": {
+      "n": 144,
+      "metrics": {
+        "catch_rate": {
+          "n": 144,
+          "mean": 0.6405,
+          "sd": 0.0664
+        },
+        "yards_per_reception": {
+          "n": 144,
+          "mean": 12.9177,
+          "sd": 2.0636
+        },
+        "yards_per_target": {
+          "n": 144,
+          "mean": 8.1728,
+          "sd": 0.8858
+        },
+        "td_rate": {
+          "n": 144,
+          "mean": 0.0499,
+          "sd": 0.0253
+        },
+        "yards_per_game": {
+          "n": 144,
+          "mean": 55.0046,
+          "sd": 14.9186
+        }
+      }
+    },
+    "weak": {
+      "n": 73,
+      "metrics": {
+        "catch_rate": {
+          "n": 73,
+          "mean": 0.6251,
+          "sd": 0.066
+        },
+        "yards_per_reception": {
+          "n": 73,
+          "mean": 11.7405,
+          "sd": 1.8986
+        },
+        "yards_per_target": {
+          "n": 73,
+          "mean": 7.2543,
+          "sd": 0.8143
+        },
+        "td_rate": {
+          "n": 73,
+          "mean": 0.0395,
+          "sd": 0.0186
+        },
+        "yards_per_game": {
+          "n": 73,
+          "mean": 48.0896,
+          "sd": 14.564
+        }
+      }
+    },
+    "replacement": {
+      "n": 36,
+      "metrics": {
+        "catch_rate": {
+          "n": 36,
+          "mean": 0.5734,
+          "sd": 0.0667
+        },
+        "yards_per_reception": {
+          "n": 36,
+          "mean": 10.8055,
+          "sd": 1.9283
+        },
+        "yards_per_target": {
+          "n": 36,
+          "mean": 6.1266,
+          "sd": 0.892
+        },
+        "td_rate": {
+          "n": 36,
+          "mean": 0.0257,
+          "sd": 0.0188
+        },
+        "yards_per_game": {
+          "n": 36,
+          "mean": 36.9551,
+          "sd": 11.5272
+        }
+      }
+    }
+  }
+}

--- a/deno.json
+++ b/deno.json
@@ -37,6 +37,7 @@
     "sim:calibrate:qb": "deno run --allow-read server/features/simulation/calibration/per-position/run-qb-calibration.ts",
     "sim:calibrate:rb": "deno run --allow-read server/features/simulation/calibration/per-position/run-rb-calibration.ts",
     "sim:calibrate:te": "deno run --allow-read server/features/simulation/calibration/per-position/run-te-calibration.ts",
+    "sim:calibrate:wr": "deno run --allow-read server/features/simulation/calibration/per-position/run-wr-calibration.ts",
     "build": "cd client && deno task build",
     "start": "cd server && deno run --env=../.env --allow-net --allow-env --allow-read --allow-sys main.ts"
   },

--- a/server/features/simulation/calibration/per-position/run-wr-calibration.ts
+++ b/server/features/simulation/calibration/per-position/run-wr-calibration.ts
@@ -1,0 +1,61 @@
+import { simulateGame } from "../../simulate-game.ts";
+import { generateCalibrationLeague } from "../generate-calibration-league.ts";
+import { CALIBRATION_SEEDS } from "../calibration-seeds.ts";
+import { formatWrCalibrationReport, runWrCalibration } from "./wr-harness.ts";
+
+// Per-issue-#496: report-only across every calibration seed so a human
+// can read the per-bucket PASS/FAIL signal against NFL WR percentile
+// bands. Gating will come later once we understand per-bucket noise.
+const bandPath = new URL(
+  "../../../../../data/bands/per-position/wr.json",
+  import.meta.url,
+);
+
+const bandJson = await Deno.readTextFile(bandPath);
+
+let allPassed = true;
+const summary: {
+  seed: number;
+  passed: number;
+  total: number;
+  underSampled: number;
+}[] = [];
+
+for (const seed of CALIBRATION_SEEDS) {
+  const league = generateCalibrationLeague({ seed });
+  const report = runWrCalibration({
+    bandJson,
+    league,
+    simulate: simulateGame,
+  });
+
+  console.log(`=== seed=0x${seed.toString(16)} ===`);
+  console.log(formatWrCalibrationReport(report));
+  console.log("");
+
+  const totalChecks = report.buckets.reduce(
+    (sum, b) => sum + b.checks.length,
+    0,
+  );
+  const passCount = totalChecks - report.failures.length;
+  const underSampled = report.buckets.filter((b) => b.underSampled).length;
+  summary.push({ seed, passed: passCount, total: totalChecks, underSampled });
+  if (!report.passed) allPassed = false;
+}
+
+console.log("=== Multi-seed summary ===");
+for (const row of summary) {
+  const status = row.passed === row.total ? "PASS" : "FAIL";
+  const underSampledNote = row.underSampled > 0
+    ? ` (${row.underSampled} bucket(s) under-sampled)`
+    : "";
+  console.log(
+    `${status} seed=0x${
+      row.seed.toString(16)
+    }: ${row.passed}/${row.total}${underSampledNote}`,
+  );
+}
+
+if (!allPassed) {
+  Deno.exit(1);
+}

--- a/server/features/simulation/calibration/per-position/wr-harness.test.ts
+++ b/server/features/simulation/calibration/per-position/wr-harness.test.ts
@@ -1,0 +1,367 @@
+import { assertEquals, assertStringIncludes } from "@std/assert";
+import type { PlayerAttributes } from "@zone-blitz/shared";
+import { formatWrCalibrationReport, runWrCalibration } from "./wr-harness.ts";
+import type { GameResult, PlayEvent } from "../../events.ts";
+import type { SimTeam } from "../../simulate-game.ts";
+import type { PlayerRuntime } from "../../resolve-play.ts";
+import type { CalibrationLeague } from "../generate-calibration-league.ts";
+
+function attrs(overrides: Partial<PlayerAttributes> = {}): PlayerAttributes {
+  const base: Record<string, number> = {};
+  const keys = [
+    "speed",
+    "acceleration",
+    "agility",
+    "strength",
+    "jumping",
+    "stamina",
+    "durability",
+    "armStrength",
+    "accuracyShort",
+    "accuracyMedium",
+    "accuracyDeep",
+    "accuracyOnTheRun",
+    "touch",
+    "release",
+    "ballCarrying",
+    "elusiveness",
+    "routeRunning",
+    "catching",
+    "contestedCatching",
+    "runAfterCatch",
+    "passBlocking",
+    "runBlocking",
+    "blockShedding",
+    "tackling",
+    "manCoverage",
+    "zoneCoverage",
+    "passRushing",
+    "runDefense",
+    "kickingPower",
+    "kickingAccuracy",
+    "puntingPower",
+    "puntingAccuracy",
+    "snapAccuracy",
+    "footballIq",
+    "decisionMaking",
+    "anticipation",
+    "composure",
+    "clutch",
+    "consistency",
+    "workEthic",
+    "coachability",
+    "leadership",
+    "greed",
+    "loyalty",
+    "ambition",
+    "vanity",
+    "schemeAttachment",
+    "mediaSensitivity",
+  ];
+  for (const k of keys) {
+    base[k] = 50;
+    base[`${k}Potential`] = 50;
+  }
+  return { ...(base as unknown as PlayerAttributes), ...overrides };
+}
+
+function wrRuntime(id: string, overall: number): PlayerRuntime {
+  return {
+    playerId: id,
+    neutralBucket: "WR",
+    attributes: attrs({
+      routeRunning: overall,
+      catching: overall,
+      speed: overall,
+      release: overall,
+    }),
+  };
+}
+
+function team(teamId: string, starterWr: PlayerRuntime): SimTeam {
+  // Single-WR teams keep the harness test deterministic: every team's
+  // pass allocation lands on its one starter WR at a known overall.
+  return {
+    teamId,
+    starters: [starterWr],
+    bench: [],
+    fingerprint: { offense: null, defense: null, overrides: {} },
+    coachingMods: {
+      schemeFitBonus: 0,
+      situationalBonus: 0,
+      aggressiveness: 50,
+      penaltyDiscipline: 1,
+    },
+  };
+}
+
+function bandJson(): string {
+  // NFL-shaped bands — elite WRs catch a higher share of their targets
+  // at more yards-per-target and TD%, replacement WRs catch fewer.
+  // yards_per_game scales with yards_per_target for the stub.
+  const band = (catchRate: number, ypt: number, tdRate: number) => ({
+    n: 20,
+    metrics: {
+      catch_rate: { n: 20, mean: catchRate, sd: 0.05 },
+      yards_per_reception: { n: 20, mean: ypt / catchRate, sd: 1.5 },
+      yards_per_target: { n: 20, mean: ypt, sd: 0.8 },
+      td_rate: { n: 20, mean: tdRate, sd: 0.015 },
+      yards_per_game: { n: 20, mean: ypt * 9, sd: 15 },
+    },
+  });
+  return JSON.stringify({
+    position: "WR",
+    seasons: [2020, 2021, 2022, 2023, 2024],
+    ranking_stat: "epa_per_play",
+    bands: {
+      elite: band(0.71, 10.1, 0.084),
+      good: band(0.68, 9.4, 0.063),
+      average: band(0.65, 8.3, 0.048),
+      weak: band(0.62, 7.2, 0.035),
+      replacement: band(0.58, 6.5, 0.028),
+    },
+  });
+}
+
+function makeGame(
+  gameId: string,
+  homeTeamId: string,
+  awayTeamId: string,
+  profile: Record<string, { catchRate: number; ypt: number; tdRate: number }>,
+): GameResult {
+  // Synthesize exactly 50 passing events per team so the sim matches
+  // the target profile with integer counts: receptions = round(50 *
+  // catchRate), of which round(50 * tdRate) are TDs.
+  const events: PlayEvent[] = [];
+  const TARGETS = 50;
+  for (const [offenseTeamId, p] of Object.entries(profile)) {
+    const defenseTeamId = offenseTeamId === homeTeamId
+      ? awayTeamId
+      : homeTeamId;
+    const receptions = Math.round(TARGETS * p.catchRate);
+    const tds = Math.round(TARGETS * p.tdRate);
+    const regularCompletions = receptions - tds;
+    const incompletes = TARGETS - receptions;
+    // Each reception gains ypt * targets / receptions yards so the
+    // per-target average matches the profile exactly.
+    const yardsPerReception = (p.ypt * TARGETS) / receptions;
+
+    for (let i = 0; i < regularCompletions; i++) {
+      events.push({
+        gameId,
+        driveIndex: 0,
+        playIndex: events.length,
+        quarter: 1,
+        clock: "15:00",
+        situation: { down: 1, distance: 10, yardLine: 25 },
+        offenseTeamId,
+        defenseTeamId,
+        call: {
+          concept: "dropback",
+          personnel: "11",
+          formation: "shotgun",
+          motion: "none",
+        },
+        coverage: { front: "4-3", coverage: "cover_2", pressure: "four_man" },
+        participants: [],
+        outcome: "pass_complete",
+        yardage: yardsPerReception,
+        tags: [],
+      });
+    }
+    for (let i = 0; i < tds; i++) {
+      events.push({
+        gameId,
+        driveIndex: 0,
+        playIndex: events.length,
+        quarter: 1,
+        clock: "15:00",
+        situation: { down: 1, distance: 10, yardLine: 25 },
+        offenseTeamId,
+        defenseTeamId,
+        call: {
+          concept: "dropback",
+          personnel: "11",
+          formation: "shotgun",
+          motion: "none",
+        },
+        coverage: { front: "4-3", coverage: "cover_2", pressure: "four_man" },
+        participants: [],
+        outcome: "touchdown",
+        yardage: yardsPerReception,
+        tags: [],
+      });
+    }
+    for (let i = 0; i < incompletes; i++) {
+      events.push({
+        gameId,
+        driveIndex: 0,
+        playIndex: events.length,
+        quarter: 1,
+        clock: "15:00",
+        situation: { down: 1, distance: 10, yardLine: 25 },
+        offenseTeamId,
+        defenseTeamId,
+        call: {
+          concept: "dropback",
+          personnel: "11",
+          formation: "shotgun",
+          motion: "none",
+        },
+        coverage: { front: "4-3", coverage: "cover_2", pressure: "four_man" },
+        participants: [],
+        outcome: "pass_incomplete",
+        yardage: 0,
+        tags: [],
+      });
+    }
+  }
+  return {
+    gameId,
+    seed: 1,
+    finalScore: { home: 0, away: 0 },
+    events,
+    boxScore: {
+      home: {
+        totalYards: 0,
+        passingYards: 0,
+        rushingYards: 0,
+        turnovers: 0,
+        sacks: 0,
+        penalties: 0,
+      },
+      away: {
+        totalYards: 0,
+        passingYards: 0,
+        rushingYards: 0,
+        turnovers: 0,
+        sacks: 0,
+        penalties: 0,
+      },
+    },
+    driveLog: [],
+    injuryReport: [],
+  };
+}
+
+Deno.test("runWrCalibration runs the sim, buckets WRs, and returns a populated report", () => {
+  // Build a league where each team's starter WR is at a different
+  // overall, giving us one team per bucket. The stub simulate maps
+  // each team's pass profile directly to its WR overall so every
+  // bucket lands in its target band.
+  const overallByTeam: Record<string, number> = {
+    "t30": 30,
+    "t40": 40,
+    "t50": 50,
+    "t60": 60,
+    "t70": 70,
+    "t80": 80,
+  };
+  const profileByOverall: Record<
+    number,
+    { catchRate: number; ypt: number; tdRate: number }
+  > = {
+    30: { catchRate: 0.58, ypt: 6.5, tdRate: 0.028 },
+    40: { catchRate: 0.62, ypt: 7.2, tdRate: 0.035 },
+    50: { catchRate: 0.65, ypt: 8.3, tdRate: 0.048 },
+    60: { catchRate: 0.68, ypt: 9.4, tdRate: 0.063 },
+    70: { catchRate: 0.71, ypt: 10.1, tdRate: 0.084 },
+    80: { catchRate: 0.71, ypt: 10.1, tdRate: 0.084 },
+  };
+
+  const teams: SimTeam[] = Object.entries(overallByTeam).map(([id, o]) =>
+    team(id, wrRuntime(`${id}-wr`, o))
+  );
+  const league: CalibrationLeague = { calibrationSeed: 1, teams };
+
+  let gameCount = 0;
+  const simulate = ({ home, away, gameId }: {
+    home: SimTeam;
+    away: SimTeam;
+    seed: number;
+    gameId: string;
+  }): GameResult => {
+    gameCount++;
+    return makeGame(gameId, home.teamId, away.teamId, {
+      [home.teamId]: profileByOverall[overallByTeam[home.teamId]],
+      [away.teamId]: profileByOverall[overallByTeam[away.teamId]],
+    });
+  };
+
+  const report = runWrCalibration({
+    bandJson: bandJson(),
+    league,
+    simulate,
+    gameCount: teams.length * 12,
+    minSamplesPerBucket: 5,
+  });
+
+  assertEquals(report.totalGames, teams.length * 12);
+  // Each matchup produces 2 samples (home + away starter WR).
+  assertEquals(report.totalSamples, gameCount * 2);
+
+  const fifty = report.buckets.find((b) => b.bucketLabel === "50")!;
+  assertEquals(fifty.samples > 0, true);
+  assertEquals(fifty.underSampled, false);
+  assertEquals(fifty.checks.length > 0, true);
+  const catchCheck = fifty.checks.find((c) => c.metricName === "catch_rate")!;
+  assertEquals(catchCheck.passed, true);
+});
+
+Deno.test("runWrCalibration marks a bucket under-sampled when below min threshold", () => {
+  const teams: SimTeam[] = [team("t50", wrRuntime("t50-wr", 50))];
+  const league: CalibrationLeague = { calibrationSeed: 1, teams };
+  const simulate = (
+    { home, away, gameId }: {
+      home: SimTeam;
+      away: SimTeam;
+      seed: number;
+      gameId: string;
+    },
+  ) =>
+    makeGame(gameId, home.teamId, away.teamId, {
+      [home.teamId]: { catchRate: 0.65, ypt: 8.3, tdRate: 0.048 },
+      [away.teamId]: { catchRate: 0.65, ypt: 8.3, tdRate: 0.048 },
+    });
+
+  const report = runWrCalibration({
+    bandJson: bandJson(),
+    league,
+    simulate,
+    gameCount: 1,
+    minSamplesPerBucket: 100,
+  });
+
+  const fifty = report.buckets.find((b) => b.bucketLabel === "50")!;
+  assertEquals(fifty.underSampled, true);
+  assertEquals(fifty.checks.length, 0);
+});
+
+Deno.test("formatWrCalibrationReport renders a human-readable summary", () => {
+  const teams: SimTeam[] = [team("t50", wrRuntime("t50-wr", 50))];
+  const league: CalibrationLeague = { calibrationSeed: 1, teams };
+  const simulate = (
+    { home, away, gameId }: {
+      home: SimTeam;
+      away: SimTeam;
+      seed: number;
+      gameId: string;
+    },
+  ) =>
+    makeGame(gameId, home.teamId, away.teamId, {
+      [home.teamId]: { catchRate: 0.65, ypt: 8.3, tdRate: 0.048 },
+      [away.teamId]: { catchRate: 0.65, ypt: 8.3, tdRate: 0.048 },
+    });
+
+  const report = runWrCalibration({
+    bandJson: bandJson(),
+    league,
+    simulate,
+    gameCount: 100,
+    minSamplesPerBucket: 1,
+  });
+  const output = formatWrCalibrationReport(report);
+  assertStringIncludes(output, "WR calibration");
+  assertStringIncludes(output, "bucket 50");
+  assertStringIncludes(output, "catch_rate");
+});

--- a/server/features/simulation/calibration/per-position/wr-harness.ts
+++ b/server/features/simulation/calibration/per-position/wr-harness.ts
@@ -1,0 +1,174 @@
+import { deriveGameSeed } from "../../rng.ts";
+import { CALIBRATION_GAME_COUNT } from "../constants.ts";
+import { generateMatchups } from "../harness.ts";
+import type { SimulateFn } from "../harness.ts";
+import type { CalibrationLeague } from "../generate-calibration-league.ts";
+import { collectWrSamples, type WrGameSample } from "./wr-sample.ts";
+import { bucketByAttr, type BucketReport } from "./bucket-by-attr.ts";
+import { type BandCheckResult, checkBand } from "./band-check.ts";
+import { loadPositionBands, type PositionBands } from "./band-loader.ts";
+
+// Headline WR metrics. catch_rate + yards_per_target are the two
+// stat-line stats that move with WR quality at the season level;
+// yards_per_reception captures the separation/after-the-catch piece;
+// td_rate surfaces the red-zone finishing dimension; yards_per_game
+// gives a volume proxy that cross-checks target-share allocation
+// against NFL per-game receiving output.
+export const WR_METRICS = [
+  "catch_rate",
+  "yards_per_reception",
+  "yards_per_target",
+  "td_rate",
+  "yards_per_game",
+] as const;
+
+export type WrMetric = typeof WR_METRICS[number];
+
+const METRIC_EXTRACTORS: Record<WrMetric, (s: WrGameSample) => number> = {
+  catch_rate: (s) => s.catch_rate,
+  yards_per_reception: (s) => s.yards_per_reception,
+  yards_per_target: (s) => s.yards_per_target,
+  td_rate: (s) => s.td_rate,
+  yards_per_game: (s) => s.yards_per_game,
+};
+
+export interface WrCalibrationOptions {
+  bandJson: string;
+  league: CalibrationLeague;
+  simulate: SimulateFn;
+  gameCount?: number;
+  // Minimum samples per bucket before we trust a band check. Under
+  // this count we still emit the summary but flag it as under-sampled
+  // so the report distinguishes "bucket is empty/noisy" from "bucket
+  // is calibrated wrong".
+  minSamplesPerBucket?: number;
+}
+
+export interface WrBucketReport {
+  bucketLabel: string;
+  bucketCenter: number;
+  samples: number;
+  underSampled: boolean;
+  checks: BandCheckResult[];
+}
+
+export interface WrCalibrationReport {
+  totalGames: number;
+  totalSamples: number;
+  bands: PositionBands;
+  buckets: WrBucketReport[];
+  failures: BandCheckResult[];
+  passed: boolean;
+}
+
+const DEFAULT_MIN_SAMPLES = 50;
+
+export function runWrCalibration(
+  options: WrCalibrationOptions,
+): WrCalibrationReport {
+  const {
+    bandJson,
+    league,
+    simulate,
+    gameCount = CALIBRATION_GAME_COUNT,
+    minSamplesPerBucket = DEFAULT_MIN_SAMPLES,
+  } = options;
+
+  const bands = loadPositionBands(bandJson);
+  const teamById = new Map(league.teams.map((t) => [t.teamId, t]));
+  const matchups = generateMatchups(league.teams, gameCount);
+
+  const samples: WrGameSample[] = [];
+
+  for (let i = 0; i < matchups.length; i++) {
+    const { home, away } = matchups[i];
+    const gameId = `wr-calibration-game-${i}`;
+    const seed = deriveGameSeed(league.calibrationSeed, gameId);
+
+    const result = simulate({ home, away, seed, gameId });
+    const gameSamples = collectWrSamples({
+      game: result,
+      home: teamById.get(home.teamId) ?? home,
+      away: teamById.get(away.teamId) ?? away,
+    });
+    samples.push(...gameSamples);
+  }
+
+  const bucketReports: BucketReport<WrGameSample>[] = bucketByAttr({
+    samples,
+    attr: (s) => s.wrOverall,
+    metrics: METRIC_EXTRACTORS,
+  });
+
+  const buckets: WrBucketReport[] = bucketReports.map((report) => {
+    const underSampled = report.samples.length < minSamplesPerBucket;
+    const checks: BandCheckResult[] = WR_METRICS.flatMap((metric) => {
+      // Don't emit band checks on under-sampled buckets — the NFL band
+      // comparison would be dominated by sampling noise and drown out
+      // the real failures from the populated buckets.
+      if (underSampled) return [];
+      return [
+        checkBand({
+          bucketLabel: report.bucket.label,
+          metricName: metric,
+          simSummary: report.metrics[metric],
+          bands,
+        }),
+      ];
+    });
+    return {
+      bucketLabel: report.bucket.label,
+      bucketCenter: report.bucket.center,
+      samples: report.samples.length,
+      underSampled,
+      checks,
+    };
+  });
+
+  const failures = buckets.flatMap((b) => b.checks.filter((c) => !c.passed));
+
+  return {
+    totalGames: matchups.length,
+    totalSamples: samples.length,
+    bands,
+    buckets,
+    failures,
+    passed: failures.length === 0,
+  };
+}
+
+export function formatWrCalibrationReport(report: WrCalibrationReport): string {
+  const lines: string[] = [];
+  lines.push(
+    `WR calibration — ${report.totalGames} games, ${report.totalSamples} WR-games`,
+  );
+  lines.push(
+    `Bands: ${report.bands.position} / ${
+      report.bands.seasons.join("-")
+    } / ranked by ${report.bands.rankingStat}`,
+  );
+  lines.push("");
+  for (const bucket of report.buckets) {
+    const header = `[bucket ${bucket.bucketLabel}] n=${bucket.samples}` +
+      (bucket.underSampled ? " (under-sampled, skipping band checks)" : "");
+    lines.push(header);
+    for (const check of bucket.checks) {
+      const verdict = check.passed ? "PASS" : "FAIL";
+      const dir = check.passed ? "" : ` (${check.direction})`;
+      lines.push(
+        `  ${verdict} ${check.metricName.padEnd(20)} ` +
+          `sim=${check.simMean.toFixed(4)}  ` +
+          `band(${check.expectedBand})=${check.bandMean.toFixed(4)}±${
+            check.bandSd.toFixed(4)
+          }  ` +
+          `z=${check.zScore.toFixed(2)}  actual=${check.actualBand}${dir}`,
+      );
+    }
+    lines.push("");
+  }
+  const passed = report.passed ? "PASS" : "FAIL";
+  lines.push(
+    `${passed}: ${report.failures.length} band check(s) missed expected band`,
+  );
+  return lines.join("\n");
+}

--- a/server/features/simulation/calibration/per-position/wr-overall.test.ts
+++ b/server/features/simulation/calibration/per-position/wr-overall.test.ts
@@ -1,0 +1,89 @@
+import { assertAlmostEquals, assertEquals } from "@std/assert";
+import type { PlayerAttributes } from "@zone-blitz/shared";
+import { WR_OVERALL_ATTRS, wrOverall } from "./wr-overall.ts";
+
+function attrs(overrides: Partial<PlayerAttributes> = {}): PlayerAttributes {
+  const base: Record<string, number> = {};
+  const keys = [
+    "speed",
+    "acceleration",
+    "agility",
+    "strength",
+    "jumping",
+    "stamina",
+    "durability",
+    "armStrength",
+    "accuracyShort",
+    "accuracyMedium",
+    "accuracyDeep",
+    "accuracyOnTheRun",
+    "touch",
+    "release",
+    "ballCarrying",
+    "elusiveness",
+    "routeRunning",
+    "catching",
+    "contestedCatching",
+    "runAfterCatch",
+    "passBlocking",
+    "runBlocking",
+    "blockShedding",
+    "tackling",
+    "manCoverage",
+    "zoneCoverage",
+    "passRushing",
+    "runDefense",
+    "kickingPower",
+    "kickingAccuracy",
+    "puntingPower",
+    "puntingAccuracy",
+    "snapAccuracy",
+    "footballIq",
+    "decisionMaking",
+    "anticipation",
+    "composure",
+    "clutch",
+    "consistency",
+    "workEthic",
+    "coachability",
+    "leadership",
+    "greed",
+    "loyalty",
+    "ambition",
+    "vanity",
+    "schemeAttachment",
+    "mediaSensitivity",
+  ];
+  for (const k of keys) {
+    base[k] = 50;
+    base[`${k}Potential`] = 50;
+  }
+  return { ...(base as unknown as PlayerAttributes), ...overrides };
+}
+
+Deno.test("wrOverall averages the four signature WR attributes", () => {
+  const result = wrOverall(
+    attrs({
+      routeRunning: 60,
+      catching: 70,
+      speed: 80,
+      release: 50,
+    }),
+  );
+  // (60 + 70 + 80 + 50) / 4 = 65
+  assertAlmostEquals(result, 65, 1e-6);
+});
+
+Deno.test("wrOverall returns the common value when all signature attrs match", () => {
+  assertEquals(wrOverall(attrs()), 50);
+});
+
+Deno.test("WR_OVERALL_ATTRS enumerates the four signature attrs in a stable order", () => {
+  assertEquals(WR_OVERALL_ATTRS.length, 4);
+  assertEquals([...WR_OVERALL_ATTRS], [
+    "routeRunning",
+    "catching",
+    "speed",
+    "release",
+  ]);
+});

--- a/server/features/simulation/calibration/per-position/wr-overall.ts
+++ b/server/features/simulation/calibration/per-position/wr-overall.ts
@@ -1,0 +1,23 @@
+import type { PlayerAttributes } from "@zone-blitz/shared";
+
+// The four signature attributes that `neutralBucket` uses to classify a
+// player as WR, plus the pairing with `RANKING_ATTRS.receiver` in
+// `resolve-matchups.ts` (`routeRunning`, `speed`, `catching`) and the
+// archetype signature (`routeRunning`, `catching`, `speed`,
+// `acceleration`). Averaging the four gives a single 0-100 "WR overall"
+// we can bucket on for calibration: a 50-overall WR should produce
+// median NFL starter numbers, 70 should be elite, etc.
+export const WR_OVERALL_ATTRS = [
+  "routeRunning",
+  "catching",
+  "speed",
+  "release",
+] as const satisfies ReadonlyArray<keyof PlayerAttributes>;
+
+export function wrOverall(attributes: PlayerAttributes): number {
+  let sum = 0;
+  for (const key of WR_OVERALL_ATTRS) {
+    sum += attributes[key];
+  }
+  return sum / WR_OVERALL_ATTRS.length;
+}

--- a/server/features/simulation/calibration/per-position/wr-sample.test.ts
+++ b/server/features/simulation/calibration/per-position/wr-sample.test.ts
@@ -1,0 +1,388 @@
+import { assertAlmostEquals, assertEquals } from "@std/assert";
+import type { PlayerAttributes } from "@zone-blitz/shared";
+import { collectWrSamples } from "./wr-sample.ts";
+import type { GameResult, PlayEvent } from "../../events.ts";
+import type { SimTeam } from "../../simulate-game.ts";
+import type { PlayerRuntime } from "../../resolve-play.ts";
+
+function attrs(overrides: Partial<PlayerAttributes> = {}): PlayerAttributes {
+  const base: Record<string, number> = {};
+  const keys = [
+    "speed",
+    "acceleration",
+    "agility",
+    "strength",
+    "jumping",
+    "stamina",
+    "durability",
+    "armStrength",
+    "accuracyShort",
+    "accuracyMedium",
+    "accuracyDeep",
+    "accuracyOnTheRun",
+    "touch",
+    "release",
+    "ballCarrying",
+    "elusiveness",
+    "routeRunning",
+    "catching",
+    "contestedCatching",
+    "runAfterCatch",
+    "passBlocking",
+    "runBlocking",
+    "blockShedding",
+    "tackling",
+    "manCoverage",
+    "zoneCoverage",
+    "passRushing",
+    "runDefense",
+    "kickingPower",
+    "kickingAccuracy",
+    "puntingPower",
+    "puntingAccuracy",
+    "snapAccuracy",
+    "footballIq",
+    "decisionMaking",
+    "anticipation",
+    "composure",
+    "clutch",
+    "consistency",
+    "workEthic",
+    "coachability",
+    "leadership",
+    "greed",
+    "loyalty",
+    "ambition",
+    "vanity",
+    "schemeAttachment",
+    "mediaSensitivity",
+  ];
+  for (const k of keys) {
+    base[k] = 50;
+    base[`${k}Potential`] = 50;
+  }
+  return { ...(base as unknown as PlayerAttributes), ...overrides };
+}
+
+function wr(id: string, overall: number): PlayerRuntime {
+  return {
+    playerId: id,
+    neutralBucket: "WR",
+    attributes: attrs({
+      routeRunning: overall,
+      catching: overall,
+      speed: overall,
+      release: overall,
+    }),
+  };
+}
+
+function team(teamId: string, wrs: PlayerRuntime[]): SimTeam {
+  return {
+    teamId,
+    starters: wrs,
+    bench: [],
+    fingerprint: { offense: null, defense: null, overrides: {} },
+    coachingMods: {
+      schemeFitBonus: 0,
+      situationalBonus: 0,
+      aggressiveness: 50,
+      penaltyDiscipline: 1,
+    },
+  };
+}
+
+function event(
+  overrides: Partial<PlayEvent> & {
+    outcome: PlayEvent["outcome"];
+    offenseTeamId: string;
+  },
+): PlayEvent {
+  return {
+    gameId: "g",
+    driveIndex: 0,
+    playIndex: 0,
+    quarter: 1,
+    clock: "15:00",
+    situation: { down: 1, distance: 10, yardLine: 25 },
+    defenseTeamId: overrides.offenseTeamId === "home" ? "away" : "home",
+    call: {
+      concept: "dropback",
+      personnel: "11",
+      formation: "shotgun",
+      motion: "none",
+    },
+    coverage: { front: "4-3", coverage: "cover_2", pressure: "four_man" },
+    participants: [],
+    yardage: 0,
+    tags: [],
+    ...overrides,
+  };
+}
+
+function gameOf(events: PlayEvent[]): GameResult {
+  return {
+    gameId: "g",
+    seed: 1,
+    finalScore: { home: 0, away: 0 },
+    events,
+    boxScore: {
+      home: {
+        totalYards: 0,
+        passingYards: 0,
+        rushingYards: 0,
+        turnovers: 0,
+        sacks: 0,
+        penalties: 0,
+      },
+      away: {
+        totalYards: 0,
+        passingYards: 0,
+        rushingYards: 0,
+        turnovers: 0,
+        sacks: 0,
+        penalties: 0,
+      },
+    },
+    driveLog: [],
+    injuryReport: [],
+  };
+}
+
+Deno.test("collectWrSamples returns one sample per starter WR per team", () => {
+  const home = team("home", [
+    wr("home-wr1", 50),
+    wr("home-wr2", 50),
+    wr("home-wr3", 50),
+  ]);
+  const away = team("away", [wr("away-wr1", 50), wr("away-wr2", 50)]);
+  const samples = collectWrSamples({
+    game: gameOf([]),
+    home,
+    away,
+  });
+  assertEquals(samples.length, 5);
+  assertEquals(samples[0].teamId, "home");
+  assertEquals(samples[0].wrPlayerId, "home-wr1");
+  assertEquals(samples[3].teamId, "away");
+});
+
+Deno.test("collectWrSamples skips a team with no starter WRs", () => {
+  const home = team("home", [wr("home-wr1", 50)]);
+  const away = team("away", []);
+  const samples = collectWrSamples({
+    game: gameOf([]),
+    home,
+    away,
+  });
+  assertEquals(samples.length, 1);
+  assertEquals(samples[0].teamId, "home");
+});
+
+Deno.test("collectWrSamples tags sample with WR overall (mean of four signature attrs)", () => {
+  const home = team("home", [
+    {
+      playerId: "home-wr1",
+      neutralBucket: "WR",
+      attributes: attrs({
+        routeRunning: 60,
+        catching: 70,
+        speed: 80,
+        release: 50,
+      }),
+    },
+  ]);
+  const [sample] = collectWrSamples({
+    game: gameOf([]),
+    home,
+    away: team("away", [wr("a", 50)]),
+  });
+  // (60 + 70 + 80 + 50) / 4 = 65
+  assertAlmostEquals(sample.wrOverall, 65, 0.01);
+});
+
+Deno.test("collectWrSamples splits team pass stats across starter WRs by routeRunning weight", () => {
+  const wr1: PlayerRuntime = {
+    playerId: "home-wr1",
+    neutralBucket: "WR",
+    attributes: attrs({
+      routeRunning: 80,
+      catching: 50,
+      speed: 50,
+      release: 50,
+    }),
+  };
+  const wr2: PlayerRuntime = {
+    playerId: "home-wr2",
+    neutralBucket: "WR",
+    attributes: attrs({
+      routeRunning: 20,
+      catching: 50,
+      speed: 50,
+      release: 50,
+    }),
+  };
+  const home = team("home", [wr1, wr2]);
+  const away = team("away", [wr("a", 50)]);
+  const events: PlayEvent[] = [
+    event({ outcome: "pass_complete", offenseTeamId: "home", yardage: 10 }),
+    event({ outcome: "pass_complete", offenseTeamId: "home", yardage: 10 }),
+    event({ outcome: "pass_complete", offenseTeamId: "home", yardage: 10 }),
+    event({ outcome: "pass_complete", offenseTeamId: "home", yardage: 10 }),
+    event({ outcome: "pass_complete", offenseTeamId: "home", yardage: 10 }),
+    event({ outcome: "pass_incomplete", offenseTeamId: "home", yardage: 0 }),
+    event({ outcome: "pass_incomplete", offenseTeamId: "home", yardage: 0 }),
+    event({ outcome: "pass_incomplete", offenseTeamId: "home", yardage: 0 }),
+    event({ outcome: "pass_incomplete", offenseTeamId: "home", yardage: 0 }),
+    event({ outcome: "pass_incomplete", offenseTeamId: "home", yardage: 0 }),
+  ];
+  const samples = collectWrSamples({
+    game: gameOf(events),
+    home,
+    away,
+  });
+  const home1 = samples.find((s) => s.wrPlayerId === "home-wr1")!;
+  const home2 = samples.find((s) => s.wrPlayerId === "home-wr2")!;
+
+  // WR1 has routeRunning 80 of 100 total -> 0.8 share; WR2 -> 0.2.
+  assertAlmostEquals(home1.targetShare, 0.8, 1e-6);
+  assertAlmostEquals(home2.targetShare, 0.2, 1e-6);
+  assertAlmostEquals(home1.targets, 10 * 0.8, 1e-6);
+  assertAlmostEquals(home2.targets, 10 * 0.2, 1e-6);
+  assertAlmostEquals(home1.receptions, 5 * 0.8, 1e-6);
+  assertAlmostEquals(home1.rec_yards, 50 * 0.8, 1e-6);
+  // catch_rate is share-invariant: 5/10 regardless of share split.
+  assertAlmostEquals(home1.catch_rate, 0.5, 1e-6);
+  assertAlmostEquals(home2.catch_rate, 0.5, 1e-6);
+  // yards_per_target is also share-invariant at the per-WR level.
+  assertAlmostEquals(home1.yards_per_target, 5, 1e-6);
+});
+
+Deno.test("collectWrSamples attributes pass-concept TDs to the WRs but skips run-concept TDs", () => {
+  const home = team("home", [wr("home-wr1", 50)]);
+  const away = team("away", [wr("away-wr1", 50)]);
+  const events: PlayEvent[] = [
+    event({
+      outcome: "touchdown",
+      offenseTeamId: "home",
+      yardage: 25,
+      call: {
+        concept: "quick_pass",
+        personnel: "11",
+        formation: "shotgun",
+        motion: "none",
+      },
+    }),
+    event({
+      outcome: "touchdown",
+      offenseTeamId: "home",
+      yardage: 2,
+      call: {
+        concept: "inside_zone",
+        personnel: "11",
+        formation: "singleback",
+        motion: "none",
+      },
+    }),
+  ];
+  const [homeSample] = collectWrSamples({
+    game: gameOf(events),
+    home,
+    away,
+  });
+  assertEquals(homeSample.targets, 1);
+  assertEquals(homeSample.receptions, 1);
+  assertEquals(homeSample.rec_tds, 1);
+  assertEquals(homeSample.rec_yards, 25);
+});
+
+Deno.test("collectWrSamples counts interceptions as targets but not receptions", () => {
+  const home = team("home", [wr("home-wr1", 50)]);
+  const away = team("away", [wr("away-wr1", 50)]);
+  const events: PlayEvent[] = [
+    event({ outcome: "pass_complete", offenseTeamId: "home", yardage: 10 }),
+    event({ outcome: "interception", offenseTeamId: "home", yardage: 0 }),
+  ];
+  const [homeSample] = collectWrSamples({
+    game: gameOf(events),
+    home,
+    away,
+  });
+  assertEquals(homeSample.targets, 2);
+  assertEquals(homeSample.receptions, 1);
+  assertAlmostEquals(homeSample.catch_rate, 0.5);
+});
+
+Deno.test("collectWrSamples isolates offense by team", () => {
+  const home = team("home", [wr("home-wr1", 50)]);
+  const away = team("away", [wr("away-wr1", 50)]);
+  const events: PlayEvent[] = [
+    event({ outcome: "pass_complete", offenseTeamId: "home", yardage: 20 }),
+    event({ outcome: "pass_complete", offenseTeamId: "away", yardage: 5 }),
+    event({ outcome: "pass_complete", offenseTeamId: "away", yardage: 15 }),
+  ];
+  const [homeSample, awaySample] = collectWrSamples({
+    game: gameOf(events),
+    home,
+    away,
+  });
+  assertEquals(homeSample.targets, 1);
+  assertEquals(homeSample.rec_yards, 20);
+  assertEquals(awaySample.targets, 2);
+  assertEquals(awaySample.rec_yards, 20);
+});
+
+Deno.test("collectWrSamples handles zero-target games without divide-by-zero", () => {
+  const home = team("home", [wr("home-wr1", 50)]);
+  const away = team("away", [wr("away-wr1", 50)]);
+  const [sample] = collectWrSamples({
+    game: gameOf([]),
+    home,
+    away,
+  });
+  assertEquals(sample.targets, 0);
+  assertEquals(sample.catch_rate, 0);
+  assertEquals(sample.yards_per_reception, 0);
+  assertEquals(sample.yards_per_target, 0);
+  assertEquals(sample.td_rate, 0);
+  assertEquals(sample.yards_per_game, 0);
+});
+
+Deno.test("collectWrSamples falls back to equal split when every WR has routeRunning 0", () => {
+  const wr1: PlayerRuntime = {
+    playerId: "home-wr1",
+    neutralBucket: "WR",
+    attributes: attrs({
+      routeRunning: 0,
+      catching: 50,
+      speed: 50,
+      release: 50,
+    }),
+  };
+  const wr2: PlayerRuntime = {
+    playerId: "home-wr2",
+    neutralBucket: "WR",
+    attributes: attrs({
+      routeRunning: 0,
+      catching: 50,
+      speed: 50,
+      release: 50,
+    }),
+  };
+  const home = team("home", [wr1, wr2]);
+  const away = team("away", [wr("away-wr1", 50)]);
+  const events: PlayEvent[] = [
+    event({ outcome: "pass_complete", offenseTeamId: "home", yardage: 8 }),
+    event({ outcome: "pass_complete", offenseTeamId: "home", yardage: 8 }),
+  ];
+  const samples = collectWrSamples({
+    game: gameOf(events),
+    home,
+    away,
+  });
+  const homeSamples = samples.filter((s) => s.teamId === "home");
+  assertEquals(homeSamples.length, 2);
+  assertAlmostEquals(homeSamples[0].targetShare, 0.5, 1e-6);
+  assertAlmostEquals(homeSamples[1].targetShare, 0.5, 1e-6);
+  assertAlmostEquals(homeSamples[0].targets, 1, 1e-6);
+});

--- a/server/features/simulation/calibration/per-position/wr-sample.ts
+++ b/server/features/simulation/calibration/per-position/wr-sample.ts
@@ -1,0 +1,151 @@
+import type { GameResult, PlayEvent } from "../../events.ts";
+import type { SimTeam } from "../../simulate-game.ts";
+import type { PlayerRuntime } from "../../resolve-play.ts";
+import { wrOverall } from "./wr-overall.ts";
+
+export interface WrGameSample {
+  teamId: string;
+  wrPlayerId: string;
+  wrOverall: number;
+  // Target-share weight used to split team pass stats across starter
+  // WRs (routeRunning / sum(routeRunning for starter WRs on this team)).
+  targetShare: number;
+  targets: number;
+  receptions: number;
+  rec_yards: number;
+  rec_tds: number;
+  catch_rate: number;
+  yards_per_reception: number;
+  yards_per_target: number;
+  td_rate: number;
+  yards_per_game: number;
+}
+
+const RUN_CONCEPTS = new Set([
+  "inside_zone",
+  "outside_zone",
+  "power",
+  "counter",
+  "draw",
+  "rpo",
+]);
+
+interface TeamPassTotals {
+  targets: number;
+  receptions: number;
+  rec_yards: number;
+  rec_tds: number;
+}
+
+function accumulateTeamPassing(
+  events: PlayEvent[],
+  teamId: string,
+): TeamPassTotals {
+  let targets = 0;
+  let receptions = 0;
+  let recYards = 0;
+  let recTds = 0;
+
+  for (const event of events) {
+    if (event.offenseTeamId !== teamId) continue;
+
+    switch (event.outcome) {
+      case "pass_complete":
+        targets++;
+        receptions++;
+        recYards += event.yardage;
+        break;
+      case "pass_incomplete":
+        targets++;
+        break;
+      case "interception":
+        // Pick-sixes still count as a target even though there's no
+        // reception — mirrors how the QB sample treats interceptions
+        // as dropbacks.
+        targets++;
+        break;
+      case "touchdown":
+        // Pass-concept TDs are completed passes to a receiver. Run
+        // concept TDs belong to the ball carrier (see RB sample).
+        if (!RUN_CONCEPTS.has(event.call.concept)) {
+          targets++;
+          receptions++;
+          recYards += event.yardage;
+          recTds++;
+        }
+        break;
+    }
+  }
+
+  return {
+    targets,
+    receptions,
+    rec_yards: recYards,
+    rec_tds: recTds,
+  };
+}
+
+export interface WrSampleInput {
+  game: GameResult;
+  home: SimTeam;
+  away: SimTeam;
+}
+
+// Attribute a team-game's pass-catching stats across the team's starter
+// WRs. The engine's `resolve-matchups.ts` does not log the targeted
+// receiver on every pass-incomplete, so we can't read per-WR stats
+// directly from events. Instead we split team pass totals by
+// routeRunning-weighted target share, which mirrors how defenders
+// allocate attention across routes in the real game: a WR with a
+// higher routeRunning rating draws a larger slice of the team's
+// targets. TEs are excluded from the split because they have their
+// own position bucket and will get their own calibration harness.
+export function collectWrSamples(input: WrSampleInput): WrGameSample[] {
+  const { game, home, away } = input;
+
+  const samples: WrGameSample[] = [];
+  for (const team of [home, away]) {
+    const wrs = team.starters.filter(
+      (p: PlayerRuntime) => p.neutralBucket === "WR",
+    );
+    if (wrs.length === 0) continue;
+
+    const routeWeights = wrs.map((p) => p.attributes.routeRunning);
+    const totalWeight = routeWeights.reduce((a, b) => a + b, 0);
+    const teamTotals = accumulateTeamPassing(game.events, team.teamId);
+
+    for (let i = 0; i < wrs.length; i++) {
+      const wr = wrs[i];
+      // If every starter WR is rated 0 somehow, fall back to an equal
+      // split so we never divide by zero and every WR still emits a
+      // sample that can be bucketed.
+      const share = totalWeight > 0
+        ? routeWeights[i] / totalWeight
+        : 1 / wrs.length;
+
+      const targets = teamTotals.targets * share;
+      const receptions = teamTotals.receptions * share;
+      const recYards = teamTotals.rec_yards * share;
+      const recTds = teamTotals.rec_tds * share;
+
+      samples.push({
+        teamId: team.teamId,
+        wrPlayerId: wr.playerId,
+        wrOverall: wrOverall(wr.attributes),
+        targetShare: share,
+        targets,
+        receptions,
+        rec_yards: recYards,
+        rec_tds: recTds,
+        catch_rate: targets > 0 ? receptions / targets : 0,
+        yards_per_reception: receptions > 0 ? recYards / receptions : 0,
+        yards_per_target: targets > 0 ? recYards / targets : 0,
+        td_rate: targets > 0 ? recTds / targets : 0,
+        // One sample spans a single game, so `yards_per_game` is just
+        // this WR's share of the team's receiving yards.
+        yards_per_game: recYards,
+      });
+    }
+  }
+  return samples;
+}


### PR DESCRIPTION
## Summary

- Adds the WR slice of the per-position calibration harness introduced in #496 (QB slice #497, RB slice #500).
- New NFL reference fixture `data/bands/per-position/wr.json` built from `data/R/bands/per-position-wr.R`: 2020-2024 WR-seasons with >=60 targets (362 WR-seasons), ranked by receiving EPA/play and carved into the elite / good / average / weak / replacement bands. Metrics: `catch_rate`, `yards_per_reception`, `yards_per_target`, `td_rate`, `yards_per_game`.
- `wr-overall.ts` averages `routeRunning + catching + speed + release` for the bucket axis.
- `wr-sample.ts` emits one sample per starter WR per team. The engine does not log the targeted receiver on `pass_incomplete` events, so team-level pass totals are split across starter WRs by `routeRunning`-weighted target share (mirrors how real defenses distribute coverage attention).
- `wr-harness.ts` + `run-wr-calibration.ts` + a `sim:calibrate:wr` Deno task wire the harness into the existing `bucket-by-attr` / `band-loader` / `band-check` modules.
- Report-only for now, per #496: the multi-seed summary prints per-bucket PASS/FAIL for each metric across all 8 calibration seeds.

## Notes (calibration gaps surfaced)

Running `deno task sim:calibrate:wr` across all 8 seeds lands roughly 8-12 of 30 band checks per seed. Consistent findings:

- **Yardage metrics under-shoot the elite/good bands across every seed.** Bucket 60 and 70 land `yards_per_target` in the weak/average bands (e.g. 70 bucket: sim 7.6-8.0 vs elite NFL mean 10.1, z ≈ -1.8 to -2.1). `yards_per_reception` sits around 11 across every bucket vs NFL elite 14.4. The sim compresses WR quality's effect on big-play yardage — elite WRs don't pull away from average ones per-target.
- **Volume (`yards_per_game`) over-shoots across every bucket** (40-70 consistently classify as elite, z = +1.2 to +2.4). This is expected from the attribution model: the starter WR absorbs ~55-60% of team receiving via target share, which is higher than the real-NFL target share for a true WR1 once TE+RB targets are removed. Flagging as a known artifact of the routeRunning-weighted split; a future iteration can either (a) add a TE calibration harness that skims target share off the WR pool or (b) switch to per-event attribution once the engine logs the targeted receiver on incompletes.
- **`td_rate` too high in low buckets, too low in high buckets.** 30-50 buckets classify as `good` (z +0.3 to +1.0) while 60-70 classify as `good` when expected `elite` (too_low). Red-zone resolution doesn't currently scale TD% with receiver quality the way NFL production does.
- **`catch_rate` largely tracks.** The 40-70 buckets usually land within ±1 band of expected; this is the one WR metric the resolver already scales cleanly with overall.
- **Bucket sizing is generator-driven.** Bucket 30 lands anywhere from 150 to 760 samples per seed and bucket 80 around 170-250, so low/high bands remain noisy across seeds. Bucket 50 is always the densest (2,500-3,000 samples); the "ratings midpoint = 50" mass parks most starter WRs in the average band.
- **Per-reception TD attribution on run-concept TDs is explicitly excluded** to match the RB slice contract. RPO TDs thrown to a WR are credited to the receiver because `rpo` is the only overlap concept; flag for future tightening alongside #496's event-logging expansion.