### PR TITLE
feat(calibration): add per-LB-bucket calibration harness (#496, LB slice)

### DIFF
--- a/data/R/bands/per-position-lb.R
+++ b/data/R/bands/per-position-lb.R
@@ -1,0 +1,163 @@
+#!/usr/bin/env Rscript
+# per-position-lb.R — NFL LB percentile-band reference.
+#
+# Pulls weekly defensive stats from load_player_stats, aggregates to
+# per-LB-season lines, filters to off-ball LB starters, ranks by a
+# composite tackle-production score, and carves the population into
+# five percentile bands (elite / good / average / weak / replacement).
+#
+# LB is a noisier bucket than QB/RB because the position straddles
+# two NFL archetypes: off-ball ILB/MLB whose production is tackles +
+# TFLs + PBUs, and edge OLBs whose production is sacks + QB hits.
+# Zone Blitz keeps edge players in the `EDGE` neutral bucket, so this
+# slice calibrates against off-ball LBs only — we exclude any OLB
+# season with sacks/game >= 0.4 to drop pass-rush-first players whose
+# tackle lines would drag every band downward.
+#
+# Output: data/bands/per-position/lb.json
+#
+# Usage:
+#   Rscript data/R/bands/per-position-lb.R [--seasons 2020:2024]
+
+suppressPackageStartupMessages({
+  library(nflreadr)
+  library(dplyr)
+})
+
+script_file <- (function() {
+  args <- commandArgs(trailingOnly = FALSE)
+  f <- grep("^--file=", args, value = TRUE)
+  if (length(f) > 0) normalizePath(sub("^--file=", "", f[1]), mustWork = FALSE) else NULL
+})()
+source(file.path(dirname(script_file), "..", "lib.R"))
+
+args <- commandArgs(trailingOnly = TRUE)
+seasons <- parse_seasons(args)
+
+cat("Loading weekly defensive stats for seasons:",
+    paste(range(seasons), collapse = "-"), "\n")
+
+weekly <- nflreadr::load_player_stats(seasons, stat_type = "defense")
+
+lb_weekly <- weekly |>
+  filter(
+    season_type == "REG",
+    position %in% c("LB", "ILB", "OLB", "MLB")
+  )
+
+# Aggregate weekly rows into per-LB-season totals. We want per-game
+# rate stats (tackles/game, TFLs/game, PBUs/game) because the sim
+# emits per-game samples and we bucket on the starter's season-long
+# production rates.
+lb_season <- lb_weekly |>
+  group_by(player_id, player_display_name, position, season) |>
+  summarise(
+    games         = n(),
+    tackles_solo  = sum(def_tackles_solo, na.rm = TRUE),
+    tackle_assists = sum(def_tackle_assists, na.rm = TRUE),
+    tfl           = sum(def_tackles_for_loss, na.rm = TRUE),
+    sacks         = sum(def_sacks, na.rm = TRUE),
+    pbu           = sum(def_pass_defended, na.rm = TRUE),
+    .groups       = "drop"
+  ) |>
+  mutate(
+    total_tackles = tackles_solo + tackle_assists,
+    tackles_per_game = ifelse(games > 0, total_tackles / games, NA_real_),
+    tfl_per_game    = ifelse(games > 0, tfl / games, NA_real_),
+    solo_tackle_rate = ifelse(total_tackles > 0,
+                              tackles_solo / total_tackles, NA_real_),
+    pbu_per_game    = ifelse(games > 0, pbu / games, NA_real_),
+    sacks_per_game  = ifelse(games > 0, sacks / games, NA_real_)
+  ) |>
+  # Starter threshold: appeared in >= 10 games with >= 40 total tackles
+  # on the season. The tackle floor filters the "starter by position"
+  # rows who were actually rotational (special teams only, spot starts
+  # due to injury) and keeps the sample honest to true starters.
+  filter(games >= 10, total_tackles >= 40) |>
+  # Exclude edge-rushing OLBs whose role is pass-rush, not off-ball
+  # coverage/run-fit. Their stat line (heavy sacks, light PBUs) would
+  # be modelled by the EDGE neutral bucket in the sim, not the LB one.
+  filter(!(position == "OLB" & sacks_per_game >= 0.4))
+
+cat("LB-seasons after starter filter:", nrow(lb_season), "\n")
+
+# Rank by a composite production score (tackles/gm + 2 * TFL/gm +
+# 2 * PBU/gm). TFL and PBU are weighted higher than raw tackles
+# because they separate playmakers from volume tacklers — an LB who
+# piles up 8 tackles/gm behind the line of scrimmage is much more
+# valuable than one who makes the same tackles four yards downfield.
+lb_ranked <- lb_season |>
+  mutate(
+    composite = tackles_per_game + 2 * tfl_per_game + 2 * pbu_per_game
+  ) |>
+  arrange(desc(composite)) |>
+  mutate(
+    pct = (row_number() - 0.5) / n(),
+    band = case_when(
+      pct <= 0.10 ~ "elite",
+      pct <= 0.30 ~ "good",
+      pct <= 0.70 ~ "average",
+      pct <= 0.90 ~ "weak",
+      TRUE        ~ "replacement"
+    )
+  )
+
+metric_keys <- c(
+  "tackles_per_game",
+  "tfl_per_game",
+  "solo_tackle_rate",
+  "pbu_per_game"
+)
+
+band_order <- c("elite", "good", "average", "weak", "replacement")
+
+band_summary <- function(rows) {
+  metrics <- list()
+  for (key in metric_keys) {
+    vals <- rows[[key]]
+    vals <- vals[!is.na(vals)]
+    metrics[[key]] <- list(
+      n = length(vals),
+      mean = mean(vals),
+      sd = stats::sd(vals)
+    )
+  }
+  list(
+    n = nrow(rows),
+    metrics = metrics
+  )
+}
+
+bands <- list()
+for (band_name in band_order) {
+  rows <- lb_ranked |> filter(band == band_name)
+  bands[[band_name]] <- band_summary(rows)
+}
+
+out <- list(
+  generated_at = format(Sys.time(), "%Y-%m-%dT%H:%M:%SZ", tz = "UTC"),
+  seasons = as.integer(seasons),
+  position = "LB",
+  qualifier = "regular-season LB-seasons, >=10 games, >=40 total tackles, excluding OLBs with >=0.4 sacks/game",
+  ranking_stat = "composite (tackles/gm + 2 * TFL/gm + 2 * PBU/gm)",
+  notes = paste0(
+    "Starter off-ball LB-seasons 2020-2024, ranked by a tackle + TFL ",
+    "+ PBU composite then carved into percentile bands (elite: top ",
+    "10%, good: 10-30%, average: 30-70%, weak: 70-90%, replacement: ",
+    "bottom 10%). Each band reports mean+sd per metric across the ",
+    "LB-seasons in that band. Edge-rushing OLBs (sacks/game >= 0.4) ",
+    "are excluded because Zone Blitz models them in the EDGE bucket."
+  ),
+  bands = bands
+)
+
+out_path <- file.path(
+  repo_root(), "data", "bands", "per-position", "lb.json"
+)
+dir.create(dirname(out_path), recursive = TRUE, showWarnings = FALSE)
+writeLines(
+  jsonlite::toJSON(out, auto_unbox = TRUE, pretty = TRUE, digits = 4,
+                   null = "null"),
+  out_path
+)
+cat("Wrote", out_path, "\n")

--- a/data/bands/per-position/lb.json
+++ b/data/bands/per-position/lb.json
@@ -1,0 +1,135 @@
+{
+  "generated_at": "2026-04-17T12:32:47Z",
+  "seasons": [2020, 2021, 2022, 2023, 2024],
+  "position": "LB",
+  "qualifier": "regular-season LB-seasons, >=10 games, >=40 total tackles, excluding OLBs with >=0.4 sacks/game",
+  "ranking_stat": "composite (tackles/gm + 2 * TFL/gm + 2 * PBU/gm)",
+  "notes": "Starter off-ball LB-seasons 2020-2024, ranked by a tackle + TFL + PBU composite then carved into percentile bands (elite: top 10%, good: 10-30%, average: 30-70%, weak: 70-90%, replacement: bottom 10%). Each band reports mean+sd per metric across the LB-seasons in that band. Edge-rushing OLBs (sacks/game >= 0.4) are excluded because Zone Blitz models them in the EDGE bucket.",
+  "bands": {
+    "elite": {
+      "n": 46,
+      "metrics": {
+        "tackles_per_game": {
+          "n": 46,
+          "mean": 8.7667,
+          "sd": 0.729
+        },
+        "tfl_per_game": {
+          "n": 46,
+          "mean": 0.4644,
+          "sd": 0.2052
+        },
+        "solo_tackle_rate": {
+          "n": 46,
+          "mean": 0.5626,
+          "sd": 0.0555
+        },
+        "pbu_per_game": {
+          "n": 46,
+          "mean": 0.3543,
+          "sd": 0.1266
+        }
+      }
+    },
+    "good": {
+      "n": 92,
+      "metrics": {
+        "tackles_per_game": {
+          "n": 92,
+          "mean": 7.2574,
+          "sd": 0.6248
+        },
+        "tfl_per_game": {
+          "n": 92,
+          "mean": 0.4201,
+          "sd": 0.2199
+        },
+        "solo_tackle_rate": {
+          "n": 92,
+          "mean": 0.5645,
+          "sd": 0.0689
+        },
+        "pbu_per_game": {
+          "n": 92,
+          "mean": 0.3139,
+          "sd": 0.1367
+        }
+      }
+    },
+    "average": {
+      "n": 185,
+      "metrics": {
+        "tackles_per_game": {
+          "n": 185,
+          "mean": 5.5688,
+          "sd": 0.8486
+        },
+        "tfl_per_game": {
+          "n": 185,
+          "mean": 0.3358,
+          "sd": 0.2071
+        },
+        "solo_tackle_rate": {
+          "n": 185,
+          "mean": 0.5657,
+          "sd": 0.0737
+        },
+        "pbu_per_game": {
+          "n": 185,
+          "mean": 0.2403,
+          "sd": 0.1557
+        }
+      }
+    },
+    "weak": {
+      "n": 92,
+      "metrics": {
+        "tackles_per_game": {
+          "n": 92,
+          "mean": 3.7825,
+          "sd": 0.5453
+        },
+        "tfl_per_game": {
+          "n": 92,
+          "mean": 0.3328,
+          "sd": 0.234
+        },
+        "solo_tackle_rate": {
+          "n": 92,
+          "mean": 0.571,
+          "sd": 0.0711
+        },
+        "pbu_per_game": {
+          "n": 92,
+          "mean": 0.1409,
+          "sd": 0.1102
+        }
+      }
+    },
+    "replacement": {
+      "n": 46,
+      "metrics": {
+        "tackles_per_game": {
+          "n": 46,
+          "mean": 3.0829,
+          "sd": 0.3569
+        },
+        "tfl_per_game": {
+          "n": 46,
+          "mean": 0.1875,
+          "sd": 0.14
+        },
+        "solo_tackle_rate": {
+          "n": 46,
+          "mean": 0.5476,
+          "sd": 0.0781
+        },
+        "pbu_per_game": {
+          "n": 46,
+          "mean": 0.0831,
+          "sd": 0.079
+        }
+      }
+    }
+  }
+}

--- a/deno.json
+++ b/deno.json
@@ -43,6 +43,7 @@
     "sim:calibrate:s": "deno run --allow-read server/features/simulation/calibration/per-position/run-s-calibration.ts",
     "sim:calibrate:iol": "deno run --allow-read server/features/simulation/calibration/per-position/run-iol-calibration.ts",
     "sim:calibrate:ot": "deno run --allow-read server/features/simulation/calibration/per-position/run-ot-calibration.ts",
+    "sim:calibrate:lb": "deno run --allow-read server/features/simulation/calibration/per-position/run-lb-calibration.ts",
     "build": "cd client && deno task build",
     "start": "cd server && deno run --env=../.env --allow-net --allow-env --allow-read --allow-sys main.ts"
   },

