### PR TITLE
feat(calibration): add per-IDL-bucket calibration harness (#496, IDL slice)

### DIFF
--- a/data/R/bands/per-position-idl.R
+++ b/data/R/bands/per-position-idl.R
@@ -1,0 +1,231 @@
+#!/usr/bin/env Rscript
+# per-position-idl.R — NFL interior-DL (DT/NT) percentile-band reference.
+#
+# ** PROXY-METRIC CAVEAT **
+# nflreadr (and the public nflverse stream more broadly) does NOT carry PFF
+# pass-rush or run-defense grades. Those are the grades that actually
+# separate a dominant interior DL (Aaron Donald / Chris Jones) from a
+# rotational plugger who posts similar box-score numbers on a worse front.
+# This v1 band uses counting stats only — sacks, QB hits, TFLs, and total
+# tackles — as proxies for "how disruptive was this interior DL this
+# season?". That has several known limitations that calibration consumers
+# need to keep in mind:
+#   * A stout 1-tech NT who eats double teams and frees up the LBs will
+#     look statistically indistinguishable from a replacement-level DT,
+#     because eating blocks doesn't show up in the box score.
+#   * Pass-rush win rate is invisible: pressures that don't finish as
+#     sacks or QB hits disappear entirely.
+#   * EDGE rushers and off-ball LBs pad their tackle/TFL totals for free
+#     on runs that bounce outside; the IDL only gets credited when they
+#     finish the play, so the interior tackle counts under-represent
+#     actual run-stopping contribution.
+# Upgrade path: once we have a PFF-grade licensing story (or a decent
+# public approximation — ESPN pass-rush win rate, PFR adv-def splits, etc.)
+# this script should switch its ranking stat from the counting-stat
+# composite to a grade-based one and re-carve the bands. Documented on
+# the PR that introduced this file so follow-up work can find it.
+#
+# What this script does:
+#   - Pulls weekly defensive player stats from load_player_stats.
+#   - Filters to position %in% c("DT", "NT"). nflverse uses NT as a
+#     distinct label from DT so both need to be included.
+#   - Aggregates to per-IDL-season totals. Starter threshold uses snap
+#     counts ( >= 400 defensive snaps, roughly 24 snaps/game over a 17
+#     game season) rather than raw games played; counting-stat totals
+#     need a minimum workload denominator to not be dominated by backups
+#     who caught one sack in a cameo appearance.
+#   - Computes per-game rates (sacks_per_game, qb_hits_per_game,
+#     tfl_per_game, tackles_per_game) because the sim emits per-game
+#     samples and the NFL reference should live at the same grain.
+#   - Ranks by a z-scored composite of those four per-game rates. A
+#     composite is necessary because no single counting stat cleanly
+#     separates tiers the way EPA/play does for QB — sacks reward
+#     pass-rush specialists, tackles reward space eaters, and neither
+#     on its own would bucket the Aaron Donalds above the Jonathan
+#     Allens.
+#   - Carves the starter population into five percentile bands
+#     (elite / good / average / weak / replacement) and reports mean+sd
+#     per metric.
+#
+# Output: data/bands/per-position/idl.json
+#
+# Usage:
+#   Rscript data/R/bands/per-position-idl.R [--seasons 2020:2024]
+
+suppressPackageStartupMessages({
+  library(nflreadr)
+  library(dplyr)
+})
+
+script_file <- (function() {
+  args <- commandArgs(trailingOnly = FALSE)
+  f <- grep("^--file=", args, value = TRUE)
+  if (length(f) > 0) normalizePath(sub("^--file=", "", f[1]), mustWork = FALSE) else NULL
+})()
+source(file.path(dirname(script_file), "..", "lib.R"))
+
+args <- commandArgs(trailingOnly = TRUE)
+seasons <- parse_seasons(args)
+
+cat("Loading weekly player stats for seasons:",
+    paste(range(seasons), collapse = "-"), "\n")
+
+weekly <- nflreadr::load_player_stats(seasons, stat_type = "defense")
+
+# Snap counts aren't in load_player_stats — they come from the
+# load_snap_counts loader. Pull them so we can apply a starter
+# filter that's more discriminating than "played >= N games".
+cat("Loading snap counts\n")
+snaps <- nflreadr::load_snap_counts(seasons) |>
+  filter(game_type == "REG") |>
+  group_by(pfr_player_id, season) |>
+  summarise(
+    def_snaps = sum(defense_snaps, na.rm = TRUE),
+    games     = n(),
+    .groups   = "drop"
+  )
+
+idl_weekly <- weekly |>
+  filter(season_type == "REG", position %in% c("DT", "NT"))
+
+# Aggregate weekly rows into per-IDL-season totals. Every metric below
+# uses "per game" as its cadence — see top-of-file note on sim grain.
+idl_season <- idl_weekly |>
+  group_by(player_id, player_display_name, position, season) |>
+  summarise(
+    weeks_played      = n(),
+    tackles_solo      = sum(def_tackles_solo, na.rm = TRUE),
+    tackles_assisted  = sum(def_tackle_assists, na.rm = TRUE),
+    tackles_for_loss  = sum(def_tackles_for_loss, na.rm = TRUE),
+    sacks             = sum(def_sacks, na.rm = TRUE),
+    qb_hits           = sum(def_qb_hits, na.rm = TRUE),
+    .groups           = "drop"
+  ) |>
+  mutate(
+    tackles_total = tackles_solo + tackles_assisted
+  )
+
+# Join snap counts via gsis_it_id -> pfr_player_id mapping. load_players
+# gives us the crosswalk.
+cat("Loading player crosswalk\n")
+players <- nflreadr::load_players() |>
+  select(gsis_id, pfr_id)
+
+idl_season <- idl_season |>
+  left_join(players, by = c("player_id" = "gsis_id")) |>
+  left_join(snaps, by = c("pfr_id" = "pfr_player_id", "season" = "season")) |>
+  mutate(
+    # Fall back to weeks_played when snap counts are missing so we don't
+    # silently drop a player — flag them via def_snaps = NA instead so
+    # the starter filter excludes them explicitly.
+    games = ifelse(is.na(games), weeks_played, games)
+  ) |>
+  filter(!is.na(def_snaps), def_snaps >= 400, games > 0)
+
+cat("IDL-seasons after starter filter (def_snaps >= 400):",
+    nrow(idl_season), "\n")
+
+idl_season <- idl_season |>
+  mutate(
+    sacks_per_game    = sacks / games,
+    qb_hits_per_game  = qb_hits / games,
+    tfl_per_game      = tackles_for_loss / games,
+    tackles_per_game  = tackles_total / games
+  )
+
+# Composite ranking: z-score each per-game rate across the starter pop,
+# then sum. Equal weights — no principled reason to weight sacks above
+# TFLs when we're already admitting this is a proxy. Documented so it
+# can be swapped for PFF grades later.
+zscore <- function(x) {
+  mu <- mean(x, na.rm = TRUE)
+  sd <- stats::sd(x, na.rm = TRUE)
+  if (is.na(sd) || sd == 0) return(rep(0, length(x)))
+  (x - mu) / sd
+}
+
+idl_ranked <- idl_season |>
+  mutate(
+    composite = zscore(sacks_per_game) +
+                zscore(qb_hits_per_game) +
+                zscore(tfl_per_game) +
+                zscore(tackles_per_game)
+  ) |>
+  arrange(desc(composite)) |>
+  mutate(
+    pct = (row_number() - 0.5) / n(),
+    band = case_when(
+      pct <= 0.10 ~ "elite",
+      pct <= 0.30 ~ "good",
+      pct <= 0.70 ~ "average",
+      pct <= 0.90 ~ "weak",
+      TRUE        ~ "replacement"
+    )
+  )
+
+metric_keys <- c(
+  "sacks_per_game",
+  "qb_hits_per_game",
+  "tfl_per_game",
+  "tackles_per_game"
+)
+
+band_order <- c("elite", "good", "average", "weak", "replacement")
+
+band_summary <- function(rows) {
+  metrics <- list()
+  for (key in metric_keys) {
+    vals <- rows[[key]]
+    vals <- vals[!is.na(vals)]
+    metrics[[key]] <- list(
+      n = length(vals),
+      mean = mean(vals),
+      sd = stats::sd(vals)
+    )
+  }
+  list(
+    n = nrow(rows),
+    metrics = metrics
+  )
+}
+
+bands <- list()
+for (band_name in band_order) {
+  rows <- idl_ranked |> filter(band == band_name)
+  bands[[band_name]] <- band_summary(rows)
+}
+
+out <- list(
+  generated_at = format(Sys.time(), "%Y-%m-%dT%H:%M:%SZ", tz = "UTC"),
+  seasons = as.integer(seasons),
+  position = "IDL",
+  qualifier = "regular-season DT/NT-seasons with >=400 defensive snaps",
+  ranking_stat = "composite z-score of sacks/gm + qb_hits/gm + tfl/gm + tackles/gm",
+  notes = paste0(
+    "PROXY-METRIC v1 — nflreadr does not carry PFF pass-rush / run-defense ",
+    "grades, so this band ranks interior DL (DT + NT) by a counting-stat ",
+    "composite instead of true disruption rate. Known gaps: space-eating ",
+    "1-tech NTs who draw double teams will under-score versus 3-techs who ",
+    "finish tackles; pressures that don't finish as sacks/QB-hits are ",
+    "invisible. Starter threshold is >=400 regular-season defensive snaps ",
+    "(via load_snap_counts). Ranking composite is the z-score sum of ",
+    "sacks/game + qb_hits/game + tfl/game + tackles/game across the ",
+    "starter population. Bands are percentile carves of that composite ",
+    "(elite: top 10%, good: 10-30%, average: 30-70%, weak: 70-90%, ",
+    "replacement: bottom 10%). Each band reports mean+sd per metric over ",
+    "the IDL-seasons in that band. Upgrade path once PFF grades are ",
+    "available: swap the ranking stat for grade and re-carve."
+  ),
+  bands = bands
+)
+
+out_path <- file.path(
+  repo_root(), "data", "bands", "per-position", "idl.json"
+)
+dir.create(dirname(out_path), recursive = TRUE, showWarnings = FALSE)
+writeLines(
+  jsonlite::toJSON(out, auto_unbox = TRUE, pretty = TRUE, digits = 4,
+                   null = "null"),
+  out_path
+)
+cat("Wrote", out_path, "\n")

--- a/data/bands/per-position/idl.json
+++ b/data/bands/per-position/idl.json
@@ -1,0 +1,135 @@
+{
+  "generated_at": "2026-04-17T12:30:32Z",
+  "seasons": [2021, 2022, 2023, 2024, 2025],
+  "position": "IDL",
+  "qualifier": "regular-season DT/NT-seasons with >=400 defensive snaps",
+  "ranking_stat": "composite z-score of sacks/gm + qb_hits/gm + tfl/gm + tackles/gm",
+  "notes": "PROXY-METRIC v1 — nflreadr does not carry PFF pass-rush / run-defense grades, so this band ranks interior DL (DT + NT) by a counting-stat composite instead of true disruption rate. Known gaps: space-eating 1-tech NTs who draw double teams will under-score versus 3-techs who finish tackles; pressures that don't finish as sacks/QB-hits are invisible. Starter threshold is >=400 regular-season defensive snaps (via load_snap_counts). Ranking composite is the z-score sum of sacks/game + qb_hits/game + tfl/game + tackles/game across the starter population. Bands are percentile carves of that composite (elite: top 10%, good: 10-30%, average: 30-70%, weak: 70-90%, replacement: bottom 10%). Each band reports mean+sd per metric over the IDL-seasons in that band. Upgrade path once PFF grades are available: swap the ranking stat for grade and re-carve.",
+  "bands": {
+    "elite": {
+      "n": 32,
+      "metrics": {
+        "sacks_per_game": {
+          "n": 32,
+          "mean": 0.5311,
+          "sd": 0.1468
+        },
+        "qb_hits_per_game": {
+          "n": 32,
+          "mean": 1.1738,
+          "sd": 0.3224
+        },
+        "tfl_per_game": {
+          "n": 32,
+          "mean": 0.681,
+          "sd": 0.1519
+        },
+        "tackles_per_game": {
+          "n": 32,
+          "mean": 3.5389,
+          "sd": 0.7303
+        }
+      }
+    },
+    "good": {
+      "n": 65,
+      "metrics": {
+        "sacks_per_game": {
+          "n": 65,
+          "mean": 0.3144,
+          "sd": 0.0961
+        },
+        "qb_hits_per_game": {
+          "n": 65,
+          "mean": 0.7811,
+          "sd": 0.2625
+        },
+        "tfl_per_game": {
+          "n": 65,
+          "mean": 0.4389,
+          "sd": 0.1306
+        },
+        "tackles_per_game": {
+          "n": 65,
+          "mean": 2.7734,
+          "sd": 0.6724
+        }
+      }
+    },
+    "average": {
+      "n": 130,
+      "metrics": {
+        "sacks_per_game": {
+          "n": 130,
+          "mean": 0.1537,
+          "sd": 0.0799
+        },
+        "qb_hits_per_game": {
+          "n": 130,
+          "mean": 0.4413,
+          "sd": 0.2009
+        },
+        "tfl_per_game": {
+          "n": 130,
+          "mean": 0.26,
+          "sd": 0.1155
+        },
+        "tackles_per_game": {
+          "n": 130,
+          "mean": 2.3988,
+          "sd": 0.5289
+        }
+      }
+    },
+    "weak": {
+      "n": 65,
+      "metrics": {
+        "sacks_per_game": {
+          "n": 65,
+          "mean": 0.0626,
+          "sd": 0.0462
+        },
+        "qb_hits_per_game": {
+          "n": 65,
+          "mean": 0.2256,
+          "sd": 0.1373
+        },
+        "tfl_per_game": {
+          "n": 65,
+          "mean": 0.1473,
+          "sd": 0.077
+        },
+        "tackles_per_game": {
+          "n": 65,
+          "mean": 2.0067,
+          "sd": 0.5138
+        }
+      }
+    },
+    "replacement": {
+      "n": 32,
+      "metrics": {
+        "sacks_per_game": {
+          "n": 32,
+          "mean": 0.029,
+          "sd": 0.0362
+        },
+        "qb_hits_per_game": {
+          "n": 32,
+          "mean": 0.1484,
+          "sd": 0.1021
+        },
+        "tfl_per_game": {
+          "n": 32,
+          "mean": 0.07,
+          "sd": 0.0595
+        },
+        "tackles_per_game": {
+          "n": 32,
+          "mean": 1.4141,
+          "sd": 0.389
+        }
+      }
+    }
+  }
+}

--- a/deno.json
+++ b/deno.json
@@ -44,6 +44,7 @@
     "sim:calibrate:iol": "deno run --allow-read server/features/simulation/calibration/per-position/run-iol-calibration.ts",
     "sim:calibrate:ot": "deno run --allow-read server/features/simulation/calibration/per-position/run-ot-calibration.ts",
     "sim:calibrate:lb": "deno run --allow-read server/features/simulation/calibration/per-position/run-lb-calibration.ts",
+    "sim:calibrate:idl": "deno run --allow-read server/features/simulation/calibration/per-position/run-idl-calibration.ts",
     "build": "cd client && deno task build",
     "start": "cd server && deno run --env=../.env --allow-net --allow-env --allow-read --allow-sys main.ts"
   },

