### PR TITLE
feat(calibration): add per-IOL-bucket calibration harness (#496, IOL slice)

### DIFF
--- a/data/R/bands/per-position-iol.R
+++ b/data/R/bands/per-position-iol.R
@@ -1,0 +1,278 @@
+#!/usr/bin/env Rscript
+# per-position-iol.R — NFL interior-OL (C, G) percentile-band reference.
+#
+# LIMITATION — PFF GAP: nflreadr does not carry PFF block/pressure grades
+# for interior offensive linemen. True IOL performance data (true pass
+# set pressure rate, reach-block success, pull-technique grades, etc.)
+# lives behind paywalled providers. This script therefore builds a V1
+# reference out of *team-level proxies* allocated to the starting
+# interior line. Treat the bands as directional, not authoritative — any
+# calibration report against them should call out that the ranking stat
+# is a team proxy, not a per-player grade.
+#
+# What we do build:
+#   - load_pbp → filter interior rushes (run_gap in c("guard","middle"))
+#     and compute per-team-season `team_stuff_rate_inside` (rushes for
+#     <= 0 yards / interior rushes). Lower is better for the offense.
+#   - load_pbp dropbacks → per-team-season `team_sack_allowed_rate`
+#     (sack / dropback). The full offensive line owns protection, so
+#     this isn't IOL-exclusive; we inherit it as a shared proxy until a
+#     true IOL pressure metric is available.
+#   - load_snap_counts → per-player C/G starter-seasons filtered by
+#     offensive snap share (>= 0.5 offense_pct on >= 12 games). The
+#     weekly player-stats offense file only emits IOL rows on games
+#     where the player committed a penalty, so it's useless for
+#     establishing "starter" — snap counts are the source of truth.
+#   - load_player_stats (offense) for C/G positions → per-player
+#     `penalties_per_game`. The `penalties` column IS populated for OL
+#     rows when they committed a penalty, so per-player penalty rate
+#     is a real (non-proxy) signal for this slice — treat it as the
+#     only band metric that isn't shared across the team.
+#
+# Ranking + bands:
+#   - Starter threshold: player-season games >= 12 in positions c("C","G","OG","OL").
+#   - Composite rank = z-score mean of the two team proxies (lower is
+#     better), broadcast per starter. All C/G starters on the same team
+#     share the same proxy rank, which is the calibration gap we
+#     explicitly accept for V1.
+#   - Five percentile bands (elite top 10%, good 10-30%, average 30-70%,
+#     weak 70-90%, replacement bottom 10%).
+#
+# Output: data/bands/per-position/iol.json
+#
+# Usage:
+#   Rscript data/R/bands/per-position-iol.R [--seasons 2020:2024]
+
+suppressPackageStartupMessages({
+  library(nflreadr)
+  library(dplyr)
+})
+
+script_file <- (function() {
+  args <- commandArgs(trailingOnly = FALSE)
+  f <- grep("^--file=", args, value = TRUE)
+  if (length(f) > 0) normalizePath(sub("^--file=", "", f[1]), mustWork = FALSE) else NULL
+})()
+source(file.path(dirname(script_file), "..", "lib.R"))
+
+args <- commandArgs(trailingOnly = TRUE)
+seasons <- parse_seasons(args)
+
+cat("Loading pbp + player stats for seasons:",
+    paste(range(seasons), collapse = "-"), "\n")
+
+pbp <- nflreadr::load_pbp(seasons)
+
+# ---- Team proxy 1: interior stuff rate -------------------------------------
+
+interior_runs <- pbp |>
+  filter(
+    season_type == "REG",
+    rush == 1,
+    qb_scramble == 0,
+    qb_kneel == 0,
+    is.na(two_point_conv_result),
+    !is.na(run_gap),
+    run_gap %in% c("guard", "middle")
+  )
+
+team_stuff <- interior_runs |>
+  group_by(posteam, season) |>
+  summarise(
+    n_interior_runs = n(),
+    stuffs = sum(yards_gained <= 0, na.rm = TRUE),
+    team_stuff_rate_inside = ifelse(n() > 0, stuffs / n(), NA_real_),
+    .groups = "drop"
+  ) |>
+  rename(team = posteam)
+
+# ---- Team proxy 2: sack-allowed rate ---------------------------------------
+
+# Dropbacks = plays where pass == 1 OR qb_scramble == 1. Sack attribution
+# is shared across the whole OL, but interior linemen own the A/B-gap
+# pocket, so we use this as an IOL proxy until per-lineman pressure
+# data is available.
+dropbacks <- pbp |>
+  filter(
+    season_type == "REG",
+    (pass == 1 | qb_scramble == 1),
+    qb_kneel == 0,
+    qb_spike == 0
+  )
+
+team_sacks <- dropbacks |>
+  group_by(posteam, season) |>
+  summarise(
+    dropbacks = n(),
+    sacks = sum(sack == 1, na.rm = TRUE),
+    team_sack_allowed_rate = ifelse(n() > 0, sacks / n(), NA_real_),
+    .groups = "drop"
+  ) |>
+  rename(team = posteam)
+
+# ---- Per-player starter filter --------------------------------------------
+
+snaps <- nflreadr::load_snap_counts(seasons)
+
+# Interior OL positions surface as "C", "G", or "OG". "OL" can appear
+# as a generic tag for depth players; we include it to catch rostered
+# IOL who only appear on special jumbo packages. 50% offensive snap
+# share on a given week counts as a "start" for calibration purposes
+# (matches how PFF tags snap-based eligibility).
+iol_snaps <- snaps |>
+  filter(
+    game_type == "REG",
+    position %in% c("C", "G", "OG", "OL"),
+    !is.na(offense_pct),
+    offense_pct >= 0.5
+  )
+
+iol_season <- iol_snaps |>
+  group_by(pfr_player_id, player, team, season) |>
+  summarise(
+    starts_per_season = n(),
+    .groups = "drop"
+  ) |>
+  filter(starts_per_season >= 12) # starter threshold (~12 of 17 games)
+
+cat("IOL starter-seasons after snap filter:", nrow(iol_season), "\n")
+
+# Per-player penalties come from the weekly offense stats file —
+# linemen only appear there when they commit a penalty, so joining on
+# (player, team, season) and defaulting missing rows to 0 gives the
+# right per-game rate.
+weekly <- nflreadr::load_player_stats(seasons)
+
+iol_penalties <- weekly |>
+  filter(
+    season_type == "REG",
+    position %in% c("C", "G", "OG", "OL")
+  ) |>
+  group_by(player_display_name, team, season) |>
+  summarise(
+    penalties_total = sum(penalties, na.rm = TRUE),
+    .groups = "drop"
+  ) |>
+  rename(player = player_display_name)
+
+iol_season <- iol_season |>
+  left_join(iol_penalties, by = c("player", "team", "season")) |>
+  mutate(
+    penalties_total = ifelse(is.na(penalties_total), 0, penalties_total),
+    penalties_per_game = penalties_total / starts_per_season
+  )
+
+# ---- Join proxies + rank ---------------------------------------------------
+
+iol_ranked <- iol_season |>
+  left_join(team_stuff, by = c("team", "season")) |>
+  left_join(team_sacks, by = c("team", "season")) |>
+  filter(
+    !is.na(team_stuff_rate_inside),
+    !is.na(team_sack_allowed_rate)
+  )
+
+cat("IOL starter-seasons with proxy coverage:", nrow(iol_ranked), "\n")
+
+# Z-score each proxy across the starter population (lower = better for
+# both metrics), average, then rank ascending (best composite first).
+zscore <- function(x) {
+  m <- mean(x, na.rm = TRUE)
+  s <- stats::sd(x, na.rm = TRUE)
+  if (is.na(s) || s == 0) return(rep(0, length(x)))
+  (x - m) / s
+}
+
+iol_ranked <- iol_ranked |>
+  mutate(
+    z_stuff = zscore(team_stuff_rate_inside),
+    z_sack = zscore(team_sack_allowed_rate),
+    # Lower proxy values are better for the offense, so invert the z
+    # score sign to keep "higher composite = better IOL".
+    composite = -(z_stuff + z_sack) / 2
+  ) |>
+  arrange(desc(composite)) |>
+  mutate(
+    pct = (row_number() - 0.5) / n(),
+    band = case_when(
+      pct <= 0.10 ~ "elite",
+      pct <= 0.30 ~ "good",
+      pct <= 0.70 ~ "average",
+      pct <= 0.90 ~ "weak",
+      TRUE        ~ "replacement"
+    )
+  )
+
+metric_keys <- c(
+  "team_sack_allowed_rate",
+  "team_stuff_rate_inside",
+  "penalties_per_game",
+  "starts_per_season"
+)
+
+band_order <- c("elite", "good", "average", "weak", "replacement")
+
+band_summary <- function(rows) {
+  metrics <- list()
+  for (key in metric_keys) {
+    vals <- rows[[key]]
+    vals <- vals[!is.na(vals)]
+    if (length(vals) == 0) {
+      metrics[[key]] <- list(n = 0, mean = 0, sd = 0)
+    } else {
+      metrics[[key]] <- list(
+        n = length(vals),
+        mean = mean(vals),
+        sd = if (length(vals) > 1) stats::sd(vals) else 0
+      )
+    }
+  }
+  list(
+    n = nrow(rows),
+    metrics = metrics
+  )
+}
+
+bands <- list()
+for (band_name in band_order) {
+  rows <- iol_ranked |> filter(band == band_name)
+  bands[[band_name]] <- band_summary(rows)
+}
+
+out <- list(
+  generated_at = format(Sys.time(), "%Y-%m-%dT%H:%M:%SZ", tz = "UTC"),
+  seasons = as.integer(seasons),
+  position = "IOL",
+  qualifier = "regular-season IOL starter-seasons (C/G/OG/OL, games >= 12)",
+  ranking_stat = paste0(
+    "composite z-score of team_stuff_rate_inside (rushes <=0 yds / ",
+    "interior rushes) + team_sack_allowed_rate (sacks / dropback); ",
+    "both proxied at the team level and broadcast to starters. Lower ",
+    "proxy value = better IOL, so the composite inverts sign."
+  ),
+  notes = paste0(
+    "PROXY-METRIC LIMITATION: nflreadr does not carry PFF pressure ",
+    "or block-grade data for interior offensive linemen. The bands ",
+    "are built from team-level proxies (interior stuff rate + ",
+    "team sack allowed rate) allocated to each team's IOL starters. ",
+    "All C/G starters on the same team share the same proxy rank, so ",
+    "this fixture cannot distinguish a great guard next to a weak ",
+    "center on the same line. penalties_per_game IS per-player (from ",
+    "nflreadr weekly penalties column) and is the one non-proxy ",
+    "metric here. Treat band separation on the team-proxy metrics as ",
+    "directional. Replace this with PFF grades (or a matchup-level ",
+    "pressure feed) when available."
+  ),
+  bands = bands
+)
+
+out_path <- file.path(
+  repo_root(), "data", "bands", "per-position", "iol.json"
+)
+dir.create(dirname(out_path), recursive = TRUE, showWarnings = FALSE)
+writeLines(
+  jsonlite::toJSON(out, auto_unbox = TRUE, pretty = TRUE, digits = 4,
+                   null = "null"),
+  out_path
+)
+cat("Wrote", out_path, "\n")

--- a/data/bands/per-position/iol.json
+++ b/data/bands/per-position/iol.json
@@ -1,0 +1,135 @@
+{
+  "generated_at": "2026-04-17T12:31:53Z",
+  "seasons": [2020, 2021, 2022, 2023, 2024],
+  "position": "IOL",
+  "qualifier": "regular-season IOL starter-seasons (C/G/OG/OL, games >= 12)",
+  "ranking_stat": "composite z-score of team_stuff_rate_inside (rushes <=0 yds / interior rushes) + team_sack_allowed_rate (sacks / dropback); both proxied at the team level and broadcast to starters. Lower proxy value = better IOL, so the composite inverts sign.",
+  "notes": "PROXY-METRIC LIMITATION: nflreadr does not carry PFF pressure or block-grade data for interior offensive linemen. The bands are built from team-level proxies (interior stuff rate + team sack allowed rate) allocated to each team's IOL starters. All C/G starters on the same team share the same proxy rank, so this fixture cannot distinguish a great guard next to a weak center on the same line. penalties_per_game IS per-player (from nflreadr weekly penalties column) and is the one non-proxy metric here. Treat band separation on the team-proxy metrics as directional. Replace this with PFF grades (or a matchup-level pressure feed) when available.",
+  "bands": {
+    "elite": {
+      "n": 37,
+      "metrics": {
+        "team_sack_allowed_rate": {
+          "n": 37,
+          "mean": 0.0362,
+          "sd": 0.0086
+        },
+        "team_stuff_rate_inside": {
+          "n": 37,
+          "mean": 0.1045,
+          "sd": 0.0318
+        },
+        "penalties_per_game": {
+          "n": 37,
+          "mean": 0.2628,
+          "sd": 0.178
+        },
+        "starts_per_season": {
+          "n": 37,
+          "mean": 15.2432,
+          "sd": 1.6899
+        }
+      }
+    },
+    "good": {
+      "n": 74,
+      "metrics": {
+        "team_sack_allowed_rate": {
+          "n": 74,
+          "mean": 0.047,
+          "sd": 0.0103
+        },
+        "team_stuff_rate_inside": {
+          "n": 74,
+          "mean": 0.1256,
+          "sd": 0.0274
+        },
+        "penalties_per_game": {
+          "n": 74,
+          "mean": 0.2131,
+          "sd": 0.1588
+        },
+        "starts_per_season": {
+          "n": 74,
+          "mean": 15.527,
+          "sd": 1.4733
+        }
+      }
+    },
+    "average": {
+      "n": 149,
+      "metrics": {
+        "team_sack_allowed_rate": {
+          "n": 149,
+          "mean": 0.0578,
+          "sd": 0.0098
+        },
+        "team_stuff_rate_inside": {
+          "n": 149,
+          "mean": 0.1473,
+          "sd": 0.0261
+        },
+        "penalties_per_game": {
+          "n": 149,
+          "mean": 0.2049,
+          "sd": 0.1733
+        },
+        "starts_per_season": {
+          "n": 149,
+          "mean": 15.2282,
+          "sd": 1.6608
+        }
+      }
+    },
+    "weak": {
+      "n": 74,
+      "metrics": {
+        "team_sack_allowed_rate": {
+          "n": 74,
+          "mean": 0.0708,
+          "sd": 0.0096
+        },
+        "team_stuff_rate_inside": {
+          "n": 74,
+          "mean": 0.1708,
+          "sd": 0.0241
+        },
+        "penalties_per_game": {
+          "n": 74,
+          "mean": 0.2143,
+          "sd": 0.1561
+        },
+        "starts_per_season": {
+          "n": 74,
+          "mean": 15.5811,
+          "sd": 1.5616
+        }
+      }
+    },
+    "replacement": {
+      "n": 37,
+      "metrics": {
+        "team_sack_allowed_rate": {
+          "n": 37,
+          "mean": 0.0762,
+          "sd": 0.0217
+        },
+        "team_stuff_rate_inside": {
+          "n": 37,
+          "mean": 0.22,
+          "sd": 0.047
+        },
+        "penalties_per_game": {
+          "n": 37,
+          "mean": 0.2486,
+          "sd": 0.1202
+        },
+        "starts_per_season": {
+          "n": 37,
+          "mean": 15.1622,
+          "sd": 2.0482
+        }
+      }
+    }
+  }
+}

--- a/deno.json
+++ b/deno.json
@@ -41,6 +41,7 @@
     "sim:calibrate:edge": "deno run --allow-read server/features/simulation/calibration/per-position/run-edge-calibration.ts",
     "sim:calibrate:cb": "deno run --allow-read server/features/simulation/calibration/per-position/run-cb-calibration.ts",
     "sim:calibrate:s": "deno run --allow-read server/features/simulation/calibration/per-position/run-s-calibration.ts",
+    "sim:calibrate:iol": "deno run --allow-read server/features/simulation/calibration/per-position/run-iol-calibration.ts",
     "build": "cd client && deno task build",
     "start": "cd server && deno run --env=../.env --allow-net --allow-env --allow-read --allow-sys main.ts"
   },