--- a/server/features/simulation/calibration/per-position/lb-harness.test.ts
+++ b/server/features/simulation/calibration/per-position/lb-harness.test.ts
@@ -1,0 +1,315 @@
+import { assertEquals, assertStringIncludes } from "@std/assert";
+import type { PlayerAttributes } from "@zone-blitz/shared";
+import { formatLbCalibrationReport, runLbCalibration } from "./lb-harness.ts";
+import type { GameResult, PlayEvent } from "../../events.ts";
+import type { SimTeam } from "../../simulate-game.ts";
+import type { PlayerRuntime } from "../../resolve-play.ts";
+import type { CalibrationLeague } from "../generate-calibration-league.ts";
+
+function attrs(overrides: Partial<PlayerAttributes> = {}): PlayerAttributes {
+  const base: Record<string, number> = {};
+  const keys = [
+    "speed",
+    "acceleration",
+    "agility",
+    "strength",
+    "jumping",
+    "stamina",
+    "durability",
+    "armStrength",
+    "accuracyShort",
+    "accuracyMedium",
+    "accuracyDeep",
+    "accuracyOnTheRun",
+    "touch",
+    "release",
+    "ballCarrying",
+    "elusiveness",
+    "routeRunning",
+    "catching",
+    "contestedCatching",
+    "runAfterCatch",
+    "passBlocking",
+    "runBlocking",
+    "blockShedding",
+    "tackling",
+    "manCoverage",
+    "zoneCoverage",
+    "passRushing",
+    "runDefense",
+    "kickingPower",
+    "kickingAccuracy",
+    "puntingPower",
+    "puntingAccuracy",
+    "snapAccuracy",
+    "footballIq",
+    "decisionMaking",
+    "anticipation",
+    "composure",
+    "clutch",
+    "consistency",
+    "workEthic",
+    "coachability",
+    "leadership",
+    "greed",
+    "loyalty",
+    "ambition",
+    "vanity",
+    "schemeAttachment",
+    "mediaSensitivity",
+  ];
+  for (const k of keys) {
+    base[k] = 50;
+    base[`${k}Potential`] = 50;
+  }
+  return { ...(base as unknown as PlayerAttributes), ...overrides };
+}
+
+function lbRuntime(id: string, overall: number): PlayerRuntime {
+  return {
+    playerId: id,
+    neutralBucket: "LB",
+    attributes: attrs({
+      blockShedding: overall,
+      tackling: overall,
+      runDefense: overall,
+      zoneCoverage: overall,
+      footballIq: overall,
+      anticipation: overall,
+    }),
+  };
+}
+
+function team(teamId: string, starterLb: PlayerRuntime): SimTeam {
+  return {
+    teamId,
+    starters: [starterLb],
+    bench: [],
+    fingerprint: { offense: null, defense: null, overrides: {} },
+    coachingMods: {
+      schemeFitBonus: 0,
+      situationalBonus: 0,
+      aggressiveness: 50,
+      penaltyDiscipline: 1,
+    },
+  };
+}
+
+function bandJson(): string {
+  const band = (tackles: number, tfl: number, solo: number, pbu: number) => ({
+    n: 20,
+    metrics: {
+      tackles_per_game: { n: 20, mean: tackles, sd: 0.8 },
+      tfl_per_game: { n: 20, mean: tfl, sd: 0.2 },
+      solo_tackle_rate: { n: 20, mean: solo, sd: 0.06 },
+      pbu_per_game: { n: 20, mean: pbu, sd: 0.1 },
+    },
+  });
+  return JSON.stringify({
+    position: "LB",
+    seasons: [2020, 2021, 2022, 2023, 2024],
+    ranking_stat: "composite",
+    bands: {
+      elite: band(8.8, 0.46, 0.56, 0.35),
+      good: band(7.3, 0.42, 0.56, 0.28),
+      average: band(5.9, 0.33, 0.56, 0.2),
+      weak: band(4.7, 0.23, 0.56, 0.15),
+      replacement: band(3.6, 0.14, 0.56, 0.08),
+    },
+  });
+}
+
+function makeGame(
+  gameId: string,
+  homeTeamId: string,
+  awayTeamId: string,
+  teamTacklesByDefense: Record<string, number>,
+): GameResult {
+  const events: PlayEvent[] = [];
+  for (
+    const [defenseTeamId, tackles] of Object.entries(teamTacklesByDefense)
+  ) {
+    const offenseTeamId = defenseTeamId === homeTeamId
+      ? awayTeamId
+      : homeTeamId;
+    for (let i = 0; i < tackles; i++) {
+      events.push({
+        gameId,
+        driveIndex: 0,
+        playIndex: events.length,
+        quarter: 1,
+        clock: "15:00",
+        situation: { down: 1, distance: 10, yardLine: 25 },
+        offenseTeamId,
+        defenseTeamId,
+        call: {
+          concept: "inside_zone",
+          personnel: "11",
+          formation: "singleback",
+          motion: "none",
+        },
+        coverage: { front: "4-3", coverage: "cover_2", pressure: "four_man" },
+        participants: [],
+        outcome: "rush",
+        yardage: 4,
+        tags: [],
+      });
+    }
+  }
+  return {
+    gameId,
+    seed: 1,
+    finalScore: { home: 0, away: 0 },
+    events,
+    boxScore: {
+      home: {
+        totalYards: 0,
+        passingYards: 0,
+        rushingYards: 0,
+        turnovers: 0,
+        sacks: 0,
+        penalties: 0,
+      },
+      away: {
+        totalYards: 0,
+        passingYards: 0,
+        rushingYards: 0,
+        turnovers: 0,
+        sacks: 0,
+        penalties: 0,
+      },
+    },
+    driveLog: [],
+    injuryReport: [],
+  };
+}
+
+Deno.test("runLbCalibration runs the sim, buckets LBs, and returns a populated report", () => {
+  // Build a league where each team's starter LB sits at a different
+  // overall. The stub simulate delivers a team-tackle volume tuned so
+  // each bucket lands on its expected NFL band's tackles/game.
+  // Allocation: team tackles * 0.45 (LB share) / 1 LB = tackles/LB.
+  // Target tackles/LB by overall: 50-bucket => 5.9 (avg), so
+  // team-tackles = 5.9 / 0.45 ≈ 13.1.
+  const overallByTeam: Record<string, number> = {
+    "t30": 30,
+    "t40": 40,
+    "t50": 50,
+    "t60": 60,
+    "t70": 70,
+    "t80": 80,
+  };
+  const tacklesPerLbByOverall: Record<number, number> = {
+    30: 3.6,
+    40: 4.7,
+    50: 5.9,
+    60: 7.3,
+    70: 8.8,
+    80: 8.8,
+  };
+
+  const teams: SimTeam[] = Object.entries(overallByTeam).map(([id, o]) =>
+    team(id, lbRuntime(`${id}-lb`, o))
+  );
+  const league: CalibrationLeague = { calibrationSeed: 1, teams };
+
+  let gameCount = 0;
+  const simulate = ({ home, away, gameId }: {
+    home: SimTeam;
+    away: SimTeam;
+    seed: number;
+    gameId: string;
+  }): GameResult => {
+    gameCount++;
+    // team tackles required so that team-tackles * 0.45 = target
+    const homeTeamTackles = Math.round(
+      tacklesPerLbByOverall[overallByTeam[home.teamId]] / 0.45,
+    );
+    const awayTeamTackles = Math.round(
+      tacklesPerLbByOverall[overallByTeam[away.teamId]] / 0.45,
+    );
+    return makeGame(gameId, home.teamId, away.teamId, {
+      [home.teamId]: homeTeamTackles,
+      [away.teamId]: awayTeamTackles,
+    });
+  };
+
+  const report = runLbCalibration({
+    bandJson: bandJson(),
+    league,
+    simulate,
+    gameCount: teams.length * 12,
+    minSamplesPerBucket: 5,
+  });
+
+  assertEquals(report.totalGames, teams.length * 12);
+  // Each matchup produces 2 samples (one per team, 1 starter each).
+  assertEquals(report.totalSamples, gameCount * 2);
+
+  const fifty = report.buckets.find((b) => b.bucketLabel === "50")!;
+  assertEquals(fifty.samples > 0, true);
+  assertEquals(fifty.underSampled, false);
+  assertEquals(fifty.checks.length > 0, true);
+  const tacklesCheck = fifty.checks.find((c) =>
+    c.metricName === "tackles_per_game"
+  )!;
+  assertEquals(tacklesCheck.passed, true);
+});
+
+Deno.test("runLbCalibration marks a bucket under-sampled when below min threshold", () => {
+  const teams: SimTeam[] = [team("t50", lbRuntime("t50-lb", 50))];
+  const league: CalibrationLeague = { calibrationSeed: 1, teams };
+  const simulate = (
+    { home, away, gameId }: {
+      home: SimTeam;
+      away: SimTeam;
+      seed: number;
+      gameId: string;
+    },
+  ) =>
+    makeGame(gameId, home.teamId, away.teamId, {
+      [home.teamId]: 13,
+      [away.teamId]: 13,
+    });
+
+  const report = runLbCalibration({
+    bandJson: bandJson(),
+    league,
+    simulate,
+    gameCount: 1,
+    minSamplesPerBucket: 100,
+  });
+
+  const fifty = report.buckets.find((b) => b.bucketLabel === "50")!;
+  assertEquals(fifty.underSampled, true);
+  assertEquals(fifty.checks.length, 0);
+});
+
+Deno.test("formatLbCalibrationReport renders a human-readable summary", () => {
+  const teams: SimTeam[] = [team("t50", lbRuntime("t50-lb", 50))];
+  const league: CalibrationLeague = { calibrationSeed: 1, teams };
+  const simulate = (
+    { home, away, gameId }: {
+      home: SimTeam;
+      away: SimTeam;
+      seed: number;
+      gameId: string;
+    },
+  ) =>
+    makeGame(gameId, home.teamId, away.teamId, {
+      [home.teamId]: 13,
+      [away.teamId]: 13,
+    });
+
+  const report = runLbCalibration({
+    bandJson: bandJson(),
+    league,
+    simulate,
+    gameCount: 100,
+    minSamplesPerBucket: 1,
+  });
+  const output = formatLbCalibrationReport(report);
+  assertStringIncludes(output, "LB calibration");
+  assertStringIncludes(output, "bucket 50");
+  assertStringIncludes(output, "tackles_per_game");
+});

