### PR TITLE
feat(calibration): add per-S-bucket calibration harness (#496, S slice)

### DIFF
--- a/data/R/bands/per-position-s.R
+++ b/data/R/bands/per-position-s.R
@@ -1,0 +1,168 @@
+#!/usr/bin/env Rscript
+# per-position-s.R — NFL safety (S) percentile-band reference.
+#
+# Pulls weekly defensive stats from load_player_stats, aggregates to
+# per-safety-season lines, filters to starters (season games >= 10 AND
+# total tackles >= 40 — snap counts aren't in load_player_stats, so we
+# proxy with games + tackle volume), ranks by a playmaker composite
+# (INTs + PBUs + forced fumbles + sacks per game), and carves the
+# population into five percentile bands.
+#
+# Caveat: nflreadr's per-player weekly defense feed does NOT expose
+# targets-allowed, completion-allowed%, or yards-allowed-per-target on
+# a per-safety basis — those stats require a play-by-play join with a
+# target-defender field that isn't in this release. The four metrics
+# below are the defensible per-season numbers we can read directly:
+# tackles/game, INT rate, PBU rate, forced-fumble rate. Downstream
+# slices that need coverage-yield metrics will need a pbp-level R
+# script; this one deliberately stays at the per-player-week grain to
+# keep the fixture reproducible.
+#
+# Output: data/bands/per-position/s.json
+#
+# Usage:
+#   Rscript data/R/bands/per-position-s.R [--seasons 2020:2024]
+
+suppressPackageStartupMessages({
+  library(nflreadr)
+  library(dplyr)
+})
+
+script_file <- (function() {
+  args <- commandArgs(trailingOnly = FALSE)
+  f <- grep("^--file=", args, value = TRUE)
+  if (length(f) > 0) normalizePath(sub("^--file=", "", f[1]), mustWork = FALSE) else NULL
+})()
+source(file.path(dirname(script_file), "..", "lib.R"))
+
+args <- commandArgs(trailingOnly = TRUE)
+seasons <- parse_seasons(args)
+
+cat("Loading weekly defensive player stats for seasons:",
+    paste(range(seasons), collapse = "-"), "\n")
+
+weekly <- nflreadr::load_player_stats(seasons, stat_type = "defense")
+
+# nflreadr collapses FS/SS into a single "S" position_group; keep the
+# filter permissive so reclassified safeties (e.g., nickel or big-slot
+# hybrids tagged as "DB") still flow through.
+s_weekly <- weekly |>
+  filter(
+    season_type == "REG",
+    position %in% c("S", "FS", "SS") |
+      position_group %in% c("S", "DB", "SAF")
+  ) |>
+  # Restrict to rows that logged any defensive activity — avoids
+  # sweeping in special-teams-only appearances.
+  filter(
+    !is.na(def_tackles_solo),
+    def_tackles_solo + def_tackle_assists +
+      def_pass_defended + def_interceptions > 0
+  )
+
+s_season <- s_weekly |>
+  group_by(player_id, player_display_name, season) |>
+  summarise(
+    games           = n(),
+    solo_tackles    = sum(def_tackles_solo, na.rm = TRUE),
+    assist_tackles  = sum(def_tackle_assists, na.rm = TRUE),
+    tackles_for_loss = sum(def_tackles_for_loss, na.rm = TRUE),
+    ints            = sum(def_interceptions, na.rm = TRUE),
+    pbus            = sum(def_pass_defended, na.rm = TRUE),
+    sacks           = sum(def_sacks, na.rm = TRUE),
+    forced_fumbles  = sum(def_fumbles_forced, na.rm = TRUE),
+    .groups         = "drop"
+  ) |>
+  mutate(
+    total_tackles       = solo_tackles + assist_tackles,
+    tackles_per_game    = ifelse(games > 0, total_tackles / games, NA_real_),
+    int_rate            = ifelse(games > 0, ints / games, NA_real_),
+    pbu_rate            = ifelse(games > 0, pbus / games, NA_real_),
+    forced_fumble_rate  = ifelse(games > 0, forced_fumbles / games, NA_real_),
+    # Playmaker composite — rewards ball production over raw tackle
+    # volume so a box safety who racks up tackles near the LOS doesn't
+    # outrank a deep ball-hawk. Sacks added because modern safeties
+    # blitz frequently and the column is already summed.
+    playmaker_per_game  = ifelse(games > 0,
+      (ints + pbus + forced_fumbles + sacks) / games, NA_real_)
+  ) |>
+  filter(games >= 10, total_tackles >= 40) # starter proxy
+
+cat("S-seasons after starter filter:", nrow(s_season), "\n")
+
+# Rank by playmaker composite then carve into percentile bands.
+s_ranked <- s_season |>
+  arrange(desc(playmaker_per_game)) |>
+  mutate(
+    pct = (row_number() - 0.5) / n(),
+    band = case_when(
+      pct <= 0.10 ~ "elite",
+      pct <= 0.30 ~ "good",
+      pct <= 0.70 ~ "average",
+      pct <= 0.90 ~ "weak",
+      TRUE        ~ "replacement"
+    )
+  )
+
+metric_keys <- c(
+  "tackles_per_game",
+  "int_rate",
+  "pbu_rate",
+  "forced_fumble_rate"
+)
+
+band_order <- c("elite", "good", "average", "weak", "replacement")
+
+band_summary <- function(rows) {
+  metrics <- list()
+  for (key in metric_keys) {
+    vals <- rows[[key]]
+    vals <- vals[!is.na(vals)]
+    metrics[[key]] <- list(
+      n = length(vals),
+      mean = mean(vals),
+      sd = stats::sd(vals)
+    )
+  }
+  list(
+    n = nrow(rows),
+    metrics = metrics
+  )
+}
+
+bands <- list()
+for (band_name in band_order) {
+  rows <- s_ranked |> filter(band == band_name)
+  bands[[band_name]] <- band_summary(rows)
+}
+
+out <- list(
+  generated_at = format(Sys.time(), "%Y-%m-%dT%H:%M:%SZ", tz = "UTC"),
+  seasons = as.integer(seasons),
+  position = "S",
+  qualifier = "regular-season S-seasons with >=10 games and >=40 total tackles",
+  ranking_stat = "playmaker_per_game ((INTs + PBUs + forced fumbles + sacks) / games)",
+  notes = paste0(
+    "Starter safety seasons 2020-2024, ranked by playmaker composite ",
+    "(INT + PBU + FF + sack per game) then carved into percentile bands ",
+    "(elite: top 10%, good: 10-30%, average: 30-70%, weak: 70-90%, ",
+    "replacement: bottom 10%). KNOWN GAP: nflreadr's per-player defense ",
+    "feed does not expose targets-allowed or completion-allowed% per ",
+    "safety, so the band set is limited to volume rates (tackles/game, ",
+    "INT/game, PBU/game, forced-fumble/game). A coverage-yield band ",
+    "would require a pbp target-defender join, which is out of scope ",
+    "for this slice."
+  ),
+  bands = bands
+)
+
+out_path <- file.path(
+  repo_root(), "data", "bands", "per-position", "s.json"
+)
+dir.create(dirname(out_path), recursive = TRUE, showWarnings = FALSE)
+writeLines(
+  jsonlite::toJSON(out, auto_unbox = TRUE, pretty = TRUE, digits = 4,
+                   null = "null"),
+  out_path
+)
+cat("Wrote", out_path, "\n")

--- a/data/bands/per-position/s.json
+++ b/data/bands/per-position/s.json
@@ -1,0 +1,135 @@
+{
+  "generated_at": "2026-04-17T12:29:04Z",
+  "seasons": [2020, 2021, 2022, 2023, 2024],
+  "position": "S",
+  "qualifier": "regular-season S-seasons with >=10 games and >=40 total tackles",
+  "ranking_stat": "playmaker_per_game ((INTs + PBUs + forced fumbles + sacks) / games)",
+  "notes": "Starter safety seasons 2020-2024, ranked by playmaker composite (INT + PBU + FF + sack per game) then carved into percentile bands (elite: top 10%, good: 10-30%, average: 30-70%, weak: 70-90%, replacement: bottom 10%). KNOWN GAP: nflreadr's per-player defense feed does not expose targets-allowed or completion-allowed% per safety, so the band set is limited to volume rates (tackles/game, INT/game, PBU/game, forced-fumble/game). A coverage-yield band would require a pbp target-defender join, which is out of scope for this slice.",
+  "bands": {
+    "elite": {
+      "n": 77,
+      "metrics": {
+        "tackles_per_game": {
+          "n": 77,
+          "mean": 4.251,
+          "sd": 0.9671
+        },
+        "int_rate": {
+          "n": 77,
+          "mean": 0.2662,
+          "sd": 0.1352
+        },
+        "pbu_rate": {
+          "n": 77,
+          "mean": 0.9659,
+          "sd": 0.1999
+        },
+        "forced_fumble_rate": {
+          "n": 77,
+          "mean": 0.068,
+          "sd": 0.089
+        }
+      }
+    },
+    "good": {
+      "n": 153,
+      "metrics": {
+        "tackles_per_game": {
+          "n": 153,
+          "mean": 4.4955,
+          "sd": 1.0164
+        },
+        "int_rate": {
+          "n": 153,
+          "mean": 0.1609,
+          "sd": 0.0933
+        },
+        "pbu_rate": {
+          "n": 153,
+          "mean": 0.6981,
+          "sd": 0.1538
+        },
+        "forced_fumble_rate": {
+          "n": 153,
+          "mean": 0.0601,
+          "sd": 0.0826
+        }
+      }
+    },
+    "average": {
+      "n": 306,
+      "metrics": {
+        "tackles_per_game": {
+          "n": 306,
+          "mean": 4.4395,
+          "sd": 1.0774
+        },
+        "int_rate": {
+          "n": 306,
+          "mean": 0.1017,
+          "sd": 0.0754
+        },
+        "pbu_rate": {
+          "n": 306,
+          "mean": 0.4704,
+          "sd": 0.1265
+        },
+        "forced_fumble_rate": {
+          "n": 306,
+          "mean": 0.0471,
+          "sd": 0.0593
+        }
+      }
+    },
+    "weak": {
+      "n": 153,
+      "metrics": {
+        "tackles_per_game": {
+          "n": 153,
+          "mean": 4.5249,
+          "sd": 1.0288
+        },
+        "int_rate": {
+          "n": 153,
+          "mean": 0.0464,
+          "sd": 0.0485
+        },
+        "pbu_rate": {
+          "n": 153,
+          "mean": 0.2945,
+          "sd": 0.0768
+        },
+        "forced_fumble_rate": {
+          "n": 153,
+          "mean": 0.0338,
+          "sd": 0.0439
+        }
+      }
+    },
+    "replacement": {
+      "n": 77,
+      "metrics": {
+        "tackles_per_game": {
+          "n": 77,
+          "mean": 4.3022,
+          "sd": 1.1195
+        },
+        "int_rate": {
+          "n": 77,
+          "mean": 0.0191,
+          "sd": 0.0347
+        },
+        "pbu_rate": {
+          "n": 77,
+          "mean": 0.1202,
+          "sd": 0.0717
+        },
+        "forced_fumble_rate": {
+          "n": 77,
+          "mean": 0.0203,
+          "sd": 0.0338
+        }
+      }
+    }
+  }
+}

--- a/deno.json
+++ b/deno.json
@@ -40,6 +40,7 @@
     "sim:calibrate:wr": "deno run --allow-read server/features/simulation/calibration/per-position/run-wr-calibration.ts",
     "sim:calibrate:edge": "deno run --allow-read server/features/simulation/calibration/per-position/run-edge-calibration.ts",
     "sim:calibrate:cb": "deno run --allow-read server/features/simulation/calibration/per-position/run-cb-calibration.ts",
+    "sim:calibrate:s": "deno run --allow-read server/features/simulation/calibration/per-position/run-s-calibration.ts",
     "build": "cd client && deno task build",
     "start": "cd server && deno run --env=../.env --allow-net --allow-env --allow-read --allow-sys main.ts"
   },