--- a/server/features/simulation/calibration/per-position/idl-harness.test.ts
+++ b/server/features/simulation/calibration/per-position/idl-harness.test.ts
@@ -1,0 +1,313 @@
+import { assertEquals, assertStringIncludes } from "@std/assert";
+import type { PlayerAttributes } from "@zone-blitz/shared";
+import {
+  formatIdlCalibrationReport,
+  runIdlCalibration,
+} from "./idl-harness.ts";
+import type { GameResult, PlayEvent } from "../../events.ts";
+import type { SimTeam } from "../../simulate-game.ts";
+import type { PlayerRuntime } from "../../resolve-play.ts";
+import type { CalibrationLeague } from "../generate-calibration-league.ts";
+
+function attrs(overrides: Partial<PlayerAttributes> = {}): PlayerAttributes {
+  const base: Record<string, number> = {};
+  const keys = [
+    "speed",
+    "acceleration",
+    "agility",
+    "strength",
+    "jumping",
+    "stamina",
+    "durability",
+    "armStrength",
+    "accuracyShort",
+    "accuracyMedium",
+    "accuracyDeep",
+    "accuracyOnTheRun",
+    "touch",
+    "release",
+    "ballCarrying",
+    "elusiveness",
+    "routeRunning",
+    "catching",
+    "contestedCatching",
+    "runAfterCatch",
+    "passBlocking",
+    "runBlocking",
+    "blockShedding",
+    "tackling",
+    "manCoverage",
+    "zoneCoverage",
+    "passRushing",
+    "runDefense",
+    "kickingPower",
+    "kickingAccuracy",
+    "puntingPower",
+    "puntingAccuracy",
+    "snapAccuracy",
+    "footballIq",
+    "decisionMaking",
+    "anticipation",
+    "composure",
+    "clutch",
+    "consistency",
+    "workEthic",
+    "coachability",
+    "leadership",
+    "greed",
+    "loyalty",
+    "ambition",
+    "vanity",
+    "schemeAttachment",
+    "mediaSensitivity",
+  ];
+  for (const k of keys) {
+    base[k] = 50;
+    base[`${k}Potential`] = 50;
+  }
+  return { ...(base as unknown as PlayerAttributes), ...overrides };
+}
+
+function idlRuntime(id: string, overall: number): PlayerRuntime {
+  return {
+    playerId: id,
+    neutralBucket: "IDL",
+    attributes: attrs({
+      passRushing: overall,
+      strength: overall,
+      blockShedding: overall,
+      runDefense: overall,
+      tackling: overall,
+    }),
+  };
+}
+
+function team(teamId: string, starters: PlayerRuntime[]): SimTeam {
+  return {
+    teamId,
+    starters,
+    bench: [],
+    fingerprint: { offense: null, defense: null, overrides: {} },
+    coachingMods: {
+      schemeFitBonus: 0,
+      situationalBonus: 0,
+      aggressiveness: 50,
+      penaltyDiscipline: 1,
+    },
+  };
+}
+
+function bandJson(): string {
+  const band = (sacks: number, tackles: number) => ({
+    n: 20,
+    metrics: {
+      sacks_per_game: { n: 20, mean: sacks, sd: 0.1 },
+      qb_hits_per_game: { n: 20, mean: sacks * 2, sd: 0.2 },
+      tfl_per_game: { n: 20, mean: sacks, sd: 0.1 },
+      tackles_per_game: { n: 20, mean: tackles, sd: 0.5 },
+    },
+  });
+  return JSON.stringify({
+    position: "IDL",
+    seasons: [2021, 2022, 2023, 2024, 2025],
+    ranking_stat: "composite z-score",
+    bands: {
+      elite: band(0.5, 3.5),
+      good: band(0.3, 2.8),
+      average: band(0.15, 2.4),
+      weak: band(0.06, 2.0),
+      replacement: band(0.03, 1.4),
+    },
+  });
+}
+
+function makeGame(
+  gameId: string,
+  homeTeamId: string,
+  awayTeamId: string,
+  sacksByDefendingTeam: Record<string, { defenderId: string; count: number }>,
+): GameResult {
+  const events: PlayEvent[] = [];
+  for (
+    const [defenseTeamId, spec] of Object.entries(sacksByDefendingTeam)
+  ) {
+    const offenseTeamId = defenseTeamId === homeTeamId
+      ? awayTeamId
+      : homeTeamId;
+    for (let i = 0; i < spec.count; i++) {
+      events.push({
+        gameId,
+        driveIndex: 0,
+        playIndex: events.length,
+        quarter: 1,
+        clock: "15:00",
+        situation: { down: 1, distance: 10, yardLine: 25 },
+        offenseTeamId,
+        defenseTeamId,
+        call: {
+          concept: "dropback",
+          personnel: "11",
+          formation: "shotgun",
+          motion: "none",
+        },
+        coverage: { front: "4-3", coverage: "cover_2", pressure: "four_man" },
+        participants: [
+          { role: "pass_rush", playerId: spec.defenderId, tags: ["sack"] },
+        ],
+        outcome: "sack",
+        yardage: -6,
+        tags: ["sack"],
+      });
+    }
+  }
+  return {
+    gameId,
+    seed: 1,
+    finalScore: { home: 0, away: 0 },
+    events,
+    boxScore: {
+      home: {
+        totalYards: 0,
+        passingYards: 0,
+        rushingYards: 0,
+        turnovers: 0,
+        sacks: 0,
+        penalties: 0,
+      },
+      away: {
+        totalYards: 0,
+        passingYards: 0,
+        rushingYards: 0,
+        turnovers: 0,
+        sacks: 0,
+        penalties: 0,
+      },
+    },
+    driveLog: [],
+    injuryReport: [],
+  };
+}
+
+Deno.test("runIdlCalibration runs the sim, buckets IDLs, and returns a populated report", () => {
+  // One team per bucket — each team's two starter IDLs are at the
+  // same overall so both map to the same bucket label.
+  const overalls = [30, 40, 50, 60, 70, 80] as const;
+  const teams: SimTeam[] = overalls.map((o) =>
+    team(`t${o}`, [
+      idlRuntime(`t${o}-idl1`, o),
+      idlRuntime(`t${o}-idl2`, o),
+    ])
+  );
+  const sacksByOverall: Record<number, number> = {
+    30: 0.03,
+    40: 0.06,
+    50: 0.15,
+    60: 0.3,
+    70: 0.5,
+    80: 0.5,
+  };
+  const league: CalibrationLeague = { calibrationSeed: 1, teams };
+
+  const simulate = (
+    { home, away, gameId }: {
+      home: SimTeam;
+      away: SimTeam;
+      seed: number;
+      gameId: string;
+    },
+  ): GameResult => {
+    const homeOverall = Number(home.teamId.slice(1));
+    const awayOverall = Number(away.teamId.slice(1));
+    // Simple mapping: expected sacks/game = bucket target * #starters,
+    // so dividing by #starters (2) lands each IDL on its band mean.
+    return makeGame(gameId, home.teamId, away.teamId, {
+      [home.teamId]: {
+        defenderId: `${home.teamId}-idl1`,
+        count: Math.round(sacksByOverall[homeOverall] * 2),
+      },
+      [away.teamId]: {
+        defenderId: `${away.teamId}-idl1`,
+        count: Math.round(sacksByOverall[awayOverall] * 2),
+      },
+    });
+  };
+
+  const report = runIdlCalibration({
+    bandJson: bandJson(),
+    league,
+    simulate,
+    gameCount: teams.length * 12,
+    minSamplesPerBucket: 5,
+  });
+
+  assertEquals(report.totalGames, teams.length * 12);
+  // Each matchup produces 4 samples (2 IDL starters per team × 2 teams).
+  assertEquals(report.totalSamples, report.totalGames * 4);
+
+  const fifty = report.buckets.find((b) => b.bucketLabel === "50")!;
+  assertEquals(fifty.samples > 0, true);
+  assertEquals(fifty.underSampled, false);
+  assertEquals(fifty.checks.length > 0, true);
+});
+
+Deno.test("runIdlCalibration marks a bucket under-sampled when below min threshold", () => {
+  const teams: SimTeam[] = [
+    team("t50", [idlRuntime("t50-idl1", 50), idlRuntime("t50-idl2", 50)]),
+  ];
+  const league: CalibrationLeague = { calibrationSeed: 1, teams };
+  const simulate = (
+    { home, away, gameId }: {
+      home: SimTeam;
+      away: SimTeam;
+      seed: number;
+      gameId: string;
+    },
+  ) =>
+    makeGame(gameId, home.teamId, away.teamId, {
+      [home.teamId]: { defenderId: `${home.teamId}-idl1`, count: 1 },
+      [away.teamId]: { defenderId: `${away.teamId}-idl1`, count: 1 },
+    });
+
+  const report = runIdlCalibration({
+    bandJson: bandJson(),
+    league,
+    simulate,
+    gameCount: 1,
+    minSamplesPerBucket: 100,
+  });
+
+  const fifty = report.buckets.find((b) => b.bucketLabel === "50")!;
+  assertEquals(fifty.underSampled, true);
+  assertEquals(fifty.checks.length, 0);
+});
+
+Deno.test("formatIdlCalibrationReport renders a human-readable summary", () => {
+  const teams: SimTeam[] = [
+    team("t50", [idlRuntime("t50-idl1", 50), idlRuntime("t50-idl2", 50)]),
+  ];
+  const league: CalibrationLeague = { calibrationSeed: 1, teams };
+  const simulate = (
+    { home, away, gameId }: {
+      home: SimTeam;
+      away: SimTeam;
+      seed: number;
+      gameId: string;
+    },
+  ) =>
+    makeGame(gameId, home.teamId, away.teamId, {
+      [home.teamId]: { defenderId: `${home.teamId}-idl1`, count: 1 },
+      [away.teamId]: { defenderId: `${away.teamId}-idl1`, count: 1 },
+    });
+
+  const report = runIdlCalibration({
+    bandJson: bandJson(),
+    league,
+    simulate,
+    gameCount: 100,
+    minSamplesPerBucket: 1,
+  });
+  const output = formatIdlCalibrationReport(report);
+  assertStringIncludes(output, "IDL calibration");
+  assertStringIncludes(output, "bucket 50");
+  assertStringIncludes(output, "sacks_per_game");
+});

