### PR TITLE
feat(calibration): free agent market + contract structure bands

### DIFF
--- a/data/R/bands/contract-structure.R
+++ b/data/R/bands/contract-structure.R
@@ -1,0 +1,373 @@
+#!/usr/bin/env Rscript
+# contract-structure.R — length / guarantee / cap-hit shape bands.
+#
+# Real NFL contracts are shaped: descending guarantee, signing bonus
+# prorated over the term, back-loaded cap hits in years 3+, and increasing
+# use of void years. The sim's offer generator and cap AI both need these
+# shapes to simulate cut/restructure decisions credibly.
+#
+# Bands produced:
+#   - length_by_position_tier  (mean / distribution of years at signing)
+#   - guarantee_share_by_position_tier  (guaranteed / value)
+#   - signing_bonus_share_by_position_tier  (prorated_bonus y1 * years / value)
+#   - cap_hit_shape_by_position_tier  (cap-hit-year-N / total cap, for N in 1:5)
+#   - void_year_usage_rate_by_position  (share of deals whose 'years' column
+#     contains a team-recorded void-year entry — see note)
+#
+# Usage:
+#   Rscript data/R/bands/contract-structure.R [--seasons 2020:2024]
+
+suppressPackageStartupMessages({
+  library(nflreadr)
+  library(dplyr)
+  library(tidyr)
+  library(purrr)
+})
+
+script_file <- (function() {
+  args <- commandArgs(trailingOnly = FALSE)
+  f <- grep("^--file=", args, value = TRUE)
+  if (length(f) > 0) normalizePath(sub("^--file=", "", f[1]), mustWork = FALSE) else NULL
+})()
+source(file.path(dirname(script_file), "..", "lib.R"))
+
+args <- commandArgs(trailingOnly = TRUE)
+seasons <- parse_seasons(args)
+
+cat("Loading contracts for seasons:", paste(range(seasons), collapse = "-"), "\n")
+contracts_raw <- nflreadr::load_contracts()
+
+# ---------------------------------------------------------------------------
+# 1. Window + position grouping + AAV tier assignment
+# ---------------------------------------------------------------------------
+contracts <- contracts_raw |>
+  filter(
+    !is.na(year_signed),
+    year_signed >= min(seasons),
+    year_signed <= max(seasons),
+    !is.na(value), value > 0,
+    !is.na(apy),
+    !is.na(years), years >= 1
+  ) |>
+  mutate(
+    position_group = case_when(
+      position == "QB"                       ~ "QB",
+      position %in% c("RB", "FB")            ~ "RB",
+      position == "WR"                       ~ "WR",
+      position == "TE"                       ~ "TE",
+      position %in% c("LT", "RT")            ~ "OT",
+      position %in% c("LG", "RG", "C")       ~ "IOL",
+      position == "ED"                       ~ "EDGE",
+      position == "IDL"                      ~ "IDL",
+      position == "LB"                       ~ "LB",
+      position == "CB"                       ~ "CB",
+      position == "S"                        ~ "S",
+      position %in% c("K", "P", "LS")        ~ "ST",
+      TRUE                                   ~ "other"
+    )
+  )
+
+tier_bucket <- function(rank) {
+  case_when(
+    rank <= 10 ~ "top_10",
+    rank <= 25 ~ "top_25",
+    rank <= 50 ~ "top_50",
+    TRUE       ~ "rest"
+  )
+}
+
+contracts <- contracts |>
+  group_by(position_group) |>
+  mutate(apy_rank = rank(-apy, ties.method = "first")) |>
+  ungroup() |>
+  mutate(tier = tier_bucket(apy_rank))
+
+cat("Contracts in window:", nrow(contracts), "\n")
+
+# ---------------------------------------------------------------------------
+# 2. Length + guarantee share per position × tier
+# ---------------------------------------------------------------------------
+length_tier <- contracts |>
+  group_by(position_group, tier) |>
+  summarise(
+    n = n(),
+    mean_years = mean(years),
+    median_years = median(years),
+    p10_years = stats::quantile(years, 0.1, names = FALSE),
+    p90_years = stats::quantile(years, 0.9, names = FALSE),
+    .groups = "drop"
+  )
+
+guar_tier <- contracts |>
+  filter(!is.na(guaranteed)) |>
+  mutate(share = pmin(guaranteed / value, 1)) |>
+  group_by(position_group, tier) |>
+  summarise(
+    n = n(),
+    mean_share = mean(share),
+    median_share = median(share),
+    p10_share = stats::quantile(share, 0.1, names = FALSE),
+    p90_share = stats::quantile(share, 0.9, names = FALSE),
+    .groups = "drop"
+  )
+
+nest_by_pos_tier <- function(df, value_fn) {
+  split(df, df$position_group) |>
+    lapply(function(sub) {
+      setNames(
+        lapply(seq_len(nrow(sub)), function(i) value_fn(sub[i, ])),
+        sub$tier
+      )
+    })
+}
+
+length_nested <- nest_by_pos_tier(length_tier, function(row) {
+  list(
+    n = row$n,
+    mean_years = row$mean_years,
+    median_years = row$median_years,
+    p10_years = row$p10_years,
+    p90_years = row$p90_years
+  )
+})
+
+guar_nested <- nest_by_pos_tier(guar_tier, function(row) {
+  list(
+    n = row$n,
+    mean_share = row$mean_share,
+    median_share = row$median_share,
+    p10_share = row$p10_share,
+    p90_share = row$p90_share
+  )
+})
+
+# ---------------------------------------------------------------------------
+# 3. Per-contract cap-hit shape and signing-bonus share.
+#    Walk the nested `cols` tibbles. For each contract:
+#      - drop the "Total" row
+#      - order the rows chronologically starting at year_signed
+#      - normalise each cap_number by the contract's total cap (sum)
+#      - keep up to 5 years (ignores void-year padding beyond 5)
+#      - compute signing-bonus share as (year-1 prorated_bonus * years) / value
+#        (proxy for "signing bonus" — OTC amortises the signing bonus evenly
+#        across the contract via prorated_bonus)
+# ---------------------------------------------------------------------------
+safe_num <- function(x) suppressWarnings(as.numeric(x))
+
+extract_shape <- function(tbl, year_signed_val, contract_years) {
+  if (is.null(tbl) || !is.data.frame(tbl)) {
+    return(list(shape = rep(NA_real_, 5), signing_bonus_share = NA_real_, has_void = FALSE))
+  }
+  rows <- tbl |>
+    filter(year != "Total") |>
+    mutate(year_i = safe_num(year)) |>
+    filter(!is.na(year_i)) |>
+    arrange(year_i)
+
+  if (nrow(rows) == 0) {
+    return(list(shape = rep(NA_real_, 5), signing_bonus_share = NA_real_, has_void = FALSE))
+  }
+
+  # The OTC nested `cols` table is the player's full cap ledger (merges
+  # rookie deal + extensions into one timeline). Isolate the signed
+  # contract's years: year_signed .. year_signed + years - 1. Rows beyond
+  # that are either a subsequent signing OR void-year padding — we treat
+  # any rows with a nonzero cap_number beyond the stated term AND before
+  # the next contract start as void-year cap padding, but because we don't
+  # know the next-signing boundary from this feed, void detection here is
+  # a weak heuristic and is noted as such in the doc.
+  term_end <- year_signed_val + contract_years - 1
+  in_term <- rows |> filter(year_i >= year_signed_val, year_i <= term_end)
+  if (nrow(in_term) == 0) {
+    return(list(shape = rep(NA_real_, 5), signing_bonus_share = NA_real_, has_void = FALSE))
+  }
+
+  caps <- in_term$cap_number
+  total_cap <- sum(caps, na.rm = TRUE)
+  shape <- rep(NA_real_, 5)
+  if (total_cap > 0) {
+    take <- pmin(length(caps), 5)
+    shape[seq_len(take)] <- caps[seq_len(take)] / total_cap
+  }
+
+  # Signing-bonus proxy: year-1 prorated_bonus * (contract length). OTC
+  # amortises the signing bonus evenly across the deal, so year-1
+  # prorated_bonus x years recovers the up-front bonus.
+  year1_prorated <- in_term$prorated_bonus[1]
+  sb_share <- NA_real_
+  if (!is.na(year1_prorated) && contract_years > 0 && total_cap > 0) {
+    sb_share <- (year1_prorated * contract_years) / total_cap
+  }
+
+  # Void-year heuristic: rows strictly beyond term_end carry a nonzero
+  # prorated_bonus (the signature of void-year cash acceleration). This
+  # is weak because subsequent signings will also show prorated_bonus on
+  # those years; we flag it anyway and caveat the aggregate.
+  tail_rows <- rows |> filter(year_i > term_end)
+  has_void <- nrow(tail_rows) > 0 &&
+    any(!is.na(tail_rows$prorated_bonus) & tail_rows$prorated_bonus > 0 &
+          (is.na(tail_rows$base_salary) | tail_rows$base_salary == 0))
+
+  list(shape = shape, signing_bonus_share = sb_share, has_void = has_void)
+}
+
+cat("Walking nested cap-hit tables for", nrow(contracts), "contracts...\n")
+
+shapes <- purrr::pmap(
+  list(contracts$cols, contracts$year_signed, contracts$years),
+  extract_shape
+)
+
+shape_mat <- do.call(rbind, lapply(shapes, function(s) s$shape))
+contracts$cap_y1 <- shape_mat[, 1]
+contracts$cap_y2 <- shape_mat[, 2]
+contracts$cap_y3 <- shape_mat[, 3]
+contracts$cap_y4 <- shape_mat[, 4]
+contracts$cap_y5 <- shape_mat[, 5]
+contracts$signing_bonus_share <- vapply(shapes, function(s) s$signing_bonus_share, numeric(1))
+contracts$has_void <- vapply(shapes, function(s) s$has_void, logical(1))
+
+# ---------------------------------------------------------------------------
+# 4. Aggregate cap-hit shape per position × tier
+# ---------------------------------------------------------------------------
+shape_tier <- contracts |>
+  group_by(position_group, tier) |>
+  summarise(
+    n = sum(!is.na(cap_y1)),
+    mean_cap_y1 = mean(cap_y1, na.rm = TRUE),
+    mean_cap_y2 = mean(cap_y2, na.rm = TRUE),
+    mean_cap_y3 = mean(cap_y3, na.rm = TRUE),
+    mean_cap_y4 = mean(cap_y4, na.rm = TRUE),
+    mean_cap_y5 = mean(cap_y5, na.rm = TRUE),
+    .groups = "drop"
+  )
+
+shape_nested <- nest_by_pos_tier(shape_tier, function(row) {
+  list(
+    n = row$n,
+    mean_pct_year_1 = row$mean_cap_y1,
+    mean_pct_year_2 = row$mean_cap_y2,
+    mean_pct_year_3 = row$mean_cap_y3,
+    mean_pct_year_4 = row$mean_cap_y4,
+    mean_pct_year_5 = row$mean_cap_y5
+  )
+})
+
+# ---------------------------------------------------------------------------
+# 5. Signing-bonus share per position × tier
+# ---------------------------------------------------------------------------
+sb_tier <- contracts |>
+  filter(!is.na(signing_bonus_share), is.finite(signing_bonus_share)) |>
+  mutate(signing_bonus_share = pmin(signing_bonus_share, 1)) |>
+  group_by(position_group, tier) |>
+  summarise(
+    n = n(),
+    mean_share = mean(signing_bonus_share),
+    median_share = median(signing_bonus_share),
+    p10_share = stats::quantile(signing_bonus_share, 0.1, names = FALSE),
+    p90_share = stats::quantile(signing_bonus_share, 0.9, names = FALSE),
+    .groups = "drop"
+  )
+
+sb_nested <- nest_by_pos_tier(sb_tier, function(row) {
+  list(
+    n = row$n,
+    mean_signing_bonus_share = row$mean_share,
+    median_signing_bonus_share = row$median_share,
+    p10_signing_bonus_share = row$p10_share,
+    p90_signing_bonus_share = row$p90_share
+  )
+})
+
+# ---------------------------------------------------------------------------
+# 6. Void-year usage rate per position
+# ---------------------------------------------------------------------------
+void_by_pos <- contracts |>
+  group_by(position_group) |>
+  summarise(
+    n = n(),
+    with_void = sum(has_void, na.rm = TRUE),
+    rate = mean(has_void, na.rm = TRUE),
+    .groups = "drop"
+  ) |>
+  arrange(desc(rate))
+
+void_by_pos_list <- setNames(
+  lapply(seq_len(nrow(void_by_pos)), function(i) {
+    list(
+      n = void_by_pos$n[i],
+      with_void = void_by_pos$with_void[i],
+      rate = void_by_pos$rate[i]
+    )
+  }),
+  void_by_pos$position_group
+)
+
+# ---------------------------------------------------------------------------
+# 7. Restructure frequency — not derivable from this feed.
+#    The nflreadr contracts feed is one row per contract-as-signed; it does
+#    not mark restructure events. OTC's "transactions" UI has them but is
+#    behind the site. We note the gap here so the sim pulls restructure
+#    priors from the research doc.
+# ---------------------------------------------------------------------------
+restructure_frequency <- list(
+  source = "data/docs/contract-structure.md",
+  note = paste0(
+    "OTC's nflreadr feed is a snapshot of each signed contract and does ",
+    "not mark restructures. Restructure frequency priors live in the ",
+    "research doc until a transactions feed is wired in."
+  )
+)
+
+# ---------------------------------------------------------------------------
+# 8. Write
+# ---------------------------------------------------------------------------
+summaries <- list(
+  length_by_position_tier = length_nested,
+  guarantee_share_by_position_tier = guar_nested,
+  signing_bonus_share_by_position_tier = sb_nested,
+  cap_hit_shape_by_position_tier = shape_nested,
+  void_year_usage_rate_by_position = void_by_pos_list,
+  restructure_frequency = restructure_frequency
+)
+
+out_path <- file.path(repo_root(), "data", "bands", "contract-structure.json")
+
+write_band(
+  out_path,
+  seasons,
+  summaries,
+  notes = paste0(
+    "OTC contracts feed (nflreadr::load_contracts()) filtered to year_signed ",
+    "in the season window. AAV tiers ranked within position_group across the ",
+    "full window: top_10, top_25 (11-25), top_50 (26-50), rest. ",
+    "Cap-hit shape normalises each contract year's cap_number by the sum of ",
+    "cap_numbers across the contract (years 1-5, truncated). ",
+    "Signing-bonus share = (year-1 prorated_bonus x contract years) / total cap. ",
+    "Void-year flag = at least one cap row exists beyond year_signed + years - 1. ",
+    "Restructure frequency is documented in data/docs/contract-structure.md; the ",
+    "feed does not mark restructures."
+  )
+)
+
+cat("Wrote", out_path, "\n")
+
+# Quick summary
+cat("\n=== Quick Summary ===\n")
+cat("Top-10 tier mean years + guarantee share by position:\n")
+for (pg in names(length_nested)) {
+  top <- length_nested[[pg]]$top_10
+  gtop <- guar_nested[[pg]]$top_10
+  if (!is.null(top) && !is.null(gtop)) {
+    cat(sprintf("  %-6s years=%.2f  guarantee=%.1f%%  (n=%d)\n",
+                pg, top$mean_years, 100 * gtop$mean_share, top$n))
+  }
+}
+cat("\nVoid-year usage rate by position:\n")
+for (pg in names(void_by_pos_list)) {
+  cat(sprintf("  %-6s %.1f%% (%d / %d)\n",
+              pg,
+              100 * void_by_pos_list[[pg]]$rate,
+              void_by_pos_list[[pg]]$with_void,
+              void_by_pos_list[[pg]]$n))
+}