--- a/server/features/simulation/calibration/per-position/run-s-calibration.ts
+++ b/server/features/simulation/calibration/per-position/run-s-calibration.ts
@@ -1,0 +1,63 @@
+import { simulateGame } from "../../simulate-game.ts";
+import { generateCalibrationLeague } from "../generate-calibration-league.ts";
+import { CALIBRATION_SEEDS } from "../calibration-seeds.ts";
+import { formatSCalibrationReport, runSCalibration } from "./s-harness.ts";
+
+// Per-issue-#496: this entry point is intentionally report-only at
+// first. We print per-bucket PASS/FAIL against NFL safety percentile
+// bands across every calibration seed so a human can eyeball the
+// signal — gating will come later once we understand noise
+// characteristics per bucket.
+const bandPath = new URL(
+  "../../../../../data/bands/per-position/s.json",
+  import.meta.url,
+);
+
+const bandJson = await Deno.readTextFile(bandPath);
+
+let allPassed = true;
+const summary: {
+  seed: number;
+  passed: number;
+  total: number;
+  underSampled: number;
+}[] = [];
+
+for (const seed of CALIBRATION_SEEDS) {
+  const league = generateCalibrationLeague({ seed });
+  const report = runSCalibration({
+    bandJson,
+    league,
+    simulate: simulateGame,
+  });
+
+  console.log(`=== seed=0x${seed.toString(16)} ===`);
+  console.log(formatSCalibrationReport(report));
+  console.log("");
+
+  const totalChecks = report.buckets.reduce(
+    (sum, b) => sum + b.checks.length,
+    0,
+  );
+  const passCount = totalChecks - report.failures.length;
+  const underSampled = report.buckets.filter((b) => b.underSampled).length;
+  summary.push({ seed, passed: passCount, total: totalChecks, underSampled });
+  if (!report.passed) allPassed = false;
+}
+
+console.log("=== Multi-seed summary ===");
+for (const row of summary) {
+  const status = row.passed === row.total ? "PASS" : "FAIL";
+  const underSampledNote = row.underSampled > 0
+    ? ` (${row.underSampled} bucket(s) under-sampled)`
+    : "";
+  console.log(
+    `${status} seed=0x${
+      row.seed.toString(16)
+    }: ${row.passed}/${row.total}${underSampledNote}`,
+  );
+}
+
+if (!allPassed) {
+  Deno.exit(1);
+}