--- a/server/features/simulation/calibration/per-position/idl-harness.ts
+++ b/server/features/simulation/calibration/per-position/idl-harness.ts
@@ -1,0 +1,174 @@
+import { deriveGameSeed } from "../../rng.ts";
+import { CALIBRATION_GAME_COUNT } from "../constants.ts";
+import { generateMatchups } from "../harness.ts";
+import type { SimulateFn } from "../harness.ts";
+import type { CalibrationLeague } from "../generate-calibration-league.ts";
+import { collectIdlSamples, type IdlGameSample } from "./idl-sample.ts";
+import { bucketByAttr, type BucketReport } from "./bucket-by-attr.ts";
+import { type BandCheckResult, checkBand } from "./band-check.ts";
+import { loadPositionBands, type PositionBands } from "./band-loader.ts";
+
+// Headline interior-DL metrics. All four are proxy counting stats —
+// see `per-position-idl.R` and the attribution gap note in
+// `idl-sample.ts` for limitations. Sacks are the only truly
+// per-defender number; the rest are team-allocated and will look
+// inflated until the engine logs per-defender tackles / TFLs / QB
+// hits.
+export const IDL_METRICS = [
+  "sacks_per_game",
+  "qb_hits_per_game",
+  "tfl_per_game",
+  "tackles_per_game",
+] as const;
+
+export type IdlMetric = typeof IDL_METRICS[number];
+
+const METRIC_EXTRACTORS: Record<IdlMetric, (s: IdlGameSample) => number> = {
+  sacks_per_game: (s) => s.sacks_per_game,
+  qb_hits_per_game: (s) => s.qb_hits_per_game,
+  tfl_per_game: (s) => s.tfl_per_game,
+  tackles_per_game: (s) => s.tackles_per_game,
+};
+
+export interface IdlCalibrationOptions {
+  bandJson: string;
+  league: CalibrationLeague;
+  simulate: SimulateFn;
+  gameCount?: number;
+  // Minimum samples per bucket before we trust a band check. Under
+  // this count we still emit the summary but flag it as under-sampled
+  // so the report distinguishes "bucket is empty/noisy" from "bucket
+  // is calibrated wrong".
+  minSamplesPerBucket?: number;
+}
+
+export interface IdlBucketReport {
+  bucketLabel: string;
+  bucketCenter: number;
+  samples: number;
+  underSampled: boolean;
+  checks: BandCheckResult[];
+}
+
+export interface IdlCalibrationReport {
+  totalGames: number;
+  totalSamples: number;
+  bands: PositionBands;
+  buckets: IdlBucketReport[];
+  failures: BandCheckResult[];
+  passed: boolean;
+}
+
+const DEFAULT_MIN_SAMPLES = 50;
+
+export function runIdlCalibration(
+  options: IdlCalibrationOptions,
+): IdlCalibrationReport {
+  const {
+    bandJson,
+    league,
+    simulate,
+    gameCount = CALIBRATION_GAME_COUNT,
+    minSamplesPerBucket = DEFAULT_MIN_SAMPLES,
+  } = options;
+
+  const bands = loadPositionBands(bandJson);
+  const teamById = new Map(league.teams.map((t) => [t.teamId, t]));
+  const matchups = generateMatchups(league.teams, gameCount);
+
+  const samples: IdlGameSample[] = [];
+
+  for (let i = 0; i < matchups.length; i++) {
+    const { home, away } = matchups[i];
+    const gameId = `idl-calibration-game-${i}`;
+    const seed = deriveGameSeed(league.calibrationSeed, gameId);
+
+    const result = simulate({ home, away, seed, gameId });
+    const gameSamples = collectIdlSamples({
+      game: result,
+      home: teamById.get(home.teamId) ?? home,
+      away: teamById.get(away.teamId) ?? away,
+    });
+    samples.push(...gameSamples);
+  }
+
+  const bucketReports: BucketReport<IdlGameSample>[] = bucketByAttr({
+    samples,
+    attr: (s) => s.idlOverall,
+    metrics: METRIC_EXTRACTORS,
+  });
+
+  const buckets: IdlBucketReport[] = bucketReports.map((report) => {
+    const underSampled = report.samples.length < minSamplesPerBucket;
+    const checks: BandCheckResult[] = IDL_METRICS.flatMap((metric) => {
+      // Don't emit band checks on under-sampled buckets — the NFL band
+      // comparison would be dominated by sampling noise and drown out
+      // the real failures from the populated buckets.
+      if (underSampled) return [];
+      return [
+        checkBand({
+          bucketLabel: report.bucket.label,
+          metricName: metric,
+          simSummary: report.metrics[metric],
+          bands,
+        }),
+      ];
+    });
+    return {
+      bucketLabel: report.bucket.label,
+      bucketCenter: report.bucket.center,
+      samples: report.samples.length,
+      underSampled,
+      checks,
+    };
+  });
+
+  const failures = buckets.flatMap((b) => b.checks.filter((c) => !c.passed));
+
+  return {
+    totalGames: matchups.length,
+    totalSamples: samples.length,
+    bands,
+    buckets,
+    failures,
+    passed: failures.length === 0,
+  };
+}
+
+export function formatIdlCalibrationReport(
+  report: IdlCalibrationReport,
+): string {
+  const lines: string[] = [];
+  lines.push(
+    `IDL calibration — ${report.totalGames} games, ${report.totalSamples} IDL-games`,
+  );
+  lines.push(
+    `Bands: ${report.bands.position} / ${
+      report.bands.seasons.join("-")
+    } / ranked by ${report.bands.rankingStat}`,
+  );
+  lines.push("");
+  for (const bucket of report.buckets) {
+    const header = `[bucket ${bucket.bucketLabel}] n=${bucket.samples}` +
+      (bucket.underSampled ? " (under-sampled, skipping band checks)" : "");
+    lines.push(header);
+    for (const check of bucket.checks) {
+      const verdict = check.passed ? "PASS" : "FAIL";
+      const dir = check.passed ? "" : ` (${check.direction})`;
+      lines.push(
+        `  ${verdict} ${check.metricName.padEnd(20)} ` +
+          `sim=${check.simMean.toFixed(4)}  ` +
+          `band(${check.expectedBand})=${check.bandMean.toFixed(4)}±${
+            check.bandSd.toFixed(4)
+          }  ` +
+          `z=${check.zScore.toFixed(2)}  actual=${check.actualBand}${dir}`,
+      );
+    }
+    lines.push("");
+  }
+  const passed = report.passed ? "PASS" : "FAIL";
+  lines.push(
+    `${passed}: ${report.failures.length} band check(s) missed expected band`,
+  );
+  return lines.join("\n");
+}

