### PR TITLE
docs(data): spruce up calibration docs with Mermaid + add docs README

### DIFF
--- a/data/docs/README.md
+++ b/data/docs/README.md
@@ -1,0 +1,109 @@
+# `data/docs/` — NFL calibration references
+
+Narrative companions to the machine-readable bands in
+[`data/bands/`](../bands/). Each doc explains **what the NFL actually does** for
+a slice of league behavior — volumes, tiers, curves, market shapes — so the Zone
+Blitz sim can be calibrated against it.
+
+The JSON in `data/bands/` is what the sim's calibration harness asserts against.
+The Markdown here is what a human (or a coding agent) reads to understand _why_
+those numbers look the way they do, and which narrative priors belong in the AI
+layer when the feed can't answer.
+
+## How the docs fit together
+
+```mermaid
+flowchart LR
+    subgraph Sources["nflreadr / OTC / PFR"]
+        PBP[load_pbp]
+        ROS[load_rosters_weekly]
+        SNAP[load_snap_counts]
+        DRAFT[load_draft_picks]
+        CTR[load_contracts]
+    end
+
+    subgraph Bands["data/bands/*.json"]
+        B1[position-market]
+        B2[draft-position-distribution]
+        B3[draft-pick-value]
+        B4[draft-hit-rates]
+        B5[free-agent-market]
+        B6[contract-structure]
+        B7[career-length]
+    end
+
+    subgraph Docs["data/docs/*.md"]
+        D0[calibration-gaps]
+        D1[position-market-sizing]
+        D2[draft-position-tendencies]
+        D3[draft-pick-trade-value]
+        D4[draft-hit-rates-by-round]
+        D5[free-agent-market]
+        D6[contract-structure]
+        D7[career-length-by-position]
+        D8[nfl-talent-distribution-by-position]
+    end
+
+    ROS --> B1 --> D1
+    DRAFT --> B2 --> D2
+    DRAFT --> B3 --> D3
+    DRAFT --> B4 --> D4
+    CTR --> B5 --> D5
+    CTR --> B6 --> D6
+    ROS --> B7 --> D7
+    PBP -. informs .-> D8
+    SNAP --> B1
+    SNAP --> B4
+
+    D0 -. indexes .-> D1 & D2 & D3 & D4 & D5 & D6 & D7
+```
+
+## Index
+
+### Meta-game (market & career)
+
+| Doc                                                            | What it covers                                                                                                      | Feeds                                                           |
+| -------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------- |
+| [calibration-gaps.md](./calibration-gaps.md)                   | Master index of what's done vs what's missing across play-level, game-level, and season/career realism.             | The roadmap.                                                    |
+| [position-market-sizing.md](./position-market-sizing.md)       | 53-man roster slots by position, meaningful contributors, clear starters. QB is 2, OL is 8, specialists are 1-deep. | Player generator, league init, depth-chart classification.      |
+| [draft-position-tendencies.md](./draft-position-tendencies.md) | Which positions go in which rounds. QB/WR/EDGE/OT/CB are ~65% of top-10; RB/LB double their R1 counts by R7.        | Draft class generator, NPC GM positional-value prior.           |
+| [draft-pick-trade-value.md](./draft-pick-trade-value.md)       | Jimmy Johnson vs Rich Hill vs Chase Stuart — three canonical trade-value charts and when they disagree.             | AI GM trade evaluator, user trade grade.                        |
+| [draft-hit-rates-by-round.md](./draft-hit-rates-by-round.md)   | P(multi-year starter \| round, position). 86% for R1, 7% for R7. Round 4 is the cliff.                              | Prospect generation, post-draft grade UI.                       |
+| [free-agent-market.md](./free-agent-market.md)                 | UFA volume, AAV tiers, signing waves, own-team re-sign rates by position.                                           | FA period generator, NPC bid AI.                                |
+| [contract-structure.md](./contract-structure.md)               | Contract shape — length, guarantee %, signing-bonus share, year-by-year cap hit, void years, restructures.          | Contract offer generator, cap AI, cut/restructure decisions.    |
+| [career-length-by-position.md](./career-length-by-position.md) | Five canonical aging shapes — specialist longevity, QB tail, OL plateau, mid-career cohort, RB/CB cliff.            | Aging system, retirement decisions, franchise-planning windows. |
+
+### Player-rating calibration
+
+| Doc                                                                                | What it covers                                                                                                               | Feeds                                   |
+| ---------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------- | --------------------------------------- |
+| [nfl-talent-distribution-by-position.md](./nfl-talent-distribution-by-position.md) | Tier splits (Replacement / Weak / Average / Strong / Elite) per position. QB is bimodal; OL compresses; EDGE rides the tail. | Player-generation rating distributions. |
+
+## Conventions used across these docs
+
+- **Rating midpoint = 50** on the Zone Blitz 0–100 scale. Average is ~50, not
+  ~60. Elite rides the tail.
+- **Tier naming** — `top_10 / top_25 / top_50 / rest` for market bands
+  (APY-ranked within a position group).
+  `Replacement / Weak / Average / Strong
+  / Elite` for rating tiers.
+- **Position canonicalization** — OL collapses T/G/C in roster feeds; CB_DB
+  includes generic `DB`; LB includes OLB / ILB / MLB. Finer splits live in the
+  draft and snap-count data.
+- **Season windows** — market and contract bands use 2020–2024 (post-COVID-cap
+  era). Draft hit-rates use 2013–2020 (`snap_counts` coverage starts 2013, 2020
+  is the latest with a full 5-year runway). Career-length uses 2005–2024 (20
+  years for aging curves).
+
+## Adding a new doc
+
+1. Generate or extend a band under `data/R/bands/` and write JSON to
+   `data/bands/`.
+2. Write the narrative here in `data/docs/`. Lead with what the NFL does and the
+   sim implications, not the R plumbing.
+3. Add a row to [calibration-gaps.md](./calibration-gaps.md) linking the band
+   and doc.
+4. Add a row to the index tables above so the next reader finds it.
+
+Use the [`nflfastr`](../../CLAUDE.md) skill for nflverse-reachable data and the
+[`bigdatabowl`](../../CLAUDE.md) skill for player-tracking-specific questions.