--- a/server/features/simulation/calibration/per-position/s-harness.test.ts
+++ b/server/features/simulation/calibration/per-position/s-harness.test.ts
@@ -1,0 +1,398 @@
+import { assertEquals, assertStringIncludes } from "@std/assert";
+import type { PlayerAttributes } from "@zone-blitz/shared";
+import { formatSCalibrationReport, runSCalibration } from "./s-harness.ts";
+import type { GameResult, PlayEvent } from "../../events.ts";
+import type { SimTeam } from "../../simulate-game.ts";
+import type { PlayerRuntime } from "../../resolve-play.ts";
+import type { CalibrationLeague } from "../generate-calibration-league.ts";
+
+function attrs(overrides: Partial<PlayerAttributes> = {}): PlayerAttributes {
+  const base: Record<string, number> = {};
+  const keys = [
+    "speed",
+    "acceleration",
+    "agility",
+    "strength",
+    "jumping",
+    "stamina",
+    "durability",
+    "armStrength",
+    "accuracyShort",
+    "accuracyMedium",
+    "accuracyDeep",
+    "accuracyOnTheRun",
+    "touch",
+    "release",
+    "ballCarrying",
+    "elusiveness",
+    "routeRunning",
+    "catching",
+    "contestedCatching",
+    "runAfterCatch",
+    "passBlocking",
+    "runBlocking",
+    "blockShedding",
+    "tackling",
+    "manCoverage",
+    "zoneCoverage",
+    "passRushing",
+    "runDefense",
+    "kickingPower",
+    "kickingAccuracy",
+    "puntingPower",
+    "puntingAccuracy",
+    "snapAccuracy",
+    "footballIq",
+    "decisionMaking",
+    "anticipation",
+    "composure",
+    "clutch",
+    "consistency",
+    "workEthic",
+    "coachability",
+    "leadership",
+    "greed",
+    "loyalty",
+    "ambition",
+    "vanity",
+    "schemeAttachment",
+    "mediaSensitivity",
+  ];
+  for (const k of keys) {
+    base[k] = 50;
+    base[`${k}Potential`] = 50;
+  }
+  return { ...(base as unknown as PlayerAttributes), ...overrides };
+}
+
+function safetyRuntime(id: string, overall: number): PlayerRuntime {
+  return {
+    playerId: id,
+    neutralBucket: "S",
+    attributes: attrs({
+      zoneCoverage: overall,
+      manCoverage: overall,
+      speed: overall,
+      tackling: overall,
+      anticipation: overall,
+    }),
+  };
+}
+
+function team(teamId: string, starters: PlayerRuntime[]): SimTeam {
+  return {
+    teamId,
+    starters,
+    bench: [],
+    fingerprint: { offense: null, defense: null, overrides: {} },
+    coachingMods: {
+      schemeFitBonus: 0,
+      situationalBonus: 0,
+      aggressiveness: 50,
+      penaltyDiscipline: 1,
+    },
+  };
+}
+
+function bandJson(): string {
+  // Band means are chosen so the default 30↔replacement, 40↔weak,
+  // 50↔average, 60↔good, 70/80↔elite mapping sorts monotonically and
+  // each bucket lands in its target band in the stub scenario below.
+  const band = (scale: number) => ({
+    n: 20,
+    metrics: {
+      tackles_per_game: { n: 20, mean: 3 + scale, sd: 1 },
+      int_rate: { n: 20, mean: 0.05 + 0.03 * scale, sd: 0.02 },
+      pbu_rate: { n: 20, mean: 0.2 + 0.1 * scale, sd: 0.05 },
+      forced_fumble_rate: { n: 20, mean: 0.02 + 0.01 * scale, sd: 0.01 },
+    },
+  });
+  return JSON.stringify({
+    position: "S",
+    seasons: [2020, 2021, 2022, 2023, 2024],
+    ranking_stat: "playmaker_per_game",
+    bands: {
+      elite: band(2),
+      good: band(1.5),
+      average: band(1),
+      weak: band(0.5),
+      replacement: band(0),
+    },
+  });
+}
+
+function makeGame(
+  gameId: string,
+  homeTeamId: string,
+  awayTeamId: string,
+  // Per-team rates of rushes/completes/incompletes/INTs/fumbles to
+  // emit. The harness divides by S starter count + secondary share,
+  // so these team totals flow straight through.
+  events: Record<string, {
+    rushes: number;
+    completes: number;
+    incompletes: number;
+    ints: number;
+    fumbles: number;
+  }>,
+): GameResult {
+  const out: PlayEvent[] = [];
+  const idx = { i: 0 };
+  function push(
+    offenseTeamId: string,
+    defenseTeamId: string,
+    outcome: PlayEvent["outcome"],
+  ) {
+    out.push({
+      gameId,
+      driveIndex: 0,
+      playIndex: idx.i++,
+      quarter: 1,
+      clock: "15:00",
+      situation: { down: 1, distance: 10, yardLine: 25 },
+      offenseTeamId,
+      defenseTeamId,
+      call: {
+        concept: "dropback",
+        personnel: "11",
+        formation: "shotgun",
+        motion: "none",
+      },
+      coverage: { front: "4-3", coverage: "cover_2", pressure: "four_man" },
+      participants: [],
+      outcome,
+      yardage: outcome === "pass_complete" || outcome === "rush" ? 5 : 0,
+      tags: [],
+    });
+  }
+  for (const [defenseTeamId, rates] of Object.entries(events)) {
+    const offenseTeamId = defenseTeamId === homeTeamId
+      ? awayTeamId
+      : homeTeamId;
+    for (let i = 0; i < rates.rushes; i++) {
+      push(offenseTeamId, defenseTeamId, "rush");
+    }
+    for (let i = 0; i < rates.completes; i++) {
+      push(offenseTeamId, defenseTeamId, "pass_complete");
+    }
+    for (let i = 0; i < rates.incompletes; i++) {
+      push(offenseTeamId, defenseTeamId, "pass_incomplete");
+    }
+    for (let i = 0; i < rates.ints; i++) {
+      push(offenseTeamId, defenseTeamId, "interception");
+    }
+    for (let i = 0; i < rates.fumbles; i++) {
+      push(offenseTeamId, defenseTeamId, "fumble");
+    }
+  }
+  return {
+    gameId,
+    seed: 1,
+    finalScore: { home: 0, away: 0 },
+    events: out,
+    boxScore: {
+      home: {
+        totalYards: 0,
+        passingYards: 0,
+        rushingYards: 0,
+        turnovers: 0,
+        sacks: 0,
+        penalties: 0,
+      },
+      away: {
+        totalYards: 0,
+        passingYards: 0,
+        rushingYards: 0,
+        turnovers: 0,
+        sacks: 0,
+        penalties: 0,
+      },
+    },
+    driveLog: [],
+    injuryReport: [],
+  };
+}
+
+Deno.test("runSCalibration runs the sim, buckets safeties, and returns a populated report", () => {
+  // Build a league where each team's two S starters share an overall,
+  // and the stub simulate emits per-team event totals that, once the
+  // sample collector applies the 0.45 secondary share and divides
+  // across 2 safeties, match the target band means.
+  //
+  // Band means for tackles_per_game are 3,3.5,4,4.5,5 for
+  // replacement..elite. To land in the "average" band (4.0 tackles/g),
+  // with 2 S starters, we need 2 * 4 / 0.45 ≈ 17.8 team tackles (≈ 18).
+  const teams: SimTeam[] = [30, 40, 50, 60, 70, 80].map((overall) => {
+    const id = `t${overall}`;
+    return team(id, [
+      safetyRuntime(`${id}-s1`, overall),
+      safetyRuntime(`${id}-s2`, overall),
+    ]);
+  });
+  const league: CalibrationLeague = { calibrationSeed: 1, teams };
+
+  // For each defense team, emit enough tackles/INTs/PBUs/FFs that the
+  // allocated per-safety rate targets the matching NFL band mean.
+  const targetByOverall: Record<number, {
+    tackles: number;
+    ints: number;
+    pbuInc: number;
+    ff: number;
+  }> = {
+    30: { tackles: 3, ints: 0.05, pbuInc: 0.2, ff: 0.02 },
+    40: { tackles: 3.5, ints: 0.08, pbuInc: 0.3, ff: 0.03 },
+    50: { tackles: 4, ints: 0.11, pbuInc: 0.4, ff: 0.04 },
+    60: { tackles: 4.5, ints: 0.14, pbuInc: 0.5, ff: 0.05 },
+    70: { tackles: 5, ints: 0.17, pbuInc: 0.6, ff: 0.06 },
+    80: { tackles: 5, ints: 0.17, pbuInc: 0.6, ff: 0.06 },
+  };
+  // sample.tackles_per_game = team_tackles * 0.45 / 2.
+  // team_tackles = target * 2 / 0.45. Round because events are ints.
+  const simulate = (
+    { home, away, gameId }: {
+      home: SimTeam;
+      away: SimTeam;
+      seed: number;
+      gameId: string;
+    },
+  ) => {
+    const per = (teamId: string) => {
+      const overall = parseInt(teamId.replace("t", ""), 10);
+      const tgt = targetByOverall[overall];
+      const teamTackles = Math.round((tgt.tackles * 2) / 0.45);
+      const teamInts = (tgt.ints * 2) / 0.45;
+      const teamPbus = (tgt.pbuInc * 2) / 0.45;
+      const teamFfs = (tgt.ff * 2) / 0.45;
+      // Split team tackles 70/30 between rushes and completes so the
+      // breakdown stays realistic; fumbles double-count as tackles so
+      // subtract them here.
+      const fumbles = Math.round(teamFfs);
+      const rushes = Math.max(0, Math.round(teamTackles * 0.6) - fumbles);
+      const completes = Math.max(
+        0,
+        teamTackles - rushes - fumbles,
+      );
+      const incompletes = Math.round(teamPbus / 0.4);
+      return {
+        rushes,
+        completes,
+        incompletes,
+        ints: Math.round(teamInts),
+        fumbles,
+      };
+    };
+    return makeGame(gameId, home.teamId, away.teamId, {
+      [home.teamId]: per(home.teamId),
+      [away.teamId]: per(away.teamId),
+    });
+  };
+
+  const report = runSCalibration({
+    bandJson: bandJson(),
+    league,
+    simulate,
+    gameCount: teams.length * 12,
+    minSamplesPerBucket: 5,
+  });
+
+  assertEquals(report.totalGames, teams.length * 12);
+  // Each matchup produces 2 teams × 2 S starters = 4 samples.
+  assertEquals(report.totalSamples, report.totalGames * 4);
+
+  const fifty = report.buckets.find((b) => b.bucketLabel === "50")!;
+  assertEquals(fifty.samples > 0, true);
+  assertEquals(fifty.underSampled, false);
+  assertEquals(fifty.checks.length, 4);
+  const tacklesCheck = fifty.checks.find((c) =>
+    c.metricName === "tackles_per_game"
+  )!;
+  // Sim tackles/game for the 50-bucket should match the "average"
+  // band mean (4.0) after allocation.
+  assertEquals(tacklesCheck.expectedBand, "average");
+});
+
+Deno.test("runSCalibration marks a bucket under-sampled when below min threshold", () => {
+  const teams: SimTeam[] = [
+    team("t50", [safetyRuntime("t50-s1", 50), safetyRuntime("t50-s2", 50)]),
+  ];
+  const league: CalibrationLeague = { calibrationSeed: 1, teams };
+  const simulate = (
+    { home, away, gameId }: {
+      home: SimTeam;
+      away: SimTeam;
+      seed: number;
+      gameId: string;
+    },
+  ) =>
+    makeGame(gameId, home.teamId, away.teamId, {
+      [home.teamId]: {
+        rushes: 10,
+        completes: 5,
+        incompletes: 8,
+        ints: 1,
+        fumbles: 0,
+      },
+      [away.teamId]: {
+        rushes: 10,
+        completes: 5,
+        incompletes: 8,
+        ints: 1,
+        fumbles: 0,
+      },
+    });
+
+  const report = runSCalibration({
+    bandJson: bandJson(),
+    league,
+    simulate,
+    gameCount: 1,
+    minSamplesPerBucket: 100,
+  });
+
+  const fifty = report.buckets.find((b) => b.bucketLabel === "50")!;
+  assertEquals(fifty.underSampled, true);
+  assertEquals(fifty.checks.length, 0);
+});
+
+Deno.test("formatSCalibrationReport renders a human-readable summary", () => {
+  const teams: SimTeam[] = [
+    team("t50", [safetyRuntime("t50-s1", 50), safetyRuntime("t50-s2", 50)]),
+  ];
+  const league: CalibrationLeague = { calibrationSeed: 1, teams };
+  const simulate = (
+    { home, away, gameId }: {
+      home: SimTeam;
+      away: SimTeam;
+      seed: number;
+      gameId: string;
+    },
+  ) =>
+    makeGame(gameId, home.teamId, away.teamId, {
+      [home.teamId]: {
+        rushes: 10,
+        completes: 5,
+        incompletes: 8,
+        ints: 1,
+        fumbles: 0,
+      },
+      [away.teamId]: {
+        rushes: 10,
+        completes: 5,
+        incompletes: 8,
+        ints: 1,
+        fumbles: 0,
+      },
+    });
+
+  const report = runSCalibration({
+    bandJson: bandJson(),
+    league,
+    simulate,
+    gameCount: 100,
+    minSamplesPerBucket: 1,
+  });
+  const output = formatSCalibrationReport(report);
+  assertStringIncludes(output, "S calibration");
+  assertStringIncludes(output, "bucket 50");
+  assertStringIncludes(output, "tackles_per_game");
+});

