### PR TITLE
feat(calibration): add per-EDGE-bucket calibration harness (#496, EDGE slice)

### DIFF
--- a/data/R/bands/per-position-edge.R
+++ b/data/R/bands/per-position-edge.R
@@ -1,0 +1,183 @@
+#!/usr/bin/env Rscript
+# per-position-edge.R — NFL EDGE rusher percentile-band reference.
+#
+# ============================================================================
+# PROXY METRICS — v1 per issue #496
+# ----------------------------------------------------------------------------
+# EDGE is not a clean nflverse position label (players show up as DE or OLB
+# depending on scheme) and — critically — nflreadr does NOT carry PFF
+# pass-rush / run-defense grades. PFF is the gold-standard public data
+# source for evaluating edge play (pass-rush win rate, run-defense grade,
+# true pressures), but it's paid and not part of the nflverse release.
+#
+# This fixture therefore uses box-score proxies only:
+#   - sacks_per_game     (proxy for pass-rush finishing)
+#   - qb_hits_per_game   (proxy for pressure generation)
+#   - tfl_per_game       (proxy for run-defense disruption)
+#
+# The ranking stat is a composite of those three. Expect higher variance
+# than the QB / RB fixtures because:
+#   1. Box-score defensive stats are lumpy week to week.
+#   2. "Pressures" — the best proxy for pass-rush quality — is NOT in
+#      load_player_stats. PFR's qb_hits is the closest free signal.
+#   3. Edge-rusher usage varies wildly across schemes; DEs in a 4-3 and
+#      OLBs in a 3-4 both show up here under the pass-rush threshold.
+#
+# Follow-up (tracked as a GitHub issue): swap the composite for a true
+# pass-rush productivity metric (ESPN pass-rush-win-rate, or a licensed
+# PFF grade pull) once available.
+# ============================================================================
+#
+# Pulls weekly player stats from load_player_stats, filters to DE/OLB
+# players meeting a pass-rush production threshold, aggregates to per-EDGE
+# season lines, filters to "starters" (games >= 10 as a snap-count proxy),
+# ranks by composite sack+qb_hit+tfl rate, and carves the population into
+# five percentile bands (elite / good / average / weak / replacement). For
+# each band, reports mean + sd + n on the proxy metrics.
+#
+# Output: data/bands/per-position/edge.json
+#
+# Usage:
+#   Rscript data/R/bands/per-position-edge.R [--seasons 2020:2024]
+
+suppressPackageStartupMessages({
+  library(nflreadr)
+  library(dplyr)
+})
+
+script_file <- (function() {
+  args <- commandArgs(trailingOnly = FALSE)
+  f <- grep("^--file=", args, value = TRUE)
+  if (length(f) > 0) normalizePath(sub("^--file=", "", f[1]), mustWork = FALSE) else NULL
+})()
+source(file.path(dirname(script_file), "..", "lib.R"))
+
+args <- commandArgs(trailingOnly = TRUE)
+seasons <- parse_seasons(args)
+
+cat("Loading weekly player stats for seasons:",
+    paste(range(seasons), collapse = "-"), "\n")
+
+# load_player_stats returns every stat category in one frame; the legacy
+# stat_type arg is deprecated in nflreadr 1.5+. Filtering on `position`
+# and the def_* columns is how we isolate edge defenders.
+weekly <- nflreadr::load_player_stats(seasons)
+
+edge_weekly <- weekly |>
+  filter(season_type == "REG", position %in% c("DE", "OLB"))
+
+# Aggregate weekly rows into per-player-season totals. Keep only seasons
+# where the player (a) met a pass-rush production threshold and (b)
+# played in >= 10 games — this combination filters out run-stuffing DEs
+# and coverage-first OLBs and keeps the population close to NFL
+# starting-caliber edge rushers.
+edge_season <- edge_weekly |>
+  group_by(player_id, player_display_name, season) |>
+  summarise(
+    games     = n(),
+    sacks     = sum(def_sacks, na.rm = TRUE),
+    qb_hits   = sum(def_qb_hits, na.rm = TRUE),
+    tfl       = sum(def_tackles_for_loss, na.rm = TRUE),
+    .groups   = "drop"
+  ) |>
+  mutate(
+    sacks_per_game    = ifelse(games > 0, sacks / games, NA_real_),
+    qb_hits_per_game  = ifelse(games > 0, qb_hits / games, NA_real_),
+    tfl_per_game      = ifelse(games > 0, tfl / games, NA_real_),
+    # Composite ranking stat: equally weighted sacks + qb_hits + tfl per
+    # game. Not a real pass-rush grade — see PROXY METRICS header.
+    rush_composite    = ifelse(games > 0,
+                                (sacks + qb_hits + tfl) / games,
+                                NA_real_)
+  ) |>
+  # Pass-rush production floor separates edge rushers from run-stuffing
+  # DEs and coverage OLBs. 10 combined sacks+qb_hits across a season is
+  # roughly the bottom of NFL starter-level edge play.
+  filter(sacks + qb_hits >= 10, games >= 10)
+
+cat("EDGE-seasons after production+games filter:", nrow(edge_season), "\n")
+
+# Rank by composite and assign percentile bands on the filtered
+# population. Bands follow the scheme from issue #496: top 10% elite,
+# next 20% good, middle 40% average, next 20% weak, bottom 10%
+# replacement.
+edge_ranked <- edge_season |>
+  arrange(desc(rush_composite)) |>
+  mutate(
+    pct = (row_number() - 0.5) / n(),
+    band = case_when(
+      pct <= 0.10 ~ "elite",
+      pct <= 0.30 ~ "good",
+      pct <= 0.70 ~ "average",
+      pct <= 0.90 ~ "weak",
+      TRUE        ~ "replacement"
+    )
+  )
+
+metric_keys <- c(
+  "sacks_per_game",
+  "qb_hits_per_game",
+  "tfl_per_game"
+)
+
+band_order <- c("elite", "good", "average", "weak", "replacement")
+
+band_summary <- function(rows) {
+  metrics <- list()
+  for (key in metric_keys) {
+    vals <- rows[[key]]
+    vals <- vals[!is.na(vals)]
+    metrics[[key]] <- list(
+      n = length(vals),
+      mean = mean(vals),
+      sd = stats::sd(vals)
+    )
+  }
+  list(
+    n = nrow(rows),
+    metrics = metrics
+  )
+}
+
+bands <- list()
+for (band_name in band_order) {
+  rows <- edge_ranked |> filter(band == band_name)
+  bands[[band_name]] <- band_summary(rows)
+}
+
+out <- list(
+  generated_at = format(Sys.time(), "%Y-%m-%dT%H:%M:%SZ", tz = "UTC"),
+  seasons = as.integer(seasons),
+  position = "EDGE",
+  qualifier = paste0(
+    "regular-season DE/OLB-seasons with season sacks+qb_hits >= 10 and ",
+    "games_played >= 10"
+  ),
+  ranking_stat = "rush_composite ((sacks + qb_hits + tfl) / games)",
+  notes = paste0(
+    "PROXY METRICS — v1 per issue #496. nflreadr does not carry PFF ",
+    "pass-rush or run-defense grades, so this fixture uses box-score ",
+    "proxies only: sacks_per_game, qb_hits_per_game, tfl_per_game. ",
+    "Starter population = DE/OLB with season sacks+qb_hits >= 10 and ",
+    "games_played >= 10 as a snap-count proxy (snap counts live in a ",
+    "separate nflverse release keyed on pfr_player_id, which this ",
+    "script intentionally does not join against — keeps the pipeline ",
+    "single-source and cheap to regenerate). Ranked by composite ",
+    "(sacks+qb_hits+tfl)/game then carved into percentile bands ",
+    "(elite: top 10%, good: 10-30%, average: 30-70%, weak: 70-90%, ",
+    "replacement: bottom 10%). Follow-up: swap composite for PFF ",
+    "pass-rush grade or ESPN pass-rush-win-rate when available."
+  ),
+  bands = bands
+)
+
+out_path <- file.path(
+  repo_root(), "data", "bands", "per-position", "edge.json"
+)
+dir.create(dirname(out_path), recursive = TRUE, showWarnings = FALSE)
+writeLines(
+  jsonlite::toJSON(out, auto_unbox = TRUE, pretty = TRUE, digits = 4,
+                   null = "null"),
+  out_path
+)
+cat("Wrote", out_path, "\n")

--- a/data/bands/per-position/edge.json
+++ b/data/bands/per-position/edge.json
@@ -1,0 +1,110 @@
+{
+  "generated_at": "2026-04-17T12:29:03Z",
+  "seasons": [2021, 2022, 2023, 2024, 2025],
+  "position": "EDGE",
+  "qualifier": "regular-season DE/OLB-seasons with season sacks+qb_hits >= 10 and games_played >= 10",
+  "ranking_stat": "rush_composite ((sacks + qb_hits + tfl) / games)",
+  "notes": "PROXY METRICS — v1 per issue #496. nflreadr does not carry PFF pass-rush or run-defense grades, so this fixture uses box-score proxies only: sacks_per_game, qb_hits_per_game, tfl_per_game. Starter population = DE/OLB with season sacks+qb_hits >= 10 and games_played >= 10 as a snap-count proxy (snap counts live in a separate nflverse release keyed on pfr_player_id, which this script intentionally does not join against — keeps the pipeline single-source and cheap to regenerate). Ranked by composite (sacks+qb_hits+tfl)/game then carved into percentile bands (elite: top 10%, good: 10-30%, average: 30-70%, weak: 70-90%, replacement: bottom 10%). Follow-up: swap composite for PFF pass-rush grade or ESPN pass-rush-win-rate when available.",
+  "bands": {
+    "elite": {
+      "n": 35,
+      "metrics": {
+        "sacks_per_game": {
+          "n": 35,
+          "mean": 0.8913,
+          "sd": 0.2186
+        },
+        "qb_hits_per_game": {
+          "n": 35,
+          "mean": 1.9015,
+          "sd": 0.3942
+        },
+        "tfl_per_game": {
+          "n": 35,
+          "mean": 1.0785,
+          "sd": 0.3072
+        }
+      }
+    },
+    "good": {
+      "n": 69,
+      "metrics": {
+        "sacks_per_game": {
+          "n": 69,
+          "mean": 0.6239,
+          "sd": 0.1301
+        },
+        "qb_hits_per_game": {
+          "n": 69,
+          "mean": 1.3558,
+          "sd": 0.2413
+        },
+        "tfl_per_game": {
+          "n": 69,
+          "mean": 0.7209,
+          "sd": 0.1654
+        }
+      }
+    },
+    "average": {
+      "n": 138,
+      "metrics": {
+        "sacks_per_game": {
+          "n": 138,
+          "mean": 0.4087,
+          "sd": 0.1148
+        },
+        "qb_hits_per_game": {
+          "n": 138,
+          "mean": 0.9486,
+          "sd": 0.2038
+        },
+        "tfl_per_game": {
+          "n": 138,
+          "mean": 0.4785,
+          "sd": 0.1406
+        }
+      }
+    },
+    "weak": {
+      "n": 69,
+      "metrics": {
+        "sacks_per_game": {
+          "n": 69,
+          "mean": 0.2738,
+          "sd": 0.0802
+        },
+        "qb_hits_per_game": {
+          "n": 69,
+          "mean": 0.6487,
+          "sd": 0.1315
+        },
+        "tfl_per_game": {
+          "n": 69,
+          "mean": 0.3525,
+          "sd": 0.1041
+        }
+      }
+    },
+    "replacement": {
+      "n": 35,
+      "metrics": {
+        "sacks_per_game": {
+          "n": 35,
+          "mean": 0.2144,
+          "sd": 0.0768
+        },
+        "qb_hits_per_game": {
+          "n": 35,
+          "mean": 0.5343,
+          "sd": 0.1061
+        },
+        "tfl_per_game": {
+          "n": 35,
+          "mean": 0.2447,
+          "sd": 0.0807
+        }
+      }
+    }
+  }
+}

--- a/deno.json
+++ b/deno.json
@@ -38,6 +38,7 @@
     "sim:calibrate:rb": "deno run --allow-read server/features/simulation/calibration/per-position/run-rb-calibration.ts",
     "sim:calibrate:te": "deno run --allow-read server/features/simulation/calibration/per-position/run-te-calibration.ts",
     "sim:calibrate:wr": "deno run --allow-read server/features/simulation/calibration/per-position/run-wr-calibration.ts",
+    "sim:calibrate:edge": "deno run --allow-read server/features/simulation/calibration/per-position/run-edge-calibration.ts",
     "build": "cd client && deno task build",
     "start": "cd server && deno run --env=../.env --allow-net --allow-env --allow-read --allow-sys main.ts"
   },