--- a/server/features/simulation/calibration/per-position/lb-harness.ts
+++ b/server/features/simulation/calibration/per-position/lb-harness.ts
@@ -1,0 +1,172 @@
+import { deriveGameSeed } from "../../rng.ts";
+import { CALIBRATION_GAME_COUNT } from "../constants.ts";
+import { generateMatchups } from "../harness.ts";
+import type { SimulateFn } from "../harness.ts";
+import type { CalibrationLeague } from "../generate-calibration-league.ts";
+import { collectLbSamples, type LbGameSample } from "./lb-sample.ts";
+import { bucketByAttr, type BucketReport } from "./bucket-by-attr.ts";
+import { type BandCheckResult, checkBand } from "./band-check.ts";
+import { loadPositionBands, type PositionBands } from "./band-loader.ts";
+
+// Headline LB metrics. Tackles/game is the volume anchor, TFL/game
+// captures the havoc side of the role, PBU/game measures coverage
+// playmaking, and solo_tackle_rate is the only stat that isolates
+// individual technique from team scheme. Forced fumbles and sacks
+// are intentionally omitted — the LB fixture ranks off-ball LBs, and
+// those stats are owned by the pass-rush (EDGE/IDL) calibration slice.
+export const LB_METRICS = [
+  "tackles_per_game",
+  "tfl_per_game",
+  "solo_tackle_rate",
+  "pbu_per_game",
+] as const;
+
+export type LbMetric = typeof LB_METRICS[number];
+
+const METRIC_EXTRACTORS: Record<LbMetric, (s: LbGameSample) => number> = {
+  tackles_per_game: (s) => s.tackles_per_game,
+  tfl_per_game: (s) => s.tfl_per_game,
+  solo_tackle_rate: (s) => s.solo_tackle_rate,
+  pbu_per_game: (s) => s.pbu_per_game,
+};
+
+export interface LbCalibrationOptions {
+  bandJson: string;
+  league: CalibrationLeague;
+  simulate: SimulateFn;
+  gameCount?: number;
+  // Minimum samples per bucket before we trust a band check. Under
+  // this count we still emit the summary but flag it as under-sampled
+  // so the report distinguishes "bucket is empty/noisy" from "bucket
+  // is calibrated wrong".
+  minSamplesPerBucket?: number;
+}
+
+export interface LbBucketReport {
+  bucketLabel: string;
+  bucketCenter: number;
+  samples: number;
+  underSampled: boolean;
+  checks: BandCheckResult[];
+}
+
+export interface LbCalibrationReport {
+  totalGames: number;
+  totalSamples: number;
+  bands: PositionBands;
+  buckets: LbBucketReport[];
+  failures: BandCheckResult[];
+  passed: boolean;
+}
+
+const DEFAULT_MIN_SAMPLES = 50;
+
+export function runLbCalibration(
+  options: LbCalibrationOptions,
+): LbCalibrationReport {
+  const {
+    bandJson,
+    league,
+    simulate,
+    gameCount = CALIBRATION_GAME_COUNT,
+    minSamplesPerBucket = DEFAULT_MIN_SAMPLES,
+  } = options;
+
+  const bands = loadPositionBands(bandJson);
+  const teamById = new Map(league.teams.map((t) => [t.teamId, t]));
+  const matchups = generateMatchups(league.teams, gameCount);
+
+  const samples: LbGameSample[] = [];
+
+  for (let i = 0; i < matchups.length; i++) {
+    const { home, away } = matchups[i];
+    const gameId = `lb-calibration-game-${i}`;
+    const seed = deriveGameSeed(league.calibrationSeed, gameId);
+
+    const result = simulate({ home, away, seed, gameId });
+    const gameSamples = collectLbSamples({
+      game: result,
+      home: teamById.get(home.teamId) ?? home,
+      away: teamById.get(away.teamId) ?? away,
+    });
+    samples.push(...gameSamples);
+  }
+
+  const bucketReports: BucketReport<LbGameSample>[] = bucketByAttr({
+    samples,
+    attr: (s) => s.lbOverall,
+    metrics: METRIC_EXTRACTORS,
+  });
+
+  const buckets: LbBucketReport[] = bucketReports.map((report) => {
+    const underSampled = report.samples.length < minSamplesPerBucket;
+    const checks: BandCheckResult[] = LB_METRICS.flatMap((metric) => {
+      // Don't emit band checks on under-sampled buckets — the NFL band
+      // comparison would be dominated by sampling noise and drown out
+      // the real failures from the populated buckets.
+      if (underSampled) return [];
+      return [
+        checkBand({
+          bucketLabel: report.bucket.label,
+          metricName: metric,
+          simSummary: report.metrics[metric],
+          bands,
+        }),
+      ];
+    });
+    return {
+      bucketLabel: report.bucket.label,
+      bucketCenter: report.bucket.center,
+      samples: report.samples.length,
+      underSampled,
+      checks,
+    };
+  });
+
+  const failures = buckets.flatMap((b) => b.checks.filter((c) => !c.passed));
+
+  return {
+    totalGames: matchups.length,
+    totalSamples: samples.length,
+    bands,
+    buckets,
+    failures,
+    passed: failures.length === 0,
+  };
+}
+
+export function formatLbCalibrationReport(report: LbCalibrationReport): string {
+  const lines: string[] = [];
+  lines.push(
+    `LB calibration — ${report.totalGames} games, ${report.totalSamples} LB-games`,
+  );
+  lines.push(
+    `Bands: ${report.bands.position} / ${
+      report.bands.seasons.join("-")
+    } / ranked by ${report.bands.rankingStat}`,
+  );
+  lines.push("");
+  for (const bucket of report.buckets) {
+    const header = `[bucket ${bucket.bucketLabel}] n=${bucket.samples}` +
+      (bucket.underSampled ? " (under-sampled, skipping band checks)" : "");
+    lines.push(header);
+    for (const check of bucket.checks) {
+      const verdict = check.passed ? "PASS" : "FAIL";
+      const dir = check.passed ? "" : ` (${check.direction})`;
+      lines.push(
+        `  ${verdict} ${check.metricName.padEnd(20)} ` +
+          `sim=${check.simMean.toFixed(4)}  ` +
+          `band(${check.expectedBand})=${check.bandMean.toFixed(4)}±${
+            check.bandSd.toFixed(4)
+          }  ` +
+          `z=${check.zScore.toFixed(2)}  actual=${check.actualBand}${dir}`,
+      );
+    }
+    lines.push("");
+  }
+  const passed = report.passed ? "PASS" : "FAIL";
+  lines.push(
+    `${passed}: ${report.failures.length} band check(s) missed expected band`,
+  );
+  return lines.join("\n");
+}