--- a/server/features/simulation/calibration/per-position/s-harness.ts
+++ b/server/features/simulation/calibration/per-position/s-harness.ts
@@ -1,0 +1,172 @@
+import { deriveGameSeed } from "../../rng.ts";
+import { CALIBRATION_GAME_COUNT } from "../constants.ts";
+import { generateMatchups } from "../harness.ts";
+import type { SimulateFn } from "../harness.ts";
+import type { CalibrationLeague } from "../generate-calibration-league.ts";
+import { collectSSamples, type SGameSample } from "./s-sample.ts";
+import { bucketByAttr, type BucketReport } from "./bucket-by-attr.ts";
+import { type BandCheckResult, checkBand } from "./band-check.ts";
+import { loadPositionBands, type PositionBands } from "./band-loader.ts";
+
+// Headline S metrics. Tackles/game and PBU rate cover the box-support
+// + underneath-coverage work, INT rate is the ball-hawking piece, and
+// forced-fumble rate surfaces physicality at the catch point. Every
+// metric is higher-is-better for a safety's defensive impact — there's
+// no lower-is-better band in this slice (coverage-yield, which would
+// be, isn't available in the per-player nflreadr feed).
+export const S_METRICS = [
+  "tackles_per_game",
+  "int_rate",
+  "pbu_rate",
+  "forced_fumble_rate",
+] as const;
+
+export type SMetric = typeof S_METRICS[number];
+
+const METRIC_EXTRACTORS: Record<SMetric, (s: SGameSample) => number> = {
+  tackles_per_game: (s) => s.tackles_per_game,
+  int_rate: (s) => s.int_rate,
+  pbu_rate: (s) => s.pbu_rate,
+  forced_fumble_rate: (s) => s.forced_fumble_rate,
+};
+
+export interface SCalibrationOptions {
+  bandJson: string;
+  league: CalibrationLeague;
+  simulate: SimulateFn;
+  gameCount?: number;
+  // Minimum samples per bucket before we trust a band check. Under
+  // this count we still emit the summary but flag it as under-sampled
+  // so the report distinguishes "bucket is empty/noisy" from "bucket
+  // is calibrated wrong".
+  minSamplesPerBucket?: number;
+}
+
+export interface SBucketReport {
+  bucketLabel: string;
+  bucketCenter: number;
+  samples: number;
+  underSampled: boolean;
+  checks: BandCheckResult[];
+}
+
+export interface SCalibrationReport {
+  totalGames: number;
+  totalSamples: number;
+  bands: PositionBands;
+  buckets: SBucketReport[];
+  failures: BandCheckResult[];
+  passed: boolean;
+}
+
+const DEFAULT_MIN_SAMPLES = 50;
+
+export function runSCalibration(
+  options: SCalibrationOptions,
+): SCalibrationReport {
+  const {
+    bandJson,
+    league,
+    simulate,
+    gameCount = CALIBRATION_GAME_COUNT,
+    minSamplesPerBucket = DEFAULT_MIN_SAMPLES,
+  } = options;
+
+  const bands = loadPositionBands(bandJson);
+  const teamById = new Map(league.teams.map((t) => [t.teamId, t]));
+  const matchups = generateMatchups(league.teams, gameCount);
+
+  const samples: SGameSample[] = [];
+
+  for (let i = 0; i < matchups.length; i++) {
+    const { home, away } = matchups[i];
+    const gameId = `s-calibration-game-${i}`;
+    const seed = deriveGameSeed(league.calibrationSeed, gameId);
+
+    const result = simulate({ home, away, seed, gameId });
+    const gameSamples = collectSSamples({
+      game: result,
+      home: teamById.get(home.teamId) ?? home,
+      away: teamById.get(away.teamId) ?? away,
+    });
+    samples.push(...gameSamples);
+  }
+
+  const bucketReports: BucketReport<SGameSample>[] = bucketByAttr({
+    samples,
+    attr: (s) => s.sOverall,
+    metrics: METRIC_EXTRACTORS,
+  });
+
+  const buckets: SBucketReport[] = bucketReports.map((report) => {
+    const underSampled = report.samples.length < minSamplesPerBucket;
+    const checks: BandCheckResult[] = S_METRICS.flatMap((metric) => {
+      // Don't emit band checks on under-sampled buckets — the NFL band
+      // comparison would be dominated by sampling noise and drown out
+      // the real failures from the populated buckets.
+      if (underSampled) return [];
+      return [
+        checkBand({
+          bucketLabel: report.bucket.label,
+          metricName: metric,
+          simSummary: report.metrics[metric],
+          bands,
+        }),
+      ];
+    });
+    return {
+      bucketLabel: report.bucket.label,
+      bucketCenter: report.bucket.center,
+      samples: report.samples.length,
+      underSampled,
+      checks,
+    };
+  });
+
+  const failures = buckets.flatMap((b) => b.checks.filter((c) => !c.passed));
+
+  return {
+    totalGames: matchups.length,
+    totalSamples: samples.length,
+    bands,
+    buckets,
+    failures,
+    passed: failures.length === 0,
+  };
+}
+
+export function formatSCalibrationReport(report: SCalibrationReport): string {
+  const lines: string[] = [];
+  lines.push(
+    `S calibration — ${report.totalGames} games, ${report.totalSamples} S-games`,
+  );
+  lines.push(
+    `Bands: ${report.bands.position} / ${
+      report.bands.seasons.join("-")
+    } / ranked by ${report.bands.rankingStat}`,
+  );
+  lines.push("");
+  for (const bucket of report.buckets) {
+    const header = `[bucket ${bucket.bucketLabel}] n=${bucket.samples}` +
+      (bucket.underSampled ? " (under-sampled, skipping band checks)" : "");
+    lines.push(header);
+    for (const check of bucket.checks) {
+      const verdict = check.passed ? "PASS" : "FAIL";
+      const dir = check.passed ? "" : ` (${check.direction})`;
+      lines.push(
+        `  ${verdict} ${check.metricName.padEnd(20)} ` +
+          `sim=${check.simMean.toFixed(4)}  ` +
+          `band(${check.expectedBand})=${check.bandMean.toFixed(4)}±${
+            check.bandSd.toFixed(4)
+          }  ` +
+          `z=${check.zScore.toFixed(2)}  actual=${check.actualBand}${dir}`,
+      );
+    }
+    lines.push("");
+  }
+  const passed = report.passed ? "PASS" : "FAIL";
+  lines.push(
+    `${passed}: ${report.failures.length} band check(s) missed expected band`,
+  );
+  return lines.join("\n");
+}