--- a/server/features/simulation/calibration/per-position/edge-harness.test.ts
+++ b/server/features/simulation/calibration/per-position/edge-harness.test.ts
@@ -1,0 +1,414 @@
+import { assertEquals, assertStringIncludes } from "@std/assert";
+import type { PlayerAttributes } from "@zone-blitz/shared";
+import {
+  formatEdgeCalibrationReport,
+  runEdgeCalibration,
+} from "./edge-harness.ts";
+import type { GameResult, PlayEvent } from "../../events.ts";
+import type { SimTeam } from "../../simulate-game.ts";
+import type { PlayerRuntime } from "../../resolve-play.ts";
+import type { CalibrationLeague } from "../generate-calibration-league.ts";
+
+function attrs(overrides: Partial<PlayerAttributes> = {}): PlayerAttributes {
+  const base: Record<string, number> = {};
+  const keys = [
+    "speed",
+    "acceleration",
+    "agility",
+    "strength",
+    "jumping",
+    "stamina",
+    "durability",
+    "armStrength",
+    "accuracyShort",
+    "accuracyMedium",
+    "accuracyDeep",
+    "accuracyOnTheRun",
+    "touch",
+    "release",
+    "ballCarrying",
+    "elusiveness",
+    "routeRunning",
+    "catching",
+    "contestedCatching",
+    "runAfterCatch",
+    "passBlocking",
+    "runBlocking",
+    "blockShedding",
+    "tackling",
+    "manCoverage",
+    "zoneCoverage",
+    "passRushing",
+    "runDefense",
+    "kickingPower",
+    "kickingAccuracy",
+    "puntingPower",
+    "puntingAccuracy",
+    "snapAccuracy",
+    "footballIq",
+    "decisionMaking",
+    "anticipation",
+    "composure",
+    "clutch",
+    "consistency",
+    "workEthic",
+    "coachability",
+    "leadership",
+    "greed",
+    "loyalty",
+    "ambition",
+    "vanity",
+    "schemeAttachment",
+    "mediaSensitivity",
+  ];
+  for (const k of keys) {
+    base[k] = 50;
+    base[`${k}Potential`] = 50;
+  }
+  return { ...(base as unknown as PlayerAttributes), ...overrides };
+}
+
+function edgeRuntime(id: string, overall: number): PlayerRuntime {
+  return {
+    playerId: id,
+    neutralBucket: "EDGE",
+    attributes: attrs({
+      passRushing: overall,
+      acceleration: overall,
+      strength: overall,
+      blockShedding: overall,
+      runDefense: overall,
+    }),
+  };
+}
+
+function team(teamId: string, starterEdge: PlayerRuntime): SimTeam {
+  return {
+    teamId,
+    starters: [starterEdge],
+    bench: [],
+    fingerprint: { offense: null, defense: null, overrides: {} },
+    coachingMods: {
+      schemeFitBonus: 0,
+      situationalBonus: 0,
+      aggressiveness: 50,
+      penaltyDiscipline: 1,
+    },
+  };
+}
+
+function bandJson(): string {
+  // Synthetic bands whose means spread monotonically across the 5
+  // percentile bins — mirrors the real EDGE fixture shape (higher =
+  // better pass-rush output) while keeping the fixture small and
+  // inline-readable. sd is set wide enough that a sim mean within one
+  // sd lands in the correct band for each bucket.
+  const band = (sacks: number, hits: number, tfls: number) => ({
+    n: 20,
+    metrics: {
+      sacks_per_game: { n: 20, mean: sacks, sd: 0.08 },
+      qb_hits_per_game: { n: 20, mean: hits, sd: 0.12 },
+      tfl_per_game: { n: 20, mean: tfls, sd: 0.1 },
+    },
+  });
+  return JSON.stringify({
+    position: "EDGE",
+    seasons: [2021, 2022, 2023, 2024, 2025],
+    ranking_stat: "rush_composite",
+    bands: {
+      elite: band(0.9, 1.9, 1.08),
+      good: band(0.62, 1.36, 0.72),
+      average: band(0.41, 0.95, 0.48),
+      weak: band(0.27, 0.65, 0.35),
+      replacement: band(0.21, 0.53, 0.24),
+    },
+  });
+}
+
+function makeGame(
+  gameId: string,
+  homeTeamId: string,
+  awayTeamId: string,
+  sacksByDefense: Record<string, number>,
+  pressuresByDefense: Record<string, number>,
+): GameResult {
+  const events: PlayEvent[] = [];
+  for (const [defenseTeamId, sackCount] of Object.entries(sacksByDefense)) {
+    const offenseTeamId = defenseTeamId === homeTeamId
+      ? awayTeamId
+      : homeTeamId;
+    // Sacks credited to the starter EDGE via participant tag.
+    const edgePlayerId = `${defenseTeamId}-edge`;
+    for (let i = 0; i < sackCount; i++) {
+      events.push({
+        gameId,
+        driveIndex: 0,
+        playIndex: events.length,
+        quarter: 1,
+        clock: "15:00",
+        situation: { down: 1, distance: 10, yardLine: 25 },
+        offenseTeamId,
+        defenseTeamId,
+        call: {
+          concept: "dropback",
+          personnel: "11",
+          formation: "shotgun",
+          motion: "none",
+        },
+        coverage: { front: "4-3", coverage: "cover_2", pressure: "four_man" },
+        participants: [
+          { role: "pass_rush", playerId: edgePlayerId, tags: ["sack"] },
+        ],
+        outcome: "sack",
+        yardage: -7,
+        tags: ["sack", "pressure"],
+      });
+    }
+  }
+  for (
+    const [defenseTeamId, pressureCount] of Object.entries(pressuresByDefense)
+  ) {
+    const offenseTeamId = defenseTeamId === homeTeamId
+      ? awayTeamId
+      : homeTeamId;
+    for (let i = 0; i < pressureCount; i++) {
+      events.push({
+        gameId,
+        driveIndex: 0,
+        playIndex: events.length,
+        quarter: 1,
+        clock: "15:00",
+        situation: { down: 1, distance: 10, yardLine: 25 },
+        offenseTeamId,
+        defenseTeamId,
+        call: {
+          concept: "dropback",
+          personnel: "11",
+          formation: "shotgun",
+          motion: "none",
+        },
+        coverage: { front: "4-3", coverage: "cover_2", pressure: "four_man" },
+        participants: [],
+        outcome: "pass_incomplete",
+        yardage: 0,
+        tags: ["pressure"],
+      });
+    }
+  }
+  return {
+    gameId,
+    seed: 1,
+    finalScore: { home: 0, away: 0 },
+    events,
+    boxScore: {
+      home: {
+        totalYards: 0,
+        passingYards: 0,
+        rushingYards: 0,
+        turnovers: 0,
+        sacks: 0,
+        penalties: 0,
+      },
+      away: {
+        totalYards: 0,
+        passingYards: 0,
+        rushingYards: 0,
+        turnovers: 0,
+        sacks: 0,
+        penalties: 0,
+      },
+    },
+    driveLog: [],
+    injuryReport: [],
+  };
+}
+
+Deno.test("runEdgeCalibration runs the sim, buckets EDGEs, and returns a populated report", () => {
+  // Build a league where each team's EDGE starter is at a different
+  // overall, giving us one team per bucket. The stub simulate maps
+  // each defense's sacks+pressures to its EDGE overall so each
+  // bucket lands in its target band on sacks_per_game and qb_hits.
+  const overallByTeam: Record<string, number> = {
+    "t30": 30,
+    "t40": 40,
+    "t50": 50,
+    "t60": 60,
+    "t70": 70,
+    "t80": 80,
+  };
+  const sacksByOverall: Record<number, number> = {
+    30: 0.21,
+    40: 0.27,
+    50: 0.41,
+    60: 0.62,
+    70: 0.9,
+    80: 0.9,
+  };
+  const pressuresByOverall: Record<number, number> = {
+    30: 0.53,
+    40: 0.65,
+    50: 0.95,
+    60: 1.36,
+    70: 1.9,
+    80: 1.9,
+  };
+
+  const teams: SimTeam[] = Object.entries(overallByTeam).map(([id, o]) =>
+    team(id, edgeRuntime(`${id}-edge`, o))
+  );
+  const league: CalibrationLeague = { calibrationSeed: 1, teams };
+
+  let gameCount = 0;
+  const simulate = ({ home, away, gameId }: {
+    home: SimTeam;
+    away: SimTeam;
+    seed: number;
+    gameId: string;
+  }): GameResult => {
+    gameCount++;
+    // Use fractional rates directly as event counts since this is a
+    // one-game sample — the harness averages across games. For exact
+    // bucket means we scale the rates into integer counts per game by
+    // interpreting them as counts (one game represents the rate).
+    return makeGame(
+      gameId,
+      home.teamId,
+      away.teamId,
+      {
+        [home.teamId]: sacksByOverall[overallByTeam[home.teamId]],
+        [away.teamId]: sacksByOverall[overallByTeam[away.teamId]],
+      },
+      {
+        [home.teamId]: pressuresByOverall[overallByTeam[home.teamId]],
+        [away.teamId]: pressuresByOverall[overallByTeam[away.teamId]],
+      },
+    );
+  };
+
+  const report = runEdgeCalibration({
+    bandJson: bandJson(),
+    league,
+    simulate,
+    gameCount: teams.length * 12,
+    minSamplesPerBucket: 5,
+  });
+
+  assertEquals(report.totalGames, teams.length * 12);
+  // Each matchup produces 2 samples (home + away EDGE starter).
+  assertEquals(report.totalSamples, gameCount * 2);
+
+  const fifty = report.buckets.find((b) => b.bucketLabel === "50")!;
+  assertEquals(fifty.samples > 0, true);
+  assertEquals(fifty.underSampled, false);
+  assertEquals(fifty.checks.length > 0, true);
+  // Every bucket should report checks on all three proxy metrics.
+  assertEquals(fifty.checks.length, 3);
+  const metricNames = fifty.checks.map((c) => c.metricName).sort();
+  assertEquals(metricNames, [
+    "qb_hits_per_game",
+    "sacks_per_game",
+    "tfl_per_game",
+  ]);
+});
+
+Deno.test("runEdgeCalibration marks a bucket under-sampled when below min threshold", () => {
+  const teams: SimTeam[] = [team("t50", edgeRuntime("t50-edge", 50))];
+  const league: CalibrationLeague = { calibrationSeed: 1, teams };
+  const simulate = (
+    { home, away, gameId }: {
+      home: SimTeam;
+      away: SimTeam;
+      seed: number;
+      gameId: string;
+    },
+  ) =>
+    makeGame(
+      gameId,
+      home.teamId,
+      away.teamId,
+      { [home.teamId]: 0, [away.teamId]: 0 },
+      { [home.teamId]: 0, [away.teamId]: 0 },
+    );
+
+  const report = runEdgeCalibration({
+    bandJson: bandJson(),
+    league,
+    simulate,
+    gameCount: 1,
+    minSamplesPerBucket: 100,
+  });
+
+  const fifty = report.buckets.find((b) => b.bucketLabel === "50")!;
+  assertEquals(fifty.underSampled, true);
+  assertEquals(fifty.checks.length, 0);
+});
+
+Deno.test("runEdgeCalibration flags tfl_per_game as a FAIL-low band check (proxy gap)", () => {
+  // Documented v1 limitation: sim never emits TFL events, so the
+  // bucket's sim mean for tfl_per_game is 0. The 50-overall bucket
+  // expects the "average" band mean (~0.48 in the fixture below),
+  // which is multiple sds above 0 — so the band check fails low.
+  const teams: SimTeam[] = [team("t50", edgeRuntime("t50-edge", 50))];
+  const league: CalibrationLeague = { calibrationSeed: 1, teams };
+  const simulate = (
+    { home, away, gameId }: {
+      home: SimTeam;
+      away: SimTeam;
+      seed: number;
+      gameId: string;
+    },
+  ) =>
+    makeGame(
+      gameId,
+      home.teamId,
+      away.teamId,
+      { [home.teamId]: 0.41, [away.teamId]: 0.41 },
+      { [home.teamId]: 0.95, [away.teamId]: 0.95 },
+    );
+
+  const report = runEdgeCalibration({
+    bandJson: bandJson(),
+    league,
+    simulate,
+    gameCount: 100,
+    minSamplesPerBucket: 1,
+  });
+
+  const fifty = report.buckets.find((b) => b.bucketLabel === "50")!;
+  const tflCheck = fifty.checks.find((c) => c.metricName === "tfl_per_game")!;
+  assertEquals(tflCheck.passed, false);
+  assertEquals(tflCheck.direction, "too_low");
+});
+
+Deno.test("formatEdgeCalibrationReport renders a human-readable summary", () => {
+  const teams: SimTeam[] = [team("t50", edgeRuntime("t50-edge", 50))];
+  const league: CalibrationLeague = { calibrationSeed: 1, teams };
+  const simulate = (
+    { home, away, gameId }: {
+      home: SimTeam;
+      away: SimTeam;
+      seed: number;
+      gameId: string;
+    },
+  ) =>
+    makeGame(
+      gameId,
+      home.teamId,
+      away.teamId,
+      { [home.teamId]: 0.41, [away.teamId]: 0.41 },
+      { [home.teamId]: 0.95, [away.teamId]: 0.95 },
+    );
+
+  const report = runEdgeCalibration({
+    bandJson: bandJson(),
+    league,
+    simulate,
+    gameCount: 50,
+    minSamplesPerBucket: 1,
+  });
+  const output = formatEdgeCalibrationReport(report);
+  assertStringIncludes(output, "EDGE calibration");
+  assertStringIncludes(output, "Proxy metrics");
+  assertStringIncludes(output, "bucket 50");
+  assertStringIncludes(output, "sacks_per_game");
+});