--- a/server/features/simulation/calibration/per-position/lb-overall.test.ts
+++ b/server/features/simulation/calibration/per-position/lb-overall.test.ts
@@ -1,0 +1,93 @@
+import { assertAlmostEquals, assertEquals } from "@std/assert";
+import type { PlayerAttributes } from "@zone-blitz/shared";
+import { LB_OVERALL_ATTRS, lbOverall } from "./lb-overall.ts";
+
+function attrs(overrides: Partial<PlayerAttributes> = {}): PlayerAttributes {
+  const base: Record<string, number> = {};
+  const keys = [
+    "speed",
+    "acceleration",
+    "agility",
+    "strength",
+    "jumping",
+    "stamina",
+    "durability",
+    "armStrength",
+    "accuracyShort",
+    "accuracyMedium",
+    "accuracyDeep",
+    "accuracyOnTheRun",
+    "touch",
+    "release",
+    "ballCarrying",
+    "elusiveness",
+    "routeRunning",
+    "catching",
+    "contestedCatching",
+    "runAfterCatch",
+    "passBlocking",
+    "runBlocking",
+    "blockShedding",
+    "tackling",
+    "manCoverage",
+    "zoneCoverage",
+    "passRushing",
+    "runDefense",
+    "kickingPower",
+    "kickingAccuracy",
+    "puntingPower",
+    "puntingAccuracy",
+    "snapAccuracy",
+    "footballIq",
+    "decisionMaking",
+    "anticipation",
+    "composure",
+    "clutch",
+    "consistency",
+    "workEthic",
+    "coachability",
+    "leadership",
+    "greed",
+    "loyalty",
+    "ambition",
+    "vanity",
+    "schemeAttachment",
+    "mediaSensitivity",
+  ];
+  for (const k of keys) {
+    base[k] = 50;
+    base[`${k}Potential`] = 50;
+  }
+  return { ...(base as unknown as PlayerAttributes), ...overrides };
+}
+
+Deno.test("lbOverall returns the 50 midpoint for an all-50 player", () => {
+  assertEquals(lbOverall(attrs()), 50);
+});
+
+Deno.test("lbOverall averages the six signature attributes only", () => {
+  const player = attrs({
+    blockShedding: 60,
+    tackling: 70,
+    runDefense: 80,
+    zoneCoverage: 40,
+    footballIq: 55,
+    anticipation: 65,
+    // Non-signature attributes should not move the overall.
+    speed: 99,
+    strength: 99,
+    manCoverage: 99,
+  });
+  // (60 + 70 + 80 + 40 + 55 + 65) / 6 = 61.6667
+  assertAlmostEquals(lbOverall(player), 61.6667, 0.001);
+});
+
+Deno.test("LB_OVERALL_ATTRS is stable and exactly six attributes", () => {
+  assertEquals(LB_OVERALL_ATTRS.length, 6);
+  assertEquals(LB_OVERALL_ATTRS.includes("blockShedding"), true);
+  assertEquals(LB_OVERALL_ATTRS.includes("tackling"), true);
+  assertEquals(LB_OVERALL_ATTRS.includes("runDefense"), true);
+  assertEquals(LB_OVERALL_ATTRS.includes("zoneCoverage"), true);
+  assertEquals(LB_OVERALL_ATTRS.includes("footballIq"), true);
+  assertEquals(LB_OVERALL_ATTRS.includes("anticipation"), true);
+});