--- a/server/features/simulation/calibration/per-position/idl-overall.test.ts
+++ b/server/features/simulation/calibration/per-position/idl-overall.test.ts
@@ -1,0 +1,105 @@
+import { assertAlmostEquals } from "@std/assert";
+import type { PlayerAttributes } from "@zone-blitz/shared";
+import { IDL_OVERALL_ATTRS, idlOverall } from "./idl-overall.ts";
+
+function attrs(overrides: Partial<PlayerAttributes> = {}): PlayerAttributes {
+  const base: Record<string, number> = {};
+  const keys = [
+    "speed",
+    "acceleration",
+    "agility",
+    "strength",
+    "jumping",
+    "stamina",
+    "durability",
+    "armStrength",
+    "accuracyShort",
+    "accuracyMedium",
+    "accuracyDeep",
+    "accuracyOnTheRun",
+    "touch",
+    "release",
+    "ballCarrying",
+    "elusiveness",
+    "routeRunning",
+    "catching",
+    "contestedCatching",
+    "runAfterCatch",
+    "passBlocking",
+    "runBlocking",
+    "blockShedding",
+    "tackling",
+    "manCoverage",
+    "zoneCoverage",
+    "passRushing",
+    "runDefense",
+    "kickingPower",
+    "kickingAccuracy",
+    "puntingPower",
+    "puntingAccuracy",
+    "snapAccuracy",
+    "footballIq",
+    "decisionMaking",
+    "anticipation",
+    "composure",
+    "clutch",
+    "consistency",
+    "workEthic",
+    "coachability",
+    "leadership",
+    "greed",
+    "loyalty",
+    "ambition",
+    "vanity",
+    "schemeAttachment",
+    "mediaSensitivity",
+  ];
+  for (const k of keys) {
+    base[k] = 50;
+    base[`${k}Potential`] = 50;
+  }
+  return { ...(base as unknown as PlayerAttributes), ...overrides };
+}
+
+Deno.test("idlOverall averages the five signature IDL attributes", () => {
+  const p = attrs({
+    passRushing: 60,
+    strength: 70,
+    blockShedding: 80,
+    runDefense: 50,
+    tackling: 40,
+  });
+  // (60 + 70 + 80 + 50 + 40) / 5 = 60
+  assertAlmostEquals(idlOverall(p), 60, 1e-9);
+});
+
+Deno.test("idlOverall with all 50s centers on the rating midpoint", () => {
+  // Calibration-league players default to 50 on every attribute; the
+  // midpoint should map to a 50 overall so the "50 bucket" lines up
+  // with the NFL average band.
+  const p = attrs();
+  assertAlmostEquals(idlOverall(p), 50, 1e-9);
+});
+
+Deno.test(
+  "IDL_OVERALL_ATTRS covers rush, anchor, and finishing attributes",
+  () => {
+    const set = new Set<string>(IDL_OVERALL_ATTRS);
+    // Rush (passRushing), anchor (strength, blockShedding), run (runDefense),
+    // finishing (tackling). Losing any of these should trip this test so a
+    // future refactor has to re-justify the composition.
+    for (
+      const attr of [
+        "passRushing",
+        "strength",
+        "blockShedding",
+        "runDefense",
+        "tackling",
+      ]
+    ) {
+      if (!set.has(attr)) {
+        throw new Error(`IDL_OVERALL_ATTRS is missing ${attr}`);
+      }
+    }
+  },
+);