--- a/server/features/simulation/calibration/per-position/edge-harness.ts
+++ b/server/features/simulation/calibration/per-position/edge-harness.ts
@@ -1,0 +1,183 @@
+import { deriveGameSeed } from "../../rng.ts";
+import { CALIBRATION_GAME_COUNT } from "../constants.ts";
+import { generateMatchups } from "../harness.ts";
+import type { SimulateFn } from "../harness.ts";
+import type { CalibrationLeague } from "../generate-calibration-league.ts";
+import { collectEdgeSamples, type EdgeGameSample } from "./edge-sample.ts";
+import { bucketByAttr, type BucketReport } from "./bucket-by-attr.ts";
+import { type BandCheckResult, checkBand } from "./band-check.ts";
+import { loadPositionBands, type PositionBands } from "./band-loader.ts";
+
+// Proxy metrics, v1 per issue #496. nflreadr doesn't carry PFF
+// pass-rush grades and the sim engine doesn't emit qb_hit / tfl
+// events, so the headline EDGE metrics here are box-score proxies.
+// See per-position-edge.R and edge-sample.ts for the full gap writeup.
+//
+// - sacks_per_game is directly attributed (engine logs the rushing
+//   defender as a participant).
+// - qb_hits_per_game is derived from team-level `pressure` tags,
+//   allocated to EDGE starters proportional to passRushing — loses
+//   individual signal but preserves team totals.
+// - tfl_per_game will always be 0 from the sim until the engine emits
+//   a TFL concept. Surfacing the gap via a FAIL-low band check is the
+//   calibration report's job.
+export const EDGE_METRICS = [
+  "sacks_per_game",
+  "qb_hits_per_game",
+  "tfl_per_game",
+] as const;
+
+export type EdgeMetric = typeof EDGE_METRICS[number];
+
+const METRIC_EXTRACTORS: Record<EdgeMetric, (s: EdgeGameSample) => number> = {
+  sacks_per_game: (s) => s.sacks_per_game,
+  qb_hits_per_game: (s) => s.qb_hits_per_game,
+  tfl_per_game: (s) => s.tfl_per_game,
+};
+
+export interface EdgeCalibrationOptions {
+  bandJson: string;
+  league: CalibrationLeague;
+  simulate: SimulateFn;
+  gameCount?: number;
+  // Minimum samples per bucket before we trust a band check. Under
+  // this count we still emit the summary but flag it as under-sampled
+  // so the report distinguishes "bucket is empty/noisy" from "bucket
+  // is calibrated wrong".
+  minSamplesPerBucket?: number;
+}
+
+export interface EdgeBucketReport {
+  bucketLabel: string;
+  bucketCenter: number;
+  samples: number;
+  underSampled: boolean;
+  checks: BandCheckResult[];
+}
+
+export interface EdgeCalibrationReport {
+  totalGames: number;
+  totalSamples: number;
+  bands: PositionBands;
+  buckets: EdgeBucketReport[];
+  failures: BandCheckResult[];
+  passed: boolean;
+}
+
+const DEFAULT_MIN_SAMPLES = 50;
+
+export function runEdgeCalibration(
+  options: EdgeCalibrationOptions,
+): EdgeCalibrationReport {
+  const {
+    bandJson,
+    league,
+    simulate,
+    gameCount = CALIBRATION_GAME_COUNT,
+    minSamplesPerBucket = DEFAULT_MIN_SAMPLES,
+  } = options;
+
+  const bands = loadPositionBands(bandJson);
+  const teamById = new Map(league.teams.map((t) => [t.teamId, t]));
+  const matchups = generateMatchups(league.teams, gameCount);
+
+  const samples: EdgeGameSample[] = [];
+
+  for (let i = 0; i < matchups.length; i++) {
+    const { home, away } = matchups[i];
+    const gameId = `edge-calibration-game-${i}`;
+    const seed = deriveGameSeed(league.calibrationSeed, gameId);
+
+    const result = simulate({ home, away, seed, gameId });
+    const gameSamples = collectEdgeSamples({
+      game: result,
+      home: teamById.get(home.teamId) ?? home,
+      away: teamById.get(away.teamId) ?? away,
+    });
+    samples.push(...gameSamples);
+  }
+
+  const bucketReports: BucketReport<EdgeGameSample>[] = bucketByAttr({
+    samples,
+    attr: (s) => s.edgeOverall,
+    metrics: METRIC_EXTRACTORS,
+  });
+
+  const buckets: EdgeBucketReport[] = bucketReports.map((report) => {
+    const underSampled = report.samples.length < minSamplesPerBucket;
+    const checks: BandCheckResult[] = EDGE_METRICS.flatMap((metric) => {
+      // Don't emit band checks on under-sampled buckets — the NFL band
+      // comparison would be dominated by sampling noise and drown out
+      // the real failures from the populated buckets.
+      if (underSampled) return [];
+      return [
+        checkBand({
+          bucketLabel: report.bucket.label,
+          metricName: metric,
+          simSummary: report.metrics[metric],
+          bands,
+        }),
+      ];
+    });
+    return {
+      bucketLabel: report.bucket.label,
+      bucketCenter: report.bucket.center,
+      samples: report.samples.length,
+      underSampled,
+      checks,
+    };
+  });
+
+  const failures = buckets.flatMap((b) => b.checks.filter((c) => !c.passed));
+
+  return {
+    totalGames: matchups.length,
+    totalSamples: samples.length,
+    bands,
+    buckets,
+    failures,
+    passed: failures.length === 0,
+  };
+}
+
+export function formatEdgeCalibrationReport(
+  report: EdgeCalibrationReport,
+): string {
+  const lines: string[] = [];
+  lines.push(
+    `EDGE calibration — ${report.totalGames} games, ${report.totalSamples} EDGE-games`,
+  );
+  lines.push(
+    `Bands: ${report.bands.position} / ${
+      report.bands.seasons.join("-")
+    } / ranked by ${report.bands.rankingStat}`,
+  );
+  lines.push(
+    "Proxy metrics (v1 per issue #496): sacks attributed, qb_hits " +
+      "allocated from team pressures, tfl not emitted by sim.",
+  );
+  lines.push("");
+  for (const bucket of report.buckets) {
+    const header = `[bucket ${bucket.bucketLabel}] n=${bucket.samples}` +
+      (bucket.underSampled ? " (under-sampled, skipping band checks)" : "");
+    lines.push(header);
+    for (const check of bucket.checks) {
+      const verdict = check.passed ? "PASS" : "FAIL";
+      const dir = check.passed ? "" : ` (${check.direction})`;
+      lines.push(
+        `  ${verdict} ${check.metricName.padEnd(20)} ` +
+          `sim=${check.simMean.toFixed(4)}  ` +
+          `band(${check.expectedBand})=${check.bandMean.toFixed(4)}±${
+            check.bandSd.toFixed(4)
+          }  ` +
+          `z=${check.zScore.toFixed(2)}  actual=${check.actualBand}${dir}`,
+      );
+    }
+    lines.push("");
+  }
+  const passed = report.passed ? "PASS" : "FAIL";
+  lines.push(
+    `${passed}: ${report.failures.length} band check(s) missed expected band`,
+  );
+  return lines.join("\n");
+}