--- a/server/features/simulation/calibration/per-position/iol-harness.test.ts
+++ b/server/features/simulation/calibration/per-position/iol-harness.test.ts
@@ -1,0 +1,390 @@
+import { assertEquals, assertStringIncludes } from "@std/assert";
+import type { PlayerAttributes } from "@zone-blitz/shared";
+import {
+  formatIolCalibrationReport,
+  runIolCalibration,
+} from "./iol-harness.ts";
+import type { GameResult, PlayEvent } from "../../events.ts";
+import type { SimTeam } from "../../simulate-game.ts";
+import type { PlayerRuntime } from "../../resolve-play.ts";
+import type { CalibrationLeague } from "../generate-calibration-league.ts";
+
+function attrs(overrides: Partial<PlayerAttributes> = {}): PlayerAttributes {
+  const base: Record<string, number> = {};
+  const keys = [
+    "speed",
+    "acceleration",
+    "agility",
+    "strength",
+    "jumping",
+    "stamina",
+    "durability",
+    "armStrength",
+    "accuracyShort",
+    "accuracyMedium",
+    "accuracyDeep",
+    "accuracyOnTheRun",
+    "touch",
+    "release",
+    "ballCarrying",
+    "elusiveness",
+    "routeRunning",
+    "catching",
+    "contestedCatching",
+    "runAfterCatch",
+    "passBlocking",
+    "runBlocking",
+    "blockShedding",
+    "tackling",
+    "manCoverage",
+    "zoneCoverage",
+    "passRushing",
+    "runDefense",
+    "kickingPower",
+    "kickingAccuracy",
+    "puntingPower",
+    "puntingAccuracy",
+    "snapAccuracy",
+    "footballIq",
+    "decisionMaking",
+    "anticipation",
+    "composure",
+    "clutch",
+    "consistency",
+    "workEthic",
+    "coachability",
+    "leadership",
+    "greed",
+    "loyalty",
+    "ambition",
+    "vanity",
+    "schemeAttachment",
+    "mediaSensitivity",
+  ];
+  for (const k of keys) {
+    base[k] = 50;
+    base[`${k}Potential`] = 50;
+  }
+  return { ...(base as unknown as PlayerAttributes), ...overrides };
+}
+
+function lineman(id: string, overall: number): PlayerRuntime {
+  return {
+    playerId: id,
+    neutralBucket: "IOL",
+    attributes: attrs({
+      passBlocking: overall,
+      runBlocking: overall,
+      strength: overall,
+      footballIq: overall,
+    }),
+  };
+}
+
+function team(teamId: string, starters: PlayerRuntime[]): SimTeam {
+  return {
+    teamId,
+    starters,
+    bench: [],
+    fingerprint: { offense: null, defense: null, overrides: {} },
+    coachingMods: {
+      schemeFitBonus: 0,
+      situationalBonus: 0,
+      aggressiveness: 50,
+      penaltyDiscipline: 1,
+    },
+  };
+}
+
+function bandJson(): string {
+  const band = (sack: number, stuff: number, pen: number) => ({
+    n: 20,
+    metrics: {
+      team_sack_allowed_rate: { n: 20, mean: sack, sd: 0.01 },
+      team_stuff_rate_inside: { n: 20, mean: stuff, sd: 0.02 },
+      penalties_per_game: { n: 20, mean: pen, sd: 0.1 },
+      starts_per_season: { n: 20, mean: 15, sd: 1.5 },
+    },
+  });
+  return JSON.stringify({
+    position: "IOL",
+    seasons: [2020, 2021, 2022, 2023, 2024],
+    ranking_stat: "composite proxy",
+    bands: {
+      elite: band(0.036, 0.10, 0.26),
+      good: band(0.047, 0.12, 0.21),
+      average: band(0.058, 0.15, 0.20),
+      weak: band(0.071, 0.17, 0.21),
+      replacement: band(0.076, 0.22, 0.25),
+    },
+  });
+}
+
+function makeGame(
+  gameId: string,
+  homeTeamId: string,
+  awayTeamId: string,
+  statsByTeam: Record<
+    string,
+    { dropbacks: number; sacks: number; interiorRuns: number; stuffs: number }
+  >,
+): GameResult {
+  const events: PlayEvent[] = [];
+  for (const [offenseTeamId, stats] of Object.entries(statsByTeam)) {
+    const defenseTeamId = offenseTeamId === homeTeamId
+      ? awayTeamId
+      : homeTeamId;
+    const nonSackDropbacks = stats.dropbacks - stats.sacks;
+    for (let i = 0; i < nonSackDropbacks; i++) {
+      events.push({
+        gameId,
+        driveIndex: 0,
+        playIndex: events.length,
+        quarter: 1,
+        clock: "15:00",
+        situation: { down: 1, distance: 10, yardLine: 25 },
+        offenseTeamId,
+        defenseTeamId,
+        call: {
+          concept: "dropback",
+          personnel: "11",
+          formation: "shotgun",
+          motion: "none",
+        },
+        coverage: { front: "4-3", coverage: "cover_2", pressure: "four_man" },
+        participants: [],
+        outcome: "pass_complete",
+        yardage: 7,
+        tags: [],
+      });
+    }
+    for (let i = 0; i < stats.sacks; i++) {
+      events.push({
+        gameId,
+        driveIndex: 0,
+        playIndex: events.length,
+        quarter: 1,
+        clock: "15:00",
+        situation: { down: 1, distance: 10, yardLine: 25 },
+        offenseTeamId,
+        defenseTeamId,
+        call: {
+          concept: "dropback",
+          personnel: "11",
+          formation: "shotgun",
+          motion: "none",
+        },
+        coverage: { front: "4-3", coverage: "cover_2", pressure: "four_man" },
+        participants: [],
+        outcome: "sack",
+        yardage: -7,
+        tags: [],
+      });
+    }
+    for (let i = 0; i < stats.interiorRuns; i++) {
+      const isStuff = i < stats.stuffs;
+      events.push({
+        gameId,
+        driveIndex: 0,
+        playIndex: events.length,
+        quarter: 1,
+        clock: "15:00",
+        situation: { down: 1, distance: 10, yardLine: 25 },
+        offenseTeamId,
+        defenseTeamId,
+        call: {
+          concept: "inside_zone",
+          personnel: "11",
+          formation: "shotgun",
+          motion: "none",
+        },
+        coverage: { front: "4-3", coverage: "cover_2", pressure: "four_man" },
+        participants: [],
+        outcome: "rush",
+        yardage: isStuff ? 0 : 5,
+        tags: [],
+      });
+    }
+  }
+  return {
+    gameId,
+    seed: 1,
+    finalScore: { home: 0, away: 0 },
+    events,
+    boxScore: {
+      home: {
+        totalYards: 0,
+        passingYards: 0,
+        rushingYards: 0,
+        turnovers: 0,
+        sacks: 0,
+        penalties: 0,
+      },
+      away: {
+        totalYards: 0,
+        passingYards: 0,
+        rushingYards: 0,
+        turnovers: 0,
+        sacks: 0,
+        penalties: 0,
+      },
+    },
+    driveLog: [],
+    injuryReport: [],
+  };
+}
+
+Deno.test("runIolCalibration buckets IOL starters and returns a populated report", () => {
+  // Map each team's IOL overall to a target sack-allowed rate that
+  // lands in its expected band. Each team has three IOL starters so
+  // per-team sample volume is 3x.
+  const overallByTeam: Record<string, number> = {
+    "t30": 30,
+    "t40": 40,
+    "t50": 50,
+    "t60": 60,
+    "t70": 70,
+    "t80": 80,
+  };
+  const sackRateByOverall: Record<number, number> = {
+    30: 0.076,
+    40: 0.071,
+    50: 0.058,
+    60: 0.047,
+    70: 0.036,
+    80: 0.036,
+  };
+
+  const teams: SimTeam[] = Object.entries(overallByTeam).map(([id, o]) =>
+    team(id, [
+      lineman(`${id}-c`, o),
+      lineman(`${id}-lg`, o),
+      lineman(`${id}-rg`, o),
+    ])
+  );
+  const league: CalibrationLeague = { calibrationSeed: 1, teams };
+
+  let gameCount = 0;
+  const simulate = ({ home, away, gameId }: {
+    home: SimTeam;
+    away: SimTeam;
+    seed: number;
+    gameId: string;
+  }): GameResult => {
+    gameCount++;
+    const sackTarget = sackRateByOverall[overallByTeam[home.teamId]];
+    const awayTarget = sackRateByOverall[overallByTeam[away.teamId]];
+    return makeGame(gameId, home.teamId, away.teamId, {
+      [home.teamId]: {
+        dropbacks: 40,
+        sacks: Math.round(40 * sackTarget),
+        interiorRuns: 20,
+        stuffs: Math.round(20 * 0.15),
+      },
+      [away.teamId]: {
+        dropbacks: 40,
+        sacks: Math.round(40 * awayTarget),
+        interiorRuns: 20,
+        stuffs: Math.round(20 * 0.15),
+      },
+    });
+  };
+
+  const report = runIolCalibration({
+    bandJson: bandJson(),
+    league,
+    simulate,
+    gameCount: teams.length * 12,
+    minSamplesPerBucket: 5,
+  });
+
+  assertEquals(report.totalGames, teams.length * 12);
+  // 2 teams per game * 3 IOL starters = 6 samples per game.
+  assertEquals(report.totalSamples, gameCount * 6);
+
+  const fifty = report.buckets.find((b) => b.bucketLabel === "50")!;
+  assertEquals(fifty.samples > 0, true);
+  assertEquals(fifty.underSampled, false);
+  assertEquals(fifty.checks.length > 0, true);
+});
+
+Deno.test("runIolCalibration marks a bucket under-sampled when below min threshold", () => {
+  const teams: SimTeam[] = [team("t50", [lineman("t50-c", 50)])];
+  const league: CalibrationLeague = { calibrationSeed: 1, teams };
+  const simulate = (
+    { home, away, gameId }: {
+      home: SimTeam;
+      away: SimTeam;
+      seed: number;
+      gameId: string;
+    },
+  ) =>
+    makeGame(gameId, home.teamId, away.teamId, {
+      [home.teamId]: {
+        dropbacks: 40,
+        sacks: 2,
+        interiorRuns: 20,
+        stuffs: 3,
+      },
+      [away.teamId]: {
+        dropbacks: 40,
+        sacks: 2,
+        interiorRuns: 20,
+        stuffs: 3,
+      },
+    });
+
+  const report = runIolCalibration({
+    bandJson: bandJson(),
+    league,
+    simulate,
+    gameCount: 1,
+    minSamplesPerBucket: 100,
+  });
+
+  const fifty = report.buckets.find((b) => b.bucketLabel === "50")!;
+  assertEquals(fifty.underSampled, true);
+  assertEquals(fifty.checks.length, 0);
+});
+
+Deno.test("formatIolCalibrationReport renders a human-readable summary that flags the proxy limitation", () => {
+  const teams: SimTeam[] = [team("t50", [lineman("t50-c", 50)])];
+  const league: CalibrationLeague = { calibrationSeed: 1, teams };
+  const simulate = (
+    { home, away, gameId }: {
+      home: SimTeam;
+      away: SimTeam;
+      seed: number;
+      gameId: string;
+    },
+  ) =>
+    makeGame(gameId, home.teamId, away.teamId, {
+      [home.teamId]: {
+        dropbacks: 40,
+        sacks: 2,
+        interiorRuns: 20,
+        stuffs: 3,
+      },
+      [away.teamId]: {
+        dropbacks: 40,
+        sacks: 2,
+        interiorRuns: 20,
+        stuffs: 3,
+      },
+    });
+
+  const report = runIolCalibration({
+    bandJson: bandJson(),
+    league,
+    simulate,
+    gameCount: 100,
+    minSamplesPerBucket: 1,
+  });
+  const output = formatIolCalibrationReport(report);
+  assertStringIncludes(output, "IOL calibration");
+  assertStringIncludes(output, "bucket 50");
+  assertStringIncludes(output, "team_sack_allowed_rate");
+  // Flags the proxy-metric caveat prominently in the output header so
+  // anyone reading the report sees the limitation up front.
+  assertStringIncludes(output, "proxies");
+});