--- a/server/features/simulation/calibration/per-position/s-overall.test.ts
+++ b/server/features/simulation/calibration/per-position/s-overall.test.ts
@@ -1,0 +1,91 @@
+import { assertAlmostEquals, assertEquals } from "@std/assert";
+import type { PlayerAttributes } from "@zone-blitz/shared";
+import { S_OVERALL_ATTRS, sOverall } from "./s-overall.ts";
+
+function attrs(overrides: Partial<PlayerAttributes> = {}): PlayerAttributes {
+  const base: Record<string, number> = {};
+  const keys = [
+    "speed",
+    "acceleration",
+    "agility",
+    "strength",
+    "jumping",
+    "stamina",
+    "durability",
+    "armStrength",
+    "accuracyShort",
+    "accuracyMedium",
+    "accuracyDeep",
+    "accuracyOnTheRun",
+    "touch",
+    "release",
+    "ballCarrying",
+    "elusiveness",
+    "routeRunning",
+    "catching",
+    "contestedCatching",
+    "runAfterCatch",
+    "passBlocking",
+    "runBlocking",
+    "blockShedding",
+    "tackling",
+    "manCoverage",
+    "zoneCoverage",
+    "passRushing",
+    "runDefense",
+    "kickingPower",
+    "kickingAccuracy",
+    "puntingPower",
+    "puntingAccuracy",
+    "snapAccuracy",
+    "footballIq",
+    "decisionMaking",
+    "anticipation",
+    "composure",
+    "clutch",
+    "consistency",
+    "workEthic",
+    "coachability",
+    "leadership",
+    "greed",
+    "loyalty",
+    "ambition",
+    "vanity",
+    "schemeAttachment",
+    "mediaSensitivity",
+  ];
+  for (const k of keys) {
+    base[k] = 50;
+    base[`${k}Potential`] = 50;
+  }
+  return { ...(base as unknown as PlayerAttributes), ...overrides };
+}
+
+Deno.test("sOverall averages the five signature S attributes", () => {
+  const result = sOverall(
+    attrs({
+      zoneCoverage: 70,
+      manCoverage: 60,
+      speed: 80,
+      tackling: 50,
+      anticipation: 65,
+    }),
+  );
+  // (70 + 60 + 80 + 50 + 65) / 5 = 65
+  assertAlmostEquals(result, 65, 1e-6);
+});
+
+Deno.test("sOverall returns the common value when all signature attrs match", () => {
+  assertEquals(sOverall(attrs()), 50);
+});
+
+Deno.test("S_OVERALL_ATTRS enumerates the five signature attrs in a stable order", () => {
+  assertEquals(S_OVERALL_ATTRS.length, 5);
+  assertEquals([...S_OVERALL_ATTRS], [
+    "zoneCoverage",
+    "manCoverage",
+    "speed",
+    "tackling",
+    "anticipation",
+  ]);
+});