--- a/server/features/simulation/calibration/per-position/edge-overall.test.ts
+++ b/server/features/simulation/calibration/per-position/edge-overall.test.ts
@@ -1,0 +1,95 @@
+import { assertAlmostEquals } from "@std/assert";
+import type { PlayerAttributes } from "@zone-blitz/shared";
+import { EDGE_OVERALL_ATTRS, edgeOverall } from "./edge-overall.ts";
+
+function attrs(overrides: Partial<PlayerAttributes> = {}): PlayerAttributes {
+  const base: Record<string, number> = {};
+  const keys = [
+    "speed",
+    "acceleration",
+    "agility",
+    "strength",
+    "jumping",
+    "stamina",
+    "durability",
+    "armStrength",
+    "accuracyShort",
+    "accuracyMedium",
+    "accuracyDeep",
+    "accuracyOnTheRun",
+    "touch",
+    "release",
+    "ballCarrying",
+    "elusiveness",
+    "routeRunning",
+    "catching",
+    "contestedCatching",
+    "runAfterCatch",
+    "passBlocking",
+    "runBlocking",
+    "blockShedding",
+    "tackling",
+    "manCoverage",
+    "zoneCoverage",
+    "passRushing",
+    "runDefense",
+    "kickingPower",
+    "kickingAccuracy",
+    "puntingPower",
+    "puntingAccuracy",
+    "snapAccuracy",
+    "footballIq",
+    "decisionMaking",
+    "anticipation",
+    "composure",
+    "clutch",
+    "consistency",
+    "workEthic",
+    "coachability",
+    "leadership",
+    "greed",
+    "loyalty",
+    "ambition",
+    "vanity",
+    "schemeAttachment",
+    "mediaSensitivity",
+  ];
+  for (const k of keys) {
+    base[k] = 50;
+    base[`${k}Potential`] = 50;
+  }
+  return { ...(base as unknown as PlayerAttributes), ...overrides };
+}
+
+Deno.test("edgeOverall averages the five signature EDGE attributes", () => {
+  const result = edgeOverall(attrs({
+    passRushing: 80,
+    acceleration: 70,
+    strength: 60,
+    blockShedding: 50,
+    runDefense: 40,
+  }));
+  // (80 + 70 + 60 + 50 + 40) / 5 = 60
+  assertAlmostEquals(result, 60, 1e-9);
+});
+
+Deno.test("edgeOverall collapses to 50 when every signature attr is 50", () => {
+  assertAlmostEquals(edgeOverall(attrs()), 50, 1e-9);
+});
+
+Deno.test("EDGE_OVERALL_ATTRS covers pass-rush and run-defense attributes", () => {
+  const asSet = new Set<string>(EDGE_OVERALL_ATTRS);
+  // Pass-rush side — matches RANKING_ATTRS.passRush in resolve-matchups.ts
+  // so a calibration EDGE overall moves in lockstep with in-sim impact.
+  for (const key of ["passRushing", "acceleration", "strength"]) {
+    if (!asSet.has(key)) {
+      throw new Error(`expected EDGE_OVERALL_ATTRS to include ${key}`);
+    }
+  }
+  // Run-defense side — issue #496 called out blockShedding + runDefense.
+  for (const key of ["blockShedding", "runDefense"]) {
+    if (!asSet.has(key)) {
+      throw new Error(`expected EDGE_OVERALL_ATTRS to include ${key}`);
+    }
+  }
+});