--- a/server/features/simulation/calibration/per-position/lb-overall.ts
+++ b/server/features/simulation/calibration/per-position/lb-overall.ts
@@ -1,0 +1,31 @@
+import type { PlayerAttributes } from "@zone-blitz/shared";
+
+// The LB overall is the mean of the off-ball linebacker's signature
+// attributes. `neutralBucket` already classifies a player as LB using
+// `tackling`, `runDefense`, `zoneCoverage`, and `footballIq`, and
+// `resolve-matchups.ts` ranks LBs for run-defense via the shared
+// `runDefense` attr set (`blockShedding`, `tackling`, `runDefense`).
+//
+// The LB bands (from `per-position-lb.R`) carve off-ball LBs on a
+// composite of tackles/gm + TFL/gm + PBU/gm — which is a mix of
+// run-fit (`blockShedding`, `tackling`, `runDefense`) and coverage
+// playmaking (`zoneCoverage`, `anticipation`). We average all six so
+// the 50-overall bucket lines up with the NFL median starter across
+// both facets of the role. A pure run-defense overall would bias the
+// bucket toward downhill thumpers and understate coverage LBs.
+export const LB_OVERALL_ATTRS = [
+  "blockShedding",
+  "tackling",
+  "runDefense",
+  "zoneCoverage",
+  "footballIq",
+  "anticipation",
+] as const satisfies ReadonlyArray<keyof PlayerAttributes>;
+
+export function lbOverall(attributes: PlayerAttributes): number {
+  let sum = 0;
+  for (const key of LB_OVERALL_ATTRS) {
+    sum += attributes[key];
+  }
+  return sum / LB_OVERALL_ATTRS.length;
+}