--- a/server/features/simulation/calibration/per-position/s-overall.ts
+++ b/server/features/simulation/calibration/per-position/s-overall.ts
@@ -1,0 +1,25 @@
+import type { PlayerAttributes } from "@zone-blitz/shared";
+
+// Signature attributes for an S "overall" rating. The neutral-bucket
+// classifier keys off zoneCoverage / tackling / footballIq /
+// anticipation to tag a player as a safety; resolve-matchups ranks
+// safeties by zoneCoverage / speed / tackling. We blend both sides so
+// the calibration bucket captures the full safety skill set — ball
+// skills (zoneCoverage, manCoverage, anticipation), range (speed), and
+// run support (tackling). No `playRecognition` attribute exists on
+// PlayerAttributes, so it's intentionally omitted.
+export const S_OVERALL_ATTRS = [
+  "zoneCoverage",
+  "manCoverage",
+  "speed",
+  "tackling",
+  "anticipation",
+] as const satisfies ReadonlyArray<keyof PlayerAttributes>;
+
+export function sOverall(attributes: PlayerAttributes): number {
+  let sum = 0;
+  for (const key of S_OVERALL_ATTRS) {
+    sum += attributes[key];
+  }
+  return sum / S_OVERALL_ATTRS.length;
+}

--- a/server/features/simulation/calibration/per-position/s-sample.test.ts
+++ b/server/features/simulation/calibration/per-position/s-sample.test.ts
@@ -1,0 +1,309 @@
+import { assertAlmostEquals, assertEquals } from "@std/assert";
+import type { PlayerAttributes } from "@zone-blitz/shared";
+import { collectSSamples } from "./s-sample.ts";
+import type { GameResult, PlayEvent } from "../../events.ts";
+import type { SimTeam } from "../../simulate-game.ts";
+import type { PlayerRuntime } from "../../resolve-play.ts";
+
+function attrs(overrides: Partial<PlayerAttributes> = {}): PlayerAttributes {
+  const base: Record<string, number> = {};
+  const keys = [
+    "speed",
+    "acceleration",
+    "agility",
+    "strength",
+    "jumping",
+    "stamina",
+    "durability",
+    "armStrength",
+    "accuracyShort",
+    "accuracyMedium",
+    "accuracyDeep",
+    "accuracyOnTheRun",
+    "touch",
+    "release",
+    "ballCarrying",
+    "elusiveness",
+    "routeRunning",
+    "catching",
+    "contestedCatching",
+    "runAfterCatch",
+    "passBlocking",
+    "runBlocking",
+    "blockShedding",
+    "tackling",
+    "manCoverage",
+    "zoneCoverage",
+    "passRushing",
+    "runDefense",
+    "kickingPower",
+    "kickingAccuracy",
+    "puntingPower",
+    "puntingAccuracy",
+    "snapAccuracy",
+    "footballIq",
+    "decisionMaking",
+    "anticipation",
+    "composure",
+    "clutch",
+    "consistency",
+    "workEthic",
+    "coachability",
+    "leadership",
+    "greed",
+    "loyalty",
+    "ambition",
+    "vanity",
+    "schemeAttachment",
+    "mediaSensitivity",
+  ];
+  for (const k of keys) {
+    base[k] = 50;
+    base[`${k}Potential`] = 50;
+  }
+  return { ...(base as unknown as PlayerAttributes), ...overrides };
+}
+
+function safety(id: string, overall: number): PlayerRuntime {
+  return {
+    playerId: id,
+    neutralBucket: "S",
+    attributes: attrs({
+      zoneCoverage: overall,
+      manCoverage: overall,
+      speed: overall,
+      tackling: overall,
+      anticipation: overall,
+    }),
+  };
+}
+
+function team(teamId: string, starters: PlayerRuntime[]): SimTeam {
+  return {
+    teamId,
+    starters,
+    bench: [],
+    fingerprint: { offense: null, defense: null, overrides: {} },
+    coachingMods: {
+      schemeFitBonus: 0,
+      situationalBonus: 0,
+      aggressiveness: 50,
+      penaltyDiscipline: 1,
+    },
+  };
+}
+
+function event(
+  overrides: Partial<PlayEvent> & {
+    outcome: PlayEvent["outcome"];
+    offenseTeamId: string;
+    defenseTeamId: string;
+  },
+): PlayEvent {
+  return {
+    gameId: "g",
+    driveIndex: 0,
+    playIndex: 0,
+    quarter: 1,
+    clock: "15:00",
+    situation: { down: 1, distance: 10, yardLine: 25 },
+    call: {
+      concept: "dropback",
+      personnel: "11",
+      formation: "shotgun",
+      motion: "none",
+    },
+    coverage: { front: "4-3", coverage: "cover_2", pressure: "four_man" },
+    participants: [],
+    yardage: 0,
+    tags: [],
+    ...overrides,
+  };
+}
+
+function gameOf(events: PlayEvent[]): GameResult {
+  return {
+    gameId: "g",
+    seed: 1,
+    finalScore: { home: 0, away: 0 },
+    events,
+    boxScore: {
+      home: {
+        totalYards: 0,
+        passingYards: 0,
+        rushingYards: 0,
+        turnovers: 0,
+        sacks: 0,
+        penalties: 0,
+      },
+      away: {
+        totalYards: 0,
+        passingYards: 0,
+        rushingYards: 0,
+        turnovers: 0,
+        sacks: 0,
+        penalties: 0,
+      },
+    },
+    driveLog: [],
+    injuryReport: [],
+  };
+}
+
+Deno.test("collectSSamples emits one sample per S starter on each team", () => {
+  const home = team("home", [safety("home-s1", 50), safety("home-s2", 60)]);
+  const away = team("away", [safety("away-s1", 50), safety("away-s2", 50)]);
+  const samples = collectSSamples({ game: gameOf([]), home, away });
+  assertEquals(samples.length, 4);
+  assertEquals(samples[0].teamId, "home");
+  assertEquals(samples[0].safetyPlayerId, "home-s1");
+  assertEquals(samples[1].safetyPlayerId, "home-s2");
+  assertEquals(samples[2].teamId, "away");
+});
+
+Deno.test("collectSSamples skips a team with no S starters", () => {
+  const home = team("home", [safety("home-s1", 50)]);
+  const away = team("away", []);
+  const samples = collectSSamples({ game: gameOf([]), home, away });
+  assertEquals(samples.length, 1);
+  assertEquals(samples[0].teamId, "home");
+});
+
+Deno.test("collectSSamples tags sample with S overall (mean of the five signature attrs)", () => {
+  const custom: PlayerRuntime = {
+    playerId: "home-s1",
+    neutralBucket: "S",
+    attributes: attrs({
+      zoneCoverage: 60,
+      manCoverage: 70,
+      speed: 80,
+      tackling: 50,
+      anticipation: 60,
+    }),
+  };
+  const home = team("home", [custom]);
+  const away = team("away", [safety("away-s1", 50)]);
+  const [homeSample] = collectSSamples({ game: gameOf([]), home, away });
+  // (60 + 70 + 80 + 50 + 60) / 5 = 64
+  assertAlmostEquals(homeSample.sOverall, 64, 1e-6);
+});
+
+Deno.test("collectSSamples team-allocates tackles/INTs/PBUs/FFs across S starters", () => {
+  const home = team("home", [safety("home-s1", 50), safety("home-s2", 50)]);
+  const away = team("away", [safety("away-s1", 50)]);
+  const events: PlayEvent[] = [
+    // 10 rushes against home defense → 10 team tackles
+    ...Array.from({ length: 10 }, () =>
+      event({
+        outcome: "rush",
+        offenseTeamId: "away",
+        defenseTeamId: "home",
+      })),
+    // 5 completions → 5 more team tackles
+    ...Array.from({ length: 5 }, () =>
+      event({
+        outcome: "pass_complete",
+        offenseTeamId: "away",
+        defenseTeamId: "home",
+      })),
+    // 10 incompletes → 10 * 0.4 = 4 PBUs credited to team
+    ...Array.from({ length: 10 }, () =>
+      event({
+        outcome: "pass_incomplete",
+        offenseTeamId: "away",
+        defenseTeamId: "home",
+      })),
+    // 2 INTs, 1 fumble (also counts as a tackle)
+    event({
+      outcome: "interception",
+      offenseTeamId: "away",
+      defenseTeamId: "home",
+    }),
+    event({
+      outcome: "interception",
+      offenseTeamId: "away",
+      defenseTeamId: "home",
+    }),
+    event({
+      outcome: "fumble",
+      offenseTeamId: "away",
+      defenseTeamId: "home",
+    }),
+  ];
+  const samples = collectSSamples({ game: gameOf(events), home, away });
+  const homeSamples = samples.filter((s) => s.teamId === "home");
+  assertEquals(homeSamples.length, 2);
+
+  // Team totals: tackles = 15 + 1 = 16; INTs = 2; PBUs = 4; FFs = 1.
+  // Secondary share = 0.45; each of the 2 S starters gets half.
+  const SECONDARY = 0.45;
+  assertAlmostEquals(homeSamples[0].tackles_per_game, (16 * SECONDARY) / 2);
+  assertAlmostEquals(homeSamples[0].int_rate, (2 * SECONDARY) / 2);
+  assertAlmostEquals(homeSamples[0].pbu_rate, (4 * SECONDARY) / 2);
+  assertAlmostEquals(homeSamples[0].forced_fumble_rate, (1 * SECONDARY) / 2);
+  // Both home safeties get the same allocated rates.
+  assertAlmostEquals(
+    homeSamples[0].tackles_per_game,
+    homeSamples[1].tackles_per_game,
+  );
+});
+
+Deno.test("collectSSamples isolates defense by team", () => {
+  const home = team("home", [safety("home-s1", 50)]);
+  const away = team("away", [safety("away-s1", 50)]);
+  const events: PlayEvent[] = [
+    event({
+      outcome: "interception",
+      offenseTeamId: "away",
+      defenseTeamId: "home",
+    }),
+    event({
+      outcome: "rush",
+      offenseTeamId: "home",
+      defenseTeamId: "away",
+    }),
+  ];
+  const samples = collectSSamples({ game: gameOf(events), home, away });
+  const home1 = samples.find((s) => s.teamId === "home")!;
+  const away1 = samples.find((s) => s.teamId === "away")!;
+  // home defense recorded the INT, away defense recorded the tackle
+  assertAlmostEquals(home1.int_rate, (1 * 0.45) / 1);
+  assertAlmostEquals(home1.tackles_per_game, 0);
+  assertAlmostEquals(away1.tackles_per_game, (1 * 0.45) / 1);
+  assertAlmostEquals(away1.int_rate, 0);
+});
+
+Deno.test("collectSSamples does not credit safeties for sacks or offensive touchdowns", () => {
+  const home = team("home", [safety("home-s1", 50)]);
+  const away = team("away", [safety("away-s1", 50)]);
+  const events: PlayEvent[] = [
+    event({
+      outcome: "sack",
+      offenseTeamId: "away",
+      defenseTeamId: "home",
+    }),
+    event({
+      outcome: "touchdown",
+      offenseTeamId: "away",
+      defenseTeamId: "home",
+    }),
+  ];
+  const [homeSample] = collectSSamples({ game: gameOf(events), home, away });
+  assertEquals(homeSample.tackles_per_game, 0);
+  assertEquals(homeSample.pbu_rate, 0);
+  assertEquals(homeSample.int_rate, 0);
+  assertEquals(homeSample.forced_fumble_rate, 0);
+});
+
+Deno.test("collectSSamples returns zero rates on an empty game without divide-by-zero", () => {
+  const home = team("home", [safety("home-s1", 50)]);
+  const away = team("away", [safety("away-s1", 50)]);
+  const samples = collectSSamples({ game: gameOf([]), home, away });
+  assertEquals(samples.length, 2);
+  for (const s of samples) {
+    assertEquals(s.tackles_per_game, 0);
+    assertEquals(s.int_rate, 0);
+    assertEquals(s.pbu_rate, 0);
+    assertEquals(s.forced_fumble_rate, 0);
+  }
+});