--- a/server/features/simulation/calibration/per-position/iol-harness.ts
+++ b/server/features/simulation/calibration/per-position/iol-harness.ts
@@ -1,0 +1,178 @@
+import { deriveGameSeed } from "../../rng.ts";
+import { CALIBRATION_GAME_COUNT } from "../constants.ts";
+import { generateMatchups } from "../harness.ts";
+import type { SimulateFn } from "../harness.ts";
+import type { CalibrationLeague } from "../generate-calibration-league.ts";
+import { collectIolSamples, type IolGameSample } from "./iol-sample.ts";
+import { bucketByAttr, type BucketReport } from "./bucket-by-attr.ts";
+import { type BandCheckResult, checkBand } from "./band-check.ts";
+import { loadPositionBands, type PositionBands } from "./band-loader.ts";
+
+// Metrics the IOL slice reports on. All four mirror the R fixture's
+// band metrics; first two are team proxies (limitation documented in
+// iol-sample.ts + iol.json notes), penalties_per_game is per-player,
+// starts_per_season is always 1 per game-sample so its "mean" reports
+// 1.0 — included for structural parity with the fixture, not as a
+// calibration signal.
+export const IOL_METRICS = [
+  "team_sack_allowed_rate",
+  "team_stuff_rate_inside",
+  "penalties_per_game",
+] as const;
+
+export type IolMetric = typeof IOL_METRICS[number];
+
+const METRIC_EXTRACTORS: Record<IolMetric, (s: IolGameSample) => number> = {
+  team_sack_allowed_rate: (s) => s.team_sack_allowed_rate,
+  team_stuff_rate_inside: (s) => s.team_stuff_rate_inside,
+  penalties_per_game: (s) => s.penalties_per_game,
+};
+
+export interface IolCalibrationOptions {
+  bandJson: string;
+  league: CalibrationLeague;
+  simulate: SimulateFn;
+  gameCount?: number;
+  // Minimum samples per bucket before we trust a band check. Under
+  // this count we still emit the summary but flag it as under-sampled.
+  minSamplesPerBucket?: number;
+}
+
+export interface IolBucketReport {
+  bucketLabel: string;
+  bucketCenter: number;
+  samples: number;
+  underSampled: boolean;
+  checks: BandCheckResult[];
+}
+
+export interface IolCalibrationReport {
+  totalGames: number;
+  totalSamples: number;
+  bands: PositionBands;
+  buckets: IolBucketReport[];
+  failures: BandCheckResult[];
+  passed: boolean;
+}
+
+const DEFAULT_MIN_SAMPLES = 50;
+
+// All three IOL metrics are "lower is better" for the offense (fewer
+// sacks, fewer stuffs, fewer penalties). The elite band mean sits
+// below the replacement band mean on each, so band-check classifies
+// naturally without a direction flip — bucket-to-expected-band mapping
+// from band-check.ts does the right thing. Documented for future
+// readers who may reuse these metrics.
+export function runIolCalibration(
+  options: IolCalibrationOptions,
+): IolCalibrationReport {
+  const {
+    bandJson,
+    league,
+    simulate,
+    gameCount = CALIBRATION_GAME_COUNT,
+    minSamplesPerBucket = DEFAULT_MIN_SAMPLES,
+  } = options;
+
+  const bands = loadPositionBands(bandJson);
+  const teamById = new Map(league.teams.map((t) => [t.teamId, t]));
+  const matchups = generateMatchups(league.teams, gameCount);
+
+  const samples: IolGameSample[] = [];
+
+  for (let i = 0; i < matchups.length; i++) {
+    const { home, away } = matchups[i];
+    const gameId = `iol-calibration-game-${i}`;
+    const seed = deriveGameSeed(league.calibrationSeed, gameId);
+
+    const result = simulate({ home, away, seed, gameId });
+    const gameSamples = collectIolSamples({
+      game: result,
+      home: teamById.get(home.teamId) ?? home,
+      away: teamById.get(away.teamId) ?? away,
+    });
+    samples.push(...gameSamples);
+  }
+
+  const bucketReports: BucketReport<IolGameSample>[] = bucketByAttr({
+    samples,
+    attr: (s) => s.iolOverall,
+    metrics: METRIC_EXTRACTORS,
+  });
+
+  const buckets: IolBucketReport[] = bucketReports.map((report) => {
+    const underSampled = report.samples.length < minSamplesPerBucket;
+    const checks: BandCheckResult[] = IOL_METRICS.flatMap((metric) => {
+      if (underSampled) return [];
+      return [
+        checkBand({
+          bucketLabel: report.bucket.label,
+          metricName: metric,
+          simSummary: report.metrics[metric],
+          bands,
+        }),
+      ];
+    });
+    return {
+      bucketLabel: report.bucket.label,
+      bucketCenter: report.bucket.center,
+      samples: report.samples.length,
+      underSampled,
+      checks,
+    };
+  });
+
+  const failures = buckets.flatMap((b) => b.checks.filter((c) => !c.passed));
+
+  return {
+    totalGames: matchups.length,
+    totalSamples: samples.length,
+    bands,
+    buckets,
+    failures,
+    passed: failures.length === 0,
+  };
+}
+
+export function formatIolCalibrationReport(
+  report: IolCalibrationReport,
+): string {
+  const lines: string[] = [];
+  lines.push(
+    `IOL calibration — ${report.totalGames} games, ${report.totalSamples} IOL-games`,
+  );
+  lines.push(
+    `Bands: ${report.bands.position} / ${
+      report.bands.seasons.join("-")
+    } / ranked by ${report.bands.rankingStat}`,
+  );
+  lines.push(
+    "NOTE: team_sack_allowed_rate and team_stuff_rate_inside are " +
+      "team-level proxies shared across all IOL starters — PFF " +
+      "block/pressure grades are not available in nflreadr.",
+  );
+  lines.push("");
+  for (const bucket of report.buckets) {
+    const header = `[bucket ${bucket.bucketLabel}] n=${bucket.samples}` +
+      (bucket.underSampled ? " (under-sampled, skipping band checks)" : "");
+    lines.push(header);
+    for (const check of bucket.checks) {
+      const verdict = check.passed ? "PASS" : "FAIL";
+      const dir = check.passed ? "" : ` (${check.direction})`;
+      lines.push(
+        `  ${verdict} ${check.metricName.padEnd(24)} ` +
+          `sim=${check.simMean.toFixed(4)}  ` +
+          `band(${check.expectedBand})=${check.bandMean.toFixed(4)}±${
+            check.bandSd.toFixed(4)
+          }  ` +
+          `z=${check.zScore.toFixed(2)}  actual=${check.actualBand}${dir}`,
+      );
+    }
+    lines.push("");
+  }
+  const passed = report.passed ? "PASS" : "FAIL";
+  lines.push(
+    `${passed}: ${report.failures.length} band check(s) missed expected band`,
+  );
+  return lines.join("\n");
+}

