### PR TITLE
feat(calibration): play-call tendencies + red-zone / 3rd-down bands

### DIFF
--- a/data/R/bands/play-call-tendencies.R
+++ b/data/R/bands/play-call-tendencies.R
@@ -1,0 +1,254 @@
+#!/usr/bin/env Rscript
+# play-call-tendencies.R — pass/run play-call rates by situation.
+#
+# Captures how pass rate shifts with down, distance, score differential,
+# time remaining, and field zone. Feeds the sim's offensive play-selection
+# AI so pass/run splits respond to game script (comeback mode, clock-kill,
+# 3rd-and-long, red-zone goal-to-go).
+#
+# Pass/run denominator = play_type in {pass, run}, excluding kneels, spikes,
+# and two-point conversion plays. A "called pass" uses qb_dropback (which
+# counts sacks and scrambles as called passes) so that pressure-affected
+# outcomes still land in the pass bucket.
+#
+# Usage:
+#   Rscript data/R/bands/play-call-tendencies.R [--seasons 2020:2024]
+
+suppressPackageStartupMessages({
+  library(nflreadr)
+  library(dplyr)
+})
+
+script_file <- (function() {
+  args <- commandArgs(trailingOnly = FALSE)
+  f <- grep("^--file=", args, value = TRUE)
+  if (length(f) > 0) normalizePath(sub("^--file=", "", f[1]), mustWork = FALSE) else NULL
+})()
+source(file.path(dirname(script_file), "..", "lib.R"))
+
+args <- commandArgs(trailingOnly = TRUE)
+seasons <- parse_seasons(args)
+
+cat("Loading pbp for seasons:", paste(range(seasons), collapse = "-"), "\n")
+pbp <- nflreadr::load_pbp(seasons)
+
+# ---- Base filter: offensive snaps that count as pass or run ---------------
+# qb_dropback == 1 captures called passes that end in a sack or scramble;
+# play_type captures the actual outcome (pass / run).
+plays <- pbp |>
+  filter(
+    season_type == "REG",
+    !is.na(play_type),
+    play_type %in% c("pass", "run"),
+    qb_kneel == 0,
+    qb_spike == 0,
+    is.na(two_point_conv_result)
+  ) |>
+  mutate(
+    called_pass = as.integer(
+      play_type == "pass" | (!is.na(qb_dropback) & qb_dropback == 1)
+    ),
+    down_label = case_when(
+      down == 1 ~ "1st",
+      down == 2 ~ "2nd",
+      down == 3 ~ "3rd",
+      down == 4 ~ "4th",
+      TRUE ~ NA_character_
+    ),
+    distance_bucket = case_when(
+      ydstogo <= 2                   ~ "short_1_2",
+      ydstogo <= 6                   ~ "medium_3_6",
+      ydstogo <= 10                  ~ "long_7_10",
+      TRUE                           ~ "very_long_11_plus"
+    ),
+    score_diff_bucket = case_when(
+      is.na(score_differential)      ~ "unknown",
+      score_differential <= -15      ~ "trailing_15_plus",
+      score_differential <= -8       ~ "trailing_8_to_14",
+      score_differential <= -1       ~ "trailing_1_to_7",
+      score_differential == 0        ~ "tied",
+      score_differential <= 7        ~ "leading_1_to_7",
+      score_differential <= 14       ~ "leading_8_to_14",
+      TRUE                           ~ "leading_15_plus"
+    ),
+    time_bucket = case_when(
+      is.na(game_seconds_remaining)                              ~ "unknown",
+      qtr == 2 & half_seconds_remaining <= 120                   ~ "two_min_h1",
+      qtr == 4 & half_seconds_remaining <= 300                   ~ "under_5_min_q4",
+      qtr == 4 & half_seconds_remaining <= 120                   ~ "two_min_q4",
+      qtr >= 4                                                   ~ "q4_early",
+      qtr == 3                                                   ~ "q3",
+      qtr == 2                                                   ~ "q2",
+      qtr == 1                                                   ~ "q1",
+      TRUE                                                       ~ "other"
+    ),
+    field_zone = case_when(
+      is.na(yardline_100)            ~ "unknown",
+      yardline_100 > 80              ~ "own_deep",
+      yardline_100 > 60              ~ "own_side",
+      yardline_100 > 40              ~ "midfield",
+      yardline_100 > 20              ~ "opp_side",
+      yardline_100 > 10              ~ "red_zone_outer",
+      yardline_100 > 4               ~ "red_zone_inner",
+      TRUE                           ~ "goal_to_go"
+    )
+  ) |>
+  filter(!is.na(down_label))
+
+cat("Plays analyzed:", nrow(plays), "\n")
+
+# ---- Helper: summarise a grouping into a nested list --------------------
+
+summarise_pass_rate <- function(df, ...) {
+  groups <- enquos(...)
+  df |>
+    group_by(!!!groups) |>
+    summarise(
+      n = n(),
+      rate = mean(called_pass),
+      called_pass = sum(called_pass),
+      .groups = "drop"
+    )
+}
+
+nest_by <- function(df, keys) {
+  # Turn a tidy summary into nested named lists in the order of `keys`.
+  if (length(keys) == 0) {
+    return(lapply(seq_len(nrow(df)), function(i) {
+      list(n = df$n[i], called_pass = df$called_pass[i], rate = df$rate[i])
+    })[[1]])
+  }
+  first <- keys[[1]]
+  rest <- keys[-1]
+  splits <- split(df, df[[first]])
+  setNames(
+    lapply(splits, function(sub) {
+      if (length(rest) == 0) {
+        list(
+          n = sub$n[1],
+          called_pass = sub$called_pass[1],
+          rate = sub$rate[1]
+        )
+      } else {
+        nest_by(sub, rest)
+      }
+    }),
+    names(splits)
+  )
+}
+
+# ---- Overall baseline ------------------------------------------------------
+
+overall <- list(
+  n = nrow(plays),
+  called_pass = sum(plays$called_pass),
+  rate = mean(plays$called_pass)
+)
+
+# ---- By down --------------------------------------------------------------
+
+by_down <- plays |>
+  summarise_pass_rate(down_label) |>
+  nest_by(list("down_label"))
+
+# ---- By down x distance ---------------------------------------------------
+
+by_down_distance <- plays |>
+  summarise_pass_rate(down_label, distance_bucket) |>
+  nest_by(list("down_label", "distance_bucket"))
+
+# ---- By score differential x time ----------------------------------------
+
+by_score_time <- plays |>
+  summarise_pass_rate(score_diff_bucket, time_bucket) |>
+  nest_by(list("score_diff_bucket", "time_bucket"))
+
+# ---- By field zone --------------------------------------------------------
+
+by_field_zone <- plays |>
+  summarise_pass_rate(field_zone) |>
+  nest_by(list("field_zone"))
+
+# ---- Key headline slices (the "big 6" callouts from the issue) -----------
+#
+# Each of these is a narrow, named cell that the calibration harness can
+# assert directly rather than walking the nested grid.
+
+slice_rate <- function(df) {
+  list(
+    n = nrow(df),
+    called_pass = sum(df$called_pass),
+    rate = if (nrow(df) > 0) mean(df$called_pass) else NA_real_
+  )
+}
+
+headline_slices <- list(
+  trailing_7_plus_late_q4 = slice_rate(
+    plays |> filter(
+      score_differential <= -7,
+      qtr == 4,
+      half_seconds_remaining <= 300
+    )
+  ),
+  leading_14_plus_q4 = slice_rate(
+    plays |> filter(
+      score_differential >= 14,
+      qtr == 4
+    )
+  ),
+  third_and_long_7_plus = slice_rate(
+    plays |> filter(down == 3, ydstogo >= 7)
+  ),
+  third_and_short_1_2 = slice_rate(
+    plays |> filter(down == 3, ydstogo <= 2)
+  ),
+  red_zone_goal_to_go = slice_rate(
+    plays |> filter(yardline_100 <= 10, goal_to_go == 1)
+  ),
+  two_min_drill_h1 = slice_rate(
+    plays |> filter(qtr == 2, half_seconds_remaining <= 120)
+  ),
+  two_min_drill_q4 = slice_rate(
+    plays |> filter(qtr == 4, half_seconds_remaining <= 120)
+  )
+)
+
+# ---- Assemble and write ---------------------------------------------------
+
+summaries <- list(
+  pass_rate_overall = overall,
+  pass_rate_by_down = by_down,
+  pass_rate_by_down_and_distance = by_down_distance,
+  pass_rate_by_score_diff_and_time = by_score_time,
+  pass_rate_by_field_zone = by_field_zone,
+  pass_rate_headline_slices = headline_slices
+)
+
+out_path <- file.path(repo_root(), "data", "bands", "play-call-tendencies.json")
+
+write_band(
+  out_path,
+  seasons,
+  summaries,
+  notes = paste0(
+    "Regular-season plays only. Pass/run denominator = play_type in ",
+    "{pass, run}, excluding kneels, spikes, and two-point conversions. ",
+    "`called_pass` counts any snap where the outcome is a pass OR qb_dropback == 1 ",
+    "(so sacks and scrambles land in the pass bucket — they represent called ",
+    "passes whose outcome was affected by pressure). ",
+    "Distance buckets: short (1-2), medium (3-6), long (7-10), very_long (11+). ",
+    "Score differential buckets (from offense perspective): trailing_15_plus, ",
+    "trailing_8_to_14, trailing_1_to_7, tied, leading_1_to_7, leading_8_to_14, ",
+    "leading_15_plus. Time buckets prioritise the late-game windows that matter ",
+    "most for clock management: two_min_h1, two_min_q4, under_5_min_q4, ",
+    "q4_early, q3, q2, q1. Field zones: own_deep (>80), own_side (61-80), ",
+    "midfield (41-60), opp_side (21-40), red_zone_outer (11-20), ",
+    "red_zone_inner (5-10), goal_to_go (<=4). ",
+    "`headline_slices` are pre-computed named cells for the big 6 tendencies ",
+    "the calibration harness cares about: trailing 7+ late Q4 (expect ~85% pass), ",
+    "leading 14+ Q4 (expect ~30% pass, clock kill), 3rd-and-long 7+ (expect ~90%), ",
+    "3rd-and-short 1-2, red-zone goal-to-go (expect ~45%), and the two 2-minute drills."
+  )
+)
+
+cat("Wrote", out_path, "\n")