--- a/server/features/simulation/calibration/per-position/s-sample.ts
+++ b/server/features/simulation/calibration/per-position/s-sample.ts
@@ -1,0 +1,126 @@
+import type { GameResult, PlayEvent } from "../../events.ts";
+import type { SimTeam } from "../../simulate-game.ts";
+import { sOverall } from "./s-overall.ts";
+
+export interface SGameSample {
+  teamId: string;
+  safetyPlayerId: string;
+  sOverall: number;
+  // Per-game allocated rates. The engine currently only logs a
+  // defender participant on sacks / interceptions / return TDs, so
+  // tackles and pass-break-ups can't be attributed to a specific
+  // safety. We instead team-allocate team-game defensive outcomes
+  // across the `S` starters on the depth chart: each starter gets an
+  // equal share of the team's allocated-to-secondary events. The NFL
+  // fixture uses the same per-game grain (tackles/game, INT/game,
+  // etc.) so the bucket means stay directly comparable.
+  tackles_per_game: number;
+  int_rate: number;
+  pbu_rate: number;
+  forced_fumble_rate: number;
+}
+
+interface TeamDefensiveTotals {
+  teamTackles: number;
+  teamInts: number;
+  teamPbus: number;
+  teamForcedFumbles: number;
+}
+
+function accumulate(
+  events: PlayEvent[],
+  defenseTeamId: string,
+): TeamDefensiveTotals {
+  // Tackles and PBUs aren't per-play logged, so we proxy them from
+  // the team-facing offense outcomes: every run-concept ball carrier
+  // gets tackled (except on TDs), and every incomplete pass is
+  // (roughly) either a broken-up ball or an off-target throw. We
+  // split incompletes 50/50 between "PBU" and "throwaway/misfire" —
+  // NFL-wide PBU rate on incompletes sits ~30-40%, so 0.4 is the
+  // honest coefficient. Tackles count every offense play that ended
+  // short of the endzone and wasn't a sack (which the DL already
+  // owns) or an out-of-bounds pass (folded into the 60% incomplete).
+  let teamTackles = 0;
+  let teamInts = 0;
+  let teamPbus = 0;
+  let teamForcedFumbles = 0;
+
+  const INCOMPLETE_PBU_SHARE = 0.4;
+
+  for (const event of events) {
+    if (event.defenseTeamId !== defenseTeamId) continue;
+
+    switch (event.outcome) {
+      case "rush":
+      case "pass_complete":
+        teamTackles++;
+        break;
+      case "pass_incomplete":
+        teamPbus += INCOMPLETE_PBU_SHARE;
+        break;
+      case "interception":
+        teamInts++;
+        break;
+      case "fumble":
+        teamForcedFumbles++;
+        teamTackles++;
+        break;
+      case "touchdown":
+        // Defense didn't make a stop on an offense TD — skip.
+        break;
+      case "sack":
+        // Sacks are pass-rush credit, not a safety tackle. Skip.
+        break;
+    }
+  }
+
+  return { teamTackles, teamInts, teamPbus, teamForcedFumbles };
+}
+
+export interface SSampleInput {
+  game: GameResult;
+  home: SimTeam;
+  away: SimTeam;
+}
+
+// Attribute a team-game's secondary production across the team's S
+// starters. The engine's `resolve-matchups.ts` puts both S starters on
+// the field together (deep/box split), so they share coverage and
+// run-support work — an even split is the honest first-pass
+// attribution until the engine logs per-play defenders on routine
+// coverage/tackle events.
+export function collectSSamples(input: SSampleInput): SGameSample[] {
+  const { game, home, away } = input;
+  const samples: SGameSample[] = [];
+
+  for (const team of [home, away]) {
+    const safeties = team.starters.filter((p) => p.neutralBucket === "S");
+    if (safeties.length === 0) continue;
+
+    const totals = accumulate(game.events, team.teamId);
+    // Safeties account for roughly half the secondary's production —
+    // corners own the other half. Splitting team tackles evenly
+    // across S + CB starters would over-credit safeties in tackling
+    // (CBs tackle plenty) so we apportion the secondary's share at
+    // `SECONDARY_SHARE_OF_TEAM` of team defensive events. This is a
+    // deliberate simplification documented so future slices can
+    // replace it with a per-play defender-logging attribution.
+    const SECONDARY_SHARE_OF_TEAM = 0.45;
+    const perSafety = safeties.length;
+
+    for (const s of safeties) {
+      samples.push({
+        teamId: team.teamId,
+        safetyPlayerId: s.playerId,
+        sOverall: sOverall(s.attributes),
+        tackles_per_game: (totals.teamTackles * SECONDARY_SHARE_OF_TEAM) /
+          perSafety,
+        int_rate: (totals.teamInts * SECONDARY_SHARE_OF_TEAM) / perSafety,
+        pbu_rate: (totals.teamPbus * SECONDARY_SHARE_OF_TEAM) / perSafety,
+        forced_fumble_rate:
+          (totals.teamForcedFumbles * SECONDARY_SHARE_OF_TEAM) / perSafety,
+      });
+    }
+  }
+  return samples;
+}