--- a/server/features/simulation/calibration/per-position/edge-overall.ts
+++ b/server/features/simulation/calibration/per-position/edge-overall.ts
@@ -1,0 +1,29 @@
+import type { PlayerAttributes } from "@zone-blitz/shared";
+
+// The signature attributes that define EDGE-rusher quality in the sim.
+// `resolve-matchups.ts` ranks edge rushers by
+// `RANKING_ATTRS.passRush` = [passRushing, acceleration, strength],
+// which is the pass-rush side of the position. We add `blockShedding`
+// and `runDefense` here so the "overall" reflects complete EDGE play
+// (pass-rush + run-defense), matching how NFL front offices evaluate
+// the position — a great pass rusher who can't set the edge on runs
+// is a role player, not a starter.
+//
+// Averaging all five gives a single 0-100 "EDGE overall" we can bucket
+// on for calibration: a 50-overall edge should land on NFL median
+// starter numbers (sacks/qb_hits/tfl per game), 70+ is elite.
+export const EDGE_OVERALL_ATTRS = [
+  "passRushing",
+  "acceleration",
+  "strength",
+  "blockShedding",
+  "runDefense",
+] as const satisfies ReadonlyArray<keyof PlayerAttributes>;
+
+export function edgeOverall(attributes: PlayerAttributes): number {
+  let sum = 0;
+  for (const key of EDGE_OVERALL_ATTRS) {
+    sum += attributes[key];
+  }
+  return sum / EDGE_OVERALL_ATTRS.length;
+}