--- a/server/features/simulation/calibration/per-position/idl-overall.ts
+++ b/server/features/simulation/calibration/per-position/idl-overall.ts
@@ -1,0 +1,25 @@
+import type { PlayerAttributes } from "@zone-blitz/shared";
+
+// Signature attributes that drive interior-DL impact in the engine.
+// `neutralBucket` classifies a player as IDL from
+// (strength, blockShedding, runDefense, passRushing); we add `tackling`
+// so the overall also captures finishing at the line of scrimmage,
+// which matters for the TFL / tackle counts the NFL reference bands
+// track. Five attributes keep the overall balanced between rush
+// (passRushing), anchor (strength, blockShedding), stopping runs
+// (runDefense), and wrapping up ball-carriers (tackling).
+export const IDL_OVERALL_ATTRS = [
+  "passRushing",
+  "strength",
+  "blockShedding",
+  "runDefense",
+  "tackling",
+] as const satisfies ReadonlyArray<keyof PlayerAttributes>;
+
+export function idlOverall(attributes: PlayerAttributes): number {
+  let sum = 0;
+  for (const key of IDL_OVERALL_ATTRS) {
+    sum += attributes[key];
+  }
+  return sum / IDL_OVERALL_ATTRS.length;
+}

--- a/server/features/simulation/calibration/per-position/idl-sample.test.ts
+++ b/server/features/simulation/calibration/per-position/idl-sample.test.ts
@@ -1,0 +1,399 @@
+import { assertAlmostEquals, assertEquals } from "@std/assert";
+import type { PlayerAttributes } from "@zone-blitz/shared";
+import { collectIdlSamples } from "./idl-sample.ts";
+import type { GameResult, PlayEvent } from "../../events.ts";
+import type { SimTeam } from "../../simulate-game.ts";
+import type { PlayerRuntime } from "../../resolve-play.ts";
+
+function attrs(overrides: Partial<PlayerAttributes> = {}): PlayerAttributes {
+  const base: Record<string, number> = {};
+  const keys = [
+    "speed",
+    "acceleration",
+    "agility",
+    "strength",
+    "jumping",
+    "stamina",
+    "durability",
+    "armStrength",
+    "accuracyShort",
+    "accuracyMedium",
+    "accuracyDeep",
+    "accuracyOnTheRun",
+    "touch",
+    "release",
+    "ballCarrying",
+    "elusiveness",
+    "routeRunning",
+    "catching",
+    "contestedCatching",
+    "runAfterCatch",
+    "passBlocking",
+    "runBlocking",
+    "blockShedding",
+    "tackling",
+    "manCoverage",
+    "zoneCoverage",
+    "passRushing",
+    "runDefense",
+    "kickingPower",
+    "kickingAccuracy",
+    "puntingPower",
+    "puntingAccuracy",
+    "snapAccuracy",
+    "footballIq",
+    "decisionMaking",
+    "anticipation",
+    "composure",
+    "clutch",
+    "consistency",
+    "workEthic",
+    "coachability",
+    "leadership",
+    "greed",
+    "loyalty",
+    "ambition",
+    "vanity",
+    "schemeAttachment",
+    "mediaSensitivity",
+  ];
+  for (const k of keys) {
+    base[k] = 50;
+    base[`${k}Potential`] = 50;
+  }
+  return { ...(base as unknown as PlayerAttributes), ...overrides };
+}
+
+function idl(id: string, overall: number): PlayerRuntime {
+  return {
+    playerId: id,
+    neutralBucket: "IDL",
+    attributes: attrs({
+      passRushing: overall,
+      strength: overall,
+      blockShedding: overall,
+      runDefense: overall,
+      tackling: overall,
+    }),
+  };
+}
+
+function edge(id: string, overall: number): PlayerRuntime {
+  return {
+    playerId: id,
+    neutralBucket: "EDGE",
+    attributes: attrs({
+      passRushing: overall,
+      acceleration: overall,
+      blockShedding: overall,
+      speed: overall,
+    }),
+  };
+}
+
+function team(teamId: string, starters: PlayerRuntime[]): SimTeam {
+  return {
+    teamId,
+    starters,
+    bench: [],
+    fingerprint: { offense: null, defense: null, overrides: {} },
+    coachingMods: {
+      schemeFitBonus: 0,
+      situationalBonus: 0,
+      aggressiveness: 50,
+      penaltyDiscipline: 1,
+    },
+  };
+}
+
+function event(
+  overrides: Partial<PlayEvent> & {
+    outcome: PlayEvent["outcome"];
+    offenseTeamId: string;
+    defenseTeamId: string;
+  },
+): PlayEvent {
+  return {
+    gameId: "g",
+    driveIndex: 0,
+    playIndex: 0,
+    quarter: 1,
+    clock: "15:00",
+    situation: { down: 1, distance: 10, yardLine: 25 },
+    call: {
+      concept: "dropback",
+      personnel: "11",
+      formation: "shotgun",
+      motion: "none",
+    },
+    coverage: { front: "4-3", coverage: "cover_2", pressure: "four_man" },
+    participants: [],
+    yardage: 0,
+    tags: [],
+    ...overrides,
+  };
+}
+
+function gameOf(events: PlayEvent[]): GameResult {
+  return {
+    gameId: "g",
+    seed: 1,
+    finalScore: { home: 0, away: 0 },
+    events,
+    boxScore: {
+      home: {
+        totalYards: 0,
+        passingYards: 0,
+        rushingYards: 0,
+        turnovers: 0,
+        sacks: 0,
+        penalties: 0,
+      },
+      away: {
+        totalYards: 0,
+        passingYards: 0,
+        rushingYards: 0,
+        turnovers: 0,
+        sacks: 0,
+        penalties: 0,
+      },
+    },
+    driveLog: [],
+    injuryReport: [],
+  };
+}
+
+Deno.test("collectIdlSamples returns one sample per starter IDL per team", () => {
+  const home = team("home", [idl("home-idl1", 50), idl("home-idl2", 50)]);
+  const away = team("away", [idl("away-idl1", 50), idl("away-idl2", 50)]);
+  const samples = collectIdlSamples({
+    game: gameOf([]),
+    home,
+    away,
+  });
+  assertEquals(samples.length, 4);
+  assertEquals(samples.map((s) => s.idlPlayerId).sort(), [
+    "away-idl1",
+    "away-idl2",
+    "home-idl1",
+    "home-idl2",
+  ]);
+});
+
+Deno.test("collectIdlSamples skips teams without starter IDLs", () => {
+  const home = team("home", [idl("home-idl1", 50)]);
+  const away = team("away", [edge("away-edge", 60)]);
+  const samples = collectIdlSamples({
+    game: gameOf([]),
+    home,
+    away,
+  });
+  assertEquals(samples.length, 1);
+  assertEquals(samples[0].teamId, "home");
+});
+
+Deno.test("collectIdlSamples tags sample with IDL overall (mean of five signature attrs)", () => {
+  const home = team("home", [{
+    playerId: "home-idl",
+    neutralBucket: "IDL",
+    attributes: attrs({
+      passRushing: 60,
+      strength: 80,
+      blockShedding: 70,
+      runDefense: 50,
+      tackling: 65,
+    }),
+  }]);
+  const away = team("away", [idl("away-idl", 50)]);
+  const [homeSample] = collectIdlSamples({
+    game: gameOf([]),
+    home,
+    away,
+  });
+  // (60 + 80 + 70 + 50 + 65) / 5 = 65
+  assertAlmostEquals(homeSample.idlOverall, 65, 0.01);
+});
+
+Deno.test("collectIdlSamples credits sacks to the tagged IDL defender", () => {
+  const home = team("home", [idl("home-idl1", 50), idl("home-idl2", 50)]);
+  const away = team("away", [idl("away-idl1", 50)]);
+  const events: PlayEvent[] = [
+    event({
+      outcome: "sack",
+      offenseTeamId: "away",
+      defenseTeamId: "home",
+      yardage: -7,
+      participants: [
+        { role: "pass_rush", playerId: "home-idl1", tags: ["sack"] },
+      ],
+    }),
+    event({
+      outcome: "sack",
+      offenseTeamId: "away",
+      defenseTeamId: "home",
+      yardage: -5,
+      participants: [
+        { role: "pass_rush", playerId: "home-idl2", tags: ["sack"] },
+      ],
+    }),
+  ];
+  const samples = collectIdlSamples({
+    game: gameOf(events),
+    home,
+    away,
+  });
+  const home1 = samples.find((s) => s.idlPlayerId === "home-idl1")!;
+  const home2 = samples.find((s) => s.idlPlayerId === "home-idl2")!;
+  assertEquals(home1.sacks, 1);
+  assertEquals(home2.sacks, 1);
+});
+
+Deno.test(
+  "collectIdlSamples ignores sacks credited to non-IDL defenders",
+  () => {
+    const home = team("home", [idl("home-idl1", 50)]);
+    const away = team("away", [
+      idl("away-idl1", 50),
+      edge("away-edge", 70),
+    ]);
+    const events: PlayEvent[] = [
+      event({
+        outcome: "sack",
+        offenseTeamId: "home",
+        defenseTeamId: "away",
+        yardage: -7,
+        participants: [
+          { role: "pass_rush", playerId: "away-edge", tags: ["sack"] },
+        ],
+      }),
+    ];
+    const samples = collectIdlSamples({
+      game: gameOf(events),
+      home,
+      away,
+    });
+    const away1 = samples.find((s) => s.idlPlayerId === "away-idl1")!;
+    assertEquals(away1.sacks, 0);
+  },
+);
+
+Deno.test(
+  "collectIdlSamples team-allocates run-stop proxies evenly across starter IDLs",
+  () => {
+    // The engine doesn't log per-defender tackle/TFL/QB-hit events, so
+    // the sample builder falls back to a team-level proxy split evenly
+    // across the IDL starters on the field. A team that forces two
+    // stuffs on rush plays and two sacks should see each of its two
+    // IDLs credited with half of the run-stop proxies.
+    const home = team("home", [idl("home-idl1", 50), idl("home-idl2", 50)]);
+    const away = team("away", [idl("away-idl1", 50), idl("away-idl2", 50)]);
+    const events: PlayEvent[] = [
+      // Two rush plays where the offense was stuffed (yardage < 1) —
+      // credit as TFLs + tackles against the defensive team.
+      event({
+        outcome: "rush",
+        offenseTeamId: "away",
+        defenseTeamId: "home",
+        yardage: -2,
+        call: {
+          concept: "inside_zone",
+          personnel: "11",
+          formation: "singleback",
+          motion: "none",
+        },
+      }),
+      event({
+        outcome: "rush",
+        offenseTeamId: "away",
+        defenseTeamId: "home",
+        yardage: 0,
+        call: {
+          concept: "power",
+          personnel: "11",
+          formation: "singleback",
+          motion: "none",
+        },
+      }),
+      // A regular 4-yard gain should count as a tackle but not a TFL.
+      event({
+        outcome: "rush",
+        offenseTeamId: "away",
+        defenseTeamId: "home",
+        yardage: 4,
+        call: {
+          concept: "outside_zone",
+          personnel: "11",
+          formation: "singleback",
+          motion: "none",
+        },
+      }),
+      // Pass with pressure -> qb_hit proxy
+      event({
+        outcome: "pass_incomplete",
+        offenseTeamId: "away",
+        defenseTeamId: "home",
+        yardage: 0,
+        tags: ["pressure"],
+      }),
+    ];
+    const samples = collectIdlSamples({
+      game: gameOf(events),
+      home,
+      away,
+    });
+    const home1 = samples.find((s) => s.idlPlayerId === "home-idl1")!;
+    const home2 = samples.find((s) => s.idlPlayerId === "home-idl2")!;
+
+    // Two stuffs plus one regular tackle => 3 team tackles, split 50/50
+    // across the two IDL starters => 1.5 tackles each.
+    assertAlmostEquals(home1.tackles, 1.5);
+    assertAlmostEquals(home2.tackles, 1.5);
+
+    // Two stuffs => 2 team TFLs => 1 TFL each.
+    assertAlmostEquals(home1.tfl, 1);
+    assertAlmostEquals(home2.tfl, 1);
+
+    // One pressure (non-sack) => 1 team QB hit => 0.5 each.
+    assertAlmostEquals(home1.qb_hits, 0.5);
+    assertAlmostEquals(home2.qb_hits, 0.5);
+  },
+);
+
+Deno.test("collectIdlSamples emits per-game rates", () => {
+  const home = team("home", [idl("home-idl1", 50), idl("home-idl2", 50)]);
+  const away = team("away", [idl("away-idl", 50)]);
+  const events: PlayEvent[] = [
+    event({
+      outcome: "sack",
+      offenseTeamId: "away",
+      defenseTeamId: "home",
+      yardage: -6,
+      participants: [
+        { role: "pass_rush", playerId: "home-idl1", tags: ["sack"] },
+      ],
+    }),
+    event({
+      outcome: "rush",
+      offenseTeamId: "away",
+      defenseTeamId: "home",
+      yardage: -1,
+      call: {
+        concept: "inside_zone",
+        personnel: "11",
+        formation: "singleback",
+        motion: "none",
+      },
+    }),
+  ];
+  const samples = collectIdlSamples({
+    game: gameOf(events),
+    home,
+    away,
+  });
+  const home1 = samples.find((s) => s.idlPlayerId === "home-idl1")!;
+  // One sample spans one game, so per-game rates equal raw counts.
+  assertEquals(home1.sacks_per_game, home1.sacks);
+  assertEquals(home1.tackles_per_game, home1.tackles);
+  assertEquals(home1.tfl_per_game, home1.tfl);
+  assertEquals(home1.qb_hits_per_game, home1.qb_hits);
+});