--- a/data/R/bands/free-agent-market.R
+++ b/data/R/bands/free-agent-market.R
@@ -1,0 +1,366 @@
+#!/usr/bin/env Rscript
+# free-agent-market.R — UFA market volume + AAV bands by position and tier.
+#
+# Sources nflreadr::load_contracts() (the OverTheCap feed) and filters to
+# veteran free-agent signings: contracts where the signing team is NOT the
+# drafting team (heuristic proxy for "external UFA" vs. re-sign/extension).
+# Re-signings (own_team) are kept in a parallel branch so the sim can
+# reproduce the observed own-team retention rate.
+#
+# Bands produced:
+#   - ufas_signed_per_offseason (by position group + overall)
+#   - aav_distribution_by_position_tier (top-10 / top-25 / top-50 / rest)
+#   - resigning_rate (own-team retention vs. external signing split)
+#   - contract_length_distribution (years signed, mean + percentiles)
+#   - guarantee_share_distribution (guaranteed / value)
+#
+# Signing-timing waves (legal-tampering / first-2-weeks / remainder) are NOT
+# computed here because the OTC feed exposes year_signed only, not date_signed.
+# The sim should pull wave priors from data/docs/free-agent-market.md until a
+# dated feed is sourced.
+#
+# Usage:
+#   Rscript data/R/bands/free-agent-market.R [--seasons 2020:2024]
+
+suppressPackageStartupMessages({
+  library(nflreadr)
+  library(dplyr)
+})
+
+script_file <- (function() {
+  args <- commandArgs(trailingOnly = FALSE)
+  f <- grep("^--file=", args, value = TRUE)
+  if (length(f) > 0) normalizePath(sub("^--file=", "", f[1]), mustWork = FALSE) else NULL
+})()
+source(file.path(dirname(script_file), "..", "lib.R"))
+
+args <- commandArgs(trailingOnly = TRUE)
+seasons <- parse_seasons(args)
+
+cat("Loading contracts (full history) for seasons:",
+    paste(range(seasons), collapse = "-"), "\n")
+contracts_raw <- nflreadr::load_contracts()
+
+# ---------------------------------------------------------------------------
+# 1. Filter to the target signing-year window and map positions into the
+#    position groups the rest of the sim uses.
+# ---------------------------------------------------------------------------
+contracts <- contracts_raw |>
+  filter(
+    !is.na(year_signed),
+    year_signed >= min(seasons),
+    year_signed <= max(seasons),
+    !is.na(value),
+    !is.na(apy),
+    years >= 1
+  ) |>
+  mutate(
+    position_group = case_when(
+      position == "QB"                       ~ "QB",
+      position %in% c("RB", "FB")            ~ "RB",
+      position == "WR"                       ~ "WR",
+      position == "TE"                       ~ "TE",
+      position %in% c("LT", "RT")            ~ "OT",
+      position %in% c("LG", "RG", "C")       ~ "IOL",
+      position %in% c("ED")                  ~ "EDGE",
+      position == "IDL"                      ~ "IDL",
+      position == "LB"                       ~ "LB",
+      position == "CB"                       ~ "CB",
+      position == "S"                        ~ "S",
+      position %in% c("K", "P", "LS")        ~ "ST",
+      TRUE                                   ~ "other"
+    ),
+    is_resign = !is.na(draft_team) & team == draft_team,
+    is_external = !is.na(draft_team) & team != draft_team
+  )
+
+cat("Contract rows in window:", nrow(contracts), "\n")
+cat("  re-signs (own team):   ", sum(contracts$is_resign), "\n")
+cat("  external signings:     ", sum(contracts$is_external), "\n")
+
+# ---------------------------------------------------------------------------
+# 2. UFA external-signing volume per offseason (by position group + overall).
+#    Here "UFA" means "contract where signing team != drafting team", which
+#    is a reasonable proxy on this feed since it excludes rookie deals
+#    (draft_team == team) and extensions (same team).
+# ---------------------------------------------------------------------------
+external <- contracts |> filter(is_external)
+
+vol_by_year_pos <- external |>
+  count(year_signed, position_group, name = "n")
+
+vol_per_offseason_by_pos <- vol_by_year_pos |>
+  group_by(position_group) |>
+  summarise(
+    seasons = n(),
+    mean = mean(n),
+    sd = sd(n),
+    min = min(n),
+    max = max(n),
+    total = sum(n),
+    .groups = "drop"
+  ) |>
+  arrange(desc(mean))
+
+vol_by_pos_list <- setNames(
+  lapply(seq_len(nrow(vol_per_offseason_by_pos)), function(i) {
+    row <- vol_per_offseason_by_pos[i, ]
+    list(
+      seasons_sampled = row$seasons,
+      mean_per_offseason = row$mean,
+      sd = row$sd,
+      min = row$min,
+      max = row$max,
+      total_in_window = row$total
+    )
+  }),
+  vol_per_offseason_by_pos$position_group
+)
+
+vol_per_offseason_overall <- external |>
+  count(year_signed, name = "n") |>
+  pull(n) |>
+  distribution_summary()
+
+# ---------------------------------------------------------------------------
+# 3. AAV tier distribution per position.
+#    Tiers are defined by rank on APY within the position group across the
+#    whole window (so rookie scale + veteran-minimum noise is absorbed):
+#       top_10  = top 10 APYs at that position
+#       top_25  = ranks 11–25
+#       top_50  = ranks 26–50
+#       rest    = everyone else
+#    For each tier we report mean/median APY and the APY floor (min) so the
+#    sim's contract generator can sample per tier.
+# ---------------------------------------------------------------------------
+tier_bucket <- function(rank) {
+  case_when(
+    rank <= 10 ~ "top_10",
+    rank <= 25 ~ "top_25",
+    rank <= 50 ~ "top_50",
+    TRUE       ~ "rest"
+  )
+}
+
+# Rank over *all* contracts (including re-signs) to anchor the market; this
+# matches how Spotrac / OTC leaderboards are presented.
+position_tiers <- contracts |>
+  group_by(position_group) |>
+  mutate(apy_rank = rank(-apy, ties.method = "first")) |>
+  ungroup() |>
+  mutate(tier = tier_bucket(apy_rank))
+
+aav_by_pos_tier <- position_tiers |>
+  group_by(position_group, tier) |>
+  summarise(
+    n = n(),
+    mean_apy = mean(apy),
+    median_apy = median(apy),
+    floor_apy = min(apy),
+    ceiling_apy = max(apy),
+    mean_value = mean(value),
+    mean_years = mean(years),
+    mean_guaranteed = mean(guaranteed, na.rm = TRUE),
+    .groups = "drop"
+  )
+
+# Nest: position_group -> tier -> metrics
+aav_nested <- split(aav_by_pos_tier, aav_by_pos_tier$position_group) |>
+  lapply(function(df) {
+    setNames(
+      lapply(seq_len(nrow(df)), function(i) {
+        list(
+          n = df$n[i],
+          mean_apy_millions = df$mean_apy[i],
+          median_apy_millions = df$median_apy[i],
+          floor_apy_millions = df$floor_apy[i],
+          ceiling_apy_millions = df$ceiling_apy[i],
+          mean_total_value_millions = df$mean_value[i],
+          mean_years = df$mean_years[i],
+          mean_guaranteed_millions = df$mean_guaranteed[i]
+        )
+      }),
+      df$tier
+    )
+  })
+
+# ---------------------------------------------------------------------------
+# 4. Re-signing rate: share of veteran (non-rookie) contracts that go back
+#    to the drafting team vs. move externally. We exclude rookie deals by
+#    dropping years_signed == draft_year (a new drafted rookie's first deal).
+# ---------------------------------------------------------------------------
+vet_contracts <- contracts |>
+  filter(
+    !is.na(draft_year),
+    year_signed > draft_year  # drop first (rookie) contracts
+  )
+
+resigning_split <- vet_contracts |>
+  mutate(kind = ifelse(is_resign, "resign_own_team", "external_signing")) |>
+  count(kind, name = "n") |>
+  mutate(proportion = n / sum(n))
+
+resigning_split_list <- setNames(
+  lapply(seq_len(nrow(resigning_split)), function(i) {
+    list(n = resigning_split$n[i], proportion = resigning_split$proportion[i])
+  }),
+  resigning_split$kind
+)
+
+# Re-signing rate per position
+resigning_by_pos <- vet_contracts |>
+  group_by(position_group) |>
+  summarise(
+    vet_contracts = n(),
+    resigned_own = sum(is_resign),
+    external = sum(is_external),
+    resign_rate = resigned_own / n(),
+    .groups = "drop"
+  ) |>
+  arrange(desc(resign_rate))
+
+resigning_by_pos_list <- setNames(
+  lapply(seq_len(nrow(resigning_by_pos)), function(i) {
+    row <- resigning_by_pos[i, ]
+    list(
+      vet_contracts = row$vet_contracts,
+      resigned_own = row$resigned_own,
+      external = row$external,
+      resign_rate = row$resign_rate
+    )
+  }),
+  resigning_by_pos$position_group
+)
+
+# ---------------------------------------------------------------------------
+# 5. Contract length + guarantee share (external signings only)
+# ---------------------------------------------------------------------------
+length_by_pos <- external |>
+  group_by(position_group) |>
+  summarise(
+    n = n(),
+    mean_years = mean(years),
+    median_years = median(years),
+    p10_years = stats::quantile(years, 0.1, names = FALSE),
+    p90_years = stats::quantile(years, 0.9, names = FALSE),
+    .groups = "drop"
+  )
+
+length_by_pos_list <- setNames(
+  lapply(seq_len(nrow(length_by_pos)), function(i) {
+    row <- length_by_pos[i, ]
+    list(
+      n = row$n,
+      mean_years = row$mean_years,
+      median_years = row$median_years,
+      p10_years = row$p10_years,
+      p90_years = row$p90_years
+    )
+  }),
+  length_by_pos$position_group
+)
+
+guar_share <- external |>
+  filter(!is.na(guaranteed), value > 0) |>
+  mutate(share = pmin(guaranteed / value, 1))
+
+guar_by_pos <- guar_share |>
+  group_by(position_group) |>
+  summarise(
+    n = n(),
+    mean_share = mean(share),
+    median_share = median(share),
+    p10_share = stats::quantile(share, 0.1, names = FALSE),
+    p90_share = stats::quantile(share, 0.9, names = FALSE),
+    .groups = "drop"
+  )
+
+guar_by_pos_list <- setNames(
+  lapply(seq_len(nrow(guar_by_pos)), function(i) {
+    row <- guar_by_pos[i, ]
+    list(
+      n = row$n,
+      mean_guarantee_share = row$mean_share,
+      median_guarantee_share = row$median_share,
+      p10_guarantee_share = row$p10_share,
+      p90_guarantee_share = row$p90_share
+    )
+  }),
+  guar_by_pos$position_group
+)
+
+# ---------------------------------------------------------------------------
+# 6. Signing-timing waves — qualitative pointer.
+#    The OTC feed does not expose date_signed. Until a dated feed is added,
+#    the waves band is documented in data/docs/free-agent-market.md and
+#    only the structural skeleton is carried here.
+# ---------------------------------------------------------------------------
+signing_timing_waves <- list(
+  source = "data/docs/free-agent-market.md",
+  note = paste0(
+    "OTC feed exposes year_signed only. Wave rates (legal tampering / ",
+    "first 2 weeks / April bargain / June post-draft) are documented in ",
+    "the research doc and should be sampled from there until a dated ",
+    "feed is integrated."
+  )
+)
+
+# ---------------------------------------------------------------------------
+# 7. Assemble and write
+# ---------------------------------------------------------------------------
+summaries <- list(
+  ufas_signed_per_offseason = list(
+    overall = vol_per_offseason_overall,
+    by_position_group = vol_by_pos_list
+  ),
+  aav_distribution_by_position_tier = aav_nested,
+  resigning_rate = list(
+    overall = resigning_split_list,
+    by_position_group = resigning_by_pos_list
+  ),
+  contract_length_years_external = length_by_pos_list,
+  guarantee_share_external = guar_by_pos_list,
+  signing_timing_waves = signing_timing_waves
+)
+
+out_path <- file.path(repo_root(), "data", "bands", "free-agent-market.json")
+
+write_band(
+  out_path,
+  seasons,
+  summaries,
+  notes = paste0(
+    "OTC contracts feed (nflreadr::load_contracts()) filtered to signings ",
+    "with year_signed in the season window. 'External signing' = team != ",
+    "draft_team; 're-sign own team' = team == draft_team (excluding first-year ",
+    "rookie contracts where year_signed == draft_year). ",
+    "AAV tiers ranked within position_group across the full window: top_10, ",
+    "top_25 (11-25), top_50 (26-50), rest. APY and values are reported in ",
+    "millions of nominal dollars (not cap-pct). ",
+    "Position groups: QB, RB (incl FB), WR, TE, OT (LT/RT), IOL (LG/RG/C), ",
+    "EDGE (ED), IDL, LB, CB, S, ST (K/P/LS). ",
+    "Signing-timing waves are documented in data/docs/free-agent-market.md ",
+    "because the feed lacks date_signed."
+  )
+)
+
+cat("Wrote", out_path, "\n")
+
+# Quick summary
+cat("\n=== Quick Summary ===\n")
+cat("External UFA signings per offseason (overall): mean",
+    round(vol_per_offseason_overall$mean, 0), "sd", round(vol_per_offseason_overall$sd, 0), "\n")
+cat("\nExternal signings per offseason by position group (mean):\n")
+for (pg in names(vol_by_pos_list)) {
+  cat(sprintf("  %-6s %.1f (sd %.1f)\n", pg,
+              vol_by_pos_list[[pg]]$mean_per_offseason,
+              vol_by_pos_list[[pg]]$sd %||% NA_real_))
+}
+cat("\nRe-signing rate (own-team) by position group:\n")
+for (pg in names(resigning_by_pos_list)) {
+  cat(sprintf("  %-6s %.1f%%  (%d re-signed / %d vet contracts)\n",
+              pg,
+              100 * resigning_by_pos_list[[pg]]$resign_rate,
+              resigning_by_pos_list[[pg]]$resigned_own,
+              resigning_by_pos_list[[pg]]$vet_contracts))
+}

--- a/data/README.md
+++ b/data/README.md
@@ -102,6 +102,24 @@ without depending on network or R at test time. Regenerate them when:
   injury category distribution (soft-tissue, knee, ankle, concussion, etc.),
   severity split (0 games / 1 game / 2-3 weeks / 4-7 weeks / season-ending), and
   re-injury rate. Non-injury reports (illness, rest, personal) excluded.
+- **`free-agent-market.json`** — UFA market volume and AAV bands from
+  `nflreadr::load_contracts()` (OverTheCap feed). Covers external UFA signings
+  per offseason by position group, AAV distribution by position × tier (top_10 /
+  top_25 / top_50 / rest) with mean / median / floor / ceiling APY, own-team
+  re-sign rate, contract length (years) and guarantee share for external
+  signings, plus a pointer to
+  [`docs/free-agent-market.md`](./docs/free-agent-market.md) for the
+  signing-timing wave narrative (legal-tampering / first-two-weeks / April /
+  post-draft). Pairs with the doc for tier-level examples (Burrow / Jefferson /
+  Barkley market anchors).
+- **`contract-structure.json`** — contract shape bands from the OTC feed's
+  nested `cols` cap ledger. Covers length (years) by position × tier, guarantee
+  share, signing-bonus share (year-1 prorated × years), and the year-by-year
+  cap-hit shape (Y1..Y5 as % of total cap) so the sim's offer generator and cap
+  AI can reproduce real back-loaded / front-loaded shapes. Void-year usage and
+  restructure frequency are documented in
+  [`docs/contract-structure.md`](./docs/contract-structure.md) with qualitative
+  priors because the feed does not tag them reliably.
 
 ## Planned bands (follow-up work)
 