--- a/data/docs/calibration-gaps.md
+++ b/data/docs/calibration-gaps.md
@@ -23,6 +23,37 @@ The sim has three layers of calibration targets:
    drafted, who retires, who gets fired. Entirely missing. Gaps listed below in
    the **Market & Career** group.
 
+```mermaid
+flowchart TB
+    subgraph L1["Layer 1 · Play-level realism ✓"]
+        direction LR
+        PL1[passing-plays]
+        PL2[rushing-plays]
+        PL3[special-teams]
+        PL4[situational]
+    end
+    subgraph L2["Layer 2 · Game-level realism ◐"]
+        direction LR
+        GL1[team-game]
+        GL2[play-call-tendencies ✓]
+        GL3[red-zone-and-third-down ✓]
+    end
+    subgraph L3["Layer 3 · Season / career realism ◐"]
+        direction LR
+        SC1[position-market ✓]
+        SC2[draft-position-distribution ✓]
+        SC3[draft-pick-value ✓]
+        SC4[draft-hit-rates ✓]
+        SC5[free-agent-market ✓]
+        SC6[contract-structure ✓]
+        SC7[career-length ✓]
+        SC8[coaching-tenure ○]
+    end
+    L1 --> L2 --> L3
+```
+
+Legend: ✓ landed · ◐ in progress · ○ not started.
+
 ## Market & Career (the league-building layer)
 
 | # | Gap                                                                                                                                                                                                           | Primary source                                          | Issue       |
@@ -41,6 +72,32 @@ These directly serve the user-named asks:
 - **Position markets** — #1, #2, #7.
 - **Draft pick economy** — #2, #3, #4.
 - **Roster movement / contracts** — #5, #6, #8.