--- a/server/features/simulation/calibration/per-position/idl-sample.ts
+++ b/server/features/simulation/calibration/per-position/idl-sample.ts
@@ -1,0 +1,162 @@
+import type { GameResult, PlayEvent } from "../../events.ts";
+import type { SimTeam } from "../../simulate-game.ts";
+import { idlOverall } from "./idl-overall.ts";
+
+export interface IdlGameSample {
+  teamId: string;
+  idlPlayerId: string;
+  idlOverall: number;
+  sacks: number;
+  qb_hits: number;
+  tfl: number;
+  tackles: number;
+  sacks_per_game: number;
+  qb_hits_per_game: number;
+  tfl_per_game: number;
+  tackles_per_game: number;
+}
+
+// ------------------------------------------------------------------
+// ATTRIBUTION GAP — read before changing the numbers in this file.
+//
+// The engine only logs per-defender events for SACKS (the pass_rush
+// participant is tagged `sack` inside `synthesize-pass-outcome.ts`).
+// Tackles, tackles-for-loss, and QB hits are not attributed to any
+// specific defender — they're computed as team-level proxies:
+//   * tackles   — every rush play against a team counts as one team
+//                 tackle (whoever finished the carry).
+//   * tfl       — rush plays stuffed for <1 yard.
+//   * qb_hits   — non-sack pass plays that the engine flagged with a
+//                 `pressure` tag (see `synthesize-pass-outcome.ts`).
+//
+// Those team-level counts are then split evenly across the team's
+// starter IDLs on the field. This mirrors the approach nflreadr's
+// counting-stat bands take — the sim knows roughly how many stops
+// happened, but can't yet distinguish the IDL who made the tackle
+// from the EDGE or LB who was also in the pile. That attribution gap
+// inflates the IDL tackle/TFL numbers relative to the NFL reference
+// (we over-credit the IDL for stops actually made by LBs/EDGEs), so
+// calibration consumers should expect the `tackles_per_game` and
+// `tfl_per_game` checks to run hot on this slice until the engine
+// starts logging tackle/TFL participants.
+// ------------------------------------------------------------------
+
+const RUN_CONCEPTS = new Set([
+  "inside_zone",
+  "outside_zone",
+  "power",
+  "counter",
+  "draw",
+  "rpo",
+]);
+
+const TFL_YARDAGE_THRESHOLD = 1;
+
+interface TeamRunStopProxies {
+  tackles: number;
+  tfl: number;
+  qb_hits: number;
+}
+
+function teamRunStopProxies(
+  events: PlayEvent[],
+  teamId: string,
+): TeamRunStopProxies {
+  let tackles = 0;
+  let tfl = 0;
+  let qbHits = 0;
+
+  for (const event of events) {
+    if (event.defenseTeamId !== teamId) continue;
+
+    // Rush / fumble on a rush play: one defender finished the carry,
+    // so book it as a team tackle. Stuffs (yardage < 1) additionally
+    // count as a TFL.
+    const isRunConcept = RUN_CONCEPTS.has(event.call.concept);
+    if (
+      isRunConcept &&
+      (event.outcome === "rush" || event.outcome === "fumble")
+    ) {
+      tackles++;
+      if (event.yardage < TFL_YARDAGE_THRESHOLD) {
+        tfl++;
+      }
+      continue;
+    }
+
+    // Non-sack pass play with a `pressure` tag counts as a team QB hit
+    // proxy. Sacks already have their own attribution path below, so
+    // don't double-count them here.
+    const hasPressure = event.tags.includes("pressure");
+    const isSack = event.outcome === "sack" || event.tags.includes("sack");
+    if (hasPressure && !isSack) {
+      qbHits++;
+    }
+  }
+
+  return { tackles, tfl, qb_hits: qbHits };
+}
+
+function countIdlSacks(events: PlayEvent[], idlPlayerId: string): number {
+  let sacks = 0;
+  for (const event of events) {
+    if (event.outcome !== "sack" && !event.tags.includes("sack")) continue;
+    for (const participant of event.participants) {
+      if (
+        participant.playerId === idlPlayerId &&
+        participant.tags.includes("sack")
+      ) {
+        sacks++;
+        break;
+      }
+    }
+  }
+  return sacks;
+}
+
+export interface IdlSampleInput {
+  game: GameResult;
+  home: SimTeam;
+  away: SimTeam;
+}
+
+export function collectIdlSamples(input: IdlSampleInput): IdlGameSample[] {
+  const { game, home, away } = input;
+  const samples: IdlGameSample[] = [];
+
+  for (const team of [home, away]) {
+    const starterIdls = team.starters.filter(
+      (p) => p.neutralBucket === "IDL",
+    );
+    if (starterIdls.length === 0) continue;
+
+    const teamProxies = teamRunStopProxies(game.events, team.teamId);
+    const split = starterIdls.length;
+
+    for (const starter of starterIdls) {
+      const sacks = countIdlSacks(game.events, starter.playerId);
+      const tackles = teamProxies.tackles / split;
+      const tfl = teamProxies.tfl / split;
+      const qbHits = teamProxies.qb_hits / split;
+
+      samples.push({
+        teamId: team.teamId,
+        idlPlayerId: starter.playerId,
+        idlOverall: idlOverall(starter.attributes),
+        sacks,
+        qb_hits: qbHits,
+        tfl,
+        tackles,
+        // Each sample spans exactly one game so per-game rates equal
+        // the raw counts. Keeping the _per_game fields aligns the
+        // sample schema with the NFL band fixture keys.
+        sacks_per_game: sacks,
+        qb_hits_per_game: qbHits,
+        tfl_per_game: tfl,
+        tackles_per_game: tackles,
+      });
+    }
+  }
+
+  return samples;
+}