--- a/data/bands/contract-structure.json
+++ b/data/bands/contract-structure.json
@@ -1,0 +1,1569 @@
+{
+  "generated_at": "2026-04-17T12:57:59Z",
+  "seasons": [2020, 2021, 2022, 2023, 2024],
+  "notes": "OTC contracts feed (nflreadr::load_contracts()) filtered to year_signed in the season window. AAV tiers ranked within position_group across the full window: top_10, top_25 (11-25), top_50 (26-50), rest. Cap-hit shape normalises each contract year's cap_number by the sum of cap_numbers across the contract (years 1-5, truncated). Signing-bonus share = (year-1 prorated_bonus x contract years) / total cap. Void-year flag = at least one cap row exists beyond year_signed + years - 1. Restructure frequency is documented in data/docs/contract-structure.md; the feed does not mark restructures.",
+  "bands": {
+    "length_by_position_tier": {
+      "CB": {
+        "rest": {
+          "n": 2810,
+          "mean_years": 1.4751,
+          "median_years": 1,
+          "p10_years": 1,
+          "p90_years": 3
+        },
+        "top_10": {
+          "n": 10,
+          "mean_years": 3.3,
+          "median_years": 4,
+          "p10_years": 1,
+          "p90_years": 5
+        },
+        "top_25": {
+          "n": 15,
+          "mean_years": 4.0667,
+          "median_years": 4,
+          "p10_years": 3,
+          "p90_years": 5
+        },
+        "top_50": {
+          "n": 25,
+          "mean_years": 2.84,
+          "median_years": 3,
+          "p10_years": 2,
+          "p90_years": 3.6
+        }
+      },
+      "EDGE": {
+        "rest": {
+          "n": 1584,
+          "mean_years": 1.6143,
+          "median_years": 1,
+          "p10_years": 1,
+          "p90_years": 3
+        },
+        "top_10": {
+          "n": 10,
+          "mean_years": 3.7,
+          "median_years": 4.5,
+          "p10_years": 1,
+          "p90_years": 5
+        },
+        "top_25": {
+          "n": 15,
+          "mean_years": 3.4,
+          "median_years": 4,
+          "p10_years": 1,
+          "p90_years": 5
+        },
+        "top_50": {
+          "n": 25,
+          "mean_years": 2.96,
+          "median_years": 3,
+          "p10_years": 1,
+          "p90_years": 4.6
+        }
+      },
+      "IDL": {
+        "rest": {
+          "n": 2345,
+          "mean_years": 1.4341,
+          "median_years": 1,
+          "p10_years": 1,
+          "p90_years": 3
+        },
+        "top_10": {
+          "n": 10,
+          "mean_years": 3.8,
+          "median_years": 4,
+          "p10_years": 2.9,
+          "p90_years": 4.1
+        },
+        "top_25": {
+          "n": 15,
+          "mean_years": 3.4,
+          "median_years": 4,
+          "p10_years": 1.8,
+          "p90_years": 4
+        },
+        "top_50": {
+          "n": 25,
+          "mean_years": 2.56,
+          "median_years": 3,
+          "p10_years": 1.4,
+          "p90_years": 4
+        }
+      },
+      "IOL": {
+        "rest": {
+          "n": 2067,
+          "mean_years": 1.5046,
+          "median_years": 1,
+          "p10_years": 1,
+          "p90_years": 3
+        },
+        "top_10": {
+          "n": 10,
+          "mean_years": 3.7,
+          "median_years": 4,
+          "p10_years": 1.9,
+          "p90_years": 5
+        },
+        "top_25": {
+          "n": 15,
+          "mean_years": 2.8667,
+          "median_years": 3,
+          "p10_years": 1,
+          "p90_years": 4
+        },
+        "top_50": {
+          "n": 25,
+          "mean_years": 3.36,
+          "median_years": 3,
+          "p10_years": 2,
+          "p90_years": 5
+        }
+      },
+      "LB": {
+        "rest": {
+          "n": 2082,
+          "mean_years": 1.4669,
+          "median_years": 1,
+          "p10_years": 1,
+          "p90_years": 3
+        },
+        "top_10": {
+          "n": 10,
+          "mean_years": 3.6,
+          "median_years": 3.5,
+          "p10_years": 2,
+          "p90_years": 5
+        },
+        "top_25": {
+          "n": 15,
+          "mean_years": 3.2667,
+          "median_years": 3,
+          "p10_years": 1.8,
+          "p90_years": 5
+        },
+        "top_50": {
+          "n": 25,
+          "mean_years": 2.36,
+          "median_years": 2,
+          "p10_years": 1,
+          "p90_years": 3
+        }
+      },
+      "OT": {
+        "rest": {
+          "n": 1451,
+          "mean_years": 1.5389,
+          "median_years": 1,
+          "p10_years": 1,
+          "p90_years": 3
+        },
+        "top_10": {
+          "n": 10,
+          "mean_years": 4,
+          "median_years": 4,
+          "p10_years": 3,
+          "p90_years": 5.1
+        },
+        "top_25": {
+          "n": 15,
+          "mean_years": 3.7333,
+          "median_years": 4,
+          "p10_years": 3,
+          "p90_years": 5
+        },
+        "top_50": {
+          "n": 25,
+          "mean_years": 3.2,
+          "median_years": 3,
+          "p10_years": 1.4,
+          "p90_years": 5
+        }
+      },
+      "QB": {
+        "rest": {
+          "n": 855,
+          "mean_years": 1.4503,
+          "median_years": 1,
+          "p10_years": 1,
+          "p90_years": 3
+        },
+        "top_10": {
+          "n": 10,
+          "mean_years": 4.6,
+          "median_years": 5,
+          "p10_years": 4,
+          "p90_years": 5
+        },
+        "top_25": {
+          "n": 15,
+          "mean_years": 4.3333,
+          "median_years": 4,
+          "p10_years": 3,
+          "p90_years": 5.6
+        },
+        "top_50": {
+          "n": 25,
+          "mean_years": 2,
+          "median_years": 2,
+          "p10_years": 1,
+          "p90_years": 4
+        }
+      },
+      "RB": {
+        "rest": {
+          "n": 1802,
+          "mean_years": 1.4595,
+          "median_years": 1,
+          "p10_years": 1,
+          "p90_years": 3
+        },
+        "top_10": {
+          "n": 10,
+          "mean_years": 3.5,
+          "median_years": 3.5,
+          "p10_years": 2,
+          "p90_years": 5
+        },
+        "top_25": {
+          "n": 15,
+          "mean_years": 2.1333,
+          "median_years": 2,
+          "p10_years": 1,
+          "p90_years": 4
+        },
+        "top_50": {
+          "n": 25,
+          "mean_years": 2.48,
+          "median_years": 2,
+          "p10_years": 1,
+          "p90_years": 4
+        }
+      },
+      "S": {
+        "rest": {
+          "n": 1667,
+          "mean_years": 1.5201,
+          "median_years": 1,
+          "p10_years": 1,
+          "p90_years": 3
+        },
+        "top_10": {
+          "n": 10,
+          "mean_years": 3.6,
+          "median_years": 4,
+          "p10_years": 2.8,
+          "p90_years": 4
+        },
+        "top_25": {
+          "n": 15,
+          "mean_years": 2.6,
+          "median_years": 3,
+          "p10_years": 1,
+          "p90_years": 4
+        },
+        "top_50": {
+          "n": 25,
+          "mean_years": 2.52,
+          "median_years": 3,
+          "p10_years": 1,
+          "p90_years": 3
+        }
+      },
+      "ST": {
+        "rest": {
+          "n": 1002,
+          "mean_years": 1.4401,
+          "median_years": 1,
+          "p10_years": 1,
+          "p90_years": 3
+        },
+        "top_10": {
+          "n": 10,
+          "mean_years": 3.6,
+          "median_years": 4,
+          "p10_years": 3,
+          "p90_years": 4
+        },
+        "top_25": {
+          "n": 15,
+          "mean_years": 3.4,
+          "median_years": 4,
+          "p10_years": 2,
+          "p90_years": 4.6
+        },
+        "top_50": {
+          "n": 25,
+          "mean_years": 2.68,
+          "median_years": 3,
+          "p10_years": 1,
+          "p90_years": 4
+        }
+      },
+      "TE": {
+        "rest": {
+          "n": 1572,
+          "mean_years": 1.4612,
+          "median_years": 1,
+          "p10_years": 1,
+          "p90_years": 3
+        },
+        "top_10": {
+          "n": 10,
+          "mean_years": 3.7,
+          "median_years": 4,
+          "p10_years": 2.9,
+          "p90_years": 4.1
+        },
+        "top_25": {
+          "n": 15,
+          "mean_years": 2.6,
+          "median_years": 3,
+          "p10_years": 1,
+          "p90_years": 4
+        },
+        "top_50": {
+          "n": 25,
+          "mean_years": 2.24,
+          "median_years": 2,
+          "p10_years": 1,
+          "p90_years": 3
+        }
+      },
+      "WR": {
+        "rest": {
+          "n": 3449,
+          "mean_years": 1.4503,
+          "median_years": 1,
+          "p10_years": 1,
+          "p90_years": 3
+        },
+        "top_10": {
+          "n": 10,
+          "mean_years": 3.8,
+          "median_years": 4,
+          "p10_years": 3,
+          "p90_years": 4.1
+        },
+        "top_25": {
+          "n": 15,
+          "mean_years": 2.7333,
+          "median_years": 3,
+          "p10_years": 1,
+          "p90_years": 4
+        },
+        "top_50": {
+          "n": 25,
+          "mean_years": 2.64,
+          "median_years": 3,
+          "p10_years": 1,
+          "p90_years": 4
+        }
+      }
+    },
+    "guarantee_share_by_position_tier": {
+      "CB": {
+        "rest": {
+          "n": 2810,
+          "mean_share": 0.0544,
+          "median_share": 0,
+          "p10_share": 0,
+          "p90_share": 0.1305
+        },
+        "top_10": {
+          "n": 10,
+          "mean_share": 0.3929,
+          "median_share": 0.4168,
+          "p10_share": 0,
+          "p90_share": 0.5705
+        },
+        "top_25": {
+          "n": 15,
+          "mean_share": 0.4715,
+          "median_share": 0.4848,
+          "p10_share": 0.3489,
+          "p90_share": 0.5762
+        },
+        "top_50": {
+          "n": 25,
+          "mean_share": 0.5765,
+          "median_share": 0.5455,
+          "p10_share": 0.4333,
+          "p90_share": 0.6705
+        }
+      },
+      "EDGE": {
+        "rest": {
+          "n": 1584,
+          "mean_share": 0.102,
+          "median_share": 0,
+          "p10_share": 0,
+          "p90_share": 0.5
+        },
+        "top_10": {
+          "n": 10,
+          "mean_share": 0.4698,
+          "median_share": 0.5283,
+          "p10_share": 0,
+          "p90_share": 0.7408
+        },
+        "top_25": {
+          "n": 15,
+          "mean_share": 0.4759,
+          "median_share": 0.381,
+          "p10_share": 0.2629,
+          "p90_share": 0.8661
+        },
+        "top_50": {
+          "n": 25,
+          "mean_share": 0.5851,
+          "median_share": 0.5078,
+          "p10_share": 0.2677,
+          "p90_share": 1
+        }
+      },
+      "IDL": {
+        "rest": {
+          "n": 2345,
+          "mean_share": 0.0698,
+          "median_share": 0,
+          "p10_share": 0,
+          "p90_share": 0.2373
+        },
+        "top_10": {
+          "n": 10,
+          "mean_share": 0.5118,
+          "median_share": 0.5036,
+          "p10_share": 0.3691,
+          "p90_share": 0.5853
+        },
+        "top_25": {
+          "n": 15,
+          "mean_share": 0.3714,
+          "median_share": 0.4054,
+          "p10_share": 0.083,
+          "p90_share": 0.4972
+        },
+        "top_50": {
+          "n": 25,
+          "mean_share": 0.5934,
+          "median_share": 0.613,
+          "p10_share": 0.3158,
+          "p90_share": 0.9433
+        }
+      },
+      "IOL": {
+        "rest": {
+          "n": 2067,
+          "mean_share": 0.0685,
+          "median_share": 0,
+          "p10_share": 0,
+          "p90_share": 0.2165
+        },
+        "top_10": {
+          "n": 10,
+          "mean_share": 0.5299,
+          "median_share": 0.4551,
+          "p10_share": 0.3429,
+          "p90_share": 1
+        },
+        "top_25": {
+          "n": 15,
+          "mean_share": 0.6213,
+          "median_share": 0.5192,
+          "p10_share": 0.342,
+          "p90_share": 1
+        },
+        "top_50": {
+          "n": 25,
+          "mean_share": 0.5445,
+          "median_share": 0.5205,
+          "p10_share": 0.3206,
+          "p90_share": 0.8837
+        }
+      },
+      "LB": {
+        "rest": {
+          "n": 2082,
+          "mean_share": 0.0629,
+          "median_share": 0,
+          "p10_share": 0,
+          "p90_share": 0.1762
+        },
+        "top_10": {
+          "n": 10,
+          "mean_share": 0.4859,
+          "median_share": 0.4917,
+          "p10_share": 0.3304,
+          "p90_share": 0.63
+        },
+        "top_25": {
+          "n": 15,
+          "mean_share": 0.5537,
+          "median_share": 0.5637,
+          "p10_share": 0.27,
+          "p90_share": 0.7907
+        },
+        "top_50": {
+          "n": 25,
+          "mean_share": 0.5714,
+          "median_share": 0.4971,
+          "p10_share": 0.3229,
+          "p90_share": 0.8604
+        }
+      },
+      "OT": {
+        "rest": {
+          "n": 1451,
+          "mean_share": 0.0795,
+          "median_share": 0,
+          "p10_share": 0,
+          "p90_share": 0.2857
+        },
+        "top_10": {
+          "n": 10,
+          "mean_share": 0.4582,
+          "median_share": 0.4021,
+          "p10_share": 0.3219,
+          "p90_share": 0.6258
+        },
+        "top_25": {
+          "n": 15,
+          "mean_share": 0.4748,
+          "median_share": 0.4785,
+          "p10_share": 0.2812,
+          "p90_share": 0.6419
+        },
+        "top_50": {
+          "n": 25,
+          "mean_share": 0.4649,
+          "median_share": 0.4852,
+          "p10_share": 0.1829,
+          "p90_share": 0.8422
+        }
+      },
+      "QB": {
+        "rest": {
+          "n": 855,
+          "mean_share": 0.1151,
+          "median_share": 0,
+          "p10_share": 0,
+          "p90_share": 0.5327
+        },
+        "top_10": {
+          "n": 10,
+          "mean_share": 0.5152,
+          "median_share": 0.5178,
+          "p10_share": 0.4379,
+          "p90_share": 0.551
+        },
+        "top_25": {
+          "n": 15,
+          "mean_share": 0.5085,
+          "median_share": 0.4801,
+          "p10_share": 0.2781,
+          "p90_share": 0.8667
+        },
+        "top_50": {
+          "n": 25,
+          "mean_share": 0.7459,
+          "median_share": 0.875,
+          "p10_share": 0.404,
+          "p90_share": 1
+        }
+      },
+      "RB": {
+        "rest": {
+          "n": 1802,
+          "mean_share": 0.0466,
+          "median_share": 0,
+          "p10_share": 0,
+          "p90_share": 0.1236
+        },
+        "top_10": {
+          "n": 10,
+          "mean_share": 0.4781,
+          "median_share": 0.4687,
+          "p10_share": 0.2571,
+          "p90_share": 0.6984
+        },
+        "top_25": {
+          "n": 15,
+          "mean_share": 0.5838,
+          "median_share": 0.4754,
+          "p10_share": 0.2292,
+          "p90_share": 1
+        },
+        "top_50": {
+          "n": 25,
+          "mean_share": 0.6177,
+          "median_share": 0.5538,
+          "p10_share": 0.4408,
+          "p90_share": 0.9527
+        }
+      },
+      "S": {
+        "rest": {
+          "n": 1667,
+          "mean_share": 0.071,
+          "median_share": 0,
+          "p10_share": 0,
+          "p90_share": 0.238
+        },
+        "top_10": {
+          "n": 10,
+          "mean_share": 0.3812,
+          "median_share": 0.4183,
+          "p10_share": 0.1994,
+          "p90_share": 0.5378
+        },
+        "top_25": {
+          "n": 15,
+          "mean_share": 0.5824,
+          "median_share": 0.5129,
+          "p10_share": 0.3057,
+          "p90_share": 1
+        },
+        "top_50": {
+          "n": 25,
+          "mean_share": 0.6132,
+          "median_share": 0.5717,
+          "p10_share": 0.4448,
+          "p90_share": 0.9556
+        }
+      },
+      "ST": {
+        "rest": {
+          "n": 1002,
+          "mean_share": 0.0472,
+          "median_share": 0,
+          "p10_share": 0,
+          "p90_share": 0.1198
+        },
+        "top_10": {
+          "n": 10,
+          "mean_share": 0.504,
+          "median_share": 0.4865,
+          "p10_share": 0.3876,
+          "p90_share": 0.6878
+        },
+        "top_25": {
+          "n": 15,
+          "mean_share": 0.4556,
+          "median_share": 0.4613,
+          "p10_share": 0.2318,
+          "p90_share": 0.6281
+        },
+        "top_50": {
+          "n": 25,
+          "mean_share": 0.3788,
+          "median_share": 0.3972,
+          "p10_share": 0.0606,
+          "p90_share": 0.5241
+        }
+      },
+      "TE": {
+        "rest": {
+          "n": 1572,
+          "mean_share": 0.0477,
+          "median_share": 0,
+          "p10_share": 0,
+          "p90_share": 0.1158
+        },
+        "top_10": {
+          "n": 10,
+          "mean_share": 0.4158,
+          "median_share": 0.3915,
+          "p10_share": 0.3056,
+          "p90_share": 0.5417
+        },
+        "top_25": {
+          "n": 15,
+          "mean_share": 0.5182,
+          "median_share": 0.4581,
+          "p10_share": 0.0959,
+          "p90_share": 1
+        },
+        "top_50": {
+          "n": 25,
+          "mean_share": 0.6439,
+          "median_share": 0.5977,
+          "p10_share": 0.3812,
+          "p90_share": 1
+        }
+      },
+      "WR": {
+        "rest": {
+          "n": 3449,
+          "mean_share": 0.0509,
+          "median_share": 0,
+          "p10_share": 0,
+          "p90_share": 0.0755
+        },
+        "top_10": {
+          "n": 10,
+          "mean_share": 0.4343,
+          "median_share": 0.4312,
+          "p10_share": 0.2762,
+          "p90_share": 0.6034
+        },
+        "top_25": {
+          "n": 15,
+          "mean_share": 0.5509,
+          "median_share": 0.4998,
+          "p10_share": 0.4122,
+          "p90_share": 0.9003
+        },
+        "top_50": {
+          "n": 25,
+          "mean_share": 0.5519,
+          "median_share": 0.5139,
+          "p10_share": 0.2867,
+          "p90_share": 0.9978
+        }
+      }
+    },
+    "signing_bonus_share_by_position_tier": {
+      "CB": {
+        "rest": {
+          "n": 1186,
+          "mean_signing_bonus_share": 0.0702,
+          "median_signing_bonus_share": 0,
+          "p10_signing_bonus_share": 0,
+          "p90_signing_bonus_share": 0.2461
+        },
+        "top_10": {
+          "n": 10,
+          "mean_signing_bonus_share": 0.4373,
+          "median_signing_bonus_share": 0.4455,
+          "p10_signing_bonus_share": 0.3351,
+          "p90_signing_bonus_share": 0.51
+        },
+        "top_25": {
+          "n": 15,
+          "mean_signing_bonus_share": 0.5663,
+          "median_signing_bonus_share": 0.4944,
+          "p10_signing_bonus_share": 0.2653,
+          "p90_signing_bonus_share": 1
+        },
+        "top_50": {
+          "n": 25,
+          "mean_signing_bonus_share": 0.4762,
+          "median_signing_bonus_share": 0.4225,
+          "p10_signing_bonus_share": 0.2047,
+          "p90_signing_bonus_share": 0.7889
+        }
+      },
+      "EDGE": {
+        "rest": {
+          "n": 724,
+          "mean_signing_bonus_share": 0.1262,
+          "median_signing_bonus_share": 0,
+          "p10_signing_bonus_share": 0,
+          "p90_signing_bonus_share": 0.446
+        },
+        "top_10": {
+          "n": 10,
+          "mean_signing_bonus_share": 0.3682,
+          "median_signing_bonus_share": 0.3196,
+          "p10_signing_bonus_share": 0.2403,
+          "p90_signing_bonus_share": 0.5839
+        },
+        "top_25": {
+          "n": 15,
+          "mean_signing_bonus_share": 0.5324,
+          "median_signing_bonus_share": 0.5114,
+          "p10_signing_bonus_share": 0.1486,
+          "p90_signing_bonus_share": 1
+        },
+        "top_50": {
+          "n": 25,
+          "mean_signing_bonus_share": 0.4514,
+          "median_signing_bonus_share": 0.4512,
+          "p10_signing_bonus_share": 0.0122,
+          "p90_signing_bonus_share": 0.8642
+        }
+      },
+      "IDL": {
+        "rest": {
+          "n": 992,
+          "mean_signing_bonus_share": 0.1,
+          "median_signing_bonus_share": 0,
+          "p10_signing_bonus_share": 0,
+          "p90_signing_bonus_share": 0.3693
+        },
+        "top_10": {
+          "n": 10,
+          "mean_signing_bonus_share": 0.4104,
+          "median_signing_bonus_share": 0.2885,
+          "p10_signing_bonus_share": 0.1834,
+          "p90_signing_bonus_share": 1
+        },
+        "top_25": {
+          "n": 15,
+          "mean_signing_bonus_share": 0.5102,
+          "median_signing_bonus_share": 0.4517,
+          "p10_signing_bonus_share": 0.1189,
+          "p90_signing_bonus_share": 0.9482
+        },
+        "top_50": {
+          "n": 25,
+          "mean_signing_bonus_share": 0.4259,
+          "median_signing_bonus_share": 0.3704,
+          "p10_signing_bonus_share": 0.1427,
+          "p90_signing_bonus_share": 0.7138
+        }
+      },
+      "IOL": {
+        "rest": {
+          "n": 946,
+          "mean_signing_bonus_share": 0.0816,
+          "median_signing_bonus_share": 0,
+          "p10_signing_bonus_share": 0,
+          "p90_signing_bonus_share": 0.2798
+        },
+        "top_10": {
+          "n": 10,
+          "mean_signing_bonus_share": 0.362,
+          "median_signing_bonus_share": 0.3215,
+          "p10_signing_bonus_share": 0.2385,
+          "p90_signing_bonus_share": 0.5589
+        },
+        "top_25": {
+          "n": 15,
+          "mean_signing_bonus_share": 0.3789,
+          "median_signing_bonus_share": 0.2833,
+          "p10_signing_bonus_share": 0.0354,
+          "p90_signing_bonus_share": 0.8185
+        },
+        "top_50": {
+          "n": 25,
+          "mean_signing_bonus_share": 0.4442,
+          "median_signing_bonus_share": 0.4,
+          "p10_signing_bonus_share": 0.2233,
+          "p90_signing_bonus_share": 0.8427
+        }
+      },
+      "LB": {
+        "rest": {
+          "n": 997,
+          "mean_signing_bonus_share": 0.067,
+          "median_signing_bonus_share": 0,
+          "p10_signing_bonus_share": 0,
+          "p90_signing_bonus_share": 0.2467
+        },
+        "top_10": {
+          "n": 10,
+          "mean_signing_bonus_share": 0.4497,
+          "median_signing_bonus_share": 0.3414,
+          "p10_signing_bonus_share": 0.2187,
+          "p90_signing_bonus_share": 0.9364
+        },
+        "top_25": {
+          "n": 15,
+          "mean_signing_bonus_share": 0.534,
+          "median_signing_bonus_share": 0.4959,
+          "p10_signing_bonus_share": 0.1767,
+          "p90_signing_bonus_share": 1
+        },
+        "top_50": {
+          "n": 25,
+          "mean_signing_bonus_share": 0.4232,
+          "median_signing_bonus_share": 0.3213,
+          "p10_signing_bonus_share": 0,
+          "p90_signing_bonus_share": 0.8985
+        }
+      },
+      "OT": {
+        "rest": {
+          "n": 597,
+          "mean_signing_bonus_share": 0.1148,
+          "median_signing_bonus_share": 0,
+          "p10_signing_bonus_share": 0,
+          "p90_signing_bonus_share": 0.4514
+        },
+        "top_10": {
+          "n": 10,
+          "mean_signing_bonus_share": 0.4912,
+          "median_signing_bonus_share": 0.421,
+          "p10_signing_bonus_share": 0.2346,
+          "p90_signing_bonus_share": 0.7475
+        },
+        "top_25": {
+          "n": 15,
+          "mean_signing_bonus_share": 0.4386,
+          "median_signing_bonus_share": 0.3947,
+          "p10_signing_bonus_share": 0.2032,
+          "p90_signing_bonus_share": 0.7569
+        },
+        "top_50": {
+          "n": 25,
+          "mean_signing_bonus_share": 0.3866,
+          "median_signing_bonus_share": 0.3072,
+          "p10_signing_bonus_share": 0.0511,
+          "p90_signing_bonus_share": 0.8169
+        }
+      },
+      "QB": {
+        "rest": {
+          "n": 490,
+          "mean_signing_bonus_share": 0.1088,
+          "median_signing_bonus_share": 0,
+          "p10_signing_bonus_share": 0,
+          "p90_signing_bonus_share": 0.4378
+        },
+        "top_10": {
+          "n": 10,
+          "mean_signing_bonus_share": 0.4863,
+          "median_signing_bonus_share": 0.424,
+          "p10_signing_bonus_share": 0.222,
+          "p90_signing_bonus_share": 0.8014
+        },
+        "top_25": {
+          "n": 15,
+          "mean_signing_bonus_share": 0.5131,
+          "median_signing_bonus_share": 0.5224,
+          "p10_signing_bonus_share": 0.1805,
+          "p90_signing_bonus_share": 0.9465
+        },
+        "top_50": {
+          "n": 25,
+          "mean_signing_bonus_share": 0.5153,
+          "median_signing_bonus_share": 0.602,
+          "p10_signing_bonus_share": 0,
+          "p90_signing_bonus_share": 0.8986
+        }
+      },
+      "RB": {
+        "rest": {
+          "n": 787,
+          "mean_signing_bonus_share": 0.0645,
+          "median_signing_bonus_share": 0,
+          "p10_signing_bonus_share": 0,
+          "p90_signing_bonus_share": 0.2424
+        },
+        "top_10": {
+          "n": 10,
+          "mean_signing_bonus_share": 0.5665,
+          "median_signing_bonus_share": 0.5232,
+          "p10_signing_bonus_share": 0.3162,
+          "p90_signing_bonus_share": 0.8692
+        },
+        "top_25": {
+          "n": 15,
+          "mean_signing_bonus_share": 0.3081,
+          "median_signing_bonus_share": 0.2603,
+          "p10_signing_bonus_share": 0.0793,
+          "p90_signing_bonus_share": 0.5557
+        },
+        "top_50": {
+          "n": 24,
+          "mean_signing_bonus_share": 0.403,
+          "median_signing_bonus_share": 0.3057,
+          "p10_signing_bonus_share": 0,
+          "p90_signing_bonus_share": 0.8864
+        }
+      },
+      "S": {
+        "rest": {
+          "n": 774,
+          "mean_signing_bonus_share": 0.0713,
+          "median_signing_bonus_share": 0,
+          "p10_signing_bonus_share": 0,
+          "p90_signing_bonus_share": 0.2533
+        },
+        "top_10": {
+          "n": 10,
+          "mean_signing_bonus_share": 0.3602,
+          "median_signing_bonus_share": 0.3263,
+          "p10_signing_bonus_share": 0.2277,
+          "p90_signing_bonus_share": 0.5125
+        },
+        "top_25": {
+          "n": 15,
+          "mean_signing_bonus_share": 0.3378,
+          "median_signing_bonus_share": 0.2607,
+          "p10_signing_bonus_share": 0,
+          "p90_signing_bonus_share": 0.5973
+        },
+        "top_50": {
+          "n": 25,
+          "mean_signing_bonus_share": 0.5252,
+          "median_signing_bonus_share": 0.5551,
+          "p10_signing_bonus_share": 0.2223,
+          "p90_signing_bonus_share": 1
+        }
+      },
+      "ST": {
+        "rest": {
+          "n": 406,
+          "mean_signing_bonus_share": 0.0557,
+          "median_signing_bonus_share": 0,
+          "p10_signing_bonus_share": 0,
+          "p90_signing_bonus_share": 0.1851
+        },
+        "top_10": {
+          "n": 10,
+          "mean_signing_bonus_share": 0.5412,
+          "median_signing_bonus_share": 0.5025,
+          "p10_signing_bonus_share": 0.3137,
+          "p90_signing_bonus_share": 0.8392
+        },
+        "top_25": {
+          "n": 14,
+          "mean_signing_bonus_share": 0.3603,
+          "median_signing_bonus_share": 0.3041,
+          "p10_signing_bonus_share": 0.1885,
+          "p90_signing_bonus_share": 0.5951
+        },
+        "top_50": {
+          "n": 24,
+          "mean_signing_bonus_share": 0.3409,
+          "median_signing_bonus_share": 0.2756,
+          "p10_signing_bonus_share": 0.1256,
+          "p90_signing_bonus_share": 0.797
+        }
+      },
+      "TE": {
+        "rest": {
+          "n": 565,
+          "mean_signing_bonus_share": 0.0644,
+          "median_signing_bonus_share": 0,
+          "p10_signing_bonus_share": 0,
+          "p90_signing_bonus_share": 0.25
+        },
+        "top_10": {
+          "n": 10,
+          "mean_signing_bonus_share": 0.2525,
+          "median_signing_bonus_share": 0.2556,
+          "p10_signing_bonus_share": 0.0276,
+          "p90_signing_bonus_share": 0.4541
+        },
+        "top_25": {
+          "n": 15,
+          "mean_signing_bonus_share": 0.4369,
+          "median_signing_bonus_share": 0.4654,
+          "p10_signing_bonus_share": 0,
+          "p90_signing_bonus_share": 0.8348
+        },
+        "top_50": {
+          "n": 25,
+          "mean_signing_bonus_share": 0.5044,
+          "median_signing_bonus_share": 0.4481,
+          "p10_signing_bonus_share": 0.3126,
+          "p90_signing_bonus_share": 0.7082
+        }
+      },
+      "WR": {
+        "rest": {
+          "n": 1260,
+          "mean_signing_bonus_share": 0.0785,
+          "median_signing_bonus_share": 0,
+          "p10_signing_bonus_share": 0,
+          "p90_signing_bonus_share": 0.3144
+        },
+        "top_10": {
+          "n": 10,
+          "mean_signing_bonus_share": 0.4385,
+          "median_signing_bonus_share": 0.3271,
+          "p10_signing_bonus_share": 0.2297,
+          "p90_signing_bonus_share": 0.6753
+        },
+        "top_25": {
+          "n": 15,
+          "mean_signing_bonus_share": 0.46,
+          "median_signing_bonus_share": 0.4332,
+          "p10_signing_bonus_share": 0.2558,
+          "p90_signing_bonus_share": 0.7659
+        },
+        "top_50": {
+          "n": 25,
+          "mean_signing_bonus_share": 0.463,
+          "median_signing_bonus_share": 0.4653,
+          "p10_signing_bonus_share": 0.063,
+          "p90_signing_bonus_share": 1
+        }
+      }
+    },
+    "cap_hit_shape_by_position_tier": {
+      "CB": {
+        "rest": {
+          "n": 2246,
+          "mean_pct_year_1": 0.8801,
+          "mean_pct_year_2": 0.3493,
+          "mean_pct_year_3": 0.3183,
+          "mean_pct_year_4": 0.339,
+          "mean_pct_year_5": "NaN"
+        },
+        "top_10": {
+          "n": 10,
+          "mean_pct_year_1": 0.3959,
+          "mean_pct_year_2": 0.2084,
+          "mean_pct_year_3": 0.3263,
+          "mean_pct_year_4": 0.2715,
+          "mean_pct_year_5": 0.3135
+        },
+        "top_25": {
+          "n": 15,
+          "mean_pct_year_1": 0.3473,
+          "mean_pct_year_2": 0.3503,
+          "mean_pct_year_3": 0.2144,
+          "mean_pct_year_4": 0.3252,
+          "mean_pct_year_5": 0.3831
+        },
+        "top_50": {
+          "n": 25,
+          "mean_pct_year_1": 0.3887,
+          "mean_pct_year_2": 0.3842,
+          "mean_pct_year_3": 0.3109,
+          "mean_pct_year_4": 0.2593,
+          "mean_pct_year_5": "NaN"
+        }
+      },
+      "EDGE": {
+        "rest": {
+          "n": 1217,
+          "mean_pct_year_1": 0.8278,
+          "mean_pct_year_2": 0.367,
+          "mean_pct_year_3": 0.2934,
+          "mean_pct_year_4": 0.3248,
+          "mean_pct_year_5": "NaN"
+        },
+        "top_10": {
+          "n": 10,
+          "mean_pct_year_1": 0.3122,
+          "mean_pct_year_2": 0.2332,
+          "mean_pct_year_3": 0.2257,
+          "mean_pct_year_4": 0.2613,
+          "mean_pct_year_5": 0.3206
+        },
+        "top_25": {
+          "n": 15,
+          "mean_pct_year_1": 0.4572,
+          "mean_pct_year_2": 0.2538,
+          "mean_pct_year_3": 0.3864,
+          "mean_pct_year_4": 0.2338,
+          "mean_pct_year_5": 0.195
+        },
+        "top_50": {
+          "n": 25,
+          "mean_pct_year_1": 0.4679,
+          "mean_pct_year_2": 0.4013,
+          "mean_pct_year_3": 0.2505,
+          "mean_pct_year_4": 0.2218,
+          "mean_pct_year_5": 0.116
+        }
+      },
+      "IDL": {
+        "rest": {
+          "n": 1877,
+          "mean_pct_year_1": 0.8723,
+          "mean_pct_year_2": 0.421,
+          "mean_pct_year_3": 0.3139,
+          "mean_pct_year_4": 0.3249,
+          "mean_pct_year_5": "NaN"
+        },
+        "top_10": {
+          "n": 10,
+          "mean_pct_year_1": 0.2332,
+          "mean_pct_year_2": 0.3132,
+          "mean_pct_year_3": 0.2866,
+          "mean_pct_year_4": 0.3657,
+          "mean_pct_year_5": 0.2825
+        },
+        "top_25": {
+          "n": 15,
+          "mean_pct_year_1": 0.3438,
+          "mean_pct_year_2": 0.2534,
+          "mean_pct_year_3": 0.2597,
+          "mean_pct_year_4": 0.3414,
+          "mean_pct_year_5": 0.1007
+        },
+        "top_50": {
+          "n": 25,
+          "mean_pct_year_1": 0.4085,
+          "mean_pct_year_2": 0.3632,
+          "mean_pct_year_3": 0.4227,
+          "mean_pct_year_4": 0.3256,
+          "mean_pct_year_5": "NaN"
+        }
+      },
+      "IOL": {
+        "rest": {
+          "n": 1664,
+          "mean_pct_year_1": 0.8664,
+          "mean_pct_year_2": 0.351,
+          "mean_pct_year_3": 0.3112,
+          "mean_pct_year_4": 0.3512,
+          "mean_pct_year_5": "NaN"
+        },
+        "top_10": {
+          "n": 10,
+          "mean_pct_year_1": 0.2451,
+          "mean_pct_year_2": 0.2154,
+          "mean_pct_year_3": 0.2871,
+          "mean_pct_year_4": 0.3457,
+          "mean_pct_year_5": 0.2734
+        },
+        "top_25": {
+          "n": 15,
+          "mean_pct_year_1": 0.4255,
+          "mean_pct_year_2": 0.3076,
+          "mean_pct_year_3": 0.3183,
+          "mean_pct_year_4": 0.3838,
+          "mean_pct_year_5": 0.1311
+        },
+        "top_50": {
+          "n": 25,
+          "mean_pct_year_1": 0.3739,
+          "mean_pct_year_2": 0.3797,
+          "mean_pct_year_3": 0.3233,
+          "mean_pct_year_4": 0.2557,
+          "mean_pct_year_5": 0.1958
+        }
+      },
+      "LB": {
+        "rest": {
+          "n": 1650,
+          "mean_pct_year_1": 0.8759,
+          "mean_pct_year_2": 0.4008,
+          "mean_pct_year_3": 0.328,
+          "mean_pct_year_4": 0.3148,
+          "mean_pct_year_5": "NaN"
+        },
+        "top_10": {
+          "n": 10,
+          "mean_pct_year_1": 0.24,
+          "mean_pct_year_2": 0.3706,
+          "mean_pct_year_3": 0.3039,
+          "mean_pct_year_4": 0.2029,
+          "mean_pct_year_5": 0.3256
+        },
+        "top_25": {
+          "n": 15,
+          "mean_pct_year_1": 0.4829,
+          "mean_pct_year_2": 0.2867,
+          "mean_pct_year_3": 0.2985,
+          "mean_pct_year_4": 0.3729,
+          "mean_pct_year_5": "NaN"
+        },
+        "top_50": {
+          "n": 25,
+          "mean_pct_year_1": 0.5147,
+          "mean_pct_year_2": 0.424,
+          "mean_pct_year_3": 0.3319,
+          "mean_pct_year_4": "NaN",
+          "mean_pct_year_5": "NaN"
+        }
+      },
+      "OT": {
+        "rest": {
+          "n": 1119,
+          "mean_pct_year_1": 0.8508,
+          "mean_pct_year_2": 0.3624,
+          "mean_pct_year_3": 0.32,
+          "mean_pct_year_4": 0.3521,
+          "mean_pct_year_5": "NaN"
+        },
+        "top_10": {
+          "n": 10,
+          "mean_pct_year_1": 0.201,
+          "mean_pct_year_2": 0.2124,
+          "mean_pct_year_3": 0.2741,
+          "mean_pct_year_4": 0.3296,
+          "mean_pct_year_5": 0.2538
+        },
+        "top_25": {
+          "n": 15,
+          "mean_pct_year_1": 0.207,
+          "mean_pct_year_2": 0.2968,
+          "mean_pct_year_3": 0.3114,
+          "mean_pct_year_4": 0.3122,
+          "mean_pct_year_5": 0.2933
+        },
+        "top_50": {
+          "n": 25,
+          "mean_pct_year_1": 0.3895,
+          "mean_pct_year_2": 0.3233,
+          "mean_pct_year_3": 0.3231,
+          "mean_pct_year_4": 0.3036,
+          "mean_pct_year_5": 0.2982
+        }
+      },
+      "QB": {
+        "rest": {
+          "n": 703,
+          "mean_pct_year_1": 0.8919,
+          "mean_pct_year_2": 0.3929,
+          "mean_pct_year_3": 0.2669,
+          "mean_pct_year_4": 0.3112,
+          "mean_pct_year_5": "NaN"
+        },
+        "top_10": {
+          "n": 10,
+          "mean_pct_year_1": 0.1556,
+          "mean_pct_year_2": 0.2237,
+          "mean_pct_year_3": 0.2007,
+          "mean_pct_year_4": 0.2773,
+          "mean_pct_year_5": 0.3408
+        },
+        "top_25": {
+          "n": 15,
+          "mean_pct_year_1": 0.2594,
+          "mean_pct_year_2": 0.262,
+          "mean_pct_year_3": 0.2434,
+          "mean_pct_year_4": 0.2649,
+          "mean_pct_year_5": 0.1671
+        },
+        "top_50": {
+          "n": 25,
+          "mean_pct_year_1": 0.7007,
+          "mean_pct_year_2": 0.3074,
+          "mean_pct_year_3": 0.3134,
+          "mean_pct_year_4": 0.3227,
+          "mean_pct_year_5": "NaN"
+        }
+      },
+      "RB": {
+        "rest": {
+          "n": 1416,
+          "mean_pct_year_1": 0.8785,
+          "mean_pct_year_2": 0.3959,
+          "mean_pct_year_3": 0.3067,
+          "mean_pct_year_4": 0.3114,
+          "mean_pct_year_5": "NaN"
+        },
+        "top_10": {
+          "n": 10,
+          "mean_pct_year_1": 0.265,
+          "mean_pct_year_2": 0.3118,
+          "mean_pct_year_3": 0.3605,
+          "mean_pct_year_4": 0.1832,
+          "mean_pct_year_5": 0.2158
+        },
+        "top_25": {
+          "n": 15,
+          "mean_pct_year_1": 0.6039,
+          "mean_pct_year_2": 0.3799,
+          "mean_pct_year_3": 0.304,
+          "mean_pct_year_4": 0.3267,
+          "mean_pct_year_5": "NaN"
+        },
+        "top_50": {
+          "n": 24,
+          "mean_pct_year_1": 0.4964,
+          "mean_pct_year_2": 0.4167,
+          "mean_pct_year_3": 0.3206,
+          "mean_pct_year_4": 0.2744,
+          "mean_pct_year_5": 0.1402
+        }
+      },
+      "S": {
+        "rest": {
+          "n": 1304,
+          "mean_pct_year_1": 0.8606,
+          "mean_pct_year_2": 0.38,
+          "mean_pct_year_3": 0.3101,
+          "mean_pct_year_4": 0.4005,
+          "mean_pct_year_5": "NaN"
+        },
+        "top_10": {
+          "n": 10,
+          "mean_pct_year_1": 0.2685,
+          "mean_pct_year_2": 0.236,
+          "mean_pct_year_3": 0.3496,
+          "mean_pct_year_4": 0.2921,
+          "mean_pct_year_5": "NaN"
+        },
+        "top_25": {
+          "n": 15,
+          "mean_pct_year_1": 0.4768,
+          "mean_pct_year_2": 0.4035,
+          "mean_pct_year_3": 0.3222,
+          "mean_pct_year_4": 0.2772,
+          "mean_pct_year_5": "NaN"
+        },
+        "top_50": {
+          "n": 25,
+          "mean_pct_year_1": 0.5266,
+          "mean_pct_year_2": 0.3664,
+          "mean_pct_year_3": 0.361,
+          "mean_pct_year_4": 0.1754,
+          "mean_pct_year_5": "NaN"
+        }
+      },
+      "ST": {
+        "rest": {
+          "n": 713,
+          "mean_pct_year_1": 0.8928,
+          "mean_pct_year_2": 0.4167,
+          "mean_pct_year_3": 0.3271,
+          "mean_pct_year_4": 0.3003,
+          "mean_pct_year_5": "NaN"
+        },
+        "top_10": {
+          "n": 10,
+          "mean_pct_year_1": 0.2989,
+          "mean_pct_year_2": 0.3205,
+          "mean_pct_year_3": 0.3161,
+          "mean_pct_year_4": 0.3206,
+          "mean_pct_year_5": "NaN"
+        },
+        "top_25": {
+          "n": 15,
+          "mean_pct_year_1": 0.3855,
+          "mean_pct_year_2": 0.325,
+          "mean_pct_year_3": 0.2846,
+          "mean_pct_year_4": 0.2289,
+          "mean_pct_year_5": 0.2595
+        },
+        "top_50": {
+          "n": 25,
+          "mean_pct_year_1": 0.5041,
+          "mean_pct_year_2": 0.3395,
+          "mean_pct_year_3": 0.3523,
+          "mean_pct_year_4": 0.2843,
+          "mean_pct_year_5": "NaN"
+        }
+      },
+      "TE": {
+        "rest": {
+          "n": 1195,
+          "mean_pct_year_1": 0.8676,
+          "mean_pct_year_2": 0.3986,
+          "mean_pct_year_3": 0.3333,
+          "mean_pct_year_4": 0.3473,
+          "mean_pct_year_5": "NaN"
+        },
+        "top_10": {
+          "n": 10,
+          "mean_pct_year_1": 0.2432,
+          "mean_pct_year_2": 0.2429,
+          "mean_pct_year_3": 0.2823,
+          "mean_pct_year_4": 0.3682,
+          "mean_pct_year_5": 0.3039
+        },
+        "top_25": {
+          "n": 15,
+          "mean_pct_year_1": 0.5396,
+          "mean_pct_year_2": 0.304,
+          "mean_pct_year_3": 0.3009,
+          "mean_pct_year_4": 0.2315,
+          "mean_pct_year_5": "NaN"
+        },
+        "top_50": {
+          "n": 25,
+          "mean_pct_year_1": 0.5412,
+          "mean_pct_year_2": 0.4349,
+          "mean_pct_year_3": 0.3208,
+          "mean_pct_year_4": 0.3182,
+          "mean_pct_year_5": "NaN"
+        }
+      },
+      "WR": {
+        "rest": {
+          "n": 2493,
+          "mean_pct_year_1": 0.8901,
+          "mean_pct_year_2": 0.3748,
+          "mean_pct_year_3": 0.2844,
+          "mean_pct_year_4": 0.3384,
+          "mean_pct_year_5": 0.2363
+        },
+        "top_10": {
+          "n": 10,
+          "mean_pct_year_1": 0.1864,
+          "mean_pct_year_2": 0.2541,
+          "mean_pct_year_3": 0.2527,
+          "mean_pct_year_4": 0.4173,
+          "mean_pct_year_5": 0.399
+        },
+        "top_25": {
+          "n": 15,
+          "mean_pct_year_1": 0.388,
+          "mean_pct_year_2": 0.3562,
+          "mean_pct_year_3": 0.3545,
+          "mean_pct_year_4": 0.3357,
+          "mean_pct_year_5": "NaN"
+        },
+        "top_50": {
+          "n": 25,
+          "mean_pct_year_1": 0.4718,
+          "mean_pct_year_2": 0.3701,
+          "mean_pct_year_3": 0.3562,
+          "mean_pct_year_4": 0.2523,
+          "mean_pct_year_5": 0.0127
+        }
+      }
+    },
+    "void_year_usage_rate_by_position": {
+      "S": {
+        "n": 1717,
+        "with_void": 11,
+        "rate": 0.0064
+      },
+      "TE": {
+        "n": 1622,
+        "with_void": 9,
+        "rate": 0.0055
+      },
+      "IDL": {
+        "n": 2395,
+        "with_void": 13,
+        "rate": 0.0054
+      },
+      "IOL": {
+        "n": 2117,
+        "with_void": 8,
+        "rate": 0.0038
+      },
+      "OT": {
+        "n": 1501,
+        "with_void": 4,
+        "rate": 0.0027
+      },
+      "EDGE": {
+        "n": 1634,
+        "with_void": 4,
+        "rate": 0.0024
+      },
+      "LB": {
+        "n": 2132,
+        "with_void": 5,
+        "rate": 0.0023
+      },
+      "QB": {
+        "n": 905,
+        "with_void": 2,
+        "rate": 0.0022
+      },
+      "WR": {
+        "n": 3499,
+        "with_void": 4,
+        "rate": 0.0011
+      },
+      "CB": {
+        "n": 2860,
+        "with_void": 3,
+        "rate": 0.001
+      },
+      "ST": {
+        "n": 1052,
+        "with_void": 1,
+        "rate": 0.001
+      },
+      "RB": {
+        "n": 1852,
+        "with_void": 0,
+        "rate": 0
+      }
+    },
+    "restructure_frequency": {
+      "source": "data/docs/contract-structure.md",
+      "note": "OTC's nflreadr feed is a snapshot of each signed contract and does not mark restructures. Restructure frequency priors live in the research doc until a transactions feed is wired in."
+    }
+  }
+}