--- a/server/features/simulation/calibration/per-position/lb-sample.test.ts
+++ b/server/features/simulation/calibration/per-position/lb-sample.test.ts
@@ -1,0 +1,355 @@
+import { assertAlmostEquals, assertEquals } from "@std/assert";
+import type { PlayerAttributes } from "@zone-blitz/shared";
+import { collectLbSamples } from "./lb-sample.ts";
+import type { GameResult, PlayEvent } from "../../events.ts";
+import type { SimTeam } from "../../simulate-game.ts";
+import type { PlayerRuntime } from "../../resolve-play.ts";
+
+function attrs(overrides: Partial<PlayerAttributes> = {}): PlayerAttributes {
+  const base: Record<string, number> = {};
+  const keys = [
+    "speed",
+    "acceleration",
+    "agility",
+    "strength",
+    "jumping",
+    "stamina",
+    "durability",
+    "armStrength",
+    "accuracyShort",
+    "accuracyMedium",
+    "accuracyDeep",
+    "accuracyOnTheRun",
+    "touch",
+    "release",
+    "ballCarrying",
+    "elusiveness",
+    "routeRunning",
+    "catching",
+    "contestedCatching",
+    "runAfterCatch",
+    "passBlocking",
+    "runBlocking",
+    "blockShedding",
+    "tackling",
+    "manCoverage",
+    "zoneCoverage",
+    "passRushing",
+    "runDefense",
+    "kickingPower",
+    "kickingAccuracy",
+    "puntingPower",
+    "puntingAccuracy",
+    "snapAccuracy",
+    "footballIq",
+    "decisionMaking",
+    "anticipation",
+    "composure",
+    "clutch",
+    "consistency",
+    "workEthic",
+    "coachability",
+    "leadership",
+    "greed",
+    "loyalty",
+    "ambition",
+    "vanity",
+    "schemeAttachment",
+    "mediaSensitivity",
+  ];
+  for (const k of keys) {
+    base[k] = 50;
+    base[`${k}Potential`] = 50;
+  }
+  return { ...(base as unknown as PlayerAttributes), ...overrides };
+}
+
+function lb(id: string, overall: number): PlayerRuntime {
+  return {
+    playerId: id,
+    neutralBucket: "LB",
+    attributes: attrs({
+      blockShedding: overall,
+      tackling: overall,
+      runDefense: overall,
+      zoneCoverage: overall,
+      footballIq: overall,
+      anticipation: overall,
+    }),
+  };
+}
+
+function team(teamId: string, starters: PlayerRuntime[]): SimTeam {
+  return {
+    teamId,
+    starters,
+    bench: [],
+    fingerprint: { offense: null, defense: null, overrides: {} },
+    coachingMods: {
+      schemeFitBonus: 0,
+      situationalBonus: 0,
+      aggressiveness: 50,
+      penaltyDiscipline: 1,
+    },
+  };
+}
+
+function event(
+  overrides: Partial<PlayEvent> & {
+    outcome: PlayEvent["outcome"];
+    offenseTeamId: string;
+  },
+): PlayEvent {
+  return {
+    gameId: "g",
+    driveIndex: 0,
+    playIndex: 0,
+    quarter: 1,
+    clock: "15:00",
+    situation: { down: 1, distance: 10, yardLine: 25 },
+    defenseTeamId: overrides.offenseTeamId === "home" ? "away" : "home",
+    call: {
+      concept: "inside_zone",
+      personnel: "11",
+      formation: "singleback",
+      motion: "none",
+    },
+    coverage: { front: "4-3", coverage: "cover_2", pressure: "four_man" },
+    participants: [],
+    yardage: 0,
+    tags: [],
+    ...overrides,
+  };
+}
+
+function gameOf(events: PlayEvent[]): GameResult {
+  return {
+    gameId: "g",
+    seed: 1,
+    finalScore: { home: 0, away: 0 },
+    events,
+    boxScore: {
+      home: {
+        totalYards: 0,
+        passingYards: 0,
+        rushingYards: 0,
+        turnovers: 0,
+        sacks: 0,
+        penalties: 0,
+      },
+      away: {
+        totalYards: 0,
+        passingYards: 0,
+        rushingYards: 0,
+        turnovers: 0,
+        sacks: 0,
+        penalties: 0,
+      },
+    },
+    driveLog: [],
+    injuryReport: [],
+  };
+}
+
+Deno.test("collectLbSamples returns one sample per starter LB per team", () => {
+  // Two LB starters per team (typical base defense). Expect 4 samples.
+  const home = team("home", [lb("home-lb1", 50), lb("home-lb2", 50)]);
+  const away = team("away", [lb("away-lb1", 50), lb("away-lb2", 50)]);
+  const samples = collectLbSamples({
+    game: gameOf([]),
+    home,
+    away,
+  });
+  assertEquals(samples.length, 4);
+  assertEquals(samples[0].teamId, "home");
+  assertEquals(samples[0].lbPlayerId, "home-lb1");
+  assertEquals(samples[2].teamId, "away");
+});
+
+Deno.test("collectLbSamples skips a team with no LB starters", () => {
+  const home = team("home", [lb("home-lb", 50)]);
+  const away = team("away", []);
+  const samples = collectLbSamples({
+    game: gameOf([]),
+    home,
+    away,
+  });
+  assertEquals(samples.length, 1);
+  assertEquals(samples[0].teamId, "home");
+});
+
+Deno.test("collectLbSamples tags each sample with LB overall (mean of six attrs)", () => {
+  const starter: PlayerRuntime = {
+    playerId: "home-lb",
+    neutralBucket: "LB",
+    attributes: attrs({
+      blockShedding: 60,
+      tackling: 70,
+      runDefense: 50,
+      zoneCoverage: 40,
+      footballIq: 80,
+      anticipation: 60,
+    }),
+  };
+  const home = team("home", [starter]);
+  const away = team("away", [lb("away-lb", 50)]);
+  const [homeSample] = collectLbSamples({
+    game: gameOf([]),
+    home,
+    away,
+  });
+  // (60 + 70 + 50 + 40 + 80 + 60) / 6 = 60
+  assertAlmostEquals(homeSample.lbOverall, 60, 0.001);
+});
+
+Deno.test("collectLbSamples allocates team tackles across LB starters", () => {
+  const home = team("home", [lb("home-lb1", 50), lb("home-lb2", 50)]);
+  const away = team("away", [lb("away-lb", 50)]);
+
+  // Home defends 10 successful offense plays => 10 team tackles.
+  const events: PlayEvent[] = [];
+  for (let i = 0; i < 10; i++) {
+    events.push(
+      event({ outcome: "rush", offenseTeamId: "away", yardage: 4 }),
+    );
+  }
+
+  const samples = collectLbSamples({
+    game: gameOf(events),
+    home,
+    away,
+  });
+
+  const homeSamples = samples.filter((s) => s.teamId === "home");
+  assertEquals(homeSamples.length, 2);
+  // Team tackles = 10, LB share = 0.45, split across 2 LBs => 2.25 each.
+  assertAlmostEquals(homeSamples[0].tackles_per_game, 2.25, 1e-6);
+  assertAlmostEquals(homeSamples[1].tackles_per_game, 2.25, 1e-6);
+
+  // Away team defended zero offense plays => 0 tackles.
+  const awaySample = samples.find((s) => s.teamId === "away")!;
+  assertEquals(awaySample.tackles_per_game, 0);
+});
+
+Deno.test("collectLbSamples counts TFLs (zero-or-negative-yardage rushes/completions)", () => {
+  const home = team("home", [lb("home-lb", 50)]);
+  const away = team("away", [lb("away-lb", 50)]);
+
+  const events: PlayEvent[] = [
+    event({ outcome: "rush", offenseTeamId: "away", yardage: -2 }),
+    event({ outcome: "rush", offenseTeamId: "away", yardage: 0 }),
+    event({ outcome: "rush", offenseTeamId: "away", yardage: 3 }),
+    event({
+      outcome: "pass_complete",
+      offenseTeamId: "away",
+      yardage: -1,
+    }),
+  ];
+
+  const [homeSample] = collectLbSamples({
+    game: gameOf(events),
+    home,
+    away,
+  });
+
+  // 3 TFLs (-2, 0, -1 yardage plays). Share = 0.45, 1 LB => 1.35.
+  assertAlmostEquals(homeSample.tfl_per_game, 3 * 0.45, 1e-6);
+});
+
+Deno.test("collectLbSamples excludes sacks from TFL count (owned by pass rush)", () => {
+  const home = team("home", [lb("home-lb", 50)]);
+  const away = team("away", [lb("away-lb", 50)]);
+
+  const events: PlayEvent[] = [
+    event({ outcome: "sack", offenseTeamId: "away", yardage: -7 }),
+    event({ outcome: "sack", offenseTeamId: "away", yardage: -5 }),
+  ];
+
+  const [homeSample] = collectLbSamples({
+    game: gameOf(events),
+    home,
+    away,
+  });
+
+  // Sacks shouldn't credit LB tackles or TFLs.
+  assertEquals(homeSample.tackles_per_game, 0);
+  assertEquals(homeSample.tfl_per_game, 0);
+});
+
+Deno.test("collectLbSamples attributes PBUs as a share of incompletes", () => {
+  const home = team("home", [lb("home-lb", 50)]);
+  const away = team("away", [lb("away-lb", 50)]);
+
+  // 10 incompletes => 10 * 0.4 = 4 team PBUs.
+  // LB share of PBUs = 0.3, single LB => 4 * 0.3 = 1.2 PBUs/game.
+  const events: PlayEvent[] = [];
+  for (let i = 0; i < 10; i++) {
+    events.push(
+      event({ outcome: "pass_incomplete", offenseTeamId: "away" }),
+    );
+  }
+
+  const [homeSample] = collectLbSamples({
+    game: gameOf(events),
+    home,
+    away,
+  });
+  assertAlmostEquals(homeSample.pbu_per_game, 1.2, 1e-6);
+});
+
+Deno.test("collectLbSamples isolates defense by team", () => {
+  const home = team("home", [lb("home-lb", 50)]);
+  const away = team("away", [lb("away-lb", 50)]);
+
+  const events: PlayEvent[] = [
+    event({ outcome: "rush", offenseTeamId: "away", yardage: 4 }), // home defends
+    event({ outcome: "rush", offenseTeamId: "home", yardage: 4 }), // away defends
+    event({ outcome: "rush", offenseTeamId: "home", yardage: 4 }), // away defends
+  ];
+
+  const samples = collectLbSamples({
+    game: gameOf(events),
+    home,
+    away,
+  });
+
+  const homeSample = samples.find((s) => s.teamId === "home")!;
+  const awaySample = samples.find((s) => s.teamId === "away")!;
+
+  // Home defended 1 play, away defended 2. Share 0.45, 1 LB each.
+  assertAlmostEquals(homeSample.tackles_per_game, 1 * 0.45, 1e-6);
+  assertAlmostEquals(awaySample.tackles_per_game, 2 * 0.45, 1e-6);
+});
+
+Deno.test("collectLbSamples returns the documented NFL-mean solo_tackle_rate constant", () => {
+  const home = team("home", [lb("home-lb", 50)]);
+  const away = team("away", [lb("away-lb", 50)]);
+
+  const [homeSample] = collectLbSamples({
+    game: gameOf([]),
+    home,
+    away,
+  });
+  // The sim doesn't distinguish solo vs. assisted tackles, so this is
+  // intentionally a constant (the NFL starter mean) — documented in
+  // lb-sample.ts as a gap to close once the engine logs tacklers.
+  assertAlmostEquals(homeSample.solo_tackle_rate, 0.56, 1e-6);
+});
+
+Deno.test("collectLbSamples counts fumbles as tackles with yardage-based TFL logic", () => {
+  const home = team("home", [lb("home-lb", 50)]);
+  const away = team("away", [lb("away-lb", 50)]);
+
+  const events: PlayEvent[] = [
+    event({ outcome: "fumble", offenseTeamId: "away", yardage: -3 }),
+  ];
+
+  const [homeSample] = collectLbSamples({
+    game: gameOf(events),
+    home,
+    away,
+  });
+  // 1 tackle (fumble => the ball-carrier was brought down) and 1 TFL.
+  assertAlmostEquals(homeSample.tackles_per_game, 1 * 0.45, 1e-6);
+  assertAlmostEquals(homeSample.tfl_per_game, 1 * 0.45, 1e-6);
+});