+
+```mermaid
+flowchart LR
+    ASK1[Position markets]
+    ASK2[Draft pick economy]
+    ASK3[Roster movement & contracts]
+
+    G1[#1 position-market]
+    G2[#2 draft-position-distribution]
+    G3[#3 draft-pick-value]
+    G4[#4 draft-hit-rates]
+    G5[#5 free-agent-market]
+    G6[#6 contract-structure]
+    G7[#7 career-length]
+    G8[#8 coaching-tenure ○]
+
+    G1 --> ASK1
+    G2 --> ASK1
+    G2 --> ASK2
+    G3 --> ASK2
+    G4 --> ASK2
+    G5 --> ASK3
+    G6 --> ASK3
+    G7 --> ASK1
+    G8 --> ASK3
+```
 
 ## Game Flow (the situational-realism layer)
 

--- a/data/docs/career-length-by-position.md
+++ b/data/docs/career-length-by-position.md
@@ -10,7 +10,28 @@ Numbers come from [`data/bands/career-length.json`](../bands/career-length.json)
 (seasons 2005–2024, 20 years of rosters). See the R script at
 [`data/R/bands/career-length.R`](../R/bands/career-length.R).
 
+## Mean retirement age at a glance
+
+```mermaid
+xychart-beta
+    title "Mean retirement age by position (2005–2024)"
+    x-axis ["LS", "P", "K", "QB", "OL", "iDL", "EDGE", "LB", "S", "TE", "RB", "CB", "WR"]
+    y-axis "Age" 24 --> 32
+    bar [31.1, 30.2, 29.9, 28.5, 27.4, 26.9, 26.7, 26.7, 26.8, 26.8, 26.3, 26.3, 26.1]
+```
+
+Specialists ride the tail; RB / CB / WR are the early-exit positions.
+
 ## The five canonical aging shapes
+
+```mermaid
+flowchart LR
+    S1[1 · Specialist longevity<br/>K · P · LS<br/>flat attrition, tails into 40s]
+    S2[2 · QB late-tail<br/>flat 22–34<br/>hard cliff 38+]
+    S3[3 · OL late-peak / plateau<br/>flattest 24–28<br/>mid-30s starts]
+    S4[4 · Mid-career cohort<br/>WR · TE · LB · S · EDGE · iDL<br/>p90 ~31–32]
+    S5[5 · Cliff positions<br/>RB · CB<br/>age-28 inflection]
+```
 
 ### 1. Specialist longevity (K / P / LS)
 
@@ -41,6 +62,14 @@ Flat decay from 22 through 34, gentle cliff at 35–37, hard cliff at 38+.
 |  36 |            26% |            39 |
 |  38 |            43% |            23 |
 |  40 |            50% |             6 |
+
+```mermaid
+xychart-beta
+    title "QB attrition (%) and active cohort by age"
+    x-axis "Age" [24, 28, 32, 36, 38, 40]
+    y-axis "Attrition %" 0 --> 60
+    bar [20, 15, 18, 26, 43, 50]
+```
 
 Mean retirement age **28.5**, p90 **36**. The tail is the story: Brady, Rodgers,
 Brees, Roethlisberger. Most QBs wash out before 30, but the ones who don't stick
@@ -96,6 +125,14 @@ The two positions where the "cliff" is real, visible, and sharp.
 |  29 |            34% |
 |  30 |            37% |
 |  31 |        **50%** |
+
+```mermaid
+xychart-beta
+    title "RB year-over-year attrition rate (%)"
+    x-axis "Age" [25, 26, 27, 28, 29, 30, 31]
+    y-axis "Attrition %" 0 --> 60
+    bar [23, 23, 23, 31, 34, 37, 50]
+```
 
 Mean retirement **26.3**, p90 **31**. The age-28 jump is the analytics cliché
 made literal. By 31, half of still-active RBs are gone the next year. Christian