--- a/data/R/bands/red-zone-and-third-down.R
+++ b/data/R/bands/red-zone-and-third-down.R
@@ -1,0 +1,264 @@
+#!/usr/bin/env Rscript
+# red-zone-and-third-down.R — headline efficiency bands.
+#
+# The two most-cited offensive-efficiency stats in NFL analysis are
+# red-zone TD rate and 3rd-down conversion rate. The sim currently has
+# neither as a direct band — both are implicit outputs of the play
+# synthesizer. Direct single-number bands let the calibration harness
+# detect drift in one assertion instead of inferring from distribution
+# shifts.
+#
+# Scope:
+# - Red zone (yardline_100 <= 20): drive-level TD rate, inside-10 TD rate,
+#   goal-to-go TD rate, play-level pass/run split, red-zone sack rate.
+# - 3rd down: conversion rate by distance bucket, pass rate by distance
+#   bucket, sack rate on 3rd-down dropbacks.
+# - 4th-and-short go-for-it conversion is covered by `situational.json`
+#   (field_zone x distance grid); this band includes a cross-link note
+#   rather than duplicating.
+#
+# Usage:
+#   Rscript data/R/bands/red-zone-and-third-down.R [--seasons 2020:2024]
+
+suppressPackageStartupMessages({
+  library(nflreadr)
+  library(dplyr)
+})
+
+script_file <- (function() {
+  args <- commandArgs(trailingOnly = FALSE)
+  f <- grep("^--file=", args, value = TRUE)
+  if (length(f) > 0) normalizePath(sub("^--file=", "", f[1]), mustWork = FALSE) else NULL
+})()
+source(file.path(dirname(script_file), "..", "lib.R"))
+
+args <- commandArgs(trailingOnly = TRUE)
+seasons <- parse_seasons(args)
+
+cat("Loading pbp for seasons:", paste(range(seasons), collapse = "-"), "\n")
+pbp <- nflreadr::load_pbp(seasons)
+
+# ---- Common offense filter ------------------------------------------------
+# Regular season, offensive play with an identifiable posteam, excluding
+# kneels, spikes, and two-point conversion plays.
+offense <- pbp |>
+  filter(
+    season_type == "REG",
+    !is.na(posteam),
+    !is.na(play_type),
+    play_type %in% c("pass", "run"),
+    qb_kneel == 0,
+    qb_spike == 0,
+    is.na(two_point_conv_result)
+  )
+
+# =========================================================================
+# Red zone
+# =========================================================================
+
+# ---- Drive-level red-zone TD rate ----------------------------------------
+# A drive "reaches" the red zone if any play in the drive has yardline_100
+# <= 20 (and the drive was for the team with the ball). TD rate = drive
+# ended in offensive TD / drives that reached the red zone.
+#
+# We use `drive` + `game_id` + `posteam` as a drive key. `fixed_drive` is
+# offense-indexed; `fixed_drive_result` holds the terminal result.
+
+drive_rows <- pbp |>
+  filter(
+    season_type == "REG",
+    !is.na(posteam),
+    !is.na(fixed_drive),
+    !is.na(yardline_100)
+  )
+
+red_zone_drives <- drive_rows |>
+  group_by(game_id, posteam, fixed_drive) |>
+  summarise(
+    reached_rz = any(yardline_100 <= 20, na.rm = TRUE),
+    reached_10 = any(yardline_100 <= 10, na.rm = TRUE),
+    reached_gtg = any(goal_to_go == 1 & yardline_100 <= 10, na.rm = TRUE),
+    result = dplyr::first(fixed_drive_result),
+    .groups = "drop"
+  ) |>
+  mutate(
+    td = as.integer(result == "Touchdown")
+  )
+
+rz_overall <- red_zone_drives |> filter(reached_rz)
+rz_inside_10 <- red_zone_drives |> filter(reached_10)
+rz_gtg <- red_zone_drives |> filter(reached_gtg)
+
+cat("Red-zone drives:", nrow(rz_overall), "\n")
+
+drive_td_rate <- function(df) {
+  list(
+    n = nrow(df),
+    touchdowns = sum(df$td, na.rm = TRUE),
+    rate = if (nrow(df) > 0) mean(df$td, na.rm = TRUE) else NA_real_
+  )
+}
+
+red_zone_td_rate <- list(
+  reach_red_zone = drive_td_rate(rz_overall),
+  reach_inside_10 = drive_td_rate(rz_inside_10),
+  reach_goal_to_go = drive_td_rate(rz_gtg)
+)
+
+# ---- Play-level red-zone pass/run split + sack rate ----------------------
+
+rz_plays <- offense |>
+  filter(!is.na(yardline_100), yardline_100 <= 20) |>
+  mutate(
+    called_pass = as.integer(
+      play_type == "pass" | (!is.na(qb_dropback) & qb_dropback == 1)
+    ),
+    is_sack = as.integer(!is.na(sack) & sack == 1)
+  )
+
+rz_dropbacks <- rz_plays |> filter(called_pass == 1)
+
+red_zone_play_mix <- list(
+  n = nrow(rz_plays),
+  called_pass = sum(rz_plays$called_pass),
+  pass_rate = if (nrow(rz_plays) > 0) mean(rz_plays$called_pass) else NA_real_,
+  run_rate = if (nrow(rz_plays) > 0) 1 - mean(rz_plays$called_pass) else NA_real_
+)
+
+red_zone_sack_rate <- list(
+  n = nrow(rz_dropbacks),
+  sacks = sum(rz_dropbacks$is_sack),
+  rate = if (nrow(rz_dropbacks) > 0) mean(rz_dropbacks$is_sack) else NA_real_
+)
+
+# =========================================================================
+# 3rd down
+# =========================================================================
+
+third_down <- offense |>
+  filter(down == 3) |>
+  mutate(
+    called_pass = as.integer(
+      play_type == "pass" | (!is.na(qb_dropback) & qb_dropback == 1)
+    ),
+    is_sack = as.integer(!is.na(sack) & sack == 1),
+    converted = as.integer(!is.na(third_down_converted) & third_down_converted == 1),
+    distance_bucket = case_when(
+      ydstogo <= 2                   ~ "short_1_2",
+      ydstogo <= 5                   ~ "medium_3_5",
+      ydstogo <= 9                   ~ "long_6_9",
+      TRUE                           ~ "very_long_10_plus"
+    )
+  )
+
+cat("3rd-down plays:", nrow(third_down), "\n")
+
+bucket_summary <- function(df, field, value_col = "rate") {
+  rows <- df |>
+    group_by(distance_bucket) |>
+    summarise(
+      n = n(),
+      numerator = sum(.data[[field]]),
+      rate = mean(.data[[field]]),
+      .groups = "drop"
+    )
+  setNames(
+    lapply(seq_len(nrow(rows)), function(i) {
+      list(n = rows$n[i], numerator = rows$numerator[i], rate = rows$rate[i])
+    }),
+    rows$distance_bucket
+  )
+}
+
+third_down_conversion_overall <- list(
+  n = nrow(third_down),
+  converted = sum(third_down$converted),
+  rate = if (nrow(third_down) > 0) mean(third_down$converted) else NA_real_
+)
+
+third_down_conversion_by_distance <- bucket_summary(third_down, "converted")
+
+third_down_pass_rate_overall <- list(
+  n = nrow(third_down),
+  called_pass = sum(third_down$called_pass),
+  rate = if (nrow(third_down) > 0) mean(third_down$called_pass) else NA_real_
+)
+
+third_down_pass_rate_by_distance <- bucket_summary(third_down, "called_pass")
+
+# Sack rate on 3rd-down dropbacks
+third_down_dropbacks <- third_down |> filter(called_pass == 1)
+
+third_down_sack_rate_overall <- list(
+  n = nrow(third_down_dropbacks),
+  sacks = sum(third_down_dropbacks$is_sack),
+  rate = if (nrow(third_down_dropbacks) > 0) mean(third_down_dropbacks$is_sack) else NA_real_
+)
+
+third_down_sack_rate_by_distance <- bucket_summary(third_down_dropbacks, "is_sack")
+
+# =========================================================================
+# Assemble and write
+# =========================================================================
+
+summaries <- list(
+  red_zone = list(
+    touchdown_rate = red_zone_td_rate,
+    play_mix = red_zone_play_mix,
+    sack_rate_on_dropbacks = red_zone_sack_rate
+  ),
+  third_down = list(
+    conversion_rate = list(
+      overall = third_down_conversion_overall,
+      by_distance = third_down_conversion_by_distance
+    ),
+    pass_rate = list(
+      overall = third_down_pass_rate_overall,
+      by_distance = third_down_pass_rate_by_distance
+    ),
+    sack_rate_on_dropbacks = list(
+      overall = third_down_sack_rate_overall,
+      by_distance = third_down_sack_rate_by_distance
+    )
+  ),
+  fourth_down_short_reference = list(
+    note = paste0(
+      "4th-and-short go-for-it conversion is covered in ",
+      "data/bands/situational.json under ",
+      "fourth_down_conversion_rate.by_field_zone_and_distance. ",
+      "Not duplicated here to avoid drift between the two artifacts."
+    )
+  )
+)
+
+out_path <- file.path(repo_root(), "data", "bands", "red-zone-and-third-down.json")
+
+write_band(
+  out_path,
+  seasons,
+  summaries,
+  notes = paste0(
+    "Regular-season plays only. ",
+    "Red-zone touchdown rate is drive-indexed: a drive counts once if any ",
+    "snap on that offensive drive reaches yardline_100 <= 20 (or <= 10 for ",
+    "inside_10, or goal_to_go for reach_goal_to_go). `touchdowns` = drives ",
+    "whose fixed_drive_result == 'Touchdown'. ",
+    "Red-zone play mix is play-indexed over the same filter as ",
+    "play-call-tendencies (play_type in {pass, run}, excluding kneels / ",
+    "spikes / two-point conversions). `called_pass` = play_type == 'pass' ",
+    "OR qb_dropback == 1 (counts sacks and scrambles as called passes). ",
+    "Red-zone sack rate = sacks / dropbacks. ",
+    "3rd-down distance buckets: short (1-2), medium (3-5), long (6-9), ",
+    "very_long (10+). Conversion rate uses `third_down_converted`; ",
+    "pass rate uses the same called_pass definition; sack rate denominator ",
+    "is 3rd-down dropbacks only. ",
+    "4th-and-short conversion is intentionally not duplicated here — see ",
+    "data/bands/situational.json. ",
+    "Measured 2020-2024 rates (for quick calibration-harness sanity check): ",
+    "red-zone drive TD rate ~60%, inside-10 TD rate ~68%, goal-to-go TD rate ~73%, ",
+    "red-zone pass rate ~54%, red-zone sack rate ~5.7%, 3rd-down conversion ~40%, ",
+    "3rd-and-short (1-2) ~65%, 3rd-and-very-long (10+) ~19%."
+  )
+)
+
+cat("Wrote", out_path, "\n")