--- a/server/features/simulation/calibration/per-position/lb-sample.ts
+++ b/server/features/simulation/calibration/per-position/lb-sample.ts
@@ -1,0 +1,136 @@
+import type { GameResult, PlayEvent } from "../../events.ts";
+import type { SimTeam } from "../../simulate-game.ts";
+import { lbOverall } from "./lb-overall.ts";
+
+export interface LbGameSample {
+  teamId: string;
+  lbPlayerId: string;
+  lbOverall: number;
+  // Per-game allocated rates. The engine logs defender participants
+  // on sacks and interceptions only — routine tackles and pass
+  // break-ups aren't credited to a specific player. We therefore
+  // team-allocate team-defensive outcomes across the LB starters on
+  // the depth chart. The NFL fixture uses the same per-game grain
+  // (tackles/game, TFL/game, PBU/game) so bucket means remain
+  // directly comparable even with the allocation.
+  tackles_per_game: number;
+  tfl_per_game: number;
+  solo_tackle_rate: number;
+  pbu_per_game: number;
+}
+
+interface TeamDefensiveTotals {
+  teamTackles: number;
+  teamTfls: number;
+  teamPbus: number;
+}
+
+function accumulate(
+  events: PlayEvent[],
+  defenseTeamId: string,
+): TeamDefensiveTotals {
+  // The sim doesn't log per-tackle participants, so we proxy team
+  // defensive production from offense outcomes:
+  //   - rush / pass_complete / fumble => a tackle happened
+  //   - rush or pass_complete with yardage <= 0 => tackle for loss
+  //   - pass_incomplete => some share is a PBU (NFL-wide ~30-40% of
+  //     incompletions are defensed; 0.4 is the honest coefficient,
+  //     matching the S slice's convention).
+  // Sacks and TDs are skipped — sacks belong to the pass-rush
+  // (EDGE/IDL) side of the ledger, and TDs are defensive failures
+  // that shouldn't credit anyone with a tackle.
+  let teamTackles = 0;
+  let teamTfls = 0;
+  let teamPbus = 0;
+
+  const INCOMPLETE_PBU_SHARE = 0.4;
+
+  for (const event of events) {
+    if (event.defenseTeamId !== defenseTeamId) continue;
+
+    switch (event.outcome) {
+      case "rush":
+      case "pass_complete":
+        teamTackles++;
+        if (event.yardage <= 0) teamTfls++;
+        break;
+      case "pass_incomplete":
+        teamPbus += INCOMPLETE_PBU_SHARE;
+        break;
+      case "fumble":
+        teamTackles++;
+        if (event.yardage <= 0) teamTfls++;
+        break;
+      case "sack":
+        // Sack TFLs belong to the pass rushers (EDGE/IDL), not to
+        // off-ball LBs. Skip them when counting LB TFLs.
+        break;
+      case "touchdown":
+      case "interception":
+        break;
+    }
+  }
+
+  return { teamTackles, teamTfls, teamPbus };
+}
+
+export interface LbSampleInput {
+  game: GameResult;
+  home: SimTeam;
+  away: SimTeam;
+}
+
+// Share of a team's defensive tackles/TFLs/PBUs that off-ball
+// linebackers absorb. NFL box scores typically put LB tackle share at
+// ~40-50% of team totals (the front seven + second level account for
+// the bulk of tackles, with the secondary picking up the rest).
+// Picking 0.45 as the centerpiece gives the 50-overall LB bucket a
+// realistic tackles/game line without over-inflating LB production
+// at the expense of the safety / CB calibration slices.
+const LB_SHARE_OF_TEAM_TACKLES = 0.45;
+const LB_SHARE_OF_TEAM_PBUS = 0.3;
+
+// Solo-tackle rate is a pure attribute of the LB, not a team-level
+// allocation: the sim doesn't model solo vs. assisted tackles at all,
+// so we return the NFL-wide starter mean (~0.56 across the bands in
+// `lb.json`) and let the bucket summary compare that constant against
+// the fixture. This is a deliberate gap: the sim will never move on
+// solo_tackle_rate until the engine logs per-play tacklers. Documented
+// so future slices can replace it.
+const NFL_STARTER_SOLO_RATE = 0.56;
+
+// Attribute a team-game's front-seven production across the team's
+// LB starters. The engine puts every LB on the field for every snap,
+// so an even split across starters matches the "each LB carries 1/N
+// of the team's LB workload" assumption. If the engine later logs
+// per-tackle participants we can replace this with direct attribution
+// via `participants[].tags.includes("tackle")`.
+export function collectLbSamples(input: LbSampleInput): LbGameSample[] {
+  const { game, home, away } = input;
+  const samples: LbGameSample[] = [];
+
+  for (const team of [home, away]) {
+    const lbs = team.starters.filter((p) => p.neutralBucket === "LB");
+    if (lbs.length === 0) continue;
+
+    const totals = accumulate(game.events, team.teamId);
+    const perLb = lbs.length;
+    const tacklesPerLb = (totals.teamTackles * LB_SHARE_OF_TEAM_TACKLES) /
+      perLb;
+    const tflPerLb = (totals.teamTfls * LB_SHARE_OF_TEAM_TACKLES) / perLb;
+    const pbuPerLb = (totals.teamPbus * LB_SHARE_OF_TEAM_PBUS) / perLb;
+
+    for (const lb of lbs) {
+      samples.push({
+        teamId: team.teamId,
+        lbPlayerId: lb.playerId,
+        lbOverall: lbOverall(lb.attributes),
+        tackles_per_game: tacklesPerLb,
+        tfl_per_game: tflPerLb,
+        solo_tackle_rate: NFL_STARTER_SOLO_RATE,
+        pbu_per_game: pbuPerLb,
+      });
+    }
+  }
+  return samples;
+}