--- a/server/features/simulation/calibration/per-position/edge-sample.test.ts
+++ b/server/features/simulation/calibration/per-position/edge-sample.test.ts
@@ -1,0 +1,397 @@
+import { assertAlmostEquals, assertEquals } from "@std/assert";
+import type { PlayerAttributes } from "@zone-blitz/shared";
+import { collectEdgeSamples } from "./edge-sample.ts";
+import type { GameResult, PlayEvent } from "../../events.ts";
+import type { SimTeam } from "../../simulate-game.ts";
+import type { PlayerRuntime } from "../../resolve-play.ts";
+
+function attrs(overrides: Partial<PlayerAttributes> = {}): PlayerAttributes {
+  const base: Record<string, number> = {};
+  const keys = [
+    "speed",
+    "acceleration",
+    "agility",
+    "strength",
+    "jumping",
+    "stamina",
+    "durability",
+    "armStrength",
+    "accuracyShort",
+    "accuracyMedium",
+    "accuracyDeep",
+    "accuracyOnTheRun",
+    "touch",
+    "release",
+    "ballCarrying",
+    "elusiveness",
+    "routeRunning",
+    "catching",
+    "contestedCatching",
+    "runAfterCatch",
+    "passBlocking",
+    "runBlocking",
+    "blockShedding",
+    "tackling",
+    "manCoverage",
+    "zoneCoverage",
+    "passRushing",
+    "runDefense",
+    "kickingPower",
+    "kickingAccuracy",
+    "puntingPower",
+    "puntingAccuracy",
+    "snapAccuracy",
+    "footballIq",
+    "decisionMaking",
+    "anticipation",
+    "composure",
+    "clutch",
+    "consistency",
+    "workEthic",
+    "coachability",
+    "leadership",
+    "greed",
+    "loyalty",
+    "ambition",
+    "vanity",
+    "schemeAttachment",
+    "mediaSensitivity",
+  ];
+  for (const k of keys) {
+    base[k] = 50;
+    base[`${k}Potential`] = 50;
+  }
+  return { ...(base as unknown as PlayerAttributes), ...overrides };
+}
+
+function edgeRuntime(id: string, overall: number): PlayerRuntime {
+  return {
+    playerId: id,
+    neutralBucket: "EDGE",
+    attributes: attrs({
+      passRushing: overall,
+      acceleration: overall,
+      strength: overall,
+      blockShedding: overall,
+      runDefense: overall,
+    }),
+  };
+}
+
+function team(teamId: string, starters: PlayerRuntime[]): SimTeam {
+  return {
+    teamId,
+    starters,
+    bench: [],
+    fingerprint: { offense: null, defense: null, overrides: {} },
+    coachingMods: {
+      schemeFitBonus: 0,
+      situationalBonus: 0,
+      aggressiveness: 50,
+      penaltyDiscipline: 1,
+    },
+  };
+}
+
+function event(
+  overrides: Partial<PlayEvent> & {
+    outcome: PlayEvent["outcome"];
+    offenseTeamId: string;
+    defenseTeamId: string;
+  },
+): PlayEvent {
+  return {
+    gameId: "g",
+    driveIndex: 0,
+    playIndex: 0,
+    quarter: 1,
+    clock: "15:00",
+    situation: { down: 1, distance: 10, yardLine: 25 },
+    call: {
+      concept: "dropback",
+      personnel: "11",
+      formation: "shotgun",
+      motion: "none",
+    },
+    coverage: { front: "4-3", coverage: "cover_2", pressure: "four_man" },
+    participants: [],
+    yardage: 0,
+    tags: [],
+    ...overrides,
+  };
+}
+
+function gameOf(events: PlayEvent[]): GameResult {
+  return {
+    gameId: "g",
+    seed: 1,
+    finalScore: { home: 0, away: 0 },
+    events,
+    boxScore: {
+      home: {
+        totalYards: 0,
+        passingYards: 0,
+        rushingYards: 0,
+        turnovers: 0,
+        sacks: 0,
+        penalties: 0,
+      },
+      away: {
+        totalYards: 0,
+        passingYards: 0,
+        rushingYards: 0,
+        turnovers: 0,
+        sacks: 0,
+        penalties: 0,
+      },
+    },
+    driveLog: [],
+    injuryReport: [],
+  };
+}
+
+Deno.test("collectEdgeSamples returns one sample per EDGE starter on each team", () => {
+  const home = team("home", [
+    edgeRuntime("home-edge-1", 60),
+    edgeRuntime("home-edge-2", 60),
+  ]);
+  const away = team("away", [edgeRuntime("away-edge", 50)]);
+  const samples = collectEdgeSamples({
+    game: gameOf([]),
+    home,
+    away,
+  });
+  assertEquals(samples.length, 3);
+  assertEquals(samples[0].teamId, "home");
+  assertEquals(samples[2].teamId, "away");
+});
+
+Deno.test("collectEdgeSamples skips a team with no EDGE starter", () => {
+  const home = team("home", [edgeRuntime("home-edge", 50)]);
+  const away = team("away", []);
+  const samples = collectEdgeSamples({
+    game: gameOf([]),
+    home,
+    away,
+  });
+  assertEquals(samples.length, 1);
+  assertEquals(samples[0].teamId, "home");
+});
+
+Deno.test("collectEdgeSamples tags sample with EDGE overall (mean of five signature attrs)", () => {
+  const home = team("home", [
+    {
+      playerId: "home-edge",
+      neutralBucket: "EDGE",
+      attributes: attrs({
+        passRushing: 80,
+        acceleration: 70,
+        strength: 60,
+        blockShedding: 50,
+        runDefense: 40,
+      }),
+    },
+  ]);
+  const away = team("away", [edgeRuntime("away-edge", 50)]);
+  const [homeSample] = collectEdgeSamples({
+    game: gameOf([]),
+    home,
+    away,
+  });
+  // (80 + 70 + 60 + 50 + 40) / 5 = 60
+  assertAlmostEquals(homeSample.edgeOverall, 60, 0.01);
+});
+
+Deno.test("collectEdgeSamples attributes sacks to the participant tagged 'sack'", () => {
+  const home = team("home", [
+    edgeRuntime("home-edge-1", 60),
+    edgeRuntime("home-edge-2", 60),
+  ]);
+  const away = team("away", [edgeRuntime("away-edge", 50)]);
+  const events: PlayEvent[] = [
+    // Home team defense sacks the away QB — participant home-edge-1 gets credit.
+    event({
+      outcome: "sack",
+      offenseTeamId: "away",
+      defenseTeamId: "home",
+      yardage: -7,
+      tags: ["sack", "pressure"],
+      participants: [
+        { role: "pass_rush", playerId: "home-edge-1", tags: ["sack"] },
+      ],
+    }),
+    // Sack on the other side shouldn't leak into home-edge samples.
+    event({
+      outcome: "sack",
+      offenseTeamId: "home",
+      defenseTeamId: "away",
+      yardage: -5,
+      tags: ["sack", "pressure"],
+      participants: [
+        { role: "pass_rush", playerId: "away-edge", tags: ["sack"] },
+      ],
+    }),
+  ];
+  const samples = collectEdgeSamples({
+    game: gameOf(events),
+    home,
+    away,
+  });
+  const h1 = samples.find((s) => s.edgePlayerId === "home-edge-1")!;
+  const h2 = samples.find((s) => s.edgePlayerId === "home-edge-2")!;
+  const a = samples.find((s) => s.edgePlayerId === "away-edge")!;
+  assertEquals(h1.sacks, 1);
+  assertEquals(h2.sacks, 0);
+  assertEquals(a.sacks, 1);
+});
+
+Deno.test("collectEdgeSamples allocates team pressures across EDGE starters by passRushing share", () => {
+  // Home team has two EDGEs: 80 and 20 passRushing. Three team pressures
+  // should split 80/100 vs 20/100 — 2.4 to the stronger rusher.
+  const strong: PlayerRuntime = {
+    playerId: "strong",
+    neutralBucket: "EDGE",
+    attributes: attrs({
+      passRushing: 80,
+      acceleration: 60,
+      strength: 60,
+      blockShedding: 50,
+      runDefense: 50,
+    }),
+  };
+  const weak: PlayerRuntime = {
+    playerId: "weak",
+    neutralBucket: "EDGE",
+    attributes: attrs({
+      passRushing: 20,
+      acceleration: 60,
+      strength: 60,
+      blockShedding: 50,
+      runDefense: 50,
+    }),
+  };
+  const home = team("home", [strong, weak]);
+  const away = team("away", [edgeRuntime("away-edge", 50)]);
+  const events: PlayEvent[] = [
+    event({
+      outcome: "sack",
+      offenseTeamId: "away",
+      defenseTeamId: "home",
+      yardage: -6,
+      tags: ["sack", "pressure"],
+      participants: [],
+    }),
+    event({
+      outcome: "pass_incomplete",
+      offenseTeamId: "away",
+      defenseTeamId: "home",
+      yardage: 0,
+      tags: ["pressure"],
+    }),
+    event({
+      outcome: "pass_complete",
+      offenseTeamId: "away",
+      defenseTeamId: "home",
+      yardage: 5,
+      tags: ["pressure"],
+    }),
+  ];
+  const samples = collectEdgeSamples({
+    game: gameOf(events),
+    home,
+    away,
+  });
+  const strongSample = samples.find((s) => s.edgePlayerId === "strong")!;
+  const weakSample = samples.find((s) => s.edgePlayerId === "weak")!;
+  assertAlmostEquals(strongSample.qb_hits, 3 * (80 / 100), 1e-9);
+  assertAlmostEquals(weakSample.qb_hits, 3 * (20 / 100), 1e-9);
+});
+
+Deno.test("collectEdgeSamples falls back to even split when every EDGE has 0 passRushing", () => {
+  const a: PlayerRuntime = {
+    playerId: "a",
+    neutralBucket: "EDGE",
+    attributes: attrs({ passRushing: 0 }),
+  };
+  const b: PlayerRuntime = {
+    playerId: "b",
+    neutralBucket: "EDGE",
+    attributes: attrs({ passRushing: 0 }),
+  };
+  const home = team("home", [a, b]);
+  const away = team("away", [edgeRuntime("away-edge", 50)]);
+  const events: PlayEvent[] = [
+    event({
+      outcome: "pass_incomplete",
+      offenseTeamId: "away",
+      defenseTeamId: "home",
+      yardage: 0,
+      tags: ["pressure"],
+    }),
+    event({
+      outcome: "pass_incomplete",
+      offenseTeamId: "away",
+      defenseTeamId: "home",
+      yardage: 0,
+      tags: ["pressure"],
+    }),
+  ];
+  const samples = collectEdgeSamples({
+    game: gameOf(events),
+    home,
+    away,
+  });
+  const aSample = samples.find((s) => s.edgePlayerId === "a")!;
+  const bSample = samples.find((s) => s.edgePlayerId === "b")!;
+  assertAlmostEquals(aSample.qb_hits, 1, 1e-9);
+  assertAlmostEquals(bSample.qb_hits, 1, 1e-9);
+});
+
+Deno.test("collectEdgeSamples reports tfl as 0 (sim does not emit TFL events)", () => {
+  // Documented proxy gap: until the engine emits a tfl participant tag,
+  // every EDGE sample reports 0 TFLs. The band check is expected to
+  // surface this as a low-direction FAIL in the calibration report.
+  const home = team("home", [edgeRuntime("home-edge", 60)]);
+  const away = team("away", [edgeRuntime("away-edge", 50)]);
+  const events: PlayEvent[] = [
+    event({
+      outcome: "rush",
+      offenseTeamId: "away",
+      defenseTeamId: "home",
+      yardage: -3,
+      tags: [],
+    }),
+  ];
+  const [homeSample] = collectEdgeSamples({
+    game: gameOf(events),
+    home,
+    away,
+  });
+  assertEquals(homeSample.tfl, 0);
+  assertEquals(homeSample.tfl_per_game, 0);
+});
+
+Deno.test("collectEdgeSamples exposes per-game rates identical to totals (one game per sample)", () => {
+  const home = team("home", [edgeRuntime("home-edge", 60)]);
+  const away = team("away", [edgeRuntime("away-edge", 50)]);
+  const events: PlayEvent[] = [
+    event({
+      outcome: "sack",
+      offenseTeamId: "away",
+      defenseTeamId: "home",
+      yardage: -7,
+      tags: ["sack", "pressure"],
+      participants: [
+        { role: "pass_rush", playerId: "home-edge", tags: ["sack"] },
+      ],
+    }),
+  ];
+  const [homeSample] = collectEdgeSamples({
+    game: gameOf(events),
+    home,
+    away,
+  });
+  assertEquals(homeSample.games, 1);
+  assertEquals(homeSample.sacks_per_game, homeSample.sacks);
+  assertEquals(homeSample.qb_hits_per_game, homeSample.qb_hits);
+});