--- a/data/bands/free-agent-market.json
+++ b/data/bands/free-agent-market.json
@@ -1,0 +1,887 @@
+{
+  "generated_at": "2026-04-17T12:54:37Z",
+  "seasons": [2020, 2021, 2022, 2023, 2024],
+  "notes": "OTC contracts feed (nflreadr::load_contracts()) filtered to signings with year_signed in the season window. 'External signing' = team != draft_team; 're-sign own team' = team == draft_team (excluding first-year rookie contracts where year_signed == draft_year). AAV tiers ranked within position_group across the full window: top_10, top_25 (11-25), top_50 (26-50), rest. APY and values are reported in millions of nominal dollars (not cap-pct). Position groups: QB, RB (incl FB), WR, TE, OT (LT/RT), IOL (LG/RG/C), EDGE (ED), IDL, LB, CB, S, ST (K/P/LS). Signing-timing waves are documented in data/docs/free-agent-market.md because the feed lacks date_signed.",
+  "bands": {
+    "ufas_signed_per_offseason": {
+      "overall": {
+        "n": 5,
+        "mean": 2963.8,
+        "sd": 243.3263,
+        "min": 2558,
+        "p10": 2716,
+        "p25": 2953,
+        "p50": 3035,
+        "p75": 3076,
+        "p90": 3148.6,
+        "max": 3197
+      },
+      "by_position_group": {
+        "WR": {
+          "seasons_sampled": 5,
+          "mean_per_offseason": 425.4,
+          "sd": 53.8219,
+          "min": 330,
+          "max": 457,
+          "total_in_window": 2127
+        },
+        "CB": {
+          "seasons_sampled": 5,
+          "mean_per_offseason": 386,
+          "sd": 29.1462,
+          "min": 339,
+          "max": 412,
+          "total_in_window": 1930
+        },
+        "IDL": {
+          "seasons_sampled": 5,
+          "mean_per_offseason": 330.8,
+          "sd": 40.7149,
+          "min": 273,
+          "max": 387,
+          "total_in_window": 1654
+        },
+        "IOL": {
+          "seasons_sampled": 5,
+          "mean_per_offseason": 266.8,
+          "sd": 23.952,
+          "min": 240,
+          "max": 288,
+          "total_in_window": 1334
+        },
+        "LB": {
+          "seasons_sampled": 5,
+          "mean_per_offseason": 265,
+          "sd": 23.5903,
+          "min": 230,
+          "max": 283,
+          "total_in_window": 1325
+        },
+        "RB": {
+          "seasons_sampled": 5,
+          "mean_per_offseason": 229.2,
+          "sd": 35.7519,
+          "min": 189,
+          "max": 273,
+          "total_in_window": 1146
+        },
+        "S": {
+          "seasons_sampled": 5,
+          "mean_per_offseason": 207.2,
+          "sd": 21.8335,
+          "min": 176,
+          "max": 232,
+          "total_in_window": 1036
+        },
+        "TE": {
+          "seasons_sampled": 5,
+          "mean_per_offseason": 199.4,
+          "sd": 20.8279,
+          "min": 180,
+          "max": 233,
+          "total_in_window": 997
+        },
+        "EDGE": {
+          "seasons_sampled": 5,
+          "mean_per_offseason": 188,
+          "sd": 29.6816,
+          "min": 163,
+          "max": 236,
+          "total_in_window": 940
+        },
+        "OT": {
+          "seasons_sampled": 5,
+          "mean_per_offseason": 181.8,
+          "sd": 19.804,
+          "min": 149,
+          "max": 198,
+          "total_in_window": 909
+        },
+        "ST": {
+          "seasons_sampled": 5,
+          "mean_per_offseason": 159.6,
+          "sd": 27.2635,
+          "min": 141,
+          "max": 207,
+          "total_in_window": 798
+        },
+        "QB": {
+          "seasons_sampled": 5,
+          "mean_per_offseason": 124.6,
+          "sd": 10.9453,
+          "min": 114,
+          "max": 138,
+          "total_in_window": 623
+        }
+      }
+    },
+    "aav_distribution_by_position_tier": {
+      "CB": {
+        "rest": {
+          "n": 2810,
+          "mean_apy_millions": 0.7923,
+          "median_apy_millions": 0.7425,
+          "floor_apy_millions": 0,
+          "ceiling_apy_millions": 8.5,
+          "mean_total_value_millions": 1.4282,
+          "mean_years": 1.4751,
+          "mean_guaranteed_millions": 0.355
+        },
+        "top_10": {
+          "n": 10,
+          "mean_apy_millions": 20.8356,
+          "median_apy_millions": 20.05,
+          "floor_apy_millions": 19.5,
+          "ceiling_apy_millions": 24.1,
+          "mean_total_value_millions": 69.0706,
+          "mean_years": 3.3,
+          "mean_guaranteed_millions": 28.523
+        },
+        "top_25": {
+          "n": 15,
+          "mean_apy_millions": 17.0501,
+          "median_apy_millions": 17.25,
+          "floor_apy_millions": 13.5,
+          "ceiling_apy_millions": 19.4,
+          "mean_total_value_millions": 70.4833,
+          "mean_years": 4.0667,
+          "mean_guaranteed_millions": 32.1113
+        },
+        "top_50": {
+          "n": 25,
+          "mean_apy_millions": 10.8156,
+          "median_apy_millions": 10.25,
+          "floor_apy_millions": 8.5,
+          "ceiling_apy_millions": 13.5,
+          "mean_total_value_millions": 31.0835,
+          "mean_years": 2.84,
+          "mean_guaranteed_millions": 17.4179
+        }
+      },
+      "EDGE": {
+        "rest": {
+          "n": 1584,
+          "mean_apy_millions": 1.165,
+          "median_apy_millions": 0.8083,
+          "floor_apy_millions": 0,
+          "ceiling_apy_millions": 13,
+          "mean_total_value_millions": 2.3376,
+          "mean_years": 1.6143,
+          "mean_guaranteed_millions": 0.9291
+        },
+        "top_10": {
+          "n": 10,
+          "mean_apy_millions": 26.7467,
+          "median_apy_millions": 26,
+          "floor_apy_millions": 24.007,
+          "ceiling_apy_millions": 34,
+          "mean_total_value_millions": 101.9275,
+          "mean_years": 3.7,
+          "mean_guaranteed_millions": 53.8465
+        },
+        "top_25": {
+          "n": 15,
+          "mean_apy_millions": 19.406,
+          "median_apy_millions": 19,
+          "floor_apy_millions": 17,
+          "ceiling_apy_millions": 24,
+          "mean_total_value_millions": 66.4069,
+          "mean_years": 3.4,
+          "mean_guaranteed_millions": 26.5775
+        },
+        "top_50": {
+          "n": 25,
+          "mean_apy_millions": 14.6802,
+          "median_apy_millions": 14.5,
+          "floor_apy_millions": 13,
+          "ceiling_apy_millions": 17,
+          "mean_total_value_millions": 43.2146,
+          "mean_years": 2.96,
+          "mean_guaranteed_millions": 21.7475
+        }
+      },
+      "IDL": {
+        "rest": {
+          "n": 2346,
+          "mean_apy_millions": 0.9495,
+          "median_apy_millions": 0.75,
+          "floor_apy_millions": 0,
+          "ceiling_apy_millions": 10.055,
+          "mean_total_value_millions": 1.686,
+          "mean_years": 1.4339,
+          "mean_guaranteed_millions": 0.5187
+        },
+        "top_10": {
+          "n": 10,
+          "mean_apy_millions": 25.6667,
+          "median_apy_millions": 24.125,
+          "floor_apy_millions": 22.5,
+          "ceiling_apy_millions": 31.75,
+          "mean_total_value_millions": 98.075,
+          "mean_years": 3.8,
+          "mean_guaranteed_millions": 47.2141
+        },
+        "top_25": {
+          "n": 15,
+          "mean_apy_millions": 19.8533,
+          "median_apy_millions": 21,
+          "floor_apy_millions": 17,
+          "ceiling_apy_millions": 22.5,
+          "mean_total_value_millions": 66.9379,
+          "mean_years": 3.4,
+          "mean_guaranteed_millions": 27.5675
+        },
+        "top_50": {
+          "n": 25,
+          "mean_apy_millions": 13.1687,
+          "median_apy_millions": 13,
+          "floor_apy_millions": 10.25,
+          "ceiling_apy_millions": 17,
+          "mean_total_value_millions": 33.9561,
+          "mean_years": 2.56,
+          "mean_guaranteed_millions": 18.0597
+        }
+      },
+      "IOL": {
+        "rest": {
+          "n": 2068,
+          "mean_apy_millions": 0.8553,
+          "median_apy_millions": 0.7617,
+          "floor_apy_millions": 0,
+          "ceiling_apy_millions": 8,
+          "mean_total_value_millions": 1.5979,
+          "mean_years": 1.5044,
+          "mean_guaranteed_millions": 0.4037
+        },
+        "top_10": {
+          "n": 10,
+          "mean_apy_millions": 18.9461,
+          "median_apy_millions": 18.4625,
+          "floor_apy_millions": 17,
+          "ceiling_apy_millions": 21,
+          "mean_total_value_millions": 70.7386,
+          "mean_years": 3.7,
+          "mean_guaranteed_millions": 32.6594
+        },
+        "top_25": {
+          "n": 15,
+          "mean_apy_millions": 14.6563,
+          "median_apy_millions": 14.25,
+          "floor_apy_millions": 13,
+          "ceiling_apy_millions": 17,
+          "mean_total_value_millions": 41.9574,
+          "mean_years": 2.8667,
+          "mean_guaranteed_millions": 21.9147
+        },
+        "top_50": {
+          "n": 25,
+          "mean_apy_millions": 10.1115,
+          "median_apy_millions": 10,
+          "floor_apy_millions": 8,
+          "ceiling_apy_millions": 12.5,
+          "mean_total_value_millions": 33.936,
+          "mean_years": 3.36,
+          "mean_guaranteed_millions": 16.3276
+        }
+      },
+      "LB": {
+        "rest": {
+          "n": 2082,
+          "mean_apy_millions": 0.8139,
+          "median_apy_millions": 0.7633,
+          "floor_apy_millions": 0.1428,
+          "ceiling_apy_millions": 6.3,
+          "mean_total_value_millions": 1.364,
+          "mean_years": 1.4669,
+          "mean_guaranteed_millions": 0.2844
+        },
+        "top_10": {
+          "n": 10,
+          "mean_apy_millions": 15.9077,
+          "median_apy_millions": 14.75,
+          "floor_apy_millions": 12.5,
+          "ceiling_apy_millions": 20,
+          "mean_total_value_millions": 60.0555,
+          "mean_years": 3.6,
+          "mean_guaranteed_millions": 26.7365
+        },
+        "top_25": {
+          "n": 15,
+          "mean_apy_millions": 10.5252,
+          "median_apy_millions": 10.25,
+          "floor_apy_millions": 9.5,
+          "ceiling_apy_millions": 12.5,
+          "mean_total_value_millions": 34.434,
+          "mean_years": 3.2667,
+          "mean_guaranteed_millions": 16.938
+        },
+        "top_50": {
+          "n": 25,
+          "mean_apy_millions": 7.5663,
+          "median_apy_millions": 7.25,
+          "floor_apy_millions": 6.3333,
+          "ceiling_apy_millions": 9.3333,
+          "mean_total_value_millions": 18.016,
+          "mean_years": 2.36,
+          "mean_guaranteed_millions": 9.2921
+        }
+      },
+      "OT": {
+        "rest": {
+          "n": 1451,
+          "mean_apy_millions": 0.9836,
+          "median_apy_millions": 0.75,
+          "floor_apy_millions": 0.0618,
+          "ceiling_apy_millions": 12,
+          "mean_total_value_millions": 1.9187,
+          "mean_years": 1.5389,
+          "mean_guaranteed_millions": 0.6864
+        },
+        "top_10": {
+          "n": 10,
+          "mean_apy_millions": 24.8188,
+          "median_apy_millions": 24.25,
+          "floor_apy_millions": 22,
+          "ceiling_apy_millions": 28.125,
+          "mean_total_value_millions": 99.3845,
+          "mean_years": 4,
+          "mean_guaranteed_millions": 43.3905
+        },
+        "top_25": {
+          "n": 15,
+          "mean_apy_millions": 19.015,
+          "median_apy_millions": 19,
+          "floor_apy_millions": 17.5,
+          "ceiling_apy_millions": 20.5,
+          "mean_total_value_millions": 71.105,
+          "mean_years": 3.7333,
+          "mean_guaranteed_millions": 32.9595
+        },
+        "top_50": {
+          "n": 25,
+          "mean_apy_millions": 15.1419,
+          "median_apy_millions": 15,
+          "floor_apy_millions": 12.5,
+          "ceiling_apy_millions": 17.5,
+          "mean_total_value_millions": 48.78,
+          "mean_years": 3.2,
+          "mean_guaranteed_millions": 21.158
+        }
+      },
+      "QB": {
+        "rest": {
+          "n": 855,
+          "mean_apy_millions": 1.055,
+          "median_apy_millions": 0.764,
+          "floor_apy_millions": 0.11,
+          "ceiling_apy_millions": 9.1984,
+          "mean_total_value_millions": 1.9225,
+          "mean_years": 1.4503,
+          "mean_guaranteed_millions": 0.9199
+        },
+        "top_10": {
+          "n": 10,
+          "mean_apy_millions": 53.6872,
+          "median_apy_millions": 53.05,
+          "floor_apy_millions": 50.2717,
+          "ceiling_apy_millions": 60,
+          "mean_total_value_millions": 236.2715,
+          "mean_years": 4.6,
+          "mean_guaranteed_millions": 120.5246
+        },
+        "top_25": {
+          "n": 15,
+          "mean_apy_millions": 41.1272,
+          "median_apy_millions": 40,
+          "floor_apy_millions": 33.3333,
+          "ceiling_apy_millions": 49,
+          "mean_total_value_millions": 183.2282,
+          "mean_years": 4.3333,
+          "mean_guaranteed_millions": 86.2784
+        },
+        "top_50": {
+          "n": 25,
+          "mean_apy_millions": 18.2442,
+          "median_apy_millions": 14,
+          "floor_apy_millions": 9.375,
+          "ceiling_apy_millions": 33,
+          "mean_total_value_millions": 36.0348,
+          "mean_years": 2,
+          "mean_guaranteed_millions": 24.6883
+        }
+      },
+      "RB": {
+        "rest": {
+          "n": 1802,
+          "mean_apy_millions": 0.7066,
+          "median_apy_millions": 0.705,
+          "floor_apy_millions": 0,
+          "ceiling_apy_millions": 4.55,
+          "mean_total_value_millions": 1.2249,
+          "mean_years": 1.4595,
+          "mean_guaranteed_millions": 0.1942
+        },
+        "top_10": {
+          "n": 10,
+          "mean_apy_millions": 13.8149,
+          "median_apy_millions": 12.5917,
+          "floor_apy_millions": 12,
+          "ceiling_apy_millions": 19,
+          "mean_total_value_millions": 47.8913,
+          "mean_years": 3.5,
+          "mean_guaranteed_millions": 20.8441
+        },
+        "top_25": {
+          "n": 15,
+          "mean_apy_millions": 10.0083,
+          "median_apy_millions": 10.091,
+          "floor_apy_millions": 8,
+          "ceiling_apy_millions": 12,
+          "mean_total_value_millions": 21.4683,
+          "mean_years": 2.1333,
+          "mean_guaranteed_millions": 9.9485
+        },
+        "top_50": {
+          "n": 25,
+          "mean_apy_millions": 6.1181,
+          "median_apy_millions": 6,
+          "floor_apy_millions": 4.875,
+          "ceiling_apy_millions": 8,
+          "mean_total_value_millions": 15.2193,
+          "mean_years": 2.48,
+          "mean_guaranteed_millions": 8.7795
+        }
+      },
+      "S": {
+        "rest": {
+          "n": 1667,
+          "mean_apy_millions": 0.8203,
+          "median_apy_millions": 0.7633,
+          "floor_apy_millions": 0.0733,
+          "ceiling_apy_millions": 7,
+          "mean_total_value_millions": 1.4657,
+          "mean_years": 1.5201,
+          "mean_guaranteed_millions": 0.3217
+        },
+        "top_10": {
+          "n": 10,
+          "mean_apy_millions": 17.49,
+          "median_apy_millions": 17.3115,
+          "floor_apy_millions": 15.25,
+          "ceiling_apy_millions": 21.025,
+          "mean_total_value_millions": 63.0231,
+          "mean_years": 3.6,
+          "mean_guaranteed_millions": 26.3306
+        },
+        "top_25": {
+          "n": 15,
+          "mean_apy_millions": 12.9239,
+          "median_apy_millions": 12.911,
+          "floor_apy_millions": 11.25,
+          "ceiling_apy_millions": 14.75,
+          "mean_total_value_millions": 34.4039,
+          "mean_years": 2.6,
+          "mean_guaranteed_millions": 16.1558
+        },
+        "top_50": {
+          "n": 25,
+          "mean_apy_millions": 8.7806,
+          "median_apy_millions": 9,
+          "floor_apy_millions": 7,
+          "ceiling_apy_millions": 11,
+          "mean_total_value_millions": 21.909,
+          "mean_years": 2.52,
+          "mean_guaranteed_millions": 12.4036
+        }
+      },
+      "ST": {
+        "rest": {
+          "n": 1004,
+          "mean_apy_millions": 0.6849,
+          "median_apy_millions": 0.7425,
+          "floor_apy_millions": 0,
+          "ceiling_apy_millions": 2.627,
+          "mean_total_value_millions": 1.1403,
+          "mean_years": 1.4392,
+          "mean_guaranteed_millions": 0.1302
+        },
+        "top_10": {
+          "n": 10,
+          "mean_apy_millions": 5.6401,
+          "median_apy_millions": 5.5005,
+          "floor_apy_millions": 5.275,
+          "ceiling_apy_millions": 6.4,
+          "mean_total_value_millions": 20.4004,
+          "mean_years": 3.6,
+          "mean_guaranteed_millions": 10.1918
+        },
+        "top_25": {
+          "n": 15,
+          "mean_apy_millions": 4.3856,
+          "median_apy_millions": 4.3,
+          "floor_apy_millions": 3.755,
+          "ceiling_apy_millions": 5.1,
+          "mean_total_value_millions": 15.1503,
+          "mean_years": 3.4,
+          "mean_guaranteed_millions": 6.3693
+        },
+        "top_50": {
+          "n": 25,
+          "mean_apy_millions": 3.1534,
+          "median_apy_millions": 3,
+          "floor_apy_millions": 2.6667,
+          "ceiling_apy_millions": 3.75,
+          "mean_total_value_millions": 8.3862,
+          "mean_years": 2.68,
+          "mean_guaranteed_millions": 3.4867
+        }
+      },
+      "TE": {
+        "rest": {
+          "n": 1573,
+          "mean_apy_millions": 0.7264,
+          "median_apy_millions": 0.705,
+          "floor_apy_millions": 0,
+          "ceiling_apy_millions": 6,
+          "mean_total_value_millions": 1.2572,
+          "mean_years": 1.4609,
+          "mean_guaranteed_millions": 0.2125
+        },
+        "top_10": {
+          "n": 10,
+          "mean_apy_millions": 14.8625,
+          "median_apy_millions": 14.2812,
+          "floor_apy_millions": 13,
+          "ceiling_apy_millions": 17.125,
+          "mean_total_value_millions": 54.45,
+          "mean_years": 3.7,
+          "mean_guaranteed_millions": 22.2423
+        },
+        "top_25": {
+          "n": 15,
+          "mean_apy_millions": 11.1819,
+          "median_apy_millions": 10.931,
+          "floor_apy_millions": 9.8333,
+          "ceiling_apy_millions": 12.5,
+          "mean_total_value_millions": 29.3863,
+          "mean_years": 2.6,
+          "mean_guaranteed_millions": 14.2701
+        },
+        "top_50": {
+          "n": 25,
+          "mean_apy_millions": 7.1408,
+          "median_apy_millions": 7,
+          "floor_apy_millions": 6,
+          "ceiling_apy_millions": 9,
+          "mean_total_value_millions": 16.1914,
+          "mean_years": 2.24,
+          "mean_guaranteed_millions": 9.6881
+        }
+      },
+      "WR": {
+        "rest": {
+          "n": 3449,
+          "mean_apy_millions": 0.8059,
+          "median_apy_millions": 0.705,
+          "floor_apy_millions": 0.1069,
+          "ceiling_apy_millions": 13,
+          "mean_total_value_millions": 1.4726,
+          "mean_years": 1.4503,
+          "mean_guaranteed_millions": 0.4215
+        },
+        "top_10": {
+          "n": 10,
+          "mean_apy_millions": 30.4752,
+          "median_apy_millions": 30,
+          "floor_apy_millions": 27.5,
+          "ceiling_apy_millions": 35,
+          "mean_total_value_millions": 115.676,
+          "mean_years": 3.8,
+          "mean_guaranteed_millions": 49.5323
+        },
+        "top_25": {
+          "n": 15,
+          "mean_apy_millions": 23.7576,
+          "median_apy_millions": 23.85,
+          "floor_apy_millions": 20.628,
+          "ceiling_apy_millions": 27.25,
+          "mean_total_value_millions": 65.4357,
+          "mean_years": 2.7333,
+          "mean_guaranteed_millions": 34.1282
+        },
+        "top_50": {
+          "n": 25,
+          "mean_apy_millions": 17.3353,
+          "median_apy_millions": 17.5,
+          "floor_apy_millions": 13.75,
+          "ceiling_apy_millions": 20.5,
+          "mean_total_value_millions": 46.0992,
+          "mean_years": 2.64,
+          "mean_guaranteed_millions": 23.1474
+        }
+      }
+    },
+    "resigning_rate": {
+      "overall": {
+        "external_signing": {
+          "n": 13833,
+          "proportion": 0.8067
+        },
+        "resign_own_team": {
+          "n": 3315,
+          "proportion": 0.1933
+        }
+      },
+      "by_position_group": {
+        "WR": {
+          "vet_contracts": 2601,
+          "resigned_own": 599,
+          "external": 1994,
+          "resign_rate": 0.2303
+        },
+        "OT": {
+          "vet_contracts": 1085,
+          "resigned_own": 248,
+          "external": 837,
+          "resign_rate": 0.2286
+        },
+        "TE": {
+          "vet_contracts": 1178,
+          "resigned_own": 267,
+          "external": 908,
+          "resign_rate": 0.2267
+        },
+        "EDGE": {
+          "vet_contracts": 1151,
+          "resigned_own": 253,
+          "external": 889,
+          "resign_rate": 0.2198
+        },
+        "RB": {
+          "vet_contracts": 1330,
+          "resigned_own": 278,
+          "external": 1048,
+          "resign_rate": 0.209
+        },
+        "S": {
+          "vet_contracts": 1215,
+          "resigned_own": 249,
+          "external": 966,
+          "resign_rate": 0.2049
+        },
+        "LB": {
+          "vet_contracts": 1525,
+          "resigned_own": 308,
+          "external": 1210,
+          "resign_rate": 0.202
+        },
+        "IOL": {
+          "vet_contracts": 1595,
+          "resigned_own": 309,
+          "external": 1247,
+          "resign_rate": 0.1937
+        },
+        "IDL": {
+          "vet_contracts": 1866,
+          "resigned_own": 296,
+          "external": 1570,
+          "resign_rate": 0.1586
+        },
+        "CB": {
+          "vet_contracts": 2081,
+          "resigned_own": 325,
+          "external": 1750,
+          "resign_rate": 0.1562
+        },
+        "QB": {
+          "vet_contracts": 692,
+          "resigned_own": 105,
+          "external": 587,
+          "resign_rate": 0.1517
+        },
+        "ST": {
+          "vet_contracts": 829,
+          "resigned_own": 78,
+          "external": 744,
+          "resign_rate": 0.0941
+        }
+      }
+    },
+    "contract_length_years_external": {
+      "CB": {
+        "n": 1930,
+        "mean_years": 1.2238,
+        "median_years": 1,
+        "p10_years": 1,
+        "p90_years": 2
+      },
+      "EDGE": {
+        "n": 940,
+        "mean_years": 1.2755,
+        "median_years": 1,
+        "p10_years": 1,
+        "p90_years": 2
+      },
+      "IDL": {
+        "n": 1654,
+        "mean_years": 1.1923,
+        "median_years": 1,
+        "p10_years": 1,
+        "p90_years": 2
+      },
+      "IOL": {
+        "n": 1334,
+        "mean_years": 1.2324,
+        "median_years": 1,
+        "p10_years": 1,
+        "p90_years": 2
+      },
+      "LB": {
+        "n": 1325,
+        "mean_years": 1.1955,
+        "median_years": 1,
+        "p10_years": 1,
+        "p90_years": 2
+      },
+      "OT": {
+        "n": 909,
+        "mean_years": 1.1969,
+        "median_years": 1,
+        "p10_years": 1,
+        "p90_years": 2
+      },
+      "QB": {
+        "n": 623,
+        "mean_years": 1.236,
+        "median_years": 1,
+        "p10_years": 1,
+        "p90_years": 2
+      },
+      "RB": {
+        "n": 1146,
+        "mean_years": 1.1832,
+        "median_years": 1,
+        "p10_years": 1,
+        "p90_years": 2
+      },
+      "S": {
+        "n": 1036,
+        "mean_years": 1.2066,
+        "median_years": 1,
+        "p10_years": 1,
+        "p90_years": 2
+      },
+      "ST": {
+        "n": 798,
+        "mean_years": 1.2581,
+        "median_years": 1,
+        "p10_years": 1,
+        "p90_years": 2
+      },
+      "TE": {
+        "n": 997,
+        "mean_years": 1.1846,
+        "median_years": 1,
+        "p10_years": 1,
+        "p90_years": 2
+      },
+      "WR": {
+        "n": 2127,
+        "mean_years": 1.166,
+        "median_years": 1,
+        "p10_years": 1,
+        "p90_years": 2
+      }
+    },
+    "guarantee_share_external": {
+      "CB": {
+        "n": 1930,
+        "mean_guarantee_share": 0.0588,
+        "median_guarantee_share": 0,
+        "p10_guarantee_share": 0,
+        "p90_guarantee_share": 0.1889
+      },
+      "EDGE": {
+        "n": 940,
+        "mean_guarantee_share": 0.1179,
+        "median_guarantee_share": 0,
+        "p10_guarantee_share": 0,
+        "p90_guarantee_share": 0.5303
+      },
+      "IDL": {
+        "n": 1653,
+        "mean_guarantee_share": 0.079,
+        "median_guarantee_share": 0,
+        "p10_guarantee_share": 0,
+        "p90_guarantee_share": 0.3786
+      },
+      "IOL": {
+        "n": 1333,
+        "mean_guarantee_share": 0.0814,
+        "median_guarantee_share": 0,
+        "p10_guarantee_share": 0,
+        "p90_guarantee_share": 0.3647
+      },
+      "LB": {
+        "n": 1325,
+        "mean_guarantee_share": 0.0778,
+        "median_guarantee_share": 0,
+        "p10_guarantee_share": 0,
+        "p90_guarantee_share": 0.3594
+      },
+      "OT": {
+        "n": 909,
+        "mean_guarantee_share": 0.0813,
+        "median_guarantee_share": 0,
+        "p10_guarantee_share": 0,
+        "p90_guarantee_share": 0.3389
+      },
+      "QB": {
+        "n": 623,
+        "mean_guarantee_share": 0.1524,
+        "median_guarantee_share": 0,
+        "p10_guarantee_share": 0,
+        "p90_guarantee_share": 0.7474
+      },
+      "RB": {
+        "n": 1146,
+        "mean_guarantee_share": 0.0605,
+        "median_guarantee_share": 0,
+        "p10_guarantee_share": 0,
+        "p90_guarantee_share": 0.2172
+      },
+      "S": {
+        "n": 1036,
+        "mean_guarantee_share": 0.0856,
+        "median_guarantee_share": 0,
+        "p10_guarantee_share": 0,
+        "p90_guarantee_share": 0.4012
+      },
+      "ST": {
+        "n": 796,
+        "mean_guarantee_share": 0.07,
+        "median_guarantee_share": 0,
+        "p10_guarantee_share": 0,
+        "p90_guarantee_share": 0.3422
+      },
+      "TE": {
+        "n": 997,
+        "mean_guarantee_share": 0.0651,
+        "median_guarantee_share": 0,
+        "p10_guarantee_share": 0,
+        "p90_guarantee_share": 0.2628
+      },
+      "WR": {
+        "n": 2127,
+        "mean_guarantee_share": 0.0603,
+        "median_guarantee_share": 0,
+        "p10_guarantee_share": 0,
+        "p90_guarantee_share": 0.162
+      }
+    },
+    "signing_timing_waves": {
+      "source": "data/docs/free-agent-market.md",
+      "note": "OTC feed exposes year_signed only. Wave rates (legal tampering / first 2 weeks / April bargain / June post-draft) are documented in the research doc and should be sampled from there until a dated feed is integrated."
+    }
+  }
+}