--- a/server/features/simulation/calibration/per-position/run-lb-calibration.ts
+++ b/server/features/simulation/calibration/per-position/run-lb-calibration.ts
@@ -1,0 +1,61 @@
+import { simulateGame } from "../../simulate-game.ts";
+import { generateCalibrationLeague } from "../generate-calibration-league.ts";
+import { CALIBRATION_SEEDS } from "../calibration-seeds.ts";
+import { formatLbCalibrationReport, runLbCalibration } from "./lb-harness.ts";
+
+// Per-issue-#496: report-only across every calibration seed so a human
+// can read the per-bucket PASS/FAIL signal against NFL LB percentile
+// bands. Gating will come later once we understand per-bucket noise.
+const bandPath = new URL(
+  "../../../../../data/bands/per-position/lb.json",
+  import.meta.url,
+);
+
+const bandJson = await Deno.readTextFile(bandPath);
+
+let allPassed = true;
+const summary: {
+  seed: number;
+  passed: number;
+  total: number;
+  underSampled: number;
+}[] = [];
+
+for (const seed of CALIBRATION_SEEDS) {
+  const league = generateCalibrationLeague({ seed });
+  const report = runLbCalibration({
+    bandJson,
+    league,
+    simulate: simulateGame,
+  });
+
+  console.log(`=== seed=0x${seed.toString(16)} ===`);
+  console.log(formatLbCalibrationReport(report));
+  console.log("");
+
+  const totalChecks = report.buckets.reduce(
+    (sum, b) => sum + b.checks.length,
+    0,
+  );
+  const passCount = totalChecks - report.failures.length;
+  const underSampled = report.buckets.filter((b) => b.underSampled).length;
+  summary.push({ seed, passed: passCount, total: totalChecks, underSampled });
+  if (!report.passed) allPassed = false;
+}
+
+console.log("=== Multi-seed summary ===");
+for (const row of summary) {
+  const status = row.passed === row.total ? "PASS" : "FAIL";
+  const underSampledNote = row.underSampled > 0
+    ? ` (${row.underSampled} bucket(s) under-sampled)`
+    : "";
+  console.log(
+    `${status} seed=0x${
+      row.seed.toString(16)
+    }: ${row.passed}/${row.total}${underSampledNote}`,
+  );
+}
+
+if (!allPassed) {
+  Deno.exit(1);
+}


### PR DESCRIPTION
## Summary

Implements the LB slice of #496 — mirrors the QB harness from #497 and the RB harness in #500 for off-ball linebackers. Tags every sim LB-game with the starter's overall (mean of `blockShedding`, `tackling`, `runDefense`, `zoneCoverage`, `footballIq`, `anticipation`), buckets samples into 10-point bands (30/40/50/60/70/80), and compares each bucket's mean stat line (tackles/gm, TFL/gm, PBU/gm, solo tackle rate) to NFL LB percentile bands.

- `data/R/bands/per-position-lb.R` pulls per-LB-season defensive stats (2020-2024, >=10 games, >=40 tackles) from `nflreadr`, excludes edge-rushing OLBs (sacks/game >= 0.4) since Zone Blitz models them in the EDGE bucket, ranks starters by a composite (tackles/gm + 2 * TFL/gm + 2 * PBU/gm), and carves the population into five percentile bands with mean+sd per metric.
- `data/bands/per-position/lb.json` is the generated fixture (461 LB-seasons after filters).
- `server/features/simulation/calibration/per-position/` gains `lb-overall`, `lb-sample`, `lb-harness`, `run-lb-calibration`. Reuses the existing `bucket-by-attr`, `band-loader`, `band-check` modules. Unit-test coverage ~98% lines on the new files.
- `deno task sim:calibrate:lb` runs the harness across every calibration seed.

Report-only for now per issue #496 — we want to read the per-bucket noise before layering on gating.

## Notes

A multi-seed run surfaces real calibration gaps that matter:

- **Tackles/gm is flat across every bucket (~6.7-6.9).** Elite and replacement LBs produce nearly identical tackle lines because the team-allocation approach (`tackles * 0.45 / N_lbs`) has no per-LB attribute signal. Low buckets come in above NFL replacement (3.0/gm) and high buckets come in well below NFL elite (8.8/gm). Closing this gap requires per-play tackler logging in the engine — documented in `lb-sample.ts`.
- **TFL/gm runs ~10x lower than NFL across every bucket.** Sim TFLs sit at ~0.03-0.12/gm vs. NFL 0.19-0.46. The sim's run outcomes rarely produce zero-or-negative yardage rushes (stuff threshold), so there are almost no TFL opportunities to allocate. Real engine tuning gap.
- **PBU/gm is too high and flat (~0.4/gm).** The 0.4 PBU-on-incomplete coefficient plus team-level allocation over-credits LBs across the board — elite LBs land on band, replacement-tier LBs massively overshoot.
- **30-overall bucket is under-sampled on some seeds.** LB generator rolls rarely land below 35, matching the RB slice finding.
- **Solo tackle rate is a constant (0.56, NFL starter mean).** The sim doesn't distinguish solo vs. assisted tackles at all — intentionally returned as a fixed value and documented as a gap.

Those become tracked follow-ups as `gh issue create` once this slice merges. Subsequent slices (WR/CB/TE/S, matchup harness) will follow as separate PRs per the issue's rollout plan.