--- a/server/features/simulation/calibration/per-position/edge-sample.ts
+++ b/server/features/simulation/calibration/per-position/edge-sample.ts
@@ -1,0 +1,137 @@
+import type { GameResult, PlayEvent } from "../../events.ts";
+import type { SimTeam } from "../../simulate-game.ts";
+import type { PlayerRuntime } from "../../resolve-play.ts";
+import { edgeOverall } from "./edge-overall.ts";
+
+export interface EdgeGameSample {
+  teamId: string;
+  edgePlayerId: string;
+  edgeOverall: number;
+  games: number;
+  sacks: number;
+  qb_hits: number;
+  tfl: number;
+  sacks_per_game: number;
+  qb_hits_per_game: number;
+  tfl_per_game: number;
+}
+
+// Accumulate per-defense-team event counts needed to allocate EDGE
+// stats. The sim engine logs the rushing defender as a participant on
+// sacks (with a `sack` tag on the participant), but NOT on "pressure"
+// events (pressure is a play-level tag without a defender attribution)
+// and it does not emit a tackle-for-loss concept at all. This helper
+// gives us the raw counts we need to split across EDGE starters below.
+interface DefenseAggregates {
+  sackParticipantByPlayerId: Map<string, number>;
+  teamPressures: number;
+}
+
+function aggregateDefense(
+  events: PlayEvent[],
+  defenseTeamId: string,
+): DefenseAggregates {
+  const sackParticipantByPlayerId = new Map<string, number>();
+  let teamPressures = 0;
+
+  for (const event of events) {
+    if (event.defenseTeamId !== defenseTeamId) continue;
+
+    if (event.outcome === "sack") {
+      for (const p of event.participants) {
+        if (p.tags.includes("sack")) {
+          sackParticipantByPlayerId.set(
+            p.playerId,
+            (sackParticipantByPlayerId.get(p.playerId) ?? 0) + 1,
+          );
+        }
+      }
+    }
+
+    // `pressure` is a play-level tag the engine adds on sacks and on
+    // pass plays where the pass-rush overwhelmed protection. It's the
+    // best signal we have for a QB-hit proxy since the engine does
+    // not emit a dedicated qb_hit event. See PROXY METRICS note in
+    // per-position-edge.R for the full gap.
+    if (event.tags.includes("pressure")) {
+      teamPressures++;
+    }
+  }
+
+  return { sackParticipantByPlayerId, teamPressures };
+}
+
+export interface EdgeSampleInput {
+  game: GameResult;
+  home: SimTeam;
+  away: SimTeam;
+}
+
+// ============================================================================
+// EDGE-sample attribution — proxy, v1 per issue #496.
+// ----------------------------------------------------------------------------
+// The engine's per-play logging is asymmetric for defensive play:
+//   - Sacks are attributed to a specific defender (participant with
+//     `sack` tag) — we credit those directly.
+//   - QB hits are NOT emitted. We proxy them as team-level `pressure`
+//     tags, then split across the team's EDGE starters weighted by
+//     passRushing (shares > 0 only). This loses the individual signal
+//     an NFL qb_hit carries but preserves the team-total magnitude so
+//     band checks remain comparable to NFL per-game means.
+//   - Tackles-for-loss aren't emitted at all. We report 0 and flag
+//     it; the band check will fail low on every EDGE bucket, which is
+//     the calibration report's job — surface the gap.
+//
+// Follow-up (tracked as an issue once this slice merges): add a
+// `qb_hit` participant tag to synthesize-pass-outcome and a `tfl`
+// tag to synthesize-run-outcome, then swap this allocation for
+// direct per-player attribution.
+// ============================================================================
+export function collectEdgeSamples(
+  input: EdgeSampleInput,
+): EdgeGameSample[] {
+  const { game, home, away } = input;
+
+  const samples: EdgeGameSample[] = [];
+  for (const team of [home, away]) {
+    const edges = team.starters.filter(
+      (p: PlayerRuntime) => p.neutralBucket === "EDGE",
+    );
+    if (edges.length === 0) continue;
+
+    const agg = aggregateDefense(game.events, team.teamId);
+
+    const totalPassRushing = edges.reduce(
+      (sum, e) => sum + (e.attributes.passRushing ?? 0),
+      0,
+    );
+
+    for (const edge of edges) {
+      const sacks = agg.sackParticipantByPlayerId.get(edge.playerId) ?? 0;
+
+      // Split team pressures proportional to passRushing. If every
+      // starter has 0 passRushing (defensive test data), fall back to
+      // even split so we still generate a non-degenerate sample.
+      const share = totalPassRushing > 0
+        ? (edge.attributes.passRushing ?? 0) / totalPassRushing
+        : 1 / edges.length;
+      const qbHits = agg.teamPressures * share;
+
+      const tfl = 0;
+
+      samples.push({
+        teamId: team.teamId,
+        edgePlayerId: edge.playerId,
+        edgeOverall: edgeOverall(edge.attributes),
+        games: 1,
+        sacks,
+        qb_hits: qbHits,
+        tfl,
+        sacks_per_game: sacks,
+        qb_hits_per_game: qbHits,
+        tfl_per_game: tfl,
+      });
+    }
+  }
+  return samples;
+}