--- a/server/features/simulation/calibration/per-position/iol-overall.test.ts
+++ b/server/features/simulation/calibration/per-position/iol-overall.test.ts
@@ -1,0 +1,84 @@
+import { assertAlmostEquals, assertEquals } from "@std/assert";
+import type { PlayerAttributes } from "@zone-blitz/shared";
+import { IOL_OVERALL_ATTRS, iolOverall } from "./iol-overall.ts";
+
+function attrs(overrides: Partial<PlayerAttributes> = {}): PlayerAttributes {
+  const base: Record<string, number> = {};
+  const keys = [
+    "speed",
+    "acceleration",
+    "agility",
+    "strength",
+    "jumping",
+    "stamina",
+    "durability",
+    "armStrength",
+    "accuracyShort",
+    "accuracyMedium",
+    "accuracyDeep",
+    "accuracyOnTheRun",
+    "touch",
+    "release",
+    "ballCarrying",
+    "elusiveness",
+    "routeRunning",
+    "catching",
+    "contestedCatching",
+    "runAfterCatch",
+    "passBlocking",
+    "runBlocking",
+    "blockShedding",
+    "tackling",
+    "manCoverage",
+    "zoneCoverage",
+    "passRushing",
+    "runDefense",
+    "kickingPower",
+    "kickingAccuracy",
+    "puntingPower",
+    "puntingAccuracy",
+    "snapAccuracy",
+    "footballIq",
+    "decisionMaking",
+    "anticipation",
+    "composure",
+    "clutch",
+    "consistency",
+    "workEthic",
+    "coachability",
+    "leadership",
+    "greed",
+    "loyalty",
+    "ambition",
+    "vanity",
+    "schemeAttachment",
+    "mediaSensitivity",
+  ];
+  for (const k of keys) {
+    base[k] = 50;
+    base[`${k}Potential`] = 50;
+  }
+  return { ...(base as unknown as PlayerAttributes), ...overrides };
+}
+
+Deno.test("iolOverall averages the four signature attributes", () => {
+  const result = iolOverall(attrs({
+    passBlocking: 60,
+    runBlocking: 70,
+    strength: 80,
+    footballIq: 50,
+  }));
+  // (60 + 70 + 80 + 50) / 4 = 65
+  assertAlmostEquals(result, 65, 1e-6);
+});
+
+Deno.test("iolOverall returns 50 for a baseline 50-everything lineman", () => {
+  assertEquals(iolOverall(attrs()), 50);
+});
+
+Deno.test("IOL_OVERALL_ATTRS covers the blocking ranking + awareness", () => {
+  assertEquals(IOL_OVERALL_ATTRS.includes("passBlocking"), true);
+  assertEquals(IOL_OVERALL_ATTRS.includes("runBlocking"), true);
+  assertEquals(IOL_OVERALL_ATTRS.includes("strength"), true);
+  assertEquals(IOL_OVERALL_ATTRS.includes("footballIq"), true);
+});