--- a/data/docs/calibration-gaps.md
+++ b/data/docs/calibration-gaps.md
@@ -25,16 +25,16 @@ The sim has three layers of calibration targets:
 
 ## Market & Career (the league-building layer)
 
-| # | Gap                                                                                              | Primary source                                          | Issue |
-| - | ------------------------------------------------------------------------------------------------ | ------------------------------------------------------- | ----- |
-| 1 | Position market sizing (roster slots, starter counts, snap-share thresholds per position)        | `nflreadr::load_rosters_weekly()`, `load_snap_counts()` | #510  |
-| 2 | Draft position distribution (positions picked per round, last 10 drafts)                         | `nflreadr::load_draft_picks()`                          | #511  |
-| 3 | Draft pick trade-value (observed vs Jimmy Johnson / Rich Hill curves)                            | `load_draft_picks()` + trade scrape                     | #512  |
-| 4 | Draft hit-rate bands — `P(multi-year starter \| round, position)`                                | `load_draft_picks()` + career snaps                     | #513  |
-| 5 | Free agent market (UFAs signed per offseason by position, AAV bands)                             | `nflreadr::load_contracts()`                            | #514  |
-| 6 | Contract structure (length, guarantee %, cap-hit shape by position × tier)                       | `load_contracts()` + OTC cross-check                    | #515  |
-| 7 | Career length + aging curves — `P(active \| age, position)`, peak years                          | `load_rosters()` longitudinal                           | #516  |
-| 8 | Coaching tenure + firing patterns (HC tenure distribution, W-L triggers, coordinator → HC rates) | Manual scrape (PFR head-coach history)                  | #517  |
+| # | Gap                                                                                                                                                    | Primary source                                          | Issue       |
+| - | ------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------- | ----------- |
+| 1 | Position market sizing (roster slots, starter counts, snap-share thresholds per position)                                                              | `nflreadr::load_rosters_weekly()`, `load_snap_counts()` | #510        |
+| 2 | Draft position distribution (positions picked per round, last 10 drafts)                                                                               | `nflreadr::load_draft_picks()`                          | #511        |
+| 3 | Draft pick trade-value (observed vs Jimmy Johnson / Rich Hill curves)                                                                                  | `load_draft_picks()` + trade scrape                     | #512        |
+| 4 | Draft hit-rate bands — `P(multi-year starter \| round, position)`                                                                                      | `load_draft_picks()` + career snaps                     | #513        |
+| 5 | Free agent market (UFAs signed per offseason by position, AAV bands) — [band](../bands/free-agent-market.json) + [doc](./free-agent-market.md)         | `nflreadr::load_contracts()`                            | #514 (done) |
+| 6 | Contract structure (length, guarantee %, cap-hit shape by position × tier) — [band](../bands/contract-structure.json) + [doc](./contract-structure.md) | `load_contracts()` + OTC cross-check                    | #515 (done) |
+| 7 | Career length + aging curves — `P(active \| age, position)`, peak years                                                                                | `load_rosters()` longitudinal                           | #516        |
+| 8 | Coaching tenure + firing patterns (HC tenure distribution, W-L triggers, coordinator → HC rates)                                                       | Manual scrape (PFR head-coach history)                  | #517        |
 
 These directly serve the user-named asks:
 