--- a/server/features/simulation/calibration/per-position/run-edge-calibration.ts
+++ b/server/features/simulation/calibration/per-position/run-edge-calibration.ts
@@ -1,0 +1,66 @@
+import { simulateGame } from "../../simulate-game.ts";
+import { generateCalibrationLeague } from "../generate-calibration-league.ts";
+import { CALIBRATION_SEEDS } from "../calibration-seeds.ts";
+import {
+  formatEdgeCalibrationReport,
+  runEdgeCalibration,
+} from "./edge-harness.ts";
+
+// Per-issue-#496: report-only across every calibration seed so a human
+// can read the per-bucket PASS/FAIL signal against NFL EDGE percentile
+// bands. Gating will come later once we understand per-bucket noise —
+// and especially once the sim emits qb_hit / tfl participant tags so
+// this harness can swap its proxy allocations for direct attribution.
+const bandPath = new URL(
+  "../../../../../data/bands/per-position/edge.json",
+  import.meta.url,
+);
+
+const bandJson = await Deno.readTextFile(bandPath);
+
+let allPassed = true;
+const summary: {
+  seed: number;
+  passed: number;
+  total: number;
+  underSampled: number;
+}[] = [];
+
+for (const seed of CALIBRATION_SEEDS) {
+  const league = generateCalibrationLeague({ seed });
+  const report = runEdgeCalibration({
+    bandJson,
+    league,
+    simulate: simulateGame,
+  });
+
+  console.log(`=== seed=0x${seed.toString(16)} ===`);
+  console.log(formatEdgeCalibrationReport(report));
+  console.log("");
+
+  const totalChecks = report.buckets.reduce(
+    (sum, b) => sum + b.checks.length,
+    0,
+  );
+  const passCount = totalChecks - report.failures.length;
+  const underSampled = report.buckets.filter((b) => b.underSampled).length;
+  summary.push({ seed, passed: passCount, total: totalChecks, underSampled });
+  if (!report.passed) allPassed = false;
+}
+
+console.log("=== Multi-seed summary ===");
+for (const row of summary) {
+  const status = row.passed === row.total ? "PASS" : "FAIL";
+  const underSampledNote = row.underSampled > 0
+    ? ` (${row.underSampled} bucket(s) under-sampled)`
+    : "";
+  console.log(
+    `${status} seed=0x${
+      row.seed.toString(16)
+    }: ${row.passed}/${row.total}${underSampledNote}`,
+  );
+}
+
+if (!allPassed) {
+  Deno.exit(1);
+}


### PR DESCRIPTION
## Summary

Adds the EDGE slice of the per-position calibration harness (issue #496).
Mirrors the structure of the QB slice (#497) and the RB slice (#500):
per-player sample collector → bucket-by-overall → band check vs. an
nflreadr-derived fixture → report-only output across every calibration
seed.

- `data/R/bands/per-position-edge.R` + `data/bands/per-position/edge.json`
  (346 EDGE-seasons, 2021-2025, DE/OLB with season sacks+qb_hits ≥ 10
  and games ≥ 10).
- `server/features/simulation/calibration/per-position/edge-overall.ts`,
  `edge-sample.ts`, `edge-harness.ts`, `run-edge-calibration.ts` +
  unit tests (15 new tests, all passing). Reuses existing
  `bucket-by-attr` / `band-loader` / `band-check` modules unchanged.
- `deno task sim:calibrate:edge` runs the harness across every seed.

## Notes

### Proxy-metric limitations (v1 per issue #496)

EDGE is the first slice where nflreadr does **not** carry the
gold-standard public data (PFF pass-rush grade / pass-rush-win-rate).
The fixture and harness therefore use box-score proxies:

| Metric | Source in sim | Gap |
|---|---|---|
| `sacks_per_game` | Directly attributed via the `sack` participant tag the engine writes in `synthesize-pass-outcome.ts`. | None. |
| `qb_hits_per_game` | No `qb_hit` event type. Proxied by splitting team-level `pressure`-tagged plays across EDGE starters proportional to `passRushing`. | Preserves team totals but loses individual signal; multiple EDGEs on the same team get fractional hits. |
| `tfl_per_game` | Not emitted at all by the engine. | Reported as 0; band check will always FAIL-low on every populated bucket. Surfacing this gap is the calibration report's job in v1. |

The R script header, the `edge-sample.ts` docblock, the harness
docblock, and the fixture `notes` field all flag this prominently.

### Sim-engine logging gaps surfaced by the harness

A full multi-seed run already shows calibration gaps worth tracking as
follow-ups:

- `qb_hits_per_game` runs ~5-10x NFL across every bucket, because the
  engine stamps a `pressure` tag on every pass play where
  `protectionScore < -5` rather than rolling a calibrated per-play
  probability.
- `sacks_per_game` under-fires at the 40/50 buckets (sim ~0.18 / 0.27
  vs. NFL weak/average ~0.27 / 0.41) and over-fires hard at the 70/80
  buckets (sim ~1.7 / 2.7 vs. NFL elite ~0.89). Bucket separation is
  too wide.
- `tfl_per_game` is 0 everywhere (see proxy table above).
- 30-overall bucket is under-sampled across seeds — the league
  generator's EDGE overall distribution sits above ~35, same pattern
  as the RB slice.

These will land as GitHub issues once this PR merges. The natural
first follow-up is adding a `qb_hit` participant tag (easy, single-site
change in `synthesize-pass-outcome.ts`) and a `tfl` tag in
`synthesize-run-outcome.ts`, then swapping the proxy allocation in
`edge-sample.ts` for direct per-player attribution.

### Verification

- `deno lint` clean on the 7 new files.
- `deno check` clean on the 7 new files.
- `deno test server/features/simulation/calibration/` — 130 tests
  pass (15 new, 115 pre-existing).
- `deno task sim:calibrate:edge` runs cleanly across all 8
  calibration seeds, emitting the expected proxy-gap FAILs.