### PR DESCRIPTION
## Summary

Implements the safety (S) slice of #496 — mirrors the QB harness from #497 for safeties. Tags every sim S-game with the starter's overall (mean of `zoneCoverage`, `manCoverage`, `speed`, `tackling`, `anticipation`), buckets samples into 10-point bands (30/40/50/60/70/80), and compares each bucket's mean stat line (tackles/game, INT/game, PBU/game, FF/game) to NFL safety percentile bands.

- `data/R/bands/per-position-s.R` pulls weekly defensive stats (2020-2024, starter proxy = games ≥ 10 and tackles ≥ 40), ranks by a playmaker composite (INT + PBU + FF + sack per game), and carves the starter population into five percentile bands.
- `data/bands/per-position/s.json` is the generated fixture (766 S-seasons after starter filter).
- `server/features/simulation/calibration/per-position/` gains `s-overall`, `s-sample`, `s-harness`, `run-s-calibration`. Shared `bucket-by-attr`, `band-loader`, `band-check` untouched.
- `deno task sim:calibrate:s` runs across every calibration seed (report-only per the issue's rollout plan).

## Notes

Known data gap — `nflreadr::load_player_stats(stat_type="defense")` does NOT expose targets-allowed, completion-allowed%, or yards-allowed-per-target per safety. The fixture is limited to volume rates; a coverage-yield band would need a pbp `target_defender` join and is deferred.

Multi-seed harness output surfaces real calibration gaps the team-game aggregates were hiding:
- **Tackles/game are ~2.3x NFL across every bucket.** Sim safeties sit at ~10 tackles/game vs. NFL average ~4.4; the 0.45 secondary-share coefficient plus team-allocation across 2 S starters still over-credits safeties because the engine routes every `rush` / `pass_complete` through a generic "team tackle" bucket. Real safeties cover deep half the time and aren't near the tackle on short gains.
- **PBU rate is elite-band at every bucket.** Sim pbu_rate sits at ~0.9-1.0 across 40/50/60/70/80 vs. NFL average 0.47 — the `0.4 * incompletes` coefficient over-counts; many incompletions are off-target throws with zero defender involvement. A better attribution would require tagging coverage defenders on pass plays.
- **30-overall bucket is under-sampled (~40 samples) across every seed.** Generator's S overall distribution sits above 35, so the replacement-tier bucket never populates meaningfully — consistent with the RB slice's #500 finding.
- **INT rate separation by bucket is weak.** Sim int_rate runs 0.14-0.20 across 40-80 vs. NFL bands spanning 0.05-0.27; the sim doesn't differentiate safety ball-hawking skill strongly enough, which tracks with the existing league-wide INT calibration being tight.

These will become tracked follow-up issues after merge.