--- a/server/features/simulation/calibration/per-position/iol-overall.ts
+++ b/server/features/simulation/calibration/per-position/iol-overall.ts
@@ -1,0 +1,23 @@
+import type { PlayerAttributes } from "@zone-blitz/shared";
+
+// Interior-OL (C, G) overall. Mirrors how `neutralBucket` classifies
+// IOL (runBlocking + passBlocking + strength) and adds `awareness`-
+// adjacent IQ attrs so inexperienced-but-athletic guards don't score
+// the same as a veteran. Averaging gives a single 0-100 "IOL overall"
+// that calibration buckets on: a 50-overall interior lineman should
+// produce NFL median-starter numbers on the band metrics, 70 should
+// be elite, etc.
+export const IOL_OVERALL_ATTRS = [
+  "passBlocking",
+  "runBlocking",
+  "strength",
+  "footballIq",
+] as const satisfies ReadonlyArray<keyof PlayerAttributes>;
+
+export function iolOverall(attributes: PlayerAttributes): number {
+  let sum = 0;
+  for (const key of IOL_OVERALL_ATTRS) {
+    sum += attributes[key];
+  }
+  return sum / IOL_OVERALL_ATTRS.length;
+}

--- a/server/features/simulation/calibration/per-position/iol-sample.test.ts
+++ b/server/features/simulation/calibration/per-position/iol-sample.test.ts
@@ -1,0 +1,404 @@
+import { assertAlmostEquals, assertEquals } from "@std/assert";
+import type { PlayerAttributes } from "@zone-blitz/shared";
+import { collectIolSamples } from "./iol-sample.ts";
+import type { GameResult, PlayEvent } from "../../events.ts";
+import type { SimTeam } from "../../simulate-game.ts";
+import type { PlayerRuntime } from "../../resolve-play.ts";
+
+function attrs(overrides: Partial<PlayerAttributes> = {}): PlayerAttributes {
+  const base: Record<string, number> = {};
+  const keys = [
+    "speed",
+    "acceleration",
+    "agility",
+    "strength",
+    "jumping",
+    "stamina",
+    "durability",
+    "armStrength",
+    "accuracyShort",
+    "accuracyMedium",
+    "accuracyDeep",
+    "accuracyOnTheRun",
+    "touch",
+    "release",
+    "ballCarrying",
+    "elusiveness",
+    "routeRunning",
+    "catching",
+    "contestedCatching",
+    "runAfterCatch",
+    "passBlocking",
+    "runBlocking",
+    "blockShedding",
+    "tackling",
+    "manCoverage",
+    "zoneCoverage",
+    "passRushing",
+    "runDefense",
+    "kickingPower",
+    "kickingAccuracy",
+    "puntingPower",
+    "puntingAccuracy",
+    "snapAccuracy",
+    "footballIq",
+    "decisionMaking",
+    "anticipation",
+    "composure",
+    "clutch",
+    "consistency",
+    "workEthic",
+    "coachability",
+    "leadership",
+    "greed",
+    "loyalty",
+    "ambition",
+    "vanity",
+    "schemeAttachment",
+    "mediaSensitivity",
+  ];
+  for (const k of keys) {
+    base[k] = 50;
+    base[`${k}Potential`] = 50;
+  }
+  return { ...(base as unknown as PlayerAttributes), ...overrides };
+}
+
+function lineman(id: string, overall: number): PlayerRuntime {
+  return {
+    playerId: id,
+    neutralBucket: "IOL",
+    attributes: attrs({
+      passBlocking: overall,
+      runBlocking: overall,
+      strength: overall,
+      footballIq: overall,
+    }),
+  };
+}
+
+function otherStarter(id: string, bucket: "QB" | "OT"): PlayerRuntime {
+  return {
+    playerId: id,
+    neutralBucket: bucket,
+    attributes: attrs(),
+  };
+}
+
+function team(teamId: string, starters: PlayerRuntime[]): SimTeam {
+  return {
+    teamId,
+    starters,
+    bench: [],
+    fingerprint: { offense: null, defense: null, overrides: {} },
+    coachingMods: {
+      schemeFitBonus: 0,
+      situationalBonus: 0,
+      aggressiveness: 50,
+      penaltyDiscipline: 1,
+    },
+  };
+}
+
+function event(
+  overrides: Partial<PlayEvent> & {
+    outcome: PlayEvent["outcome"];
+    offenseTeamId: string;
+  },
+): PlayEvent {
+  return {
+    gameId: "g",
+    driveIndex: 0,
+    playIndex: 0,
+    quarter: 1,
+    clock: "15:00",
+    situation: { down: 1, distance: 10, yardLine: 25 },
+    defenseTeamId: overrides.offenseTeamId === "home" ? "away" : "home",
+    call: {
+      concept: "inside_zone",
+      personnel: "11",
+      formation: "shotgun",
+      motion: "none",
+    },
+    coverage: { front: "4-3", coverage: "cover_2", pressure: "four_man" },
+    participants: [],
+    yardage: 0,
+    tags: [],
+    ...overrides,
+  };
+}
+
+function gameOf(events: PlayEvent[]): GameResult {
+  return {
+    gameId: "g",
+    seed: 1,
+    finalScore: { home: 0, away: 0 },
+    events,
+    boxScore: {
+      home: {
+        totalYards: 0,
+        passingYards: 0,
+        rushingYards: 0,
+        turnovers: 0,
+        sacks: 0,
+        penalties: 0,
+      },
+      away: {
+        totalYards: 0,
+        passingYards: 0,
+        rushingYards: 0,
+        turnovers: 0,
+        sacks: 0,
+        penalties: 0,
+      },
+    },
+    driveLog: [],
+    injuryReport: [],
+  };
+}
+
+Deno.test("collectIolSamples emits one sample per IOL starter per team", () => {
+  const home = team("home", [
+    otherStarter("qb1", "QB"),
+    lineman("c1", 50),
+    lineman("lg1", 50),
+    lineman("rg1", 50),
+  ]);
+  const away = team("away", [
+    otherStarter("qb2", "QB"),
+    lineman("c2", 50),
+    lineman("lg2", 50),
+    lineman("rg2", 50),
+  ]);
+  const samples = collectIolSamples({
+    game: gameOf([]),
+    home,
+    away,
+  });
+  assertEquals(samples.length, 6);
+  assertEquals(samples.filter((s) => s.teamId === "home").length, 3);
+  assertEquals(samples.filter((s) => s.teamId === "away").length, 3);
+});
+
+Deno.test("collectIolSamples skips teams without IOL starters", () => {
+  const home = team("home", [lineman("c1", 50)]);
+  const away = team("away", [
+    otherStarter("qb2", "QB"),
+    otherStarter("ot2", "OT"),
+  ]);
+  const samples = collectIolSamples({
+    game: gameOf([]),
+    home,
+    away,
+  });
+  assertEquals(samples.length, 1);
+  assertEquals(samples[0].teamId, "home");
+});
+
+Deno.test("collectIolSamples tags each sample with IOL overall (mean of four signature attrs)", () => {
+  const home = team(
+    "home",
+    [
+      {
+        playerId: "c1",
+        neutralBucket: "IOL",
+        attributes: attrs({
+          passBlocking: 60,
+          runBlocking: 70,
+          strength: 80,
+          footballIq: 50,
+        }),
+      },
+    ],
+  );
+  const away = team("away", [lineman("c2", 50)]);
+  const [home_sample] = collectIolSamples({
+    game: gameOf([]),
+    home,
+    away,
+  });
+  // (60 + 70 + 80 + 50) / 4 = 65
+  assertAlmostEquals(home_sample.iolOverall, 65, 1e-6);
+});
+
+Deno.test("collectIolSamples computes team_sack_allowed_rate across all IOL starters on a team", () => {
+  const home = team("home", [lineman("c1", 50), lineman("lg1", 50)]);
+  const away = team("away", [lineman("c2", 50)]);
+  const events: PlayEvent[] = [
+    event({ outcome: "pass_complete", offenseTeamId: "home" }),
+    event({ outcome: "pass_incomplete", offenseTeamId: "home" }),
+    event({ outcome: "pass_incomplete", offenseTeamId: "home" }),
+    event({ outcome: "sack", offenseTeamId: "home", yardage: -7 }),
+  ];
+  const samples = collectIolSamples({
+    game: gameOf(events),
+    home,
+    away,
+  });
+  const homeSamples = samples.filter((s) => s.teamId === "home");
+  assertEquals(homeSamples.length, 2);
+  for (const s of homeSamples) {
+    assertEquals(s.team_dropbacks, 4);
+    assertEquals(s.team_sacks, 1);
+    assertAlmostEquals(s.team_sack_allowed_rate, 0.25, 1e-6);
+  }
+});
+
+Deno.test("collectIolSamples counts interior rushes for stuff-rate denominator", () => {
+  const home = team("home", [lineman("c1", 50)]);
+  const away = team("away", [lineman("c2", 50)]);
+  const events: PlayEvent[] = [
+    // Three interior runs, two of them stuffs.
+    event({
+      outcome: "rush",
+      offenseTeamId: "home",
+      yardage: 5,
+      call: {
+        concept: "inside_zone",
+        personnel: "11",
+        formation: "shotgun",
+        motion: "none",
+      },
+    }),
+    event({
+      outcome: "rush",
+      offenseTeamId: "home",
+      yardage: 0,
+      call: {
+        concept: "power",
+        personnel: "12",
+        formation: "singleback",
+        motion: "none",
+      },
+    }),
+    event({
+      outcome: "rush",
+      offenseTeamId: "home",
+      yardage: -2,
+      call: {
+        concept: "counter",
+        personnel: "11",
+        formation: "shotgun",
+        motion: "none",
+      },
+    }),
+    // Outside-zone run — does NOT count toward interior stuff rate.
+    event({
+      outcome: "rush",
+      offenseTeamId: "home",
+      yardage: 0,
+      call: {
+        concept: "outside_zone",
+        personnel: "11",
+        formation: "shotgun",
+        motion: "none",
+      },
+    }),
+  ];
+  const [homeSample] = collectIolSamples({
+    game: gameOf(events),
+    home,
+    away,
+  });
+  assertEquals(homeSample.team_interior_runs, 3);
+  assertEquals(homeSample.team_interior_stuffs, 2);
+  assertAlmostEquals(homeSample.team_stuff_rate_inside, 2 / 3, 1e-6);
+});
+
+Deno.test("collectIolSamples attributes per-player penalties by againstPlayerId", () => {
+  const home = team("home", [lineman("c1", 50), lineman("lg1", 50)]);
+  const away = team("away", [lineman("c2", 50)]);
+  const events: PlayEvent[] = [
+    {
+      ...event({ outcome: "penalty", offenseTeamId: "home" }),
+      penalty: {
+        type: "holding",
+        phase: "post_snap",
+        yardage: 10,
+        automaticFirstDown: false,
+        againstTeamId: "home",
+        againstPlayerId: "c1",
+        accepted: true,
+      },
+    },
+    {
+      ...event({ outcome: "penalty", offenseTeamId: "home" }),
+      penalty: {
+        type: "false_start",
+        phase: "pre_snap",
+        yardage: 5,
+        automaticFirstDown: false,
+        againstTeamId: "home",
+        againstPlayerId: "c1",
+        accepted: true,
+      },
+    },
+    {
+      ...event({ outcome: "penalty", offenseTeamId: "home" }),
+      penalty: {
+        type: "holding",
+        phase: "post_snap",
+        yardage: 10,
+        automaticFirstDown: false,
+        againstTeamId: "home",
+        againstPlayerId: "lg1",
+        accepted: true,
+      },
+    },
+  ];
+  const samples = collectIolSamples({
+    game: gameOf(events),
+    home,
+    away,
+  });
+  const c1 = samples.find((s) => s.iolPlayerId === "c1")!;
+  const lg1 = samples.find((s) => s.iolPlayerId === "lg1")!;
+  assertEquals(c1.penalties, 2);
+  assertEquals(c1.penalties_per_game, 2);
+  assertEquals(lg1.penalties, 1);
+});
+
+Deno.test("collectIolSamples treats starts_per_season as 1 per game-sample", () => {
+  const home = team("home", [lineman("c1", 50)]);
+  const away = team("away", [lineman("c2", 50)]);
+  const [homeSample] = collectIolSamples({
+    game: gameOf([]),
+    home,
+    away,
+  });
+  assertEquals(homeSample.starts_per_season, 1);
+});
+
+Deno.test("collectIolSamples isolates events by offenseTeamId", () => {
+  const home = team("home", [lineman("c1", 50)]);
+  const away = team("away", [lineman("c2", 50)]);
+  const events: PlayEvent[] = [
+    event({ outcome: "sack", offenseTeamId: "home", yardage: -5 }),
+    event({ outcome: "pass_complete", offenseTeamId: "home" }),
+    event({ outcome: "pass_incomplete", offenseTeamId: "away" }),
+  ];
+  const samples = collectIolSamples({
+    game: gameOf(events),
+    home,
+    away,
+  });
+  const homeSample = samples.find((s) => s.teamId === "home")!;
+  const awaySample = samples.find((s) => s.teamId === "away")!;
+  assertEquals(homeSample.team_sacks, 1);
+  assertEquals(homeSample.team_dropbacks, 2);
+  assertEquals(awaySample.team_sacks, 0);
+  assertEquals(awaySample.team_dropbacks, 1);
+});
+
+Deno.test("collectIolSamples handles zero-play games without divide-by-zero", () => {
+  const home = team("home", [lineman("c1", 50)]);
+  const away = team("away", [lineman("c2", 50)]);
+  const [sample] = collectIolSamples({
+    game: gameOf([]),
+    home,
+    away,
+  });
+  assertEquals(sample.team_sack_allowed_rate, 0);
+  assertEquals(sample.team_stuff_rate_inside, 0);
+  assertEquals(sample.penalties_per_game, 0);
+});