--- a/data/README.md
+++ b/data/README.md
@@ -94,6 +94,22 @@ without depending on network or R at test time. Regenerate them when:
   `load_snap_counts()` for CB snap share. Mid-season QB changes and injured
   starters are handled naturally — weekly stats are summed per player, so a
   starter who misses games accumulates less and the backup's share rises.
+- **`play-call-tendencies.json`** — pass vs run called-play rate by situation.
+  Pass rate broken out by down, down x distance bucket, score differential x
+  time bucket (including two-minute drills and last-5-min-Q4), and field zone,
+  plus pre-computed headline slices (trailing 7+ late Q4, leading 14+ Q4,
+  3rd-and-long 7+, 3rd-and-short 1-2, red-zone goal-to-go, two-minute drills).
+  `called_pass` counts any snap where `play_type == "pass"` OR
+  `qb_dropback == 1` so sacks and scrambles land in the pass bucket. Feeds the
+  sim's offensive play-selection AI and game-script realism (comeback-mode pass
+  rates, late-lead clock kill).
+- **`red-zone-and-third-down.json`** — headline efficiency bands for the two
+  most-cited offensive-efficiency stats. Red-zone drive TD rate (drives reaching
+  the 20, 10, and goal-to-go), red-zone pass/run split, red-zone sack rate, and
+  3rd-down conversion + pass + sack rates broken out by distance bucket (short
+  1-2 / medium 3-5 / long 6-9 / very-long 10+). 4th-and-short go-for-it
+  conversion is referenced, not duplicated, from `situational.json`. Direct
+  single-number bands for fast drift detection.
 - **`injuries.json`** — injury rate bands by position, severity, and category.
   Derived from `nflreadr::load_injuries()` joined to
   `nflreadr::load_rosters_weekly()` to determine actual weeks missed (severity

--- a/data/bands/play-call-tendencies.json
+++ b/data/bands/play-call-tendencies.json
@@ -1,0 +1,424 @@
+{
+  "generated_at": "2026-04-17T12:56:37Z",
+  "seasons": [2020, 2021, 2022, 2023, 2024],
+  "notes": "Regular-season plays only. Pass/run denominator = play_type in {pass, run}, excluding kneels, spikes, and two-point conversions. `called_pass` counts any snap where the outcome is a pass OR qb_dropback == 1 (so sacks and scrambles land in the pass bucket — they represent called passes whose outcome was affected by pressure). Distance buckets: short (1-2), medium (3-6), long (7-10), very_long (11+). Score differential buckets (from offense perspective): trailing_15_plus, trailing_8_to_14, trailing_1_to_7, tied, leading_1_to_7, leading_8_to_14, leading_15_plus. Time buckets prioritise the late-game windows that matter most for clock management: two_min_h1, two_min_q4, under_5_min_q4, q4_early, q3, q2, q1. Field zones: own_deep (>80), own_side (61-80), midfield (41-60), opp_side (21-40), red_zone_outer (11-20), red_zone_inner (5-10), goal_to_go (<=4). `headline_slices` are pre-computed named cells for the big 6 tendencies the calibration harness cares about: trailing 7+ late Q4 (expect ~85% pass), leading 14+ Q4 (expect ~30% pass, clock kill), 3rd-and-long 7+ (expect ~90%), 3rd-and-short 1-2, red-zone goal-to-go (expect ~45%), and the two 2-minute drills.",
+  "bands": {
+    "pass_rate_overall": {
+      "n": 167254,
+      "called_pass": 101750,
+      "rate": 0.6084
+    },
+    "pass_rate_by_down": {
+      "1st": {
+        "n": 73647,
+        "called_pass": 37405,
+        "rate": 0.5079
+      },
+      "2nd": {
+        "n": 55636,
+        "called_pass": 34392,
+        "rate": 0.6182
+      },
+      "3rd": {
+        "n": 34230,
+        "called_pass": 27520,
+        "rate": 0.804
+      },
+      "4th": {
+        "n": 3741,
+        "called_pass": 2433,
+        "rate": 0.6504
+      }
+    },
+    "pass_rate_by_down_and_distance": {
+      "1st": {
+        "long_7_10": {
+          "n": 67590,
+          "called_pass": 34322,
+          "rate": 0.5078
+        },
+        "medium_3_6": {
+          "n": 2187,
+          "called_pass": 824,
+          "rate": 0.3768
+        },
+        "short_1_2": {
+          "n": 1148,
+          "called_pass": 307,
+          "rate": 0.2674
+        },
+        "very_long_11_plus": {
+          "n": 2722,
+          "called_pass": 1952,
+          "rate": 0.7171
+        }
+      },
+      "2nd": {
+        "long_7_10": {
+          "n": 25429,
+          "called_pass": 17486,
+          "rate": 0.6876
+        },
+        "medium_3_6": {
+          "n": 16351,
+          "called_pass": 8444,
+          "rate": 0.5164
+        },
+        "short_1_2": {
+          "n": 5892,
+          "called_pass": 1994,
+          "rate": 0.3384
+        },
+        "very_long_11_plus": {
+          "n": 7964,
+          "called_pass": 6468,
+          "rate": 0.8122
+        }
+      },
+      "3rd": {
+        "long_7_10": {
+          "n": 9594,
+          "called_pass": 9064,
+          "rate": 0.9448
+        },
+        "medium_3_6": {
+          "n": 11371,
+          "called_pass": 10009,
+          "rate": 0.8802
+        },
+        "short_1_2": {
+          "n": 7139,
+          "called_pass": 2946,
+          "rate": 0.4127
+        },
+        "very_long_11_plus": {
+          "n": 6126,
+          "called_pass": 5501,
+          "rate": 0.898
+        }
+      },
+      "4th": {
+        "long_7_10": {
+          "n": 418,
+          "called_pass": 398,
+          "rate": 0.9522
+        },
+        "medium_3_6": {
+          "n": 952,
+          "called_pass": 899,
+          "rate": 0.9443
+        },
+        "short_1_2": {
+          "n": 2076,
+          "called_pass": 856,
+          "rate": 0.4123
+        },
+        "very_long_11_plus": {
+          "n": 295,
+          "called_pass": 280,
+          "rate": 0.9492
+        }
+      }
+    },
+    "pass_rate_by_score_diff_and_time": {
+      "leading_1_to_7": {
+        "q1": {
+          "n": 5527,
+          "called_pass": 3120,
+          "rate": 0.5645
+        },
+        "q2": {
+          "n": 8625,
+          "called_pass": 4995,
+          "rate": 0.5791
+        },
+        "q3": {
+          "n": 7835,
+          "called_pass": 4414,
+          "rate": 0.5634
+        },
+        "q4_early": {
+          "n": 4835,
+          "called_pass": 2566,
+          "rate": 0.5307
+        },
+        "two_min_h1": {
+          "n": 2964,
+          "called_pass": 2333,
+          "rate": 0.7871
+        },
+        "under_5_min_q4": {
+          "n": 2473,
+          "called_pass": 800,
+          "rate": 0.3235
+        }
+      },
+      "leading_15_plus": {
+        "q1": {
+          "n": 30,
+          "called_pass": 17,
+          "rate": 0.5667
+        },
+        "q2": {
+          "n": 665,
+          "called_pass": 387,
+          "rate": 0.582
+        },
+        "q3": {
+          "n": 3335,
+          "called_pass": 1720,
+          "rate": 0.5157
+        },
+        "q4_early": {
+          "n": 2887,
+          "called_pass": 1049,
+          "rate": 0.3634
+        },
+        "two_min_h1": {
+          "n": 601,
+          "called_pass": 474,
+          "rate": 0.7887
+        },
+        "under_5_min_q4": {
+          "n": 1329,
+          "called_pass": 226,
+          "rate": 0.1701
+        }
+      },
+      "leading_8_to_14": {
+        "q1": {
+          "n": 412,
+          "called_pass": 239,
+          "rate": 0.5801
+        },
+        "q2": {
+          "n": 2829,
+          "called_pass": 1564,
+          "rate": 0.5528
+        },
+        "q3": {
+          "n": 5049,
+          "called_pass": 2795,
+          "rate": 0.5536
+        },
+        "q4_early": {
+          "n": 3514,
+          "called_pass": 1675,
+          "rate": 0.4767
+        },
+        "two_min_h1": {
+          "n": 1488,
+          "called_pass": 1155,
+          "rate": 0.7762
+        },
+        "under_5_min_q4": {
+          "n": 1593,
+          "called_pass": 327,
+          "rate": 0.2053
+        }
+      },
+      "tied": {
+        "q1": {
+          "n": 20479,
+          "called_pass": 11677,
+          "rate": 0.5702
+        },
+        "q2": {
+          "n": 4717,
+          "called_pass": 2797,
+          "rate": 0.593
+        },
+        "q3": {
+          "n": 2354,
+          "called_pass": 1339,
+          "rate": 0.5688
+        },
+        "q4_early": {
+          "n": 2331,
+          "called_pass": 1370,
+          "rate": 0.5877
+        },
+        "two_min_h1": {
+          "n": 1077,
+          "called_pass": 855,
+          "rate": 0.7939
+        },
+        "under_5_min_q4": {
+          "n": 1139,
+          "called_pass": 749,
+          "rate": 0.6576
+        }
+      },
+      "trailing_1_to_7": {
+        "q1": {
+          "n": 10223,
+          "called_pass": 5977,
+          "rate": 0.5847
+        },
+        "q2": {
+          "n": 10165,
+          "called_pass": 5944,
+          "rate": 0.5848
+        },
+        "q3": {
+          "n": 8455,
+          "called_pass": 4879,
+          "rate": 0.5771
+        },
+        "q4_early": {
+          "n": 5203,
+          "called_pass": 3194,
+          "rate": 0.6139
+        },
+        "two_min_h1": {
+          "n": 3194,
+          "called_pass": 2558,
+          "rate": 0.8009
+        },
+        "under_5_min_q4": {
+          "n": 5061,
+          "called_pass": 4066,
+          "rate": 0.8034
+        }
+      },
+      "trailing_15_plus": {
+        "q1": {
+          "n": 89,
+          "called_pass": 54,
+          "rate": 0.6067
+        },
+        "q2": {
+          "n": 1250,
+          "called_pass": 776,
+          "rate": 0.6208
+        },
+        "q3": {
+          "n": 4817,
+          "called_pass": 3200,
+          "rate": 0.6643
+        },
+        "q4_early": {
+          "n": 4624,
+          "called_pass": 3684,
+          "rate": 0.7967
+        },
+        "two_min_h1": {
+          "n": 996,
+          "called_pass": 857,
+          "rate": 0.8604
+        },
+        "under_5_min_q4": {
+          "n": 3297,
+          "called_pass": 2686,
+          "rate": 0.8147
+        }
+      },
+      "trailing_8_to_14": {
+        "q1": {
+          "n": 1094,
+          "called_pass": 650,
+          "rate": 0.5941
+        },
+        "q2": {
+          "n": 4825,
+          "called_pass": 2904,
+          "rate": 0.6019
+        },
+        "q3": {
+          "n": 6270,
+          "called_pass": 3817,
+          "rate": 0.6088
+        },
+        "q4_early": {
+          "n": 4752,
+          "called_pass": 3503,
+          "rate": 0.7372
+        },
+        "two_min_h1": {
+          "n": 1828,
+          "called_pass": 1557,
+          "rate": 0.8518
+        },
+        "under_5_min_q4": {
+          "n": 3023,
+          "called_pass": 2801,
+          "rate": 0.9266
+        }
+      }
+    },
+    "pass_rate_by_field_zone": {
+      "goal_to_go": {
+        "n": 5316,
+        "called_pass": 2271,
+        "rate": 0.4272
+      },
+      "midfield": {
+        "n": 41927,
+        "called_pass": 26349,
+        "rate": 0.6284
+      },
+      "opp_side": {
+        "n": 31695,
+        "called_pass": 18850,
+        "rate": 0.5947
+      },
+      "own_deep": {
+        "n": 13210,
+        "called_pass": 7926,
+        "rate": 0.6
+      },
+      "own_side": {
+        "n": 55129,
+        "called_pass": 34984,
+        "rate": 0.6346
+      },
+      "red_zone_inner": {
+        "n": 6971,
+        "called_pass": 3894,
+        "rate": 0.5586
+      },
+      "red_zone_outer": {
+        "n": 13006,
+        "called_pass": 7476,
+        "rate": 0.5748
+      }
+    },
+    "pass_rate_headline_slices": {
+      "trailing_7_plus_late_q4": {
+        "n": 7362,
+        "called_pass": 6368,
+        "rate": 0.865
+      },
+      "leading_14_plus_q4": {
+        "n": 5243,
+        "called_pass": 1655,
+        "rate": 0.3157
+      },
+      "third_and_long_7_plus": {
+        "n": 15720,
+        "called_pass": 14565,
+        "rate": 0.9265
+      },
+      "third_and_short_1_2": {
+        "n": 7139,
+        "called_pass": 2946,
+        "rate": 0.4127
+      },
+      "red_zone_goal_to_go": {
+        "n": 9774,
+        "called_pass": 4815,
+        "rate": 0.4926
+      },
+      "two_min_drill_h1": {
+        "n": 12148,
+        "called_pass": 9789,
+        "rate": 0.8058
+      },
+      "two_min_drill_q4": {
+        "n": 7399,
+        "called_pass": 5376,
+        "rate": 0.7266
+      }
+    }
+  }
+}

--- a/data/bands/red-zone-and-third-down.json
+++ b/data/bands/red-zone-and-third-down.json
@@ -1,0 +1,129 @@
+{
+  "generated_at": "2026-04-17T12:55:40Z",
+  "seasons": [2020, 2021, 2022, 2023, 2024],
+  "notes": "Regular-season plays only. Red-zone touchdown rate is drive-indexed: a drive counts once if any snap on that offensive drive reaches yardline_100 <= 20 (or <= 10 for inside_10, or goal_to_go for reach_goal_to_go). `touchdowns` = drives whose fixed_drive_result == 'Touchdown'. Red-zone play mix is play-indexed over the same filter as play-call-tendencies (play_type in {pass, run}, excluding kneels / spikes / two-point conversions). `called_pass` = play_type == 'pass' OR qb_dropback == 1 (counts sacks and scrambles as called passes). Red-zone sack rate = sacks / dropbacks. 3rd-down distance buckets: short (1-2), medium (3-5), long (6-9), very_long (10+). Conversion rate uses `third_down_converted`; pass rate uses the same called_pass definition; sack rate denominator is 3rd-down dropbacks only. 4th-and-short conversion is intentionally not duplicated here — see data/bands/situational.json. Measured 2020-2024 rates (for quick calibration-harness sanity check): red-zone drive TD rate ~60%, inside-10 TD rate ~68%, goal-to-go TD rate ~73%, red-zone pass rate ~54%, red-zone sack rate ~5.7%, 3rd-down conversion ~40%, 3rd-and-short (1-2) ~65%, 3rd-and-very-long (10+) ~19%.",
+  "bands": {
+    "red_zone": {
+      "touchdown_rate": {
+        "reach_red_zone": {
+          "n": 10877,
+          "touchdowns": 6561,
+          "rate": 0.6032
+        },
+        "reach_inside_10": {
+          "n": 6241,
+          "touchdowns": 4258,
+          "rate": 0.6823
+        },
+        "reach_goal_to_go": {
+          "n": 4686,
+          "touchdowns": 3424,
+          "rate": 0.7307
+        }
+      },
+      "play_mix": {
+        "n": 25293,
+        "called_pass": 13641,
+        "pass_rate": 0.5393,
+        "run_rate": 0.4607
+      },
+      "sack_rate_on_dropbacks": {
+        "n": 13641,
+        "sacks": 783,
+        "rate": 0.0574
+      }
+    },
+    "third_down": {
+      "conversion_rate": {
+        "overall": {
+          "n": 34230,
+          "converted": 13778,
+          "rate": 0.4025
+        },
+        "by_distance": {
+          "long_6_9": {
+            "n": 9426,
+            "numerator": 3387,
+            "rate": 0.3593
+          },
+          "medium_3_5": {
+            "n": 8609,
+            "numerator": 4047,
+            "rate": 0.4701
+          },
+          "short_1_2": {
+            "n": 7139,
+            "numerator": 4622,
+            "rate": 0.6474
+          },
+          "very_long_10_plus": {
+            "n": 9056,
+            "numerator": 1722,
+            "rate": 0.1902
+          }
+        }
+      },
+      "pass_rate": {
+        "overall": {
+          "n": 34230,
+          "called_pass": 27520,
+          "rate": 0.804
+        },
+        "by_distance": {
+          "long_6_9": {
+            "n": 9426,
+            "numerator": 8827,
+            "rate": 0.9365
+          },
+          "medium_3_5": {
+            "n": 8609,
+            "numerator": 7446,
+            "rate": 0.8649
+          },
+          "short_1_2": {
+            "n": 7139,
+            "numerator": 2946,
+            "rate": 0.4127
+          },
+          "very_long_10_plus": {
+            "n": 9056,
+            "numerator": 8301,
+            "rate": 0.9166
+          }
+        }
+      },
+      "sack_rate_on_dropbacks": {
+        "overall": {
+          "n": 27520,
+          "sacks": 2578,
+          "rate": 0.0937
+        },
+        "by_distance": {
+          "long_6_9": {
+            "n": 8827,
+            "numerator": 952,
+            "rate": 0.1079
+          },
+          "medium_3_5": {
+            "n": 7446,
+            "numerator": 631,
+            "rate": 0.0847
+          },
+          "short_1_2": {
+            "n": 2946,
+            "numerator": 176,
+            "rate": 0.0597
+          },
+          "very_long_10_plus": {
+            "n": 8301,
+            "numerator": 819,
+            "rate": 0.0987
+          }
+        }
+      }
+    },
+    "fourth_down_short_reference": {
+      "note": "4th-and-short go-for-it conversion is covered in data/bands/situational.json under fourth_down_conversion_rate.by_field_zone_and_distance. Not duplicated here to avoid drift between the two artifacts."
+    }
+  }
+}

--- a/data/docs/calibration-gaps.md
+++ b/data/docs/calibration-gaps.md
@@ -44,10 +44,10 @@ These directly serve the user-named asks:
 
 ## Game Flow (the situational-realism layer)
 
-| #  | Gap                                                                               | Primary source         | Issue |
-| -- | --------------------------------------------------------------------------------- | ---------------------- | ----- |
-| 9  | Play-call tendencies by situation (pass/run by D&D, score diff, time, field zone) | `nflreadr::load_pbp()` | #518  |
-| 10 | Red-zone + 3rd-down efficiency (play-call mix + conversion rates)                 | `load_pbp()`           | #519  |
+| #  | Gap                                                                               | Primary source         | Issue | Status                                                                         |
+| -- | --------------------------------------------------------------------------------- | ---------------------- | ----- | ------------------------------------------------------------------------------ |
+| 9  | Play-call tendencies by situation (pass/run by D&D, score diff, time, field zone) | `nflreadr::load_pbp()` | #518  | Done — [`play-call-tendencies.json`](../bands/play-call-tendencies.json)       |
+| 10 | Red-zone + 3rd-down efficiency (play-call mix + conversion rates)                 | `load_pbp()`           | #519  | Done — [`red-zone-and-third-down.json`](../bands/red-zone-and-third-down.json) |
 
 ## Future consideration (not yet issue-filed)
 


### PR DESCRIPTION
## Summary

Closes the two Game Flow rows in `data/docs/calibration-gaps.md` — both direct analogs of the existing `situational.json` band.

- `data/bands/play-call-tendencies.json` + `data/R/bands/play-call-tendencies.R` — pass rate conditioned on down, down x distance bucket, score differential x time bucket (two-minute drills, last-5-min-Q4, per-quarter), and field zone, plus pre-computed headline slices for the big 6 situational rules called out in #518. `called_pass` counts any snap where `play_type == "pass"` OR `qb_dropback == 1` so sacks and scrambles land in the pass bucket (they were called passes whose outcome was altered by pressure).
- `data/bands/red-zone-and-third-down.json` + `data/R/bands/red-zone-and-third-down.R` — drive-level red-zone TD rate (20 / 10 / goal-to-go), red-zone pass/run split, red-zone sack rate, and 3rd-down conversion + pass + sack rates broken out by distance bucket (short 1-2 / medium 3-5 / long 6-9 / very-long 10+). 4th-and-short go-for-it conversion is cross-referenced to `situational.json` rather than duplicated.
- `data/README.md` gets a bullet per band under "Bands currently produced"; `data/docs/calibration-gaps.md` gets a Status column with both rows marked Done.
- Per issue guidance, no separate research docs — findings live in the `notes` field of each JSON artifact.

Measured 2020-2024 results line up with the expected bands in the issues: trailing 7+ late Q4 -> 86.5% pass, leading 14+ Q4 -> 31.6%, 3rd-and-long 7+ -> 92.6%, red-zone goal-to-go -> 49.3%, red-zone drive TD rate 60%, 3rd-down conversion 40%.

Closes #518
Closes #519