--- a/data/docs/contract-structure.md
+++ b/data/docs/contract-structure.md
@@ -1,0 +1,215 @@
+# NFL Contract Structure — Length, Guarantee, Cap-Hit Shape
+
+A calibration reference for the Zone Blitz sim's **contract offer generator**,
+**cap management AI**, and **extension-timing AI**. Real NFL contracts are
+shaped — signing bonuses amortize, guarantees descend, cap hits back-load for
+competitive windows, and void years push cash forward while deferring cap pain.
+Without that shape the sim can't credibly simulate a cut, a restructure, or
+dead-cap consequences.
+
+Companion band:
+[`data/bands/contract-structure.json`](../bands/contract-structure.json).
+Companion script:
+[`data/R/bands/contract-structure.R`](../R/bands/contract-structure.R). Gap
+index row: [calibration-gaps.md #6 (#515)](./calibration-gaps.md).
+
+## Sources
+
+- `nflreadr::load_contracts()` — OTC historical feed plus the nested `cols`
+  table (year-by-year cap ledger: `base_salary`, `prorated_bonus`,
+  `roster_bonus`, `guaranteed_salary`, `cap_number`).
+- OverTheCap contract pages for verified structure examples:
+  - <https://overthecap.com/contract/joe-burrow/>
+  - <https://overthecap.com/contract/patrick-mahomes/>
+  - <https://overthecap.com/contract/quinnen-williams/>
+- Spotrac signing-bonus / guarantee breakdowns for cross-check:
+  - <https://www.spotrac.com/nfl/contracts/sort-signing-bonus/all-time/limit-50/>
+- Season window: **2020–2024**.
+
+## Vocabulary — what the feed calls what
+
+| OTC column                 | Meaning                                                                  |
+| -------------------------- | ------------------------------------------------------------------------ |
+| `value`                    | Total nominal contract value (sum of all cash over the stated term)      |
+| `apy`                      | Average-per-year = value / years                                         |
+| `years`                    | Stated contract length in years (does not count void years)              |
+| `guaranteed`               | Practical total guarantee (full + injury + rolling). **Not** fully guar. |
+| `cols$prorated_bonus` (y1) | Signing-bonus cap charge for year 1 (signing_bonus / years)              |
+| `cols$cap_number` (y_N)    | Total cap hit in year N (base + prorated + roster + workout + per-game)  |
+| `cols$guaranteed_salary`   | Portion of base salary guaranteed in year N                              |
+
+**Signing bonus** (up-front cash) is amortized evenly across the contract's
+`years`. That's why the band reconstructs signing-bonus share from the year-1
+prorated_bonus × years.
+
+## Tier methodology
+
+Same as the free-agent band: contracts in 2020–2024 are ranked by APY within
+each position group. Tiers: `top_10` / `top_25` (ranks 11–25) / `top_50` (ranks
+26–50) / `rest`. This matches how Spotrac and OTC present position market
+leaderboards.
+
+## Length and guarantee by position × tier (top-10 only)
+
+| Position | Mean years | Mean guarantee share | Read                                                    |
+| -------- | ---------- | -------------------- | ------------------------------------------------------- |
+| QB       | 4.6        | 51.5%                | Longest terms, highest practical guarantees             |
+| OT       | 4.0        | 45.8%                | OL age well; teams lock them up long                    |
+| WR       | 3.8        | 43.4%                | 4-year deals are modal at the top                       |
+| IDL      | 3.8        | 51.2%                | Chris Jones / Quinnen Williams tier — long + guaranteed |
+| EDGE     | 3.7        | 47.0%                | Similar shape to IDL; younger tail                      |
+| IOL      | 3.7        | 53.0%                | Highest guarantee share in the league                   |
+| TE       | 3.7        | 41.6%                | 3–4 years modal; lower guarantees                       |
+| LB       | 3.6        | 48.6%                | Warner / Roquan tier                                    |
+| S        | 3.6        | 38.1%                | Compressed market; Minkah tier is the outlier           |
+| ST       | 3.6        | 50.4%                | Kickers get surprising term when they hit               |
+| RB       | 3.5        | 47.8%                | Shortest at the top; guarantee floor is real            |
+| CB       | 3.3        | 39.3%                | CBs sign shortest and least-guaranteed at the top       |
+
+Full per-tier numbers live in the band JSON.
+
+## Cap-hit shape — the "Y1 cheap, Y3 expensive" pattern
+
+The band normalizes each contract's cap_number for years 1–5 by the sum of its
+cap hits. Top-10 tier shape by position (share of total cap hit):
+
+| Position | Y1                                                                 | Y2    | Y3    | Y4    | Y5    |
+| -------- | ------------------------------------------------------------------ | ----- | ----- | ----- | ----- |
+| QB       | 15.6%                                                              | 22.4% | 20.1% | 27.7% | 34.1% |
+| RB       | 26.5%                                                              | 31.2% | 36.1% | 18.3% | 21.6% |
+| WR       | 20% — driven by signing-bonus + low-base Y1, ramping to 30%+ by Y4 |       |       |       |       |
+| OT       | Similar to QB — back-loaded with the tackle sweet spot in Y3–Y4    |       |       |       |       |
+
+(Full matrix in `cap_hit_shape_by_position_tier` in the band JSON.)
+
+Read: top-10 QB contracts carry only ~15% of the total cap hit in year 1 (most
+of the cash is in a signing bonus that gets prorated) and climb to ~34% by
+year 5. That back-loaded shape is what makes restructures possible later — the
+team can convert base salary to signing bonus in year 3 or 4, pushing the hit
+further down the contract.
+
+RB contracts are the opposite shape: front-loaded in Y1–Y3 because teams know
+Y4–Y5 might not happen. Barkley's PHI deal and Jacobs' GB deal both fit this
+pattern — the cash comes early, the cap hit tracks the cash.
+
+## Signing-bonus share by tier
+
+Top-10 QB mean signing-bonus share ~49% (median 42%, p10 22%, p90 80%). This is
+the mechanism — when a GM wants to lower a Y1 cap hit, they convert guaranteed
+base salary into signing bonus, proratating it across years. The higher the
+signing-bonus share, the more aggressively the contract has been
+cash-accelerated.
+
+Position patterns:
+
+- **QB top-10** — highest signing-bonus share in the league. Burrow, Jackson,
+  Allen all sit at 40–55% of total cap hit in prorated signing bonus.
+- **OT / IDL top-10** — mid 40s%. These are stable cap shapes.
+- **RB top-10** — mid 30s%. Teams don't want long amortization tails on RBs.
+- **Specialists** — low teens. Kickers and punters get paid mostly in base.
+
+## Void years — the cash-flow trick
+
+A **void year** is a fake contract year tacked onto the end of the deal for
+cap-accounting purposes only. It lets the team spread a signing bonus over more
+years — lowering the prorated cap hit per year — with the knowledge that the
+player will never play under it. The void year "voids" automatically at end of
+the stated term and the remaining amortization accelerates into the next league
+year as dead cap.
+
+The band provides a **weak** void-year usage rate per position (0.1–0.6%)
+because the OTC feed's nested `cols` table doesn't explicitly mark void years —
+it merges all of a player's contracts (rookie deal + extension) into one cap
+timeline, making void-year detection nearly impossible from this source. The
+published rates understate real usage by an order of magnitude: independent OTC
+reporting shows **~30%+ of top-10 QB contracts and ~20%+ of top-10 EDGE
+contracts** carry void years. The sim should use those qualitative priors, not
+the weak heuristic rates.
+
+**Canonical void-year deals:**
+
+- Dak Prescott (DAL, 2024, 4 years + 2 void) — classic void-year structure.
+- Aaron Rodgers (NYJ, 2023 restructure) — void years converted $35M base to
+  bonus.
+- Myles Garrett (CLE, 2020 extension + 2024 restructure) — void years on every
+  restructure pass.
+
+## Restructures — not in the feed
+
+The OTC `load_contracts()` feed is one row per **signed** contract; it does not
+log restructure events (where an existing deal gets its base salary converted to
+bonus to lower the current-year cap hit). The band exposes
+`restructure_frequency` as a pointer to this doc.
+
+Qualitative priors (from OTC restructure tracking, 2020–2024):
+
+- **Top-10 QB contracts** get restructured in ~60% of Y2 and ~70% of Y3. Every
+  big QB deal is restructured at least once before Y4.
+- **Top-10 WR/EDGE/IDL** deals: ~30–40% restructure rate in Y2 or Y3, driven by
+  whether the signing team is in a competitive window.
+- **RB / S / CB top-10** deals: restructure rate <15%; shorter terms and
+  cut-friendly structures mean teams just absorb or cut rather than restructure.
+- **Sub-top-10 tiers**: restructures are rare (<5%).
+
+The sim's cap AI should model restructures as a per-Y2/Y3 roll: team competitive
+window + top-10 tier → high restructure probability; otherwise cut-or-keep
+decision against dead cap.
+
+## Dead-cap mechanics (sim-relevant summary)
+
+When a team releases a player, the unamortized signing bonus accelerates into
+dead cap. Two variants:
+
+- **Pre-June-1 cut** — all remaining prorated signing bonus hits the current
+  year's cap. Painful for teams cutting star contracts.
+- **Post-June-1 cut** (real date or designation, teams get 2/yr) — current year
+  absorbs the current year's prorated hit only; the remaining balance hits next
+  year's cap.
+
+For the sim:
+
+1. Track remaining prorated balance per contract. On cut, compute dead cap = sum
+   of remaining prorated shares.
+2. Offer the team a "post-June-1 designation" option (max 2/team/yr) that splits
+   dead cap across two years.
+3. Void-year amortization accelerates on the regular March league-year rollover
+   — the sim should automatically roll void-year dead cap into the next cap
+   cycle.
+
+## What the sim should do with this band
+
+1. **Contract offer generator (user + NPC)** — sample
+   - length from `length_by_position_tier`
+   - guarantee % from `guarantee_share_by_position_tier`
+   - signing-bonus % from `signing_bonus_share_by_position_tier`
+   - year-by-year cap hit shape from `cap_hit_shape_by_position_tier`
+
+   Apply tier probability weights that mirror the observed signing distribution
+   (most deals fall in `rest`, a handful in `top_10`).
+
+2. **Cap-hit timeline** — use the normalized Y1..Y5 shares, multiply by total
+   cap (= sum of year cap_numbers, which equals value + prorated tail), and
+   schedule each year's cap hit. Year 6+ deals are rare outside of QB.
+
+3. **Restructure AI** — Y2/Y3 rolls against the qualitative priors above; on
+   restructure, convert 60–80% of the current year's base salary to signing
+   bonus, reprorating across the remaining term (including any existing or
+   freshly-added void years).
+
+4. **Cut decisions** — the combination of remaining prorated balance + the
+   current year's guarantee status drives the release decision. Guarantee shares
+   in the band tell you _approximately_ how much is still guaranteed in each
+   year of the deal.
+
+## Known gaps / follow-ups
+
+- **Void years**: detection from this feed is unreliable; the sim should use the
+  qualitative rates above, not the band's `void_year_usage_rate_by_position`
+  numbers, until an OTC transactions feed is sourced.
+- **Restructures**: not tracked in the feed at all — qualitative priors only.
+- **Guarantee decay by year**: the feed gives one `guaranteed` number per
+  contract, not a per-year breakdown. The sim should apply a standard decay (Y1
+  fully, Y2 mostly, Y3 partial, Y4+ none) unless a richer source is added.
+- **Offset language and per-game roster bonuses**: the `per_game_roster_bonus`
+  column in `cols` is present but not reduced in the band. These are
+  second-order concerns for the offer generator's first pass.

--- a/data/docs/free-agent-market.md
+++ b/data/docs/free-agent-market.md
@@ -1,0 +1,220 @@
+# NFL Free Agent Market — Volume, AAV, and Signing Waves
+
+A calibration reference for the Zone Blitz sim's free agent period. Covers **how
+many UFAs sign per offseason**, **at what AAVs by position and tier**, **when in
+the calendar signings happen**, and **how often players re-sign with their
+drafting team** vs. leave in free agency.
+
+Companion band:
+[`data/bands/free-agent-market.json`](../bands/free-agent-market.json).
+Companion script:
+[`data/R/bands/free-agent-market.R`](../R/bands/free-agent-market.R). Gap index
+row: [calibration-gaps.md #5 (#514)](./calibration-gaps.md).
+
+## Sources
+
+- `nflreadr::load_contracts()` — OverTheCap historical feed, one row per signed
+  contract (`player`, `position`, `team`, `year_signed`, `years`, `value`,
+  `apy`, `guaranteed`, `draft_team`).
+- Spotrac position leaderboards — cross-checked for top-of-market AAVs.
+  - <https://www.spotrac.com/nfl/rankings/player/_/year/2024/sort/contract_value>
+  - <https://www.spotrac.com/nfl/rankings/player/_/year/2024/position/qb/sort/cap_average>
+- OverTheCap market pages — cross-checked for tier boundaries.
+  - <https://overthecap.com/position/>
+- Season window: **2020–2024** (post-COVID-cap era).
+
+## What counts as a "UFA signing" in the band
+
+The OTC feed does not tag contracts as rookie / extension / UFA, so the band
+uses a heuristic:
+
+- **External UFA signing** = `team != draft_team` and
+  `year_signed > draft_year`. This captures veterans who changed teams.
+- **Own-team re-sign** = `team == draft_team` and `year_signed > draft_year`.
+  Captures extensions and "re-sign before hitting the market" deals; _does not_
+  distinguish between a clean extension and a UFA who came back.
+- **Rookie deals** (`year_signed == draft_year` with the drafting team) are
+  excluded from UFA volume metrics but included in AAV-tier ranking so that
+  rookie-scale contracts don't distort the top-tier pool.
+
+This means "external UFA volume" per offseason overshoots the canonical "veteran
+UFA market" count (which PFF puts at ~200–250 meaningful deals/yr) because the
+feed includes practice-squad signings, futures contracts, ERFA tenders, and
+minimum-salary depth churn. The **relative shape across positions is what the
+sim should anchor on** — not the absolute row count.
+
+## The three market tiers
+
+The band ranks all contracts in the 2020–2024 window by APY within each position
+group and buckets them:
+
+- **`top_10`** — franchise-tier APYs. For QBs, these are the Burrow / Allen /
+  Jackson / Herbert / Hurts / Prescott extensions. For RBs, McCaffrey / Barkley
+  (pre-cut). For WRs, Jefferson / Tyreek / CeeDee.
+- **`top_25`** (ranks 11–25) — clear-starter market. WR2/WR1 tier, starting CBs,
+  starting OTs.
+- **`top_50`** (ranks 26–50) — mid-market starters and first-contract veterans
+  hitting the open market.
+- **`rest`** — depth, specialists, camp bodies, minimums.
+
+The sim's NPC GM FA bidding AI should sample APY from the tier's
+`mean_apy_millions` / `median_apy_millions` fields, bounded by
+`floor_apy_millions` and `ceiling_apy_millions`, with length sampled from
+`contract_length_years_external`.
+
+## Position-market narratives
+
+### Quarterback — franchise tag or bust
+
+- Top-10 APY floor ~\$40M+/yr. Burrow (5/\$275M), Jackson (5/\$260M), Herbert
+  (5/\$262.5M), Hurts (5/\$255M), and Prescott (4/\$240M) all reset the market
+  between 2023 and 2024.
+- Mid-market QBs almost never hit open FA — they get franchise-tagged (Prescott,
+  Jackson) or extended on cheap "bridge-veteran" deals (Tannehill, Cousins
+  year-to-year). Purely "external" QB signings are overwhelmingly backups.
+- Re-signing rate on vet QB deals in the band is the _lowest_ of any offensive
+  position group (~15%) because the feed treats "one-year backup pitstop"
+  signings as external, which dominates the QB row count.
+
+### Running back — short, guarantee-light, post-Barkley
+
+- RB is the position where the market most visibly punishes length. Barkley
+  (3/\$37.75M with PHI, 2024) and Jacobs (4/\$48M with GB) were considered
+  market corrections upward after a brutal 2023 FA cycle.
+- Top-10 RB mean years ~3.5 and guarantee share ~48% — the lowest length among
+  skill positions.
+- RB1/RB2 separation matters: backups routinely sign 1-year/\$1–2M minimums
+  after Week 1 cutdowns.
+
+### Wide receiver — the deepest market
+
+- WR has the most external signings per offseason of any skill position (~425/yr
+  in the band, driven by the volume of WR4-WR6 depth churn).
+- Top-10 WRs are extended by their drafting team (Jefferson 4/\$140M with MIN,
+  Chase 4/\$161M with CIN). The "open-market" top-tier WR deal is rare; when it
+  happens (Tyreek trade-then-extend with MIA, 4/\$120M) it reprices the
+  position.
+- WR1 money is gated by the top-10 APY floor; WR2 money sits in top_25.
+
+### Tight end — bimodal by role
+
+- Kelce, Andrews, Kittle, LaPorta, Goedert top the APY table; blocking-first TEs
+  cluster in the `rest` tier.
+- Top-10 guarantee share (~42%) runs lower than QB/WR because TEs have shorter
+  healthy careers and teams hedge.
+
+### Offensive line — OT premium, IOL compressed
+
+- OT (LT/RT) top-10 APY runs well above IOL (LG/RG/C); Penei Sewell (4/\$112M),
+  Trent Williams (3/\$69M), Laremy Tunsil (3/\$75M) anchor the OT market.
+- IOL top-10 is headlined by Quenton Nelson (4/\$80M) and Joe Thuney deals, but
+  compresses fast: a top-25 guard makes ~half of a top-10 tackle.
+- OL contracts carry some of the **highest guarantee shares** (top-10 IOL at
+  53%) because the position ages well and teams bet on continuity.
+
+### EDGE and IDL — pay the elite, stream the rest
+
+- Top-10 EDGE is QB-adjacent in APY: Bosa (5/\$170M), Parsons future extension,
+  Watt (4/\$112M), Garrett (5/\$125M), Crosby (3/\$35.5M/yr).
+- Mid-tier EDGE gets churned ruthlessly — 3–5 sack starters hit the market and
+  accept 1-year "prove it" deals.
+- IDL splits into the premium 3-technique archetype (Chris Jones 5/\$158.75M,
+  Quinnen Williams 4/\$96M, DeForest Buckner 2/\$45M) and run-plugging NTs who
+  sign modest 2-3 year deals.
+
+### Secondary — CB premium, S commodity
+
+- CB top-10 is paced by Ramsey, Sauce Gardner (rookie-deal), Diggs, Humphrey.
+  Top-10 APY floor sits at the mid-\$20Ms.
+- Safety top-10 runs ~20% below CB at the same tier, reflecting the position's
+  commoditization. Minkah, Derwin James, Budda Baker anchor the top tier; the
+  drop-off to top_25 is steep.
+- CBs have the **second-lowest own-team re-sign rate** in the band (~16%) —
+  cornerbacks move more than any other defensive starter.
+
+### Specialists — the stickiest market
+
+- K/P/LS contracts cluster tight (Tucker 4/\$24M, Butker 4/\$24.75M at the top;
+  mid-market kickers at 2/\$6M).
+- Own-team re-sign rate is the lowest in the band (~9%) largely because
+  specialists churn on minimum 1-year deals and the "team" column flips with
+  every cut-day signing, _not_ because they actually move a lot.
+
+## Signing-timing waves
+
+The OTC feed exposes `year_signed` but **not `date_signed`**. The band carries a
+pointer here; wave rates are documented qualitatively for the sim to sample
+until a dated feed is wired in.
+
+Four canonical waves per offseason (NFL league-year opens mid-March):
+
+1. **Legal tampering (day -2 → day 0)** — ~35–45% of the offseason's total spend
+   and the vast majority of top-10-tier deals. Agreements leak Monday afternoon
+   before the Wednesday league year; by Wednesday 4pm ET most top-tier FAs are
+   off the board. This is where Kirk Cousins to ATL (4/\$180M, 2024), Tee
+   Higgins franchise-tag, and Saquon Barkley to PHI all landed.
+2. **First two weeks post-opening** — ~25–30% of spend. Tier 2 (top_25) and tier
+   3 (top_50) sign here as teams fill out starting lineups.
+3. **April bargain period (pre-draft)** — ~10–15% of spend. Veterans who didn't
+   get their number take 1-year "prove-it" deals. High variance tier for
+   mid-career players.
+4. **June post-draft + training camp** — ~15–20% of spend by count, but mostly
+   minimum-value deals. This is where cut-candidates from other teams land
+   (post-June-1 designations free up real cap) and where UDFAs replace injured
+   camp bodies.
+
+Share numbers are from Spotrac / OTC year-over-year rollup reporting; they are
+not computed from the band and should be treated as priors.
+
+## Re-signing rate (own-team retention)
+
+Observed in the 2020–2024 window, vet contracts only (excludes rookie deals):
+
+| Position | Re-sign rate |
+| -------- | ------------ |
+| WR       | 23.0%        |
+| OT       | 22.9%        |
+| TE       | 22.7%        |
+| EDGE     | 22.0%        |
+| RB       | 20.9%        |
+| S        | 20.5%        |
+| LB       | 20.2%        |
+| IOL      | 19.4%        |
+| IDL      | 15.9%        |
+| CB       | 15.6%        |
+| QB       | 15.2%        |
+| ST       | 9.4%         |
+
+**Read with caveat:** the denominator includes every vet contract signed with
+any team, including minimum-salary depth. The "own-team re-sign rate for a
+**starting-caliber veteran**" runs meaningfully higher — closer to 35–45% on the
+first FA trip for top_25-tier players. The sim should apply a tier multiplier
+(top_10 → ~60% own-team retention via extension-before-FA, top_25 → ~45%, top_50
+→ ~30%, rest → the observed rate above).
+
+## What the sim should do with this band
+
+1. **FA period generator** — pick a number of UFAs per position from
+   `ufas_signed_per_offseason.by_position_group`, then sample APY by assigning
+   each UFA to a tier (with weights top_10:top_25:top_50:rest ~= observed
+   volumes) and drawing from the tier's `mean_apy_millions` / `sd` band.
+2. **Waves** — distribute signings across the four waves using the doc's
+   qualitative priors; top-tier contracts should concentrate in Wave 1.
+3. **Own-team retention** — before a player hits the open market, roll the
+   re-sign rate per position × tier; on success, the drafting team gets
+   right-of-first-refusal at `mean_apy` with no open bidding.
+4. **NPC GM bidding AI** — cap-strapped teams bid at `p10_apy`, cap-rich
+   contending teams bid at `p90_apy`; sample bid length from
+   `contract_length_years_external` with QB/OL skewing high and RB/S skewing
+   low.
+
+## Known gaps / follow-ups
+
+- `date_signed` is not in the OTC feed — the waves band is qualitative. Filing a
+  follow-up to scrape OTC "Free Agent Tracker" archival pages is tracked
+  separately.
+- Restricted / Exclusive Rights FA tenders are not tagged in this feed and blend
+  into "own-team re-signs" (RFA tender) or the `rest` tier (ERFA).
+- Franchise-tag / transition-tag contracts appear as 1-year `years == 1` with
+  APY = the tag amount. The sim should treat them as a distinct contract type,
+  not an FA signing.


### PR DESCRIPTION
## Summary

Adds the two "money and movement" calibration artifacts the sim needs before it can credibly simulate the offseason — the free-agent market band (volume, AAV tiers, own-team re-sign rate) and the contract-structure band (length, guarantee share, signing-bonus share, year-by-year cap-hit shape).

- **`data/bands/free-agent-market.json`** + **`data/R/bands/free-agent-market.R`** — UFA signings per offseason by position group, AAV distribution per position × tier (top_10 / top_25 / top_50 / rest) with mean / median / floor / ceiling APY, own-team re-sign rate, and contract length + guarantee share for external signings. Sourced from `nflreadr::load_contracts()` for 2020–2024.
- **`data/bands/contract-structure.json`** + **`data/R/bands/contract-structure.R`** — walks the OTC feed's nested per-year cap ledger to produce length by position × tier, guarantee share, signing-bonus share (year-1 prorated × years), and Y1..Y5 cap-hit shape as % of total cap. Top-10 QBs back-load from ~15% Y1 to ~34% Y5; top-10 RBs front-load Y1–Y3.
- **`data/docs/free-agent-market.md`** — narrative on the three market tiers, per-position reads (QB franchise-tag or bust, RB short + guarantee-light post-Barkley, WR depth-heaviest, etc.), the four signing-timing waves (legal tampering / first two weeks / April bargain / post-draft), and tier-level re-sign multipliers.
- **`data/docs/contract-structure.md`** — vocabulary for OTC columns, length + guarantee table per position top-10 tier, cap-hit shape explanation (why back-loading enables restructures, why RBs front-load), signing-bonus share patterns, void-year mechanics with canonical examples (Prescott 4+2 void, Rodgers restructure, Garrett extensions), and dead-cap / post-June-1 rules the sim's cap AI needs.
- **`data/README.md`** updated with both bands in the "Bands currently produced" list.
- **`data/docs/calibration-gaps.md`** rows #514 and #515 marked done with band + doc links.

Two gaps are documented rather than computed because the OTC feed doesn't expose them:

- Signing-timing waves — feed lacks `date_signed`; qualitative wave-share priors live in the free-agent-market doc.
- Restructure frequency and void-year usage — the feed does not mark restructures and the merged cap ledger makes void-year detection unreliable; qualitative priors (e.g. ~60% of top-10 QB deals restructured by Y2) live in the contract-structure doc.

Closes #514
Closes #515