--- a/server/features/simulation/calibration/per-position/run-idl-calibration.ts
+++ b/server/features/simulation/calibration/per-position/run-idl-calibration.ts
@@ -1,0 +1,73 @@
+import { simulateGame } from "../../simulate-game.ts";
+import { generateCalibrationLeague } from "../generate-calibration-league.ts";
+import { CALIBRATION_SEEDS } from "../calibration-seeds.ts";
+import {
+  formatIdlCalibrationReport,
+  runIdlCalibration,
+} from "./idl-harness.ts";
+
+// Per-issue-#496: this entry point is intentionally report-only at
+// first. We print per-bucket PASS/FAIL against NFL IDL percentile
+// bands across every calibration seed so a human can eyeball the
+// signal — gating will come later once we understand noise
+// characteristics per bucket.
+//
+// Extra caveat for this slice: the underlying NFL bands are built
+// from counting-stat proxies (nflreadr doesn't ship PFF grades) and
+// the sim only attributes sacks per-defender. Expect the tackles /
+// TFL / QB-hit checks to look noisy until both sides of the
+// comparison get richer logging. See `per-position-idl.R` and
+// `idl-sample.ts` for the full list of known gaps.
+const bandPath = new URL(
+  "../../../../../data/bands/per-position/idl.json",
+  import.meta.url,
+);
+
+const bandJson = await Deno.readTextFile(bandPath);
+
+let allPassed = true;
+const summary: {
+  seed: number;
+  passed: number;
+  total: number;
+  underSampled: number;
+}[] = [];
+
+for (const seed of CALIBRATION_SEEDS) {
+  const league = generateCalibrationLeague({ seed });
+  const report = runIdlCalibration({
+    bandJson,
+    league,
+    simulate: simulateGame,
+  });
+
+  console.log(`=== seed=0x${seed.toString(16)} ===`);
+  console.log(formatIdlCalibrationReport(report));
+  console.log("");
+
+  const totalChecks = report.buckets.reduce(
+    (sum, b) => sum + b.checks.length,
+    0,
+  );
+  const passCount = totalChecks - report.failures.length;
+  const underSampled = report.buckets.filter((b) => b.underSampled).length;
+  summary.push({ seed, passed: passCount, total: totalChecks, underSampled });
+  if (!report.passed) allPassed = false;
+}
+
+console.log("=== Multi-seed summary ===");
+for (const row of summary) {
+  const status = row.passed === row.total ? "PASS" : "FAIL";
+  const underSampledNote = row.underSampled > 0
+    ? ` (${row.underSampled} bucket(s) under-sampled)`
+    : "";
+  console.log(
+    `${status} seed=0x${
+      row.seed.toString(16)
+    }: ${row.passed}/${row.total}${underSampledNote}`,
+  );
+}
+
+if (!allPassed) {
+  Deno.exit(1);
+}