--- a/server/features/simulation/calibration/per-position/iol-sample.ts
+++ b/server/features/simulation/calibration/per-position/iol-sample.ts
@@ -1,0 +1,156 @@
+import type { GameResult, PlayEvent } from "../../events.ts";
+import type { SimTeam } from "../../simulate-game.ts";
+import { iolOverall } from "./iol-overall.ts";
+
+// Run concepts where the ball carrier goes between the tackles.
+// Interior OL "own" these runs for the stuff-rate proxy, mirroring
+// how the R script filters pbp rows with run_gap in ("guard","middle").
+// Anything not in this set (outside_zone, sweeps, etc.) is attributed
+// elsewhere.
+const INTERIOR_RUN_CONCEPTS = new Set([
+  "inside_zone",
+  "power",
+  "counter",
+  "draw",
+]);
+
+export interface IolGameSample {
+  teamId: string;
+  iolPlayerId: string;
+  iolOverall: number;
+  // Team-level proxy metrics. Every IOL starter on the same team in
+  // the same game sees the same value — calibration gap inherited
+  // from the R fixture and documented in the notes.
+  team_dropbacks: number;
+  team_sacks: number;
+  team_sack_allowed_rate: number;
+  team_interior_runs: number;
+  team_interior_stuffs: number;
+  team_stuff_rate_inside: number;
+  // Per-player metric. Sourced from penalty events whose
+  // `againstPlayerId` matches this lineman.
+  penalties: number;
+  penalties_per_game: number;
+  // Snap/start attribution — each starter counts as having played the
+  // game, so this is 1 per sample and aggregates to starts-per-season
+  // when rolled up across matchups in a season.
+  starts_per_season: number;
+}
+
+function teamTotals(events: PlayEvent[], teamId: string) {
+  let dropbacks = 0;
+  let sacks = 0;
+  let interiorRuns = 0;
+  let interiorStuffs = 0;
+
+  for (const event of events) {
+    if (event.offenseTeamId !== teamId) continue;
+
+    const concept = event.call.concept;
+    const isInteriorRun = INTERIOR_RUN_CONCEPTS.has(concept);
+
+    switch (event.outcome) {
+      case "sack":
+        dropbacks++;
+        sacks++;
+        break;
+      case "pass_complete":
+      case "pass_incomplete":
+      case "interception":
+        dropbacks++;
+        break;
+      case "rush":
+        if (isInteriorRun) {
+          interiorRuns++;
+          if (event.yardage <= 0) interiorStuffs++;
+        }
+        break;
+      case "fumble":
+        // Fumbles that came off a rush still count as an interior run
+        // attempt for stuff-rate denominator purposes — they're not
+        // stuffs (yardage can be positive at the point of the fumble),
+        // so compare on yardage only.
+        if (isInteriorRun) {
+          interiorRuns++;
+          if (event.yardage <= 0) interiorStuffs++;
+        }
+        break;
+      case "touchdown":
+        if (isInteriorRun) {
+          interiorRuns++;
+          // Touchdown runs are definitionally not stuffs.
+        } else if (!INTERIOR_RUN_CONCEPTS.has(concept)) {
+          // Pass-concept TDs count as a completed dropback.
+          dropbacks++;
+        }
+        break;
+    }
+  }
+
+  return { dropbacks, sacks, interiorRuns, interiorStuffs };
+}
+
+function countPenaltiesFor(events: PlayEvent[], playerId: string): number {
+  let n = 0;
+  for (const event of events) {
+    const penalty = event.penalty;
+    if (!penalty) continue;
+    if (penalty.againstPlayerId === playerId) {
+      n++;
+    }
+  }
+  return n;
+}
+
+export interface IolSampleInput {
+  game: GameResult;
+  home: SimTeam;
+  away: SimTeam;
+}
+
+// Build one sample per IOL starter on each team per game. Because the
+// ranking fixture's team proxies can't distinguish linemen on the same
+// line, each starter carries the same team_sack_allowed_rate and
+// team_stuff_rate_inside for that game; only `penalties` is per-player.
+// This mirrors the R script's team-proxy-broadcast approach and
+// documents the aggregation gap explicitly.
+export function collectIolSamples(
+  input: IolSampleInput,
+): IolGameSample[] {
+  const { game, home, away } = input;
+
+  const samples: IolGameSample[] = [];
+  for (const team of [home, away]) {
+    const iolStarters = team.starters.filter(
+      (p) => p.neutralBucket === "IOL",
+    );
+    if (iolStarters.length === 0) continue;
+
+    const totals = teamTotals(game.events, team.teamId);
+    const sack_rate = totals.dropbacks > 0
+      ? totals.sacks / totals.dropbacks
+      : 0;
+    const stuff_rate = totals.interiorRuns > 0
+      ? totals.interiorStuffs / totals.interiorRuns
+      : 0;
+
+    for (const lineman of iolStarters) {
+      const penalties = countPenaltiesFor(game.events, lineman.playerId);
+      samples.push({
+        teamId: team.teamId,
+        iolPlayerId: lineman.playerId,
+        iolOverall: iolOverall(lineman.attributes),
+        team_dropbacks: totals.dropbacks,
+        team_sacks: totals.sacks,
+        team_sack_allowed_rate: sack_rate,
+        team_interior_runs: totals.interiorRuns,
+        team_interior_stuffs: totals.interiorStuffs,
+        team_stuff_rate_inside: stuff_rate,
+        penalties,
+        penalties_per_game: penalties,
+        starts_per_season: 1,
+      });
+    }
+  }
+  return samples;
+}