--- a/data/docs/contract-structure.md
+++ b/data/docs/contract-structure.md
@@ -13,6 +13,23 @@ Companion script:
 [`data/R/bands/contract-structure.R`](../R/bands/contract-structure.R). Gap
 index row: [calibration-gaps.md #6 (#515)](./calibration-gaps.md).
 
+## Contract lifecycle — the events the sim has to model
+
+```mermaid
+flowchart LR
+    SIGN([Signing]) --> Y1[Y1 cap hit<br/>low base + bonus proration]
+    Y1 --> RESTR{Restructure?<br/>Y2 or Y3}
+    RESTR -- "~60–70% for top-10 QB" --> CONV[Convert base → bonus<br/>reprorate over remaining years]
+    RESTR -- no --> Y3[Y3 cap hit<br/>back-loaded peak]
+    CONV --> Y3
+    Y3 --> DECIDE{Keep · Cut · Extend?}
+    DECIDE -- keep --> Y4[Y4–Y5 cap hit<br/>full non-guaranteed base]
+    DECIDE -- cut pre-June-1 --> DC1[All remaining proration<br/>hits current year as dead cap]
+    DECIDE -- cut post-June-1 --> DC2[Split dead cap<br/>across two cap years]
+    DECIDE -- extend --> NEW([New contract<br/>cycle restarts])
+    Y4 --> END([Contract ends<br/>void years accelerate])
+```
+
 ## Sources
 
 - `nflreadr::load_contracts()` — OTC historical feed plus the nested `cols`
@@ -66,6 +83,14 @@ leaderboards.
 | RB       | 3.5        | 47.8%                | Shortest at the top; guarantee floor is real            |
 | CB       | 3.3        | 39.3%                | CBs sign shortest and least-guaranteed at the top       |
 
+```mermaid
+xychart-beta
+    title "Top-10 guarantee share by position (%)"
+    x-axis ["IOL", "QB", "IDL", "ST", "LB", "RB", "EDGE", "OT", "WR", "TE", "CB", "S"]
+    y-axis "Guarantee share (%)" 0 --> 60
+    bar [53.0, 51.5, 51.2, 50.4, 48.6, 47.8, 47.0, 45.8, 43.4, 41.6, 39.3, 38.1]
+```
+
 Full per-tier numbers live in the band JSON.
 
 ## Cap-hit shape — the "Y1 cheap, Y3 expensive" pattern
@@ -79,6 +104,25 @@ cap hits. Top-10 tier shape by position (share of total cap hit):
 | RB       | 26.5%                                                              | 31.2% | 36.1% | 18.3% | 21.6% |
 | WR       | 20% — driven by signing-bonus + low-base Y1, ramping to 30%+ by Y4 |       |       |       |       |
 | OT       | Similar to QB — back-loaded with the tackle sweet spot in Y3–Y4    |       |       |       |       |
+
+```mermaid
+xychart-beta
+    title "Top-10 QB cap hit share by year (%)"
+    x-axis "Contract year" [Y1, Y2, Y3, Y4, Y5]
+    y-axis "Share of total cap hit (%)" 0 --> 40
+    bar [15.6, 22.4, 20.1, 27.7, 34.1]
+```
+
+```mermaid
+xychart-beta
+    title "Top-10 RB cap hit share by year (%)"
+    x-axis "Contract year" [Y1, Y2, Y3, Y4, Y5]
+    y-axis "Share of total cap hit (%)" 0 --> 40
+    bar [26.5, 31.2, 36.1, 18.3, 21.6]
+```
+
+QB contracts back-load; RB contracts front-load. Same Y1 cap cost hides opposite
+design intent.
 
 (Full matrix in `cap_hit_shape_by_position_tier` in the band JSON.)
 

--- a/data/docs/draft-hit-rates-by-round.md
+++ b/data/docs/draft-hit-rates-by-round.md
@@ -42,6 +42,25 @@ The headline: a 1st-rounder is ~4x as likely to become a real starter as a
 3rd-rounder, and ~12x as likely as a 7th-rounder. Round 4 is a cliff — the
 chance of "hit" drops from ~47% in round 3 to ~29%.
 
+```mermaid
+xychart-beta
+    title "P(started 16 games in 3 years) by round"
+    x-axis "Round" [1, 2, 3, 4, 5, 6, 7]
+    y-axis "Hit rate (%)" 0 --> 100
+    bar [86, 65, 47, 29, 23, 11, 7]
+```
+
+```mermaid
+xychart-beta
+    title "P(out of league by Y3) by round"
+    x-axis "Round" [1, 2, 3, 4, 5, 6, 7]
+    y-axis "Bust rate (%)" 0 --> 70
+    bar [24, 20, 28, 34, 37, 46, 58]
+```
+
+Hit-rate decays; bust-rate grows. The crossover sits inside round 4 — the "real
+NFL draft cliff" described below.
+
 ## Why round 2 is famously worse than round 1 _and_ round 3 at quarterback
 
 The round 2 hit-rate for QBs is a long-running source of draft discourse. Across

--- a/data/docs/draft-pick-trade-value.md
+++ b/data/docs/draft-pick-trade-value.md
@@ -98,6 +98,20 @@ needle. The sim's AI GM should use Rich Hill as its primary valuator and use
 Stuart (or a blend) as the "what do you actually get?" lens surfaced to the
 user.
 
+```mermaid
+xychart-beta
+    title "Pick value (normalised to pick 1 = 1.0)"
+    x-axis "Pick" [1, 5, 10, 32, 64, 100, 150]
+    y-axis "Value (pick 1 = 1.0)" 0 --> 1
+    line [1.00, 0.57, 0.43, 0.20, 0.09, 0.04, 0.01]
+    line [1.00, 0.62, 0.49, 0.27, 0.13, 0.06, 0.02]
+    line [1.00, 0.73, 0.52, 0.27, 0.16, 0.10, 0.05]
+```
+
+Top line to bottom at pick 150: **Stuart** (flattest) · **Rich Hill** (middle) ·
+**Jimmy Johnson** (steepest). The JJ curve's steep decay is exactly what
+overpays trade-ups against the Hill analytics consensus.
+
 ## Future-pick discount
 
 Rule of thumb, endorsed by both Hill and Stuart:
@@ -109,6 +123,14 @@ So a 2nd-round pick next year trades for roughly a 3rd-round pick this year. Two
 years out compounds to 0.64x; three years out is 0.51x. This discount dominates
 most mid-round trade negotiations; GMs willing to take future picks usually
 extract a round of value simply by accepting the time shift.
+
+```mermaid
+xychart-beta
+    title "Future-pick discount (0.8x compounding)"
+    x-axis "Years out" [0, 1, 2, 3, 4]
+    y-axis "Discount factor" 0 --> 1
+    bar [1.00, 0.80, 0.64, 0.51, 0.41]
+```
 
 ## Worked examples from real trades
 

--- a/data/docs/draft-position-tendencies.md
+++ b/data/docs/draft-position-tendencies.md
@@ -35,6 +35,23 @@ Together they account for roughly 65% of the top 10 but only 40% of the full
 draft. Everything else (RB, TE, iDL, LB, S, OL interior, specialists) is
 disproportionately late.
 
+```mermaid
+pie showData
+    title Top-10 pick share by position (10 drafts)
+    "QB" : 26
+    "WR" : 13
+    "EDGE" : 12
+    "OT" : 8
+    "CB" : 7
+    "RB" : 6
+    "LB" : 6
+    "iDL" : 4
+    "TE" : 2
+    "S" : 1
+    "OG" : 1
+    "Other" : 14
+```
+
 ## Per-round picks per position (mean)
 
 Across the seven rounds, mean picks per position per draft:
@@ -58,6 +75,26 @@ Across the seven rounds, mean picks per position per draft:
 
 (Rounded to nearest tenth. Full distributions with p10/p50/p90 are in the band
 JSON.)
+
+```mermaid
+xychart-beta
+    title "RB picks per round (mean) — the positional-value shift"
+    x-axis "Round" [1, 2, 3, 4, 5, 6, 7]
+    y-axis "Picks per draft" 0 --> 5
+    bar [1.8, 2.5, 2.8, 3.4, 3.5, 3.7, 4.2]
+```
+
+```mermaid
+xychart-beta
+    title "QB picks per round (mean) — the top-heavy shape"
+    x-axis "Round" [1, 2, 3, 4, 5, 6, 7]
+    y-axis "Picks per draft" 0 --> 5
+    bar [2.8, 1.3, 1.2, 1.6, 1.4, 1.4, 1.6]
+```
+
+RB more than doubles its R1 count by R7; QB peaks hard in R1 then flattens.
+These are the two clearest positional-value stories in the last decade of
+drafts.
 
 ### Positional run phenomena to model
 

--- a/data/docs/free-agent-market.md
+++ b/data/docs/free-agent-market.md
@@ -163,6 +163,23 @@ Four canonical waves per offseason (NFL league-year opens mid-March):
    (post-June-1 designations free up real cap) and where UDFAs replace injured
    camp bodies.
 
+```mermaid
+pie showData
+    title Offseason spend by signing wave
+    "Wave 1 · Legal tampering" : 40
+    "Wave 2 · First two weeks" : 28
+    "Wave 3 · April pre-draft" : 12
+    "Wave 4 · June post-draft" : 20
+```
+
+```mermaid
+flowchart LR
+    W1[Wave 1<br/>Legal tampering<br/>top_10 deals] --> W2[Wave 2<br/>First two weeks<br/>top_25 · top_50]
+    W2 --> W3[Wave 3<br/>April pre-draft<br/>prove-it 1-year]
+    W3 --> DR([Draft])
+    DR --> W4[Wave 4<br/>June post-draft<br/>min-value · cuts]
+```
+
 Share numbers are from Spotrac / OTC year-over-year rollup reporting; they are
 not computed from the band and should be treated as priors.
 
@@ -184,6 +201,14 @@ Observed in the 2020–2024 window, vet contracts only (excludes rookie deals):
 | CB       | 15.6%        |
 | QB       | 15.2%        |
 | ST       | 9.4%         |
+
+```mermaid
+xychart-beta
+    title "Observed own-team re-sign rate by position (%)"
+    x-axis ["WR", "OT", "TE", "EDGE", "RB", "S", "LB", "IOL", "IDL", "CB", "QB", "ST"]
+    y-axis "Re-sign rate (%)" 0 --> 25
+    bar [23.0, 22.9, 22.7, 22.0, 20.9, 20.5, 20.2, 19.4, 15.9, 15.6, 15.2, 9.4]
+```
 
 **Read with caveat:** the denominator includes every vet contract signed with
 any team, including minimum-salary depth. The "own-team re-sign rate for a

--- a/data/docs/nfl-talent-distribution-by-position.md
+++ b/data/docs/nfl-talent-distribution-by-position.md
@@ -20,6 +20,36 @@ Tier boundaries are fuzzy; the shapes matter more than the exact cutoffs.
 
 **Rating midpoint (0–100) = 50.** Average = ~50. Elite rides the tail.
 
+## Shape at a glance — QB vs OL vs EDGE
+
+The three archetypal shapes the sim needs to support:
+
+```mermaid
+xychart-beta
+    title "QB — bimodal, thin middle, fat tails"
+    x-axis ["Elite", "Strong", "Average", "Weak", "Replacement"]
+    y-axis "% of position" 0 --> 40
+    bar [7, 18, 28, 28, 28]
+```
+
+```mermaid
+xychart-beta
+    title "OL — tight, compressed toward the middle"
+    x-axis ["Elite", "Strong", "Average", "Weak", "Replacement"]
+    y-axis "% of position" 0 --> 40
+    bar [4, 18, 38, 28, 13]
+```
+
+```mermaid
+xychart-beta
+    title "EDGE — top-heavy, long right tail"
+    x-axis ["Elite", "Strong", "Average", "Weak", "Replacement"]
+    y-axis "% of position" 0 --> 40
+    bar [4, 13, 32, 28, 22]
+```
+
+OL compresses toward the mean. QB and EDGE let the Elite tier ride the tail.
+
 ---
 
 ## Quarterback (QB)

--- a/data/docs/position-market-sizing.md
+++ b/data/docs/position-market-sizing.md
@@ -26,6 +26,15 @@ The three layers are what the sim needs:
 - Starters tell it how many every-down anchors exist — the gap between
   contributors and starters is the "rotation tax" (especially big for DL).
 
+```mermaid
+flowchart TB
+    L1[All rostered · 53 active] --> L2[Meaningful contributors · ≥ 25% snap share]
+    L2 --> L3[Clear starters · ≥ 70% snap share]
+    L1 -. "roster builder · how many to stock" .-> USE1([Player generator])
+    L2 -. "how many must be playable" .-> USE2([Depth-chart tiering])
+    L3 -. "every-down anchors" .-> USE3([Scheme / lineup AI])
+```
+
 ## 53-man composition (typical week)
 
 Per-team-week averages (ACT status only, regular season 2020–2024):
@@ -43,6 +52,14 @@ Per-team-week averages (ACT status only, regular season 2020–2024):
 | P           | 1.0        | Binary                                                   |
 | LS          | 1.0        | Binary                                                   |
 | K           | 1.0        | Binary                                                   |
+
+```mermaid
+xychart-beta
+    title "Typical 53-man composition (mean slots per position)"
+    x-axis ["DB", "OL", "iDL", "LB", "WR", "RB", "TE", "QB", "P", "LS", "K"]
+    y-axis "Active slots" 0 --> 10
+    bar [9.2, 8.0, 7.0, 6.8, 5.2, 3.6, 3.1, 2.0, 1.0, 1.0, 1.0]
+```
 
 **53 adds up to ~52** — the remainder goes to FB/emergency QB/practice-squad
 elevations. The sim's roster builder can treat these as the hard base.
@@ -96,6 +113,17 @@ Across 32 teams in a typical season:
 | K        | ~40                        | Barely above 32 — low churn          |
 | P        | ~38                        | Low churn                            |
 | LS       | ~36                        | Lowest churn in the league           |
+
+```mermaid
+xychart-beta
+    title "Unique players per season (league-wide)"
+    x-axis ["OL", "DB", "iDL", "LB", "WR", "RB", "TE", "QB", "K", "P", "LS"]
+    y-axis "Players" 0 --> 400
+    bar [380, 380, 310, 300, 230, 175, 160, 96, 40, 38, 36]
+```
+
+QB is the scarcest non-specialist by a wide margin. LS has the lowest churn of
+any roster spot.
 
 ## Roster-construction conventions the sim must honor
 


### PR DESCRIPTION
## Summary

- New `data/docs/README.md` that indexes all nine calibration reference docs,
  shows how sources → bands → docs fit together as a Mermaid flow, and
  documents the shared conventions (rating midpoint, tier naming, position
  canonicalization, season windows).
- Adds Mermaid visualizations across every existing doc so the headline
  shapes are legible without re-reading the tables:
  - `calibration-gaps.md` — three-layer architecture + user-ask mapping.
  - `career-length-by-position.md` — retirement age ranking, QB and RB
    attrition curves, five canonical aging shapes.
  - `contract-structure.md` — contract lifecycle flow, QB vs RB cap-hit
    shape, guarantee share by position.
  - `draft-hit-rates-by-round.md` — hit-rate and bust-rate by round.
  - `draft-pick-trade-value.md` — JJ vs Hill vs Stuart normalised curves,
    future-pick discount.
  - `draft-position-tendencies.md` — top-10 pick share pie, RB and QB
    per-round distributions.
  - `free-agent-market.md` — offseason spend by wave, wave timeline,
    re-sign rate by position.
  - `nfl-talent-distribution-by-position.md` — QB bimodal / OL compressed
    / EDGE top-heavy tier shapes side-by-side.
  - `position-market-sizing.md` — three-view layer diagram, 53-man
    composition, league-wide unique players per season.
- All charts read from the band-backed numbers already in the docs; no
  data changes.