### PR DESCRIPTION
## Summary

Third slice of issue #496 (per-position calibration). Adds a calibration harness for interior defensive linemen (DT/NT) mirroring the QB (#497) and RB (#500) slices:

- `data/R/bands/per-position-idl.R` pulls NFL DT/NT stats (2021-2025, >=400 defensive snaps via `load_snap_counts`), ranks by a z-score composite of `sacks/gm + qb_hits/gm + tfl/gm + tackles/gm`, and carves into five percentile bands with mean+sd per metric.
- `data/bands/per-position/idl.json` is the generated fixture (324 IDL-seasons after the starter filter).
- `server/features/simulation/calibration/per-position/` gains `idl-overall`, `idl-sample`, `idl-harness`, `run-idl-calibration`. Reuses the existing `bucket-by-attr` / `band-loader` / `band-check` modules.
- `deno task sim:calibrate:idl` runs the harness across every calibration seed.

Report-only for now per issue #496 — reading the per-bucket noise before layering gating on top.

## Notes

### Proxy-metric limitation (NFL side)

nflreadr does not carry PFF pass-rush or run-defense grades, so this v1 ranks interior DL by counting-stat composite instead of a grade. Known gaps flagged prominently in both the R script and fixture `notes`:

- Space-eating 1-tech NTs who draw double teams look statistically identical to replacement-level DTs — eating blocks doesn't show up in the box score.
- Pass-rush win rate is invisible: pressures that don't finish as sacks or QB hits disappear.
- Interior-only tackle / TFL counts under-represent run-stopping impact because LBs / EDGEs pad their totals on runs that bounce outside.

Upgrade path once we have PFF (or a public approximation): swap the ranking composite for grade and re-carve the bands.

### Sim-side attribution gaps

- **Sacks** are logged per-defender (`synthesize-pass-outcome.ts` tags the pass_rush participant with `sack`) — these attribute cleanly to IDLs.
- **Tackles / TFLs / QB hits** are NOT logged per-defender. The sample builder falls back to team-level proxies (rush plays → team tackle; stuffs < 1 yard → TFL; pressure tag on non-sack → QB hit) split evenly across the team's starter IDLs. This over-credits IDLs for stops actually made by LBs/EDGEs.

Documented inline in `idl-sample.ts`.

### Calibration run observations

A full multi-seed smoke run of `deno task sim:calibrate:idl` surfaces real gaps:

- **Sack bands mostly PASS** — per-defender attribution works, and the bucket separation the `idlOverall` drives is close enough to the NFL distribution.
- **QB-hit and tackle bands consistently FAIL high** (~12 tackles/gm per IDL vs ~3/gm NFL) because of the team-allocation split above.
- **TFL bands consistently FAIL low** — the rush-stuff heuristic (<1 yard) is stricter than the NFL's TFL accounting rule.
- **30-overall bucket is empty across most seeds** — the generator's IDL overall distribution sits above 35.

These become tracked follow-ups (GitHub issues) once this slice merges.

Closes part of #496.