--- a/server/features/simulation/calibration/per-position/run-iol-calibration.ts
+++ b/server/features/simulation/calibration/per-position/run-iol-calibration.ts
@@ -1,0 +1,67 @@
+import { simulateGame } from "../../simulate-game.ts";
+import { generateCalibrationLeague } from "../generate-calibration-league.ts";
+import { CALIBRATION_SEEDS } from "../calibration-seeds.ts";
+import {
+  formatIolCalibrationReport,
+  runIolCalibration,
+} from "./iol-harness.ts";
+
+// Per-issue-#496: this entry point is intentionally report-only at
+// first. We print per-bucket PASS/FAIL against NFL IOL percentile
+// bands across every calibration seed so a human can eyeball the
+// signal — gating will come later once we understand noise
+// characteristics per bucket (particularly given the team-proxy
+// limitations documented in iol.json).
+const bandPath = new URL(
+  "../../../../../data/bands/per-position/iol.json",
+  import.meta.url,
+);
+
+const bandJson = await Deno.readTextFile(bandPath);
+
+let allPassed = true;
+const summary: {
+  seed: number;
+  passed: number;
+  total: number;
+  underSampled: number;
+}[] = [];
+
+for (const seed of CALIBRATION_SEEDS) {
+  const league = generateCalibrationLeague({ seed });
+  const report = runIolCalibration({
+    bandJson,
+    league,
+    simulate: simulateGame,
+  });
+
+  console.log(`=== seed=0x${seed.toString(16)} ===`);
+  console.log(formatIolCalibrationReport(report));
+  console.log("");
+
+  const totalChecks = report.buckets.reduce(
+    (sum, b) => sum + b.checks.length,
+    0,
+  );
+  const passCount = totalChecks - report.failures.length;
+  const underSampled = report.buckets.filter((b) => b.underSampled).length;
+  summary.push({ seed, passed: passCount, total: totalChecks, underSampled });
+  if (!report.passed) allPassed = false;
+}
+
+console.log("=== Multi-seed summary ===");
+for (const row of summary) {
+  const status = row.passed === row.total ? "PASS" : "FAIL";
+  const underSampledNote = row.underSampled > 0
+    ? ` (${row.underSampled} bucket(s) under-sampled)`
+    : "";
+  console.log(
+    `${status} seed=0x${
+      row.seed.toString(16)
+    }: ${row.passed}/${row.total}${underSampledNote}`,
+  );
+}
+
+if (!allPassed) {
+  Deno.exit(1);
+}


### PR DESCRIPTION
## Summary

Implements the IOL (C, G) slice of #496 — mirrors the QB harness from #497 for interior offensive linemen. Tags every sim IOL-game with the starter's overall (mean of `passBlocking`, `runBlocking`, `strength`, `footballIq`), buckets samples into 10-point bands (30/40/50/60/70/80), and compares each bucket's mean stat line to NFL IOL percentile bands.

- `data/R/bands/per-position-iol.R` builds the reference fixture from five seasons (2020-2024) of `load_pbp` + `load_snap_counts` and writes `data/bands/per-position/iol.json` (371 IOL starter-seasons, five percentile bands).
- `server/features/simulation/calibration/per-position/` gains `iol-overall`, `iol-sample`, `iol-harness`, `run-iol-calibration`. Reuses the existing `bucket-by-attr`, `band-loader`, `band-check` modules.
- `deno task sim:calibrate:iol` runs the harness across every calibration seed.
- 15 unit tests across the three new modules, all passing.

Report-only for now per issue #496.

## Notes

**PROXY-METRIC LIMITATION (flagged throughout R comments, fixture `notes`, and the TS report output):** nflreadr does not carry PFF block/pressure grades for interior offensive linemen. This V1 reference is built from team-level proxies allocated to the starting IOL, so it cannot distinguish a great guard next to a weak center on the same line. Band separation on the two team-proxy metrics is directional, not authoritative. The third metric, `penalties_per_game`, IS per-player on both sides (NFL via `nflreadr` weekly `penalties`; sim via penalty-event `againstPlayerId`).

**Ranking metric:** composite z-score of `team_stuff_rate_inside` (rushes <=0 yds / interior rushes where `run_gap %in% c("guard","middle")`) and `team_sack_allowed_rate` (sacks / dropback), sign-inverted so higher composite = better IOL.

**Starter identity:** `load_snap_counts` with `offense_pct >= 0.5` and `games >= 12`. `load_player_stats` only emits IOL rows on penalty games, so it cannot establish starters on its own.

**Multi-seed run surfaces real calibration gaps the team-game aggregates were hiding:**
- **Interior stuff rate is ~20x too low.** Sim sits at 0.005-0.015 across every bucket vs. NFL average 0.147 / replacement 0.22. The engine rarely holds an inside run to <=0 yards — likely `synthesize-run-outcome` tuning, or the calibration league's front-seven overall doesn't match starting NFL defenses. Present in every seed, every bucket.
- **Sack-allowed rate doesn't separate by IOL bucket.** Across buckets 30-70 sim sack rate clusters 0.060-0.075 regardless of overall, vs. the NFL band spread of 0.036 (elite) → 0.076 (replacement). The 50 bucket also lands ~0.5-1.5 sd high on the average band. Engine is likely attributing sacks to pass-rush strength without matching weight on IOL pass-protection.
- **Per-player penalty rate is ~3x too low.** Sim bucket means sit 0.05-0.11 vs. NFL average ~0.20. Either penalty-generation rates under-fire for OL, or `againstPlayerId` attribution is under-selecting interior linemen.
- **All six buckets populate well** (~455-2154 samples per seed per bucket) — sample volume is not the issue, so these are tuning/attribution gaps, not noise.

**Sim logging gaps:**
- The R fixture pulls `run_gap` from pbp to isolate interior runs. The sim doesn't emit a `run_gap` on `PlayEvent`, so the sample collector uses concept-based proxy (`inside_zone`/`power`/`counter`/`draw`). If the engine later adds explicit gap metadata, the sample collector should switch to it.
- Penalty attribution to IOL linemen relies on `resolve-penalty.ts` choosing an IOL when an OL penalty fires. Worth spot-checking that `againstPlayerId` for holding/false-start penalties isn't over-biasing tackles (OT bucket) relative to interior.

Follow-ups will be filed as `gh issue create` once this merges. Subsequent slices (WR/CB, OL/pass-rush at the matchup level, TE/S, matchup harness) will follow per the issue's rollout plan.