### PR TITLE
feat(calibration): add per-OT-bucket calibration harness (#496, OT slice)

### DIFF
--- a/data/R/bands/per-position-ot.R
+++ b/data/R/bands/per-position-ot.R
@@ -1,0 +1,244 @@
+#!/usr/bin/env Rscript
+# per-position-ot.R — NFL OT percentile-band reference (PROXY METRICS).
+#
+# ============================================================================
+# IMPORTANT LIMITATION: nflreadr DOES NOT carry PFF block/pressure grades.
+# ============================================================================
+# OL performance is typically measured via PFF pass-block/run-block grades,
+# pressures allowed, and pressure rate — none of which are surfaced through
+# nflreadr's public play-by-play or player-stats tables. This script therefore
+# produces a v1 **proxy** band using:
+#
+#   * team_sack_allowed_rate — team-season sacks / dropbacks. Proxy for OT
+#     pass-protection quality, but commingles IOL protection, QB pocket
+#     discipline, scheme, and receiver separation. Both starting tackles on
+#     a team get the same team value.
+#
+#   * team_rush_ypc — team-season rushing yards / carries. Proxy for OL
+#     run-blocking; commingles RB talent, scheme, and defensive quality.
+#     Also shared across both tackles.
+#
+#   * penalties_per_game — cleanly per-player. Derived from pbp by counting
+#     accepted penalties against a given tackle's gsis_id. This is the only
+#     metric that cleanly isolates an individual OT, and even then OT
+#     penalties (false starts, holdings) correlate only loosely with
+#     block quality.
+#
+#   * starts_per_season — games with >= 40 offensive snaps (snap-count
+#     proxy for a starting appearance). Sanity check; not a skill metric.
+#
+# Starters are identified via load_snap_counts (position == "T") filtered
+# to players with >= 600 offensive snaps in the season. Tackles are then
+# joined to load_rosters (position == "OL" & depth_chart_position == "T")
+# to pick up gsis_id for penalty attribution, and to load_pbp-derived
+# team proxies.
+#
+# Bands are carved by a **composite rank**: mean of three z-scores for
+# (lower-is-better) team_sack_allowed_rate, (higher-is-better)
+# team_rush_ypc, and (lower-is-better) penalties_per_game. Ranks run from
+# elite (best composite) to replacement.
+#
+# When downstream consumers inspect this fixture, they MUST treat it as a
+# weak v1 calibration reference. Proper OT bands require ingesting PFF
+# grades or similar per-player tracking data (TruMedia, SIS, NGS charting).
+#
+# Output: data/bands/per-position/ot.json
+#
+# Usage:
+#   Rscript data/R/bands/per-position-ot.R [--seasons 2020:2024]
+
+suppressPackageStartupMessages({
+  library(nflreadr)
+  library(dplyr)
+  library(tidyr)
+})
+
+script_file <- (function() {
+  args <- commandArgs(trailingOnly = FALSE)
+  f <- grep("^--file=", args, value = TRUE)
+  if (length(f) > 0) normalizePath(sub("^--file=", "", f[1]), mustWork = FALSE) else NULL
+})()
+source(file.path(dirname(script_file), "..", "lib.R"))
+
+args <- commandArgs(trailingOnly = TRUE)
+seasons <- parse_seasons(args)
+
+cat("Loading pbp, snap counts, and rosters for seasons:",
+    paste(range(seasons), collapse = "-"), "\n")
+
+# ---- 1. Team-season protection + run proxies from pbp ---------------------
+pbp <- nflreadr::load_pbp(seasons)
+
+team_proxies <- pbp |>
+  filter(season_type == "REG", !is.na(posteam)) |>
+  mutate(
+    is_dropback = !is.na(pass_attempt) & (pass_attempt == 1 | sack == 1),
+    is_sack     = !is.na(sack) & sack == 1,
+    is_rush     = !is.na(rush_attempt) & rush_attempt == 1 &
+                  (is.na(qb_scramble) | qb_scramble == 0)
+  ) |>
+  group_by(posteam, season) |>
+  summarise(
+    dropbacks   = sum(is_dropback, na.rm = TRUE),
+    sacks       = sum(is_sack, na.rm = TRUE),
+    rushes      = sum(is_rush, na.rm = TRUE),
+    rush_yards  = sum(ifelse(is_rush, yards_gained, 0), na.rm = TRUE),
+    .groups     = "drop"
+  ) |>
+  mutate(
+    team_sack_allowed_rate = ifelse(dropbacks > 0, sacks / dropbacks, NA_real_),
+    team_rush_ypc          = ifelse(rushes > 0, rush_yards / rushes, NA_real_)
+  ) |>
+  rename(team = posteam)
+
+cat("Team-seasons with proxies:", nrow(team_proxies), "\n")
+
+# ---- 2. Per-player penalties from pbp (gsis_id keyed) ----------------------
+pbp_penalties <- pbp |>
+  filter(season_type == "REG", penalty == 1, !is.na(penalty_player_id)) |>
+  group_by(penalty_player_id, season) |>
+  summarise(penalties = dplyr::n(), .groups = "drop") |>
+  rename(gsis_id = penalty_player_id)
+
+# ---- 3. Starting tackles via load_snap_counts -----------------------------
+snaps <- nflreadr::load_snap_counts(seasons)
+
+ot_snap_season <- snaps |>
+  filter(game_type == "REG", position == "T") |>
+  group_by(pfr_player_id, player, season, team) |>
+  summarise(
+    # Compute starts *before* collapsing offense_snaps so the comparison
+    # still sees the weekly snap count, not the grouped sum.
+    starts_per_season = sum(offense_snaps >= 40, na.rm = TRUE),
+    total_offense_snaps = sum(offense_snaps, na.rm = TRUE),
+    games = dplyr::n(),
+    .groups = "drop"
+  ) |>
+  filter(total_offense_snaps >= 600) # starter threshold
+
+cat("OT player-seasons with >=600 snaps:", nrow(ot_snap_season), "\n")
+
+# ---- 4. Join players table (gsis_id <-> pfr_id crosswalk) for penalties ---
+# load_rosters does not populate pfr_id; load_players is the canonical
+# crosswalk. It's season-agnostic, so we join only by pfr_id.
+players_crosswalk <- nflreadr::load_players() |>
+  filter(!is.na(pfr_id), !is.na(gsis_id)) |>
+  select(gsis_id, pfr_id, full_name = display_name) |>
+  distinct(pfr_id, .keep_all = TRUE) |>
+  rename(pfr_player_id = pfr_id)
+
+ot_season <- ot_snap_season |>
+  left_join(players_crosswalk, by = "pfr_player_id") |>
+  left_join(pbp_penalties, by = c("season", "gsis_id")) |>
+  mutate(
+    penalties = replace_na(penalties, 0L),
+    penalties_per_game = ifelse(games > 0, penalties / games, NA_real_)
+  ) |>
+  left_join(team_proxies, by = c("team", "season"))
+
+cat("OT player-seasons after joins:", nrow(ot_season), "\n")
+cat("  with gsis_id resolved:", sum(!is.na(ot_season$gsis_id)), "\n")
+cat("  with team proxies:",
+    sum(!is.na(ot_season$team_sack_allowed_rate)), "\n")
+
+ot_season <- ot_season |>
+  filter(!is.na(team_sack_allowed_rate),
+         !is.na(team_rush_ypc),
+         !is.na(penalties_per_game))
+
+if (nrow(ot_season) < 20) {
+  stop(paste0(
+    "Too few OT player-seasons (", nrow(ot_season),
+    ") — schema drift in snap counts or rosters? Check position filters."
+  ))
+}
+
+# ---- 5. Composite rank + percentile bands ---------------------------------
+# Lower-is-better metrics get their z-score negated so a single "bigger =
+# better" composite sorts once.
+ot_ranked <- ot_season |>
+  mutate(
+    z_sack       = -as.numeric(scale(team_sack_allowed_rate)),
+    z_rush_ypc   =  as.numeric(scale(team_rush_ypc)),
+    z_penalties  = -as.numeric(scale(penalties_per_game)),
+    composite    = (z_sack + z_rush_ypc + z_penalties) / 3
+  ) |>
+  arrange(desc(composite)) |>
+  mutate(
+    pct = (row_number() - 0.5) / dplyr::n(),
+    band = case_when(
+      pct <= 0.10 ~ "elite",
+      pct <= 0.30 ~ "good",
+      pct <= 0.70 ~ "average",
+      pct <= 0.90 ~ "weak",
+      TRUE        ~ "replacement"
+    )
+  )
+
+metric_keys <- c(
+  "team_sack_allowed_rate",
+  "team_rush_ypc",
+  "penalties_per_game",
+  "starts_per_season"
+)
+
+band_order <- c("elite", "good", "average", "weak", "replacement")
+
+band_summary <- function(rows) {
+  metrics <- list()
+  for (key in metric_keys) {
+    vals <- rows[[key]]
+    vals <- vals[!is.na(vals)]
+    metrics[[key]] <- list(
+      n = length(vals),
+      mean = mean(vals),
+      sd = stats::sd(vals)
+    )
+  }
+  list(
+    n = nrow(rows),
+    metrics = metrics
+  )
+}
+
+bands <- list()
+for (band_name in band_order) {
+  rows <- ot_ranked |> filter(band == band_name)
+  bands[[band_name]] <- band_summary(rows)
+}
+
+out <- list(
+  generated_at = format(Sys.time(), "%Y-%m-%dT%H:%M:%SZ", tz = "UTC"),
+  seasons = as.integer(seasons),
+  position = "OT",
+  qualifier = "regular-season OT player-seasons with >=600 offensive snaps",
+  ranking_stat = paste0(
+    "composite of (-)team_sack_allowed_rate, team_rush_ypc, ",
+    "(-)penalties_per_game (z-score mean)"
+  ),
+  notes = paste0(
+    "PROXY METRICS v1 — nflreadr does not expose PFF block/pressure grades, ",
+    "so OT quality here is inferred from team-level protection/run proxies ",
+    "(sacks allowed / rush YPC) shared by both starting tackles on a team, ",
+    "plus a clean per-player penalties_per_game metric. This fixture is a ",
+    "structural placeholder: z-score and band-classification logic is sound, ",
+    "but per-bucket means commingle IOL/QB/scheme effects and should be ",
+    "treated as a weak v1 calibration reference. Proper OT bands require ",
+    "per-player block grades from PFF or tracking data. Starter filter: ",
+    "player-seasons with >=600 offensive snaps at position==T in ",
+    "load_snap_counts. Bands: elite top 10%, good 10-30%, average 30-70%, ",
+    "weak 70-90%, replacement bottom 10% by composite score."
+  ),
+  bands = bands
+)
+
+out_path <- file.path(
+  repo_root(), "data", "bands", "per-position", "ot.json"
+)
+dir.create(dirname(out_path), recursive = TRUE, showWarnings = FALSE)
+writeLines(
+  jsonlite::toJSON(out, auto_unbox = TRUE, pretty = TRUE, digits = 4,
+                   null = "null"),
+  out_path
+)
+cat("Wrote", out_path, "\n")

--- a/data/bands/per-position/ot.json
+++ b/data/bands/per-position/ot.json
@@ -1,0 +1,135 @@
+{
+  "generated_at": "2026-04-17T12:32:53Z",
+  "seasons": [2020, 2021, 2022, 2023, 2024],
+  "position": "OT",
+  "qualifier": "regular-season OT player-seasons with >=600 offensive snaps",
+  "ranking_stat": "composite of (-)team_sack_allowed_rate, team_rush_ypc, (-)penalties_per_game (z-score mean)",
+  "notes": "PROXY METRICS v1 — nflreadr does not expose PFF block/pressure grades, so OT quality here is inferred from team-level protection/run proxies (sacks allowed / rush YPC) shared by both starting tackles on a team, plus a clean per-player penalties_per_game metric. This fixture is a structural placeholder: z-score and band-classification logic is sound, but per-bucket means commingle IOL/QB/scheme effects and should be treated as a weak v1 calibration reference. Proper OT bands require per-player block grades from PFF or tracking data. Starter filter: player-seasons with >=600 offensive snaps at position==T in load_snap_counts. Bands: elite top 10%, good 10-30%, average 30-70%, weak 70-90%, replacement bottom 10% by composite score.",
+  "bands": {
+    "elite": {
+      "n": 28,
+      "metrics": {
+        "team_sack_allowed_rate": {
+          "n": 28,
+          "mean": 0.0507,
+          "sd": 0.0113
+        },
+        "team_rush_ypc": {
+          "n": 28,
+          "mean": 4.7164,
+          "sd": 0.4013
+        },
+        "penalties_per_game": {
+          "n": 28,
+          "mean": 0.2166,
+          "sd": 0.1494
+        },
+        "starts_per_season": {
+          "n": 28,
+          "mean": 13.9286,
+          "sd": 2.7343
+        }
+      }
+    },
+    "good": {
+      "n": 55,
+      "metrics": {
+        "team_sack_allowed_rate": {
+          "n": 55,
+          "mean": 0.0545,
+          "sd": 0.0131
+        },
+        "team_rush_ypc": {
+          "n": 55,
+          "mean": 4.3488,
+          "sd": 0.3227
+        },
+        "penalties_per_game": {
+          "n": 55,
+          "mean": 0.2902,
+          "sd": 0.1251
+        },
+        "starts_per_season": {
+          "n": 55,
+          "mean": 14.4545,
+          "sd": 2.3319
+        }
+      }
+    },
+    "average": {
+      "n": 110,
+      "metrics": {
+        "team_sack_allowed_rate": {
+          "n": 110,
+          "mean": 0.0647,
+          "sd": 0.0137
+        },
+        "team_rush_ypc": {
+          "n": 110,
+          "mean": 4.0583,
+          "sd": 0.3311
+        },
+        "penalties_per_game": {
+          "n": 110,
+          "mean": 0.3338,
+          "sd": 0.17
+        },
+        "starts_per_season": {
+          "n": 110,
+          "mean": 14.0182,
+          "sd": 2.2584
+        }
+      }
+    },
+    "weak": {
+      "n": 55,
+      "metrics": {
+        "team_sack_allowed_rate": {
+          "n": 55,
+          "mean": 0.0756,
+          "sd": 0.0164
+        },
+        "team_rush_ypc": {
+          "n": 55,
+          "mean": 3.8351,
+          "sd": 0.3341
+        },
+        "penalties_per_game": {
+          "n": 55,
+          "mean": 0.4252,
+          "sd": 0.1846
+        },
+        "starts_per_season": {
+          "n": 55,
+          "mean": 14.6,
+          "sd": 2.4766
+        }
+      }
+    },
+    "replacement": {
+      "n": 28,
+      "metrics": {
+        "team_sack_allowed_rate": {
+          "n": 28,
+          "mean": 0.0864,
+          "sd": 0.0193
+        },
+        "team_rush_ypc": {
+          "n": 28,
+          "mean": 3.7524,
+          "sd": 0.3381
+        },
+        "penalties_per_game": {
+          "n": 28,
+          "mean": 0.6352,
+          "sd": 0.2225
+        },
+        "starts_per_season": {
+          "n": 28,
+          "mean": 13.5714,
+          "sd": 2.9867
+        }
+      }
+    }
+  }
+}

--- a/deno.json
+++ b/deno.json
@@ -42,6 +42,7 @@
     "sim:calibrate:cb": "deno run --allow-read server/features/simulation/calibration/per-position/run-cb-calibration.ts",
     "sim:calibrate:s": "deno run --allow-read server/features/simulation/calibration/per-position/run-s-calibration.ts",
     "sim:calibrate:iol": "deno run --allow-read server/features/simulation/calibration/per-position/run-iol-calibration.ts",
+    "sim:calibrate:ot": "deno run --allow-read server/features/simulation/calibration/per-position/run-ot-calibration.ts",
     "build": "cd client && deno task build",
     "start": "cd server && deno run --env=../.env --allow-net --allow-env --allow-read --allow-sys main.ts"
   },

--- a/server/features/simulation/calibration/per-position/ot-harness.test.ts
+++ b/server/features/simulation/calibration/per-position/ot-harness.test.ts
@@ -1,0 +1,369 @@
+import { assertEquals, assertStringIncludes } from "@std/assert";
+import type { PlayerAttributes } from "@zone-blitz/shared";
+import { formatOtCalibrationReport, runOtCalibration } from "./ot-harness.ts";
+import type { GameResult, PlayEvent } from "../../events.ts";
+import type { SimTeam } from "../../simulate-game.ts";
+import type { PlayerRuntime } from "../../resolve-play.ts";
+import type { CalibrationLeague } from "../generate-calibration-league.ts";
+
+function attrs(overrides: Partial<PlayerAttributes> = {}): PlayerAttributes {
+  const base: Record<string, number> = {};
+  const keys = [
+    "speed",
+    "acceleration",
+    "agility",
+    "strength",
+    "jumping",
+    "stamina",
+    "durability",
+    "armStrength",
+    "accuracyShort",
+    "accuracyMedium",
+    "accuracyDeep",
+    "accuracyOnTheRun",
+    "touch",
+    "release",
+    "ballCarrying",
+    "elusiveness",
+    "routeRunning",
+    "catching",
+    "contestedCatching",
+    "runAfterCatch",
+    "passBlocking",
+    "runBlocking",
+    "blockShedding",
+    "tackling",
+    "manCoverage",
+    "zoneCoverage",
+    "passRushing",
+    "runDefense",
+    "kickingPower",
+    "kickingAccuracy",
+    "puntingPower",
+    "puntingAccuracy",
+    "snapAccuracy",
+    "footballIq",
+    "decisionMaking",
+    "anticipation",
+    "composure",
+    "clutch",
+    "consistency",
+    "workEthic",
+    "coachability",
+    "leadership",
+    "greed",
+    "loyalty",
+    "ambition",
+    "vanity",
+    "schemeAttachment",
+    "mediaSensitivity",
+  ];
+  for (const k of keys) {
+    base[k] = 50;
+    base[`${k}Potential`] = 50;
+  }
+  return { ...(base as unknown as PlayerAttributes), ...overrides };
+}
+
+function ot(id: string, overall: number): PlayerRuntime {
+  return {
+    playerId: id,
+    neutralBucket: "OT",
+    attributes: attrs({
+      passBlocking: overall,
+      runBlocking: overall,
+      strength: overall,
+      agility: overall,
+      footballIq: overall,
+    }),
+  };
+}
+
+function team(teamId: string, tackles: PlayerRuntime[]): SimTeam {
+  return {
+    teamId,
+    starters: tackles,
+    bench: [],
+    fingerprint: { offense: null, defense: null, overrides: {} },
+    coachingMods: {
+      schemeFitBonus: 0,
+      situationalBonus: 0,
+      aggressiveness: 50,
+      penaltyDiscipline: 1,
+    },
+  };
+}
+
+// Five-band OT fixture with monotonic means on all three metrics. Built
+// to match DEFAULT_EXPECTED_BAND: 30->replacement, 50->average, 70->elite.
+function bandJson(): string {
+  const band = (sackRate: number, rushYpc: number, pen: number) => ({
+    n: 20,
+    metrics: {
+      team_sack_allowed_rate: { n: 20, mean: sackRate, sd: 0.01 },
+      team_rush_ypc: { n: 20, mean: rushYpc, sd: 0.2 },
+      penalties_per_game: { n: 20, mean: pen, sd: 0.1 },
+      starts_per_season: { n: 20, mean: 14, sd: 1 },
+    },
+  });
+  return JSON.stringify({
+    position: "OT",
+    seasons: [2020, 2021, 2022, 2023, 2024],
+    ranking_stat: "composite proxy",
+    bands: {
+      elite: band(0.05, 4.7, 0.2),
+      good: band(0.055, 4.35, 0.29),
+      average: band(0.065, 4.05, 0.33),
+      weak: band(0.075, 3.85, 0.42),
+      replacement: band(0.086, 3.75, 0.63),
+    },
+  });
+}
+
+// Stubs a game whose team-level sack rate and rush YPC mirror the
+// expected-band means for each side's OT overall.
+function makeGame(
+  gameId: string,
+  homeTeamId: string,
+  awayTeamId: string,
+  statsByTeam: Record<
+    string,
+    { sackRate: number; rushYpc: number; penaltyCount: number }
+  >,
+): GameResult {
+  const events: PlayEvent[] = [];
+  for (
+    const [offenseTeamId, s] of Object.entries(statsByTeam)
+  ) {
+    const defenseTeamId = offenseTeamId === homeTeamId
+      ? awayTeamId
+      : homeTeamId;
+    // 200 dropbacks at the given sack rate to minimize rounding drift
+    // between the requested rate and the int sack count.
+    const dropbacks = 200;
+    const sacks = Math.round(dropbacks * s.sackRate);
+    const passes = dropbacks - sacks;
+    for (let i = 0; i < passes; i++) {
+      events.push({
+        gameId,
+        driveIndex: 0,
+        playIndex: events.length,
+        quarter: 1,
+        clock: "15:00",
+        situation: { down: 1, distance: 10, yardLine: 25 },
+        offenseTeamId,
+        defenseTeamId,
+        call: {
+          concept: "dropback",
+          personnel: "11",
+          formation: "shotgun",
+          motion: "none",
+        },
+        coverage: { front: "4-3", coverage: "cover_2", pressure: "four_man" },
+        participants: [],
+        outcome: "pass_complete",
+        yardage: 7,
+        tags: [],
+      });
+    }
+    for (let i = 0; i < sacks; i++) {
+      events.push({
+        gameId,
+        driveIndex: 0,
+        playIndex: events.length,
+        quarter: 1,
+        clock: "15:00",
+        situation: { down: 1, distance: 10, yardLine: 25 },
+        offenseTeamId,
+        defenseTeamId,
+        call: {
+          concept: "dropback",
+          personnel: "11",
+          formation: "shotgun",
+          motion: "none",
+        },
+        coverage: { front: "4-3", coverage: "cover_2", pressure: "four_man" },
+        participants: [],
+        outcome: "sack",
+        yardage: -7,
+        tags: [],
+      });
+    }
+    // 20 rushes at the given YPC.
+    const rushes = 20;
+    const rushYards = Math.round(rushes * s.rushYpc);
+    for (let i = 0; i < rushes; i++) {
+      events.push({
+        gameId,
+        driveIndex: 0,
+        playIndex: events.length,
+        quarter: 1,
+        clock: "15:00",
+        situation: { down: 1, distance: 10, yardLine: 25 },
+        offenseTeamId,
+        defenseTeamId,
+        call: {
+          concept: "inside_zone",
+          personnel: "11",
+          formation: "singleback",
+          motion: "none",
+        },
+        coverage: { front: "4-3", coverage: "cover_2", pressure: "four_man" },
+        participants: [],
+        outcome: "rush",
+        yardage: i === 0 ? rushYards : 0,
+        tags: [],
+      });
+    }
+  }
+  return {
+    gameId,
+    seed: 1,
+    finalScore: { home: 0, away: 0 },
+    events,
+    boxScore: {
+      home: {
+        totalYards: 0,
+        passingYards: 0,
+        rushingYards: 0,
+        turnovers: 0,
+        sacks: 0,
+        penalties: 0,
+      },
+      away: {
+        totalYards: 0,
+        passingYards: 0,
+        rushingYards: 0,
+        turnovers: 0,
+        sacks: 0,
+        penalties: 0,
+      },
+    },
+    driveLog: [],
+    injuryReport: [],
+  };
+}
+
+Deno.test("runOtCalibration buckets tackles by overall and returns a populated report", () => {
+  const overallByTeam: Record<string, number> = {
+    t30: 30,
+    t40: 40,
+    t50: 50,
+    t60: 60,
+    t70: 70,
+    t80: 80,
+  };
+  // Map each overall onto the target band's team-level means so the
+  // bucket should land in its expected band.
+  const statsByOverall: Record<
+    number,
+    { sackRate: number; rushYpc: number; penaltyCount: number }
+  > = {
+    30: { sackRate: 0.086, rushYpc: 3.75, penaltyCount: 0 },
+    40: { sackRate: 0.075, rushYpc: 3.85, penaltyCount: 0 },
+    50: { sackRate: 0.065, rushYpc: 4.05, penaltyCount: 0 },
+    60: { sackRate: 0.055, rushYpc: 4.35, penaltyCount: 0 },
+    70: { sackRate: 0.05, rushYpc: 4.7, penaltyCount: 0 },
+    80: { sackRate: 0.05, rushYpc: 4.7, penaltyCount: 0 },
+  };
+
+  const teams: SimTeam[] = Object.entries(overallByTeam).map(([id, o]) =>
+    team(id, [ot(`${id}-lt`, o), ot(`${id}-rt`, o)])
+  );
+  const league: CalibrationLeague = { calibrationSeed: 1, teams };
+
+  let gameCount = 0;
+  const simulate = ({ home, away, gameId }: {
+    home: SimTeam;
+    away: SimTeam;
+    seed: number;
+    gameId: string;
+  }): GameResult => {
+    gameCount++;
+    return makeGame(gameId, home.teamId, away.teamId, {
+      [home.teamId]: statsByOverall[overallByTeam[home.teamId]],
+      [away.teamId]: statsByOverall[overallByTeam[away.teamId]],
+    });
+  };
+
+  const report = runOtCalibration({
+    bandJson: bandJson(),
+    league,
+    simulate,
+    gameCount: teams.length * 12,
+    minSamplesPerBucket: 5,
+  });
+
+  assertEquals(report.totalGames, teams.length * 12);
+  // Each matchup produces 4 OT samples (2 per team).
+  assertEquals(report.totalSamples, gameCount * 4);
+
+  const fifty = report.buckets.find((b) => b.bucketLabel === "50")!;
+  assertEquals(fifty.samples > 0, true);
+  assertEquals(fifty.underSampled, false);
+  // At least the sack_allowed_rate check should land in the average band.
+  const sackCheck = fifty.checks.find((c) =>
+    c.metricName === "team_sack_allowed_rate"
+  )!;
+  assertEquals(sackCheck.expectedBand, "average");
+  assertEquals(sackCheck.passed, true);
+});
+
+Deno.test("runOtCalibration marks a bucket under-sampled when below threshold", () => {
+  const teams: SimTeam[] = [team("t50", [ot("t50-lt", 50), ot("t50-rt", 50)])];
+  const league: CalibrationLeague = { calibrationSeed: 1, teams };
+  const simulate = (
+    { home, away, gameId }: {
+      home: SimTeam;
+      away: SimTeam;
+      seed: number;
+      gameId: string;
+    },
+  ) =>
+    makeGame(gameId, home.teamId, away.teamId, {
+      [home.teamId]: { sackRate: 0.065, rushYpc: 4.05, penaltyCount: 0 },
+      [away.teamId]: { sackRate: 0.065, rushYpc: 4.05, penaltyCount: 0 },
+    });
+
+  const report = runOtCalibration({
+    bandJson: bandJson(),
+    league,
+    simulate,
+    gameCount: 1,
+    minSamplesPerBucket: 100,
+  });
+
+  const fifty = report.buckets.find((b) => b.bucketLabel === "50")!;
+  assertEquals(fifty.underSampled, true);
+  assertEquals(fifty.checks.length, 0);
+});
+
+Deno.test("formatOtCalibrationReport renders a human-readable summary with the PFF caveat", () => {
+  const teams: SimTeam[] = [team("t50", [ot("t50-lt", 50), ot("t50-rt", 50)])];
+  const league: CalibrationLeague = { calibrationSeed: 1, teams };
+  const simulate = (
+    { home, away, gameId }: {
+      home: SimTeam;
+      away: SimTeam;
+      seed: number;
+      gameId: string;
+    },
+  ) =>
+    makeGame(gameId, home.teamId, away.teamId, {
+      [home.teamId]: { sackRate: 0.065, rushYpc: 4.05, penaltyCount: 0 },
+      [away.teamId]: { sackRate: 0.065, rushYpc: 4.05, penaltyCount: 0 },
+    });
+
+  const report = runOtCalibration({
+    bandJson: bandJson(),
+    league,
+    simulate,
+    gameCount: 100,
+    minSamplesPerBucket: 1,
+  });
+  const output = formatOtCalibrationReport(report);
+  assertStringIncludes(output, "OT calibration");
+  assertStringIncludes(output, "bucket 50");
+  assertStringIncludes(output, "team_sack_allowed_rate");
+  assertStringIncludes(output, "PROXY METRICS");
+});

--- a/server/features/simulation/calibration/per-position/ot-harness.ts
+++ b/server/features/simulation/calibration/per-position/ot-harness.ts
@@ -1,0 +1,192 @@
+import { deriveGameSeed } from "../../rng.ts";
+import { CALIBRATION_GAME_COUNT } from "../constants.ts";
+import { generateMatchups } from "../harness.ts";
+import type { SimulateFn } from "../harness.ts";
+import type { CalibrationLeague } from "../generate-calibration-league.ts";
+import { collectOtSamples, type OtGameSample } from "./ot-sample.ts";
+import { bucketByAttr, type BucketReport } from "./bucket-by-attr.ts";
+import { type BandCheckResult, checkBand } from "./band-check.ts";
+import { loadPositionBands, type PositionBands } from "./band-loader.ts";
+
+// Metrics the OT slice reports on. All are **proxy metrics** (see the
+// band-generation script at data/R/bands/per-position-ot.R) because
+// nflreadr does not expose PFF pass-block / run-block grades or pressure
+// counts. team_sack_allowed_rate and team_rush_ypc are team-level and
+// shared by both starting tackles; penalties_per_game is clean per-player.
+// starts_per_season is a participation sanity check.
+//
+// For this proxy fixture most headline metrics are "lower is better"
+// (fewer sacks allowed, fewer penalties). team_rush_ypc is
+// higher-is-better. The band-check flips direction labels accordingly.
+export const OT_METRICS = [
+  "team_sack_allowed_rate",
+  "team_rush_ypc",
+  "penalties_per_game",
+] as const;
+
+export type OtMetric = typeof OT_METRICS[number];
+
+const METRIC_EXTRACTORS: Record<OtMetric, (s: OtGameSample) => number> = {
+  team_sack_allowed_rate: (s) => s.team_sack_allowed_rate,
+  team_rush_ypc: (s) => s.team_rush_ypc,
+  penalties_per_game: (s) => s.penalties_per_game,
+};
+
+// Map metric name -> direction. Used to flip the verdict labels in the
+// BandCheckResult: for a "lower is better" metric, a z-score above the
+// band mean means the sim is too *bad*, not too "high".
+const LOWER_IS_BETTER: Record<OtMetric, boolean> = {
+  team_sack_allowed_rate: true,
+  team_rush_ypc: false,
+  penalties_per_game: true,
+};
+
+export interface OtCalibrationOptions {
+  bandJson: string;
+  league: CalibrationLeague;
+  simulate: SimulateFn;
+  gameCount?: number;
+  // Minimum samples per bucket before we trust a band check. Under
+  // this count we still emit the summary but flag it as under-sampled
+  // so the report distinguishes "bucket is empty/noisy" from "bucket
+  // is calibrated wrong".
+  minSamplesPerBucket?: number;
+}
+
+export interface OtBucketReport {
+  bucketLabel: string;
+  bucketCenter: number;
+  samples: number;
+  underSampled: boolean;
+  checks: BandCheckResult[];
+}
+
+export interface OtCalibrationReport {
+  totalGames: number;
+  totalSamples: number;
+  bands: PositionBands;
+  buckets: OtBucketReport[];
+  failures: BandCheckResult[];
+  passed: boolean;
+}
+
+// OT games produce two samples per team-game (two starting tackles),
+// so twice as many samples per game as QB. Keep a comparable minimum
+// per-bucket count (~50 samples) which is achievable at default
+// CALIBRATION_GAME_COUNT.
+const DEFAULT_MIN_SAMPLES = 50;
+
+export function runOtCalibration(
+  options: OtCalibrationOptions,
+): OtCalibrationReport {
+  const {
+    bandJson,
+    league,
+    simulate,
+    gameCount = CALIBRATION_GAME_COUNT,
+    minSamplesPerBucket = DEFAULT_MIN_SAMPLES,
+  } = options;
+
+  const bands = loadPositionBands(bandJson);
+  const teamById = new Map(league.teams.map((t) => [t.teamId, t]));
+  const matchups = generateMatchups(league.teams, gameCount);
+
+  const samples: OtGameSample[] = [];
+
+  for (let i = 0; i < matchups.length; i++) {
+    const { home, away } = matchups[i];
+    const gameId = `ot-calibration-game-${i}`;
+    const seed = deriveGameSeed(league.calibrationSeed, gameId);
+
+    const result = simulate({ home, away, seed, gameId });
+    const gameSamples = collectOtSamples({
+      game: result,
+      home: teamById.get(home.teamId) ?? home,
+      away: teamById.get(away.teamId) ?? away,
+    });
+    samples.push(...gameSamples);
+  }
+
+  const bucketReports: BucketReport<OtGameSample>[] = bucketByAttr({
+    samples,
+    attr: (s) => s.otOverall,
+    metrics: METRIC_EXTRACTORS,
+  });
+
+  const buckets: OtBucketReport[] = bucketReports.map((report) => {
+    const underSampled = report.samples.length < minSamplesPerBucket;
+    const checks: BandCheckResult[] = OT_METRICS.flatMap((metric) => {
+      // Don't emit band checks on under-sampled buckets — the NFL band
+      // comparison would be dominated by sampling noise.
+      if (underSampled) return [];
+      return [
+        checkBand({
+          bucketLabel: report.bucket.label,
+          metricName: metric,
+          simSummary: report.metrics[metric],
+          bands,
+          lowerIsBetter: LOWER_IS_BETTER[metric],
+        }),
+      ];
+    });
+    return {
+      bucketLabel: report.bucket.label,
+      bucketCenter: report.bucket.center,
+      samples: report.samples.length,
+      underSampled,
+      checks,
+    };
+  });
+
+  const failures = buckets.flatMap((b) => b.checks.filter((c) => !c.passed));
+
+  return {
+    totalGames: matchups.length,
+    totalSamples: samples.length,
+    bands,
+    buckets,
+    failures,
+    passed: failures.length === 0,
+  };
+}
+
+export function formatOtCalibrationReport(report: OtCalibrationReport): string {
+  const lines: string[] = [];
+  lines.push(
+    `OT calibration — ${report.totalGames} games, ${report.totalSamples} OT-games`,
+  );
+  lines.push(
+    `Bands: ${report.bands.position} / ${
+      report.bands.seasons.join("-")
+    } / ranked by ${report.bands.rankingStat}`,
+  );
+  lines.push(
+    "NOTE: PROXY METRICS v1 — team_sack_allowed_rate and team_rush_ypc are " +
+      "team-level, shared by both starting tackles. See " +
+      "data/bands/per-position/ot.json notes for the PFF-grade gap.",
+  );
+  lines.push("");
+  for (const bucket of report.buckets) {
+    const header = `[bucket ${bucket.bucketLabel}] n=${bucket.samples}` +
+      (bucket.underSampled ? " (under-sampled, skipping band checks)" : "");
+    lines.push(header);
+    for (const check of bucket.checks) {
+      const verdict = check.passed ? "PASS" : "FAIL";
+      const dir = check.passed ? "" : ` (${check.direction})`;
+      lines.push(
+        `  ${verdict} ${check.metricName.padEnd(22)} ` +
+          `sim=${check.simMean.toFixed(4)}  ` +
+          `band(${check.expectedBand})=${check.bandMean.toFixed(4)}±${
+            check.bandSd.toFixed(4)
+          }  ` +
+          `z=${check.zScore.toFixed(2)}  actual=${check.actualBand}${dir}`,
+      );
+    }
+    lines.push("");
+  }
+  const passed = report.passed ? "PASS" : "FAIL";
+  lines.push(
+    `${passed}: ${report.failures.length} band check(s) missed expected band`,
+  );
+  return lines.join("\n");
+}

--- a/server/features/simulation/calibration/per-position/ot-overall.test.ts
+++ b/server/features/simulation/calibration/per-position/ot-overall.test.ts
@@ -1,0 +1,99 @@
+import { assertAlmostEquals, assertEquals } from "@std/assert";
+import type { PlayerAttributes } from "@zone-blitz/shared";
+import { OT_OVERALL_ATTRS, otOverall } from "./ot-overall.ts";
+
+function attrs(overrides: Partial<PlayerAttributes> = {}): PlayerAttributes {
+  const base: Record<string, number> = {};
+  const keys = [
+    "speed",
+    "acceleration",
+    "agility",
+    "strength",
+    "jumping",
+    "stamina",
+    "durability",
+    "armStrength",
+    "accuracyShort",
+    "accuracyMedium",
+    "accuracyDeep",
+    "accuracyOnTheRun",
+    "touch",
+    "release",
+    "ballCarrying",
+    "elusiveness",
+    "routeRunning",
+    "catching",
+    "contestedCatching",
+    "runAfterCatch",
+    "passBlocking",
+    "runBlocking",
+    "blockShedding",
+    "tackling",
+    "manCoverage",
+    "zoneCoverage",
+    "passRushing",
+    "runDefense",
+    "kickingPower",
+    "kickingAccuracy",
+    "puntingPower",
+    "puntingAccuracy",
+    "snapAccuracy",
+    "footballIq",
+    "decisionMaking",
+    "anticipation",
+    "composure",
+    "clutch",
+    "consistency",
+    "workEthic",
+    "coachability",
+    "leadership",
+    "greed",
+    "loyalty",
+    "ambition",
+    "vanity",
+    "schemeAttachment",
+    "mediaSensitivity",
+  ];
+  for (const k of keys) {
+    base[k] = 50;
+    base[`${k}Potential`] = 50;
+  }
+  return { ...(base as unknown as PlayerAttributes), ...overrides };
+}
+
+Deno.test("OT_OVERALL_ATTRS lists the five OT signature attrs", () => {
+  assertEquals(OT_OVERALL_ATTRS.length, 5);
+  assertEquals(OT_OVERALL_ATTRS.includes("passBlocking"), true);
+  assertEquals(OT_OVERALL_ATTRS.includes("runBlocking"), true);
+  assertEquals(OT_OVERALL_ATTRS.includes("strength"), true);
+  assertEquals(OT_OVERALL_ATTRS.includes("agility"), true);
+  assertEquals(OT_OVERALL_ATTRS.includes("footballIq"), true);
+});
+
+Deno.test("otOverall averages the five signature attributes", () => {
+  const a = attrs({
+    passBlocking: 80,
+    runBlocking: 70,
+    strength: 60,
+    agility: 50,
+    footballIq: 40,
+  });
+  // (80 + 70 + 60 + 50 + 40) / 5 = 60
+  assertAlmostEquals(otOverall(a), 60);
+});
+
+Deno.test("otOverall returns 50 for a median-50 attribute set", () => {
+  assertEquals(otOverall(attrs()), 50);
+});
+
+Deno.test("otOverall is invariant to attributes outside the signature set", () => {
+  const baseline = otOverall(attrs());
+  const tweaked = otOverall(
+    attrs({
+      speed: 99,
+      catching: 99,
+      passRushing: 99,
+    }),
+  );
+  assertEquals(baseline, tweaked);
+});

--- a/server/features/simulation/calibration/per-position/ot-overall.ts
+++ b/server/features/simulation/calibration/per-position/ot-overall.ts
@@ -1,0 +1,26 @@
+import type { PlayerAttributes } from "@zone-blitz/shared";
+
+// Signature attributes that make an OT effective. Starts from the
+// `RANKING_ATTRS.blocking` set used by `resolve-matchups.ts`
+// (passBlocking, runBlocking, strength) and adds `agility` (lateral
+// movement / kick-slide quality) and `footballIq` (recognition of
+// stunts/blitzes — the attribute library does not expose an explicit
+// "awareness" attribute, so footballIq stands in as the mental anchor).
+// Averaging these gives a single 0-100 "OT overall" that we can bucket
+// on for calibration: a 50-overall OT should produce median NFL
+// starter proxy numbers, 70 should be elite, etc.
+export const OT_OVERALL_ATTRS = [
+  "passBlocking",
+  "runBlocking",
+  "strength",
+  "agility",
+  "footballIq",
+] as const satisfies ReadonlyArray<keyof PlayerAttributes>;
+
+export function otOverall(attributes: PlayerAttributes): number {
+  let sum = 0;
+  for (const key of OT_OVERALL_ATTRS) {
+    sum += attributes[key];
+  }
+  return sum / OT_OVERALL_ATTRS.length;
+}

--- a/server/features/simulation/calibration/per-position/ot-sample.test.ts
+++ b/server/features/simulation/calibration/per-position/ot-sample.test.ts
@@ -1,0 +1,363 @@
+import { assertAlmostEquals, assertEquals } from "@std/assert";
+import type { PlayerAttributes } from "@zone-blitz/shared";
+import { collectOtSamples } from "./ot-sample.ts";
+import type { GameResult, PenaltyInfo, PlayEvent } from "../../events.ts";
+import type { SimTeam } from "../../simulate-game.ts";
+import type { PlayerRuntime } from "../../resolve-play.ts";
+
+function attrs(overrides: Partial<PlayerAttributes> = {}): PlayerAttributes {
+  const base: Record<string, number> = {};
+  const keys = [
+    "speed",
+    "acceleration",
+    "agility",
+    "strength",
+    "jumping",
+    "stamina",
+    "durability",
+    "armStrength",
+    "accuracyShort",
+    "accuracyMedium",
+    "accuracyDeep",
+    "accuracyOnTheRun",
+    "touch",
+    "release",
+    "ballCarrying",
+    "elusiveness",
+    "routeRunning",
+    "catching",
+    "contestedCatching",
+    "runAfterCatch",
+    "passBlocking",
+    "runBlocking",
+    "blockShedding",
+    "tackling",
+    "manCoverage",
+    "zoneCoverage",
+    "passRushing",
+    "runDefense",
+    "kickingPower",
+    "kickingAccuracy",
+    "puntingPower",
+    "puntingAccuracy",
+    "snapAccuracy",
+    "footballIq",
+    "decisionMaking",
+    "anticipation",
+    "composure",
+    "clutch",
+    "consistency",
+    "workEthic",
+    "coachability",
+    "leadership",
+    "greed",
+    "loyalty",
+    "ambition",
+    "vanity",
+    "schemeAttachment",
+    "mediaSensitivity",
+  ];
+  for (const k of keys) {
+    base[k] = 50;
+    base[`${k}Potential`] = 50;
+  }
+  return { ...(base as unknown as PlayerAttributes), ...overrides };
+}
+
+function ot(id: string, overall: number): PlayerRuntime {
+  return {
+    playerId: id,
+    neutralBucket: "OT",
+    attributes: attrs({
+      passBlocking: overall,
+      runBlocking: overall,
+      strength: overall,
+      agility: overall,
+      footballIq: overall,
+    }),
+  };
+}
+
+function team(teamId: string, tackles: PlayerRuntime[]): SimTeam {
+  return {
+    teamId,
+    starters: tackles,
+    bench: [],
+    fingerprint: { offense: null, defense: null, overrides: {} },
+    coachingMods: {
+      schemeFitBonus: 0,
+      situationalBonus: 0,
+      aggressiveness: 50,
+      penaltyDiscipline: 1,
+    },
+  };
+}
+
+function event(
+  overrides: Partial<PlayEvent> & {
+    outcome: PlayEvent["outcome"];
+    offenseTeamId: string;
+  },
+): PlayEvent {
+  return {
+    gameId: "g",
+    driveIndex: 0,
+    playIndex: 0,
+    quarter: 1,
+    clock: "15:00",
+    situation: { down: 1, distance: 10, yardLine: 25 },
+    defenseTeamId: overrides.offenseTeamId === "home" ? "away" : "home",
+    call: {
+      concept: "dropback",
+      personnel: "11",
+      formation: "shotgun",
+      motion: "none",
+    },
+    coverage: { front: "4-3", coverage: "cover_2", pressure: "four_man" },
+    participants: [],
+    yardage: 0,
+    tags: [],
+    ...overrides,
+  };
+}
+
+function penaltyOn(playerId: string, accepted = true): PenaltyInfo {
+  return {
+    type: "holding",
+    phase: "post_snap",
+    yardage: -10,
+    automaticFirstDown: false,
+    againstTeamId: "home",
+    againstPlayerId: playerId,
+    accepted,
+  };
+}
+
+function gameOf(events: PlayEvent[]): GameResult {
+  return {
+    gameId: "g",
+    seed: 1,
+    finalScore: { home: 0, away: 0 },
+    events,
+    boxScore: {
+      home: {
+        totalYards: 0,
+        passingYards: 0,
+        rushingYards: 0,
+        turnovers: 0,
+        sacks: 0,
+        penalties: 0,
+      },
+      away: {
+        totalYards: 0,
+        passingYards: 0,
+        rushingYards: 0,
+        turnovers: 0,
+        sacks: 0,
+        penalties: 0,
+      },
+    },
+    driveLog: [],
+    injuryReport: [],
+  };
+}
+
+Deno.test("collectOtSamples emits one sample per starting tackle per team", () => {
+  const home = team("home", [ot("h-lt", 50), ot("h-rt", 50)]);
+  const away = team("away", [ot("a-lt", 50), ot("a-rt", 50)]);
+  const samples = collectOtSamples({ game: gameOf([]), home, away });
+  assertEquals(samples.length, 4);
+  const ids = samples.map((s) => s.otPlayerId).sort();
+  assertEquals(ids, ["a-lt", "a-rt", "h-lt", "h-rt"]);
+});
+
+Deno.test("collectOtSamples skips a team with no starting tackles", () => {
+  const home = team("home", [ot("h-lt", 50), ot("h-rt", 50)]);
+  const away: SimTeam = { ...team("away", []), starters: [] };
+  const samples = collectOtSamples({ game: gameOf([]), home, away });
+  assertEquals(samples.length, 2);
+  for (const s of samples) assertEquals(s.teamId, "home");
+});
+
+Deno.test("collectOtSamples tags each sample with OT overall", () => {
+  const home = team("home", [
+    {
+      playerId: "h-lt",
+      neutralBucket: "OT",
+      attributes: attrs({
+        passBlocking: 80,
+        runBlocking: 70,
+        strength: 60,
+        agility: 50,
+        footballIq: 40,
+      }),
+    },
+  ]);
+  const away = team("away", [ot("a-lt", 50)]);
+  const [homeSample] = collectOtSamples({ game: gameOf([]), home, away });
+  // (80 + 70 + 60 + 50 + 40) / 5 = 60
+  assertAlmostEquals(homeSample.otOverall, 60);
+});
+
+Deno.test("collectOtSamples accumulates team dropbacks, sacks, rushes, and rush yards", () => {
+  const home = team("home", [ot("h-lt", 50), ot("h-rt", 50)]);
+  const away = team("away", [ot("a-lt", 50), ot("a-rt", 50)]);
+  const events: PlayEvent[] = [
+    event({ outcome: "pass_complete", offenseTeamId: "home", yardage: 10 }),
+    event({ outcome: "pass_incomplete", offenseTeamId: "home", yardage: 0 }),
+    event({ outcome: "sack", offenseTeamId: "home", yardage: -7 }),
+    event({
+      outcome: "rush",
+      offenseTeamId: "home",
+      yardage: 5,
+      call: {
+        concept: "inside_zone",
+        personnel: "11",
+        formation: "singleback",
+        motion: "none",
+      },
+    }),
+    event({
+      outcome: "rush",
+      offenseTeamId: "home",
+      yardage: 3,
+      call: {
+        concept: "outside_zone",
+        personnel: "11",
+        formation: "singleback",
+        motion: "none",
+      },
+    }),
+    // Away team: one sack, one dropback. Isolated from home aggregation.
+    event({ outcome: "pass_complete", offenseTeamId: "away", yardage: 4 }),
+    event({ outcome: "sack", offenseTeamId: "away", yardage: -5 }),
+  ];
+  const samples = collectOtSamples({ game: gameOf(events), home, away });
+  const homeSamples = samples.filter((s) => s.teamId === "home");
+  const awaySamples = samples.filter((s) => s.teamId === "away");
+
+  // Home team totals: dropbacks = 3 (2 pass + 1 sack), sacks = 1,
+  // rushes = 2, rush yards = 8.
+  for (const s of homeSamples) {
+    assertEquals(s.team_dropbacks, 3);
+    assertEquals(s.team_sacks_allowed, 1);
+    assertEquals(s.team_rushes, 2);
+    assertEquals(s.team_rush_yards, 8);
+    assertAlmostEquals(s.team_sack_allowed_rate, 1 / 3, 1e-6);
+    assertAlmostEquals(s.team_rush_ypc, 4);
+  }
+  for (const s of awaySamples) {
+    assertEquals(s.team_dropbacks, 2);
+    assertEquals(s.team_sacks_allowed, 1);
+    assertAlmostEquals(s.team_sack_allowed_rate, 0.5);
+  }
+});
+
+Deno.test("collectOtSamples shares team stats equally across both starting tackles", () => {
+  const home = team("home", [ot("h-lt", 50), ot("h-rt", 50)]);
+  const away = team("away", [ot("a-lt", 50), ot("a-rt", 50)]);
+  const events: PlayEvent[] = [
+    event({ outcome: "sack", offenseTeamId: "home", yardage: -7 }),
+    event({ outcome: "pass_complete", offenseTeamId: "home", yardage: 8 }),
+  ];
+  const samples = collectOtSamples({ game: gameOf(events), home, away });
+  const homeSamples = samples.filter((s) => s.teamId === "home");
+  assertEquals(homeSamples.length, 2);
+  // Both tackles see the same team-level proxy rate.
+  assertEquals(
+    homeSamples[0].team_sack_allowed_rate,
+    homeSamples[1].team_sack_allowed_rate,
+  );
+});
+
+Deno.test("collectOtSamples attributes penalties only to the specific tackle via againstPlayerId", () => {
+  const home = team("home", [ot("h-lt", 50), ot("h-rt", 50)]);
+  const away = team("away", [ot("a-lt", 50), ot("a-rt", 50)]);
+  const events: PlayEvent[] = [
+    event({
+      outcome: "penalty",
+      offenseTeamId: "home",
+      penalty: penaltyOn("h-lt"),
+    }),
+    event({
+      outcome: "penalty",
+      offenseTeamId: "home",
+      penalty: penaltyOn("h-lt"),
+    }),
+    event({
+      outcome: "penalty",
+      offenseTeamId: "home",
+      penalty: penaltyOn("h-rt"),
+    }),
+  ];
+  const samples = collectOtSamples({ game: gameOf(events), home, away });
+  const lt = samples.find((s) => s.otPlayerId === "h-lt")!;
+  const rt = samples.find((s) => s.otPlayerId === "h-rt")!;
+  assertEquals(lt.penalties, 2);
+  assertEquals(rt.penalties, 1);
+  assertEquals(lt.penalties_per_game, 2);
+  assertEquals(rt.penalties_per_game, 1);
+});
+
+Deno.test("collectOtSamples ignores declined penalties", () => {
+  const home = team("home", [ot("h-lt", 50), ot("h-rt", 50)]);
+  const away = team("away", [ot("a-lt", 50), ot("a-rt", 50)]);
+  const events: PlayEvent[] = [
+    event({
+      outcome: "penalty",
+      offenseTeamId: "home",
+      penalty: penaltyOn("h-lt", false), // declined
+    }),
+    event({
+      outcome: "penalty",
+      offenseTeamId: "home",
+      penalty: penaltyOn("h-lt", true),
+    }),
+  ];
+  const samples = collectOtSamples({ game: gameOf(events), home, away });
+  const lt = samples.find((s) => s.otPlayerId === "h-lt")!;
+  assertEquals(lt.penalties, 1);
+});
+
+Deno.test("collectOtSamples handles zero-dropback games without divide-by-zero", () => {
+  const home = team("home", [ot("h-lt", 50), ot("h-rt", 50)]);
+  const away = team("away", [ot("a-lt", 50), ot("a-rt", 50)]);
+  const [sample] = collectOtSamples({ game: gameOf([]), home, away });
+  assertEquals(sample.team_sack_allowed_rate, 0);
+  assertEquals(sample.team_rush_ypc, 0);
+  assertEquals(sample.penalties_per_game, 0);
+  assertEquals(sample.starts_per_season, 1);
+});
+
+Deno.test("collectOtSamples treats run-concept TDs as rushes for team_rush_ypc proxy", () => {
+  const home = team("home", [ot("h-lt", 50), ot("h-rt", 50)]);
+  const away = team("away", [ot("a-lt", 50), ot("a-rt", 50)]);
+  const events: PlayEvent[] = [
+    event({
+      outcome: "touchdown",
+      offenseTeamId: "home",
+      yardage: 4,
+      call: {
+        concept: "inside_zone",
+        personnel: "11",
+        formation: "singleback",
+        motion: "none",
+      },
+    }),
+    event({
+      outcome: "touchdown",
+      offenseTeamId: "home",
+      yardage: 20,
+      call: {
+        concept: "quick_pass",
+        personnel: "11",
+        formation: "shotgun",
+        motion: "none",
+      },
+    }),
+  ];
+  const [homeSample] = collectOtSamples({ game: gameOf(events), home, away });
+  assertEquals(homeSample.team_rushes, 1);
+  assertEquals(homeSample.team_rush_yards, 4);
+  assertEquals(homeSample.team_dropbacks, 1); // pass-concept TD counts as a dropback
+});

--- a/server/features/simulation/calibration/per-position/ot-sample.ts
+++ b/server/features/simulation/calibration/per-position/ot-sample.ts
@@ -1,0 +1,158 @@
+import type { GameResult, PlayEvent } from "../../events.ts";
+import type { SimTeam } from "../../simulate-game.ts";
+import { otOverall } from "./ot-overall.ts";
+
+// Per-OT game sample. Because the sim engine does not log individual
+// OT participation on blocking plays (pass-pro or run-block), the
+// "team_sack_allowed_rate" and "team_rush_ypc" fields are populated
+// from the team's aggregate performance and shared equally across both
+// starting tackles. penalties_per_game is attributed cleanly per-player
+// using `event.penalty.againstPlayerId` when present.
+//
+// This matches the PROXY METRICS v1 caveat in
+// data/R/bands/per-position-ot.R and data/bands/per-position/ot.json:
+// the sim's team-level protection is our best signal until we log
+// per-player block grades.
+export interface OtGameSample {
+  teamId: string;
+  otPlayerId: string;
+  otOverall: number;
+  // Team-level denominators the OT "shares" with the other starting tackle.
+  team_dropbacks: number;
+  team_sacks_allowed: number;
+  team_rushes: number;
+  team_rush_yards: number;
+  // Per-player (clean).
+  penalties: number;
+  // Derived rate metrics (match the NFL fixture's metric keys).
+  team_sack_allowed_rate: number;
+  team_rush_ypc: number;
+  penalties_per_game: number;
+  // Participation sanity check: samples are always collected for one
+  // game, so this is effectively 1. Kept for parity with the NFL
+  // fixture's `starts_per_season` metric.
+  starts_per_season: number;
+}
+
+const RUN_CONCEPTS = new Set([
+  "inside_zone",
+  "outside_zone",
+  "power",
+  "counter",
+  "draw",
+  "rpo",
+]);
+
+interface TeamAggregate {
+  dropbacks: number;
+  sacksAllowed: number;
+  rushes: number;
+  rushYards: number;
+}
+
+function emptyAgg(): TeamAggregate {
+  return { dropbacks: 0, sacksAllowed: 0, rushes: 0, rushYards: 0 };
+}
+
+function accumulateTeam(
+  events: PlayEvent[],
+  teamId: string,
+): TeamAggregate {
+  const agg = emptyAgg();
+  for (const event of events) {
+    if (event.offenseTeamId !== teamId) continue;
+
+    switch (event.outcome) {
+      case "pass_complete":
+      case "pass_incomplete":
+      case "interception":
+        agg.dropbacks++;
+        break;
+      case "sack":
+        agg.dropbacks++;
+        agg.sacksAllowed++;
+        break;
+      case "touchdown":
+        if (RUN_CONCEPTS.has(event.call.concept)) {
+          agg.rushes++;
+          agg.rushYards += event.yardage;
+        } else {
+          agg.dropbacks++;
+        }
+        break;
+      case "rush":
+        agg.rushes++;
+        agg.rushYards += event.yardage;
+        break;
+      case "fumble":
+        // Downstream of a rush in the sim's current outcome model.
+        agg.rushes++;
+        agg.rushYards += event.yardage;
+        break;
+      default:
+        break;
+    }
+  }
+  return agg;
+}
+
+function countPenalties(events: PlayEvent[], playerId: string): number {
+  let count = 0;
+  for (const event of events) {
+    const penalty = event.penalty;
+    if (!penalty) continue;
+    if (!penalty.accepted) continue;
+    if (penalty.againstPlayerId === playerId) count++;
+  }
+  return count;
+}
+
+export interface OtSampleInput {
+  game: GameResult;
+  home: SimTeam;
+  away: SimTeam;
+}
+
+// Emit one OtGameSample per starting tackle on each team. Teams carry
+// two OT starters by design (see STARTER_SLOTS in
+// generate-calibration-league.ts), so this produces up to four samples
+// per game — two per side. Team-level denominators are shared; each
+// tackle's penalties are tallied from `penalty.againstPlayerId`.
+export function collectOtSamples(
+  input: OtSampleInput,
+): OtGameSample[] {
+  const { game, home, away } = input;
+
+  const samples: OtGameSample[] = [];
+  for (const team of [home, away]) {
+    const tackles = team.starters.filter((p) => p.neutralBucket === "OT");
+    if (tackles.length === 0) continue;
+
+    const teamAgg = accumulateTeam(game.events, team.teamId);
+    const team_sack_allowed_rate = teamAgg.dropbacks > 0
+      ? teamAgg.sacksAllowed / teamAgg.dropbacks
+      : 0;
+    const team_rush_ypc = teamAgg.rushes > 0
+      ? teamAgg.rushYards / teamAgg.rushes
+      : 0;
+
+    for (const ot of tackles) {
+      const penalties = countPenalties(game.events, ot.playerId);
+      samples.push({
+        teamId: team.teamId,
+        otPlayerId: ot.playerId,
+        otOverall: otOverall(ot.attributes),
+        team_dropbacks: teamAgg.dropbacks,
+        team_sacks_allowed: teamAgg.sacksAllowed,
+        team_rushes: teamAgg.rushes,
+        team_rush_yards: teamAgg.rushYards,
+        penalties,
+        team_sack_allowed_rate,
+        team_rush_ypc,
+        penalties_per_game: penalties,
+        starts_per_season: 1,
+      });
+    }
+  }
+  return samples;
+}

--- a/server/features/simulation/calibration/per-position/run-ot-calibration.ts
+++ b/server/features/simulation/calibration/per-position/run-ot-calibration.ts
@@ -1,0 +1,72 @@
+import { simulateGame } from "../../simulate-game.ts";
+import { generateCalibrationLeague } from "../generate-calibration-league.ts";
+import { CALIBRATION_SEEDS } from "../calibration-seeds.ts";
+import { formatOtCalibrationReport, runOtCalibration } from "./ot-harness.ts";
+
+// Per-issue-#496: this entry point is intentionally report-only at
+// first. We print per-bucket PASS/FAIL against NFL OT percentile
+// bands across every calibration seed so a human can eyeball the
+// signal — gating will come later once we understand noise
+// characteristics per bucket.
+//
+// IMPORTANT: the underlying NFL bands are PROXY METRICS v1 (nflreadr
+// does not carry PFF block grades). Large numbers of failures are
+// expected here and do not necessarily indicate a sim bug — they
+// reflect the limited fidelity of team-level protection proxies.
+const bandPath = new URL(
+  "../../../../../data/bands/per-position/ot.json",
+  import.meta.url,
+);
+
+const bandJson = await Deno.readTextFile(bandPath);
+
+let allPassed = true;
+const summary: {
+  seed: number;
+  passed: number;
+  total: number;
+  underSampled: number;
+}[] = [];
+
+for (const seed of CALIBRATION_SEEDS) {
+  const league = generateCalibrationLeague({ seed });
+  const report = runOtCalibration({
+    bandJson,
+    league,
+    simulate: simulateGame,
+  });
+
+  console.log(`=== seed=0x${seed.toString(16)} ===`);
+  console.log(formatOtCalibrationReport(report));
+  console.log("");
+
+  const totalChecks = report.buckets.reduce(
+    (sum, b) => sum + b.checks.length,
+    0,
+  );
+  const passCount = totalChecks - report.failures.length;
+  const underSampled = report.buckets.filter((b) => b.underSampled).length;
+  summary.push({ seed, passed: passCount, total: totalChecks, underSampled });
+  if (!report.passed) allPassed = false;
+}
+
+console.log("=== Multi-seed summary ===");
+for (const row of summary) {
+  const status = row.passed === row.total ? "PASS" : "FAIL";
+  const underSampledNote = row.underSampled > 0
+    ? ` (${row.underSampled} bucket(s) under-sampled)`
+    : "";
+  console.log(
+    `${status} seed=0x${
+      row.seed.toString(16)
+    }: ${row.passed}/${row.total}${underSampledNote}`,
+  );
+}
+
+if (!allPassed) {
+  // Report-only for now: do not exit non-zero so CI users can observe
+  // the expected proxy-metric failures without the task breaking.
+  console.log(
+    "(report-only: proxy metric failures are expected; not exiting non-zero)",
+  );
+}


### PR DESCRIPTION
## Summary

Mirrors the QB slice (PR #497) for offensive tackles: generates an NFL
OT percentile-band reference (`data/bands/per-position/ot.json`),
samples OT stats per simulated game from each team's two starting
tackles, buckets by OT overall, and emits per-bucket PASS/FAIL vs. the
NFL bands. Adds `deno task sim:calibrate:ot` plus unit coverage for
the three new modules (16 tests, >93% branch / >97% line on OT files).

## Notes

- **PROXY METRICS v1 — PFF-grade gap.** nflreadr does not expose PFF
  pass-block/run-block grades or pressure counts. This fixture is a
  structural placeholder that ranks OTs by a composite z-score of
  (lower-is-better) team sack-allowed-rate, (higher-is-better) team
  rush YPC, and (lower-is-better) penalties-per-game. The first two
  are team-level and shared by both starting tackles; only
  penalties-per-game is cleanly per-player. Proper OT bands will
  require per-player block grades from PFF or tracking data. Both the
  R script and the JSON fixture's `notes` field flag this prominently.

- **Sim logging gap.** The engine doesn't log per-player participation
  on blocking plays, so the OT sampler attributes team dropbacks,
  sacks, rushes, and rush yards equally across both starting tackles.
  Individual tackles are only distinguished by accepted penalties keyed
  on `penalty.againstPlayerId`.

- **Calibration gaps observed** (report-only across all 8 seeds; the
  entry point intentionally does not exit non-zero because proxy
  failures are expected):
  - Sim penalties-per-game are ~0.07-0.10 across every bucket vs. NFL
    bands of 0.22 (elite) to 0.63 (replacement) — the engine emits far
    fewer OL penalties than the NFL.
  - Sack-allowed-rate drifts high by ~0.01-0.02 in buckets 40/50/60
    relative to their expected bands (the upper buckets still resemble
    the bucket below).
  - Rush YPC runs about a half-tier hotter than NFL bands in the mid
    tiers.
  - Bucket 30 is consistently under-sampled (often n=0-44 across
    1,344 games) because the procedurally generated OTs rarely roll
    five signature attributes that low.

- Follow-ups worth filing after this merges: (1) track the per-player
  block-event logging gap so the sim can populate true per-OT metrics,
  (2) ingest a PFF-grade source to replace the team-level proxies,
  (3) look at why OL penalties are so under-produced.