### PR TITLE
feat(calibration): position-conditioned age + career-length curves

### DIFF
--- a/server/features/players/age-curves.test.ts
+++ b/server/features/players/age-curves.test.ts
@@ -1,0 +1,170 @@
+import { assertEquals } from "@std/assert";
+import { mulberry32, type NeutralBucket } from "@zone-blitz/shared";
+import {
+  AGE_CURVE_PRIORS,
+  BUCKET_AGE_CURVES,
+  sampleBucketAge,
+} from "./age-curves.ts";
+
+const ALL_BUCKETS: readonly NeutralBucket[] = [
+  "QB",
+  "RB",
+  "WR",
+  "TE",
+  "OT",
+  "IOL",
+  "EDGE",
+  "IDL",
+  "LB",
+  "CB",
+  "S",
+  "K",
+  "P",
+  "LS",
+];
+
+const SAMPLES = 8000;
+
+function collectSamples(
+  bucket: NeutralBucket,
+  seed: number,
+  count = SAMPLES,
+): number[] {
+  const random = mulberry32(seed);
+  const ages: number[] = [];
+  for (let i = 0; i < count; i++) {
+    ages.push(sampleBucketAge(random, bucket));
+  }
+  return ages;
+}
+
+function mean(values: number[]): number {
+  return values.reduce((s, v) => s + v, 0) / values.length;
+}
+
+function percentile(values: number[], p: number): number {
+  const sorted = [...values].sort((a, b) => a - b);
+  const idx = Math.min(
+    sorted.length - 1,
+    Math.max(0, Math.floor((p / 100) * sorted.length)),
+  );
+  return sorted[idx];
+}
+
+Deno.test("every neutral bucket has an age curve and prior", () => {
+  for (const bucket of ALL_BUCKETS) {
+    const curve = BUCKET_AGE_CURVES[bucket];
+    assertEquals(curve.ages.length > 0, true, `${bucket} has no ages`);
+    assertEquals(curve.ages.length, curve.weights.length);
+    assertEquals(curve.cumulative.length, curve.weights.length);
+    assertEquals(curve.totalWeight > 0, true);
+    const prior = AGE_CURVE_PRIORS[bucket];
+    assertEquals(prior.meanAge > 21, true);
+    assertEquals(prior.p50Age >= 22, true);
+    assertEquals(prior.p90Age >= prior.p50Age, true);
+  }
+});
+
+Deno.test("per-bucket sampled mean age converges to the prior mean", () => {
+  const tolerance = 0.5;
+  for (const bucket of ALL_BUCKETS) {
+    const ages = collectSamples(bucket, 1234 + bucket.length);
+    const sampledMean = mean(ages);
+    const priorMean = AGE_CURVE_PRIORS[bucket].meanAge;
+    const delta = Math.abs(sampledMean - priorMean);
+    assertEquals(
+      delta <= tolerance,
+      true,
+      `${bucket} sampled mean ${sampledMean.toFixed(2)} vs prior ${
+        priorMean.toFixed(2)
+      } (Δ=${delta.toFixed(2)})`,
+    );
+  }
+});
+
+Deno.test("per-bucket sampled p90 converges to the prior p90", () => {
+  for (const bucket of ALL_BUCKETS) {
+    const ages = collectSamples(bucket, 9900 + bucket.length);
+    const sampledP90 = percentile(ages, 90);
+    const priorP90 = AGE_CURVE_PRIORS[bucket].p90Age;
+    const delta = Math.abs(sampledP90 - priorP90);
+    assertEquals(
+      delta <= 1,
+      true,
+      `${bucket} sampled p90 ${sampledP90} vs prior ${priorP90}`,
+    );
+  }
+});
+
+Deno.test("RB age distribution shows the post-28 cliff", () => {
+  const ages = collectSamples("RB", 9001);
+  const over30Share = ages.filter((a) => a >= 30).length / ages.length;
+  const priorP90 = AGE_CURVE_PRIORS["RB"].p90Age;
+  // RB p_active drops below 10% at age 30 in real data.
+  assertEquals(
+    priorP90 <= 30,
+    true,
+    `RB prior p90 ${priorP90} too high for a cliff bucket`,
+  );
+  assertEquals(
+    over30Share <= 0.12,
+    true,
+    `RB 30+ share ${(over30Share * 100).toFixed(1)}% too high`,
+  );
+});
+
+Deno.test("QB has a longer active-age tail than RB", () => {
+  const qbAges = collectSamples("QB", 42);
+  const rbAges = collectSamples("RB", 42);
+  const qb33Share = qbAges.filter((a) => a >= 33).length / qbAges.length;
+  const rb33Share = rbAges.filter((a) => a >= 33).length / rbAges.length;
+  assertEquals(
+    qb33Share > rb33Share * 3,
+    true,
+    `QB 33+ share ${
+      (qb33Share * 100).toFixed(1)
+    }% not meaningfully longer than RB ${(rb33Share * 100).toFixed(1)}%`,
+  );
+});
+
+Deno.test("OL buckets plateau longer than RB", () => {
+  const rbShare = collectSamples("RB", 3000).filter((a) => a >= 30).length /
+    SAMPLES;
+  for (const bucket of ["OT", "IOL"] as const) {
+    const share = collectSamples(bucket, 3100 + bucket.length).filter((a) =>
+      a >= 30
+    )
+      .length / SAMPLES;
+    assertEquals(
+      share > rbShare,
+      true,
+      `${bucket} 30+ share ${(share * 100).toFixed(1)}% should exceed RB ${
+        (rbShare * 100).toFixed(1)
+      }%`,
+    );
+  }
+});
+
+Deno.test("specialist buckets have a much longer tail than skill positions", () => {
+  const wrShare = collectSamples("WR", 4100).filter((a) => a >= 33).length /
+    SAMPLES;
+  for (const bucket of ["K", "P", "LS"] as const) {
+    const share = collectSamples(bucket, 4200 + bucket.length).filter((a) =>
+      a >= 33
+    )
+      .length / SAMPLES;
+    assertEquals(
+      share > wrShare * 2,
+      true,
+      `${bucket} 33+ share ${(share * 100).toFixed(1)}% should dwarf WR ${
+        (wrShare * 100).toFixed(1)
+      }%`,
+    );
+  }
+});
+
+Deno.test("sampleBucketAge is deterministic given the same rng seed", () => {
+  const a = collectSamples("WR", 2026, 500);
+  const b = collectSamples("WR", 2026, 500);
+  assertEquals(a, b);
+});

--- a/server/features/players/age-curves.ts
+++ b/server/features/players/age-curves.ts
@@ -1,0 +1,392 @@
+import type { NeutralBucket } from "@zone-blitz/shared";
+
+/**
+ * Per-bucket active-age weight tables sourced from
+ * `data/bands/career-length.json` (field `p_active_by_age`). The values
+ * are fraction of the age-22 cohort still on an NFL roster at each
+ * older age — a cohort survival curve. Used as sampling weights they
+ * reproduce the population's age distribution: modal age 23–24 across
+ * most buckets, with bucket-specific tails (RB/CB cliff at 28, OL
+ * plateau into mid-30s, QB long tail past 36, specialists effectively
+ * indefinite). We extend the curve downward to age 21 with a small
+ * weight — rare but real for early-declaring draftees — and upward
+ * past the raw data for specialists whose real-world careers run past
+ * age 40 (K/P/LS retirement p90 is 38).
+ */
+
+interface RawCurve {
+  /** age → raw relative weight (p_active from real data). */
+  ageWeights: Readonly<Record<number, number>>;
+  /** Relative weight for age 21 (not covered by the age-22 cohort). */
+  age21Weight: number;
+}
+
+const NON_SPECIALIST_AGE_21_WEIGHT = 0.3;
+const SPECIALIST_AGE_21_WEIGHT = 0.05;
+
+const QB_CURVE: Readonly<Record<number, number>> = {
+  22: 1,
+  23: 0.8454,
+  24: 0.7835,
+  25: 0.6495,
+  26: 0.5155,
+  27: 0.4845,
+  28: 0.3814,
+  29: 0.299,
+  30: 0.2371,
+  31: 0.1856,
+  32: 0.1443,
+  33: 0.1134,
+  34: 0.0825,
+  35: 0.0825,
+  36: 0.0515,
+  37: 0.0309,
+  38: 0.0309,
+  39: 0.0103,
+  40: 0.0103,
+};
+
+const RB_CURVE: Readonly<Record<number, number>> = {
+  22: 1,
+  23: 0.7839,
+  24: 0.6734,
+  25: 0.5251,
+  26: 0.4271,
+  27: 0.2864,
+  28: 0.206,
+  29: 0.1482,
+  30: 0.0879,
+  31: 0.0503,
+  32: 0.0226,
+  33: 0.0176,
+  34: 0.0101,
+  35: 0.0075,
+  36: 0.0075,
+};
+
+const WR_CURVE: Readonly<Record<number, number>> = {
+  22: 1,
+  23: 0.7875,
+  24: 0.6638,
+  25: 0.5436,
+  26: 0.4251,
+  27: 0.3293,
+  28: 0.2282,
+  29: 0.1603,
+  30: 0.1028,
+  31: 0.0732,
+  32: 0.0401,
+  33: 0.0209,
+  34: 0.0122,
+  35: 0.007,
+  36: 0.0035,
+};
+
+const TE_CURVE: Readonly<Record<number, number>> = {
+  22: 1,
+  23: 0.8466,
+  24: 0.7354,
+  25: 0.6085,
+  26: 0.4815,
+  27: 0.381,
+  28: 0.291,
+  29: 0.1905,
+  30: 0.127,
+  31: 0.0741,
+  32: 0.0582,
+  33: 0.037,
+  34: 0.0265,
+  35: 0.0212,
+  36: 0.0106,
+};
+
+const OL_CURVE: Readonly<Record<number, number>> = {
+  22: 1,
+  23: 0.8345,
+  24: 0.7324,
+  25: 0.6349,
+  26: 0.5125,
+  27: 0.3991,
+  28: 0.2925,
+  29: 0.2132,
+  30: 0.1655,
+  31: 0.1066,
+  32: 0.0567,
+  33: 0.0317,
+  34: 0.0159,
+  35: 0.0068,
+  36: 0.0023,
+};
+
+const EDGE_CURVE: Readonly<Record<number, number>> = {
+  22: 1,
+  23: 0.6906,
+  24: 0.518,
+  25: 0.3669,
+  26: 0.2518,
+  27: 0.1871,
+  28: 0.1295,
+  29: 0.0863,
+  30: 0.0576,
+  31: 0.036,
+  32: 0.0144,
+  // Empirical retirement p90 for EDGE reaches age 32 — pad the tail a
+  // little past the raw cohort endpoint so the occasional 33-34 year
+  // old outlier can occur.
+  33: 0.007,
+  34: 0.003,
+};
+
+const IDL_CURVE: Readonly<Record<number, number>> = {
+  22: 1,
+  23: 0.7879,
+  24: 0.6616,
+  25: 0.5429,
+  26: 0.4318,
+  27: 0.3232,
+  28: 0.2677,
+  29: 0.1995,
+  30: 0.1212,
+  31: 0.0606,
+  32: 0.0379,
+  33: 0.0152,
+  34: 0.0152,
+  35: 0.0101,
+  36: 0.0025,
+};
+
+const LB_CURVE: Readonly<Record<number, number>> = {
+  22: 1,
+  23: 0.8073,
+  24: 0.6744,
+  25: 0.5665,
+  26: 0.4451,
+  27: 0.3468,
+  28: 0.264,
+  29: 0.1965,
+  30: 0.1175,
+  31: 0.0771,
+  32: 0.0366,
+  33: 0.0212,
+  34: 0.0154,
+  35: 0.0058,
+  36: 0.0019,
+};
+
+const CB_CURVE: Readonly<Record<number, number>> = {
+  22: 1,
+  23: 0.8006,
+  24: 0.6935,
+  25: 0.5674,
+  26: 0.4663,
+  27: 0.3446,
+  28: 0.2463,
+  29: 0.1584,
+  30: 0.1085,
+  31: 0.0645,
+  32: 0.0425,
+  33: 0.0293,
+  34: 0.0103,
+  35: 0.0029,
+};
+
+const S_CURVE: Readonly<Record<number, number>> = {
+  22: 1,
+  23: 0.8092,
+  24: 0.6489,
+  25: 0.5038,
+  26: 0.3664,
+  27: 0.2748,
+  28: 0.1527,
+  29: 0.084,
+  30: 0.0458,
+  31: 0.0153,
+  // Pad the tail — real safeties show up past 32 on retirement curves
+  // even though this cohort's raw p_active drops off at 31.
+  32: 0.008,
+  33: 0.004,
+};
+
+const K_CURVE: Readonly<Record<number, number>> = {
+  22: 1,
+  23: 0.7805,
+  24: 0.6829,
+  25: 0.6098,
+  26: 0.5854,
+  27: 0.561,
+  28: 0.5122,
+  29: 0.4146,
+  30: 0.3415,
+  31: 0.2439,
+  32: 0.2195,
+  33: 0.1707,
+  34: 0.1707,
+  35: 0.1463,
+  36: 0.122,
+  37: 0.0976,
+  38: 0.0732,
+  39: 0.0488,
+  40: 0.025,
+  41: 0.02,
+  42: 0.015,
+  43: 0.01,
+  44: 0.005,
+};
+
+const P_CURVE: Readonly<Record<number, number>> = {
+  22: 1,
+  23: 0.875,
+  24: 0.8333,
+  25: 0.75,
+  26: 0.6667,
+  27: 0.5417,
+  28: 0.375,
+  29: 0.25,
+  30: 0.1667,
+  31: 0.125,
+  32: 0.0833,
+  33: 0.0833,
+  34: 0.0833,
+  35: 0.0417,
+  36: 0.0417,
+  37: 0.03,
+  38: 0.02,
+  39: 0.015,
+  40: 0.01,
+};
+
+const LS_CURVE: Readonly<Record<number, number>> = {
+  22: 1,
+  23: 0.8889,
+  24: 0.6667,
+  25: 0.5556,
+  26: 0.5556,
+  27: 0.5556,
+  28: 0.5556,
+  29: 0.5556,
+  30: 0.4444,
+  31: 0.3333,
+  32: 0.2222,
+  33: 0.1111,
+  34: 0.1111,
+  35: 0.08,
+  36: 0.06,
+  37: 0.05,
+  38: 0.04,
+  39: 0.02,
+};
+
+const RAW_CURVES: Record<NeutralBucket, RawCurve> = {
+  QB: { ageWeights: QB_CURVE, age21Weight: NON_SPECIALIST_AGE_21_WEIGHT },
+  RB: { ageWeights: RB_CURVE, age21Weight: NON_SPECIALIST_AGE_21_WEIGHT },
+  WR: { ageWeights: WR_CURVE, age21Weight: NON_SPECIALIST_AGE_21_WEIGHT },
+  TE: { ageWeights: TE_CURVE, age21Weight: NON_SPECIALIST_AGE_21_WEIGHT },
+  OT: { ageWeights: OL_CURVE, age21Weight: NON_SPECIALIST_AGE_21_WEIGHT },
+  IOL: { ageWeights: OL_CURVE, age21Weight: NON_SPECIALIST_AGE_21_WEIGHT },
+  EDGE: { ageWeights: EDGE_CURVE, age21Weight: NON_SPECIALIST_AGE_21_WEIGHT },
+  IDL: { ageWeights: IDL_CURVE, age21Weight: NON_SPECIALIST_AGE_21_WEIGHT },
+  LB: { ageWeights: LB_CURVE, age21Weight: NON_SPECIALIST_AGE_21_WEIGHT },
+  CB: { ageWeights: CB_CURVE, age21Weight: NON_SPECIALIST_AGE_21_WEIGHT },
+  S: { ageWeights: S_CURVE, age21Weight: NON_SPECIALIST_AGE_21_WEIGHT },
+  K: { ageWeights: K_CURVE, age21Weight: SPECIALIST_AGE_21_WEIGHT },
+  P: { ageWeights: P_CURVE, age21Weight: SPECIALIST_AGE_21_WEIGHT },
+  LS: { ageWeights: LS_CURVE, age21Weight: SPECIALIST_AGE_21_WEIGHT },
+};
+
+export interface BucketAgeCurve {
+  readonly ages: readonly number[];
+  readonly weights: readonly number[];
+  readonly cumulative: readonly number[];
+  readonly totalWeight: number;
+}
+
+export interface BucketAgePrior {
+  readonly meanAge: number;
+  readonly p50Age: number;
+  readonly p90Age: number;
+}
+
+function buildCurve(raw: RawCurve): BucketAgeCurve {
+  const entries: Array<{ age: number; weight: number }> = [
+    { age: 21, weight: raw.age21Weight },
+  ];
+  for (const [ageKey, weight] of Object.entries(raw.ageWeights)) {
+    entries.push({ age: Number(ageKey), weight });
+  }
+  entries.sort((a, b) => a.age - b.age);
+  const ages = entries.map((e) => e.age);
+  const weights = entries.map((e) => e.weight);
+  const cumulative: number[] = [];
+  let running = 0;
+  for (const w of weights) {
+    running += w;
+    cumulative.push(running);
+  }
+  return {
+    ages,
+    weights,
+    cumulative,
+    totalWeight: running,
+  };
+}
+
+function buildPrior(curve: BucketAgeCurve): BucketAgePrior {
+  const total = curve.totalWeight;
+  let weightedSum = 0;
+  for (let i = 0; i < curve.ages.length; i++) {
+    weightedSum += curve.ages[i] * curve.weights[i];
+  }
+  const meanAge = weightedSum / total;
+  const percentileAge = (p: number): number => {
+    const target = (p / 100) * total;
+    for (let i = 0; i < curve.cumulative.length; i++) {
+      if (curve.cumulative[i] >= target) return curve.ages[i];
+    }
+    return curve.ages[curve.ages.length - 1];
+  };
+  return {
+    meanAge,
+    p50Age: percentileAge(50),
+    p90Age: percentileAge(90),
+  };
+}
+
+const entries = Object.entries(RAW_CURVES) as Array<[NeutralBucket, RawCurve]>;
+
+export const BUCKET_AGE_CURVES: Record<NeutralBucket, BucketAgeCurve> = Object
+  .fromEntries(
+    entries.map(([bucket, raw]) => [bucket, buildCurve(raw)]),
+  ) as Record<NeutralBucket, BucketAgeCurve>;
+
+export const AGE_CURVE_PRIORS: Record<NeutralBucket, BucketAgePrior> = Object
+  .fromEntries(
+    entries.map((
+      [bucket],
+    ) => [bucket, buildPrior(BUCKET_AGE_CURVES[bucket])]),
+  ) as Record<NeutralBucket, BucketAgePrior>;
+
+/**
+ * Weighted-sample an age for a player in the given neutral bucket using
+ * a cohort survival curve derived from real NFL rosters (2005–2024).
+ * Cumulative-binary-search over the precomputed CDF keeps the per-call
+ * cost constant — important because the generator rolls thousands of
+ * ages per league.
+ */
+export function sampleBucketAge(
+  random: () => number,
+  bucket: NeutralBucket,
+): number {
+  const curve = BUCKET_AGE_CURVES[bucket];
+  const target = random() * curve.totalWeight;
+  let lo = 0;
+  let hi = curve.cumulative.length - 1;
+  while (lo < hi) {
+    const mid = (lo + hi) >> 1;
+    if (curve.cumulative[mid] >= target) {
+      hi = mid;
+    } else {
+      lo = mid + 1;
+    }
+  }
+  return curve.ages[lo];
+}

--- a/server/features/players/players-generator.test.ts
+++ b/server/features/players/players-generator.test.ts
@@ -22,6 +22,7 @@ import {
   SALARY_PER_QUALITY_POINT,
   stubAttributesFor,
 } from "./players-generator.ts";
+import { AGE_CURVE_PRIORS } from "./age-curves.ts";
 
 const TEAM_IDS = ["team-1", "team-2", "team-3"];
 const INPUT = {
@@ -368,10 +369,88 @@ Deno.test("ages span a rookie-to-veteran curve", () => {
   const minAge = Math.min(...ages);
   const maxAge = Math.max(...ages);
   assertEquals(minAge >= 21, true);
-  assertEquals(maxAge <= 36, true);
+  // Position-conditioned curves extend past 36 for QB/OL/specialists —
+  // real NFL rosters routinely carry players into their early 40s at
+  // those positions. Cap the sanity bound at the documented specialist
+  // extreme so the test still fails on a true blow-up.
+  assertEquals(maxAge <= 48, true);
   // There should be both rookies (<=23) and veterans (>=30) in a 159-man pool.
   assertEquals(ages.some((a) => a <= 23), true);
   assertEquals(ages.some((a) => a >= 30), true);
+});
+
+Deno.test("rostered age histograms track per-bucket NFL priors", () => {
+  // Oversample a large league so bucket cohorts are big enough for
+  // stable mean / p90 checks against the real-NFL priors. Per-bucket
+  // rostered counts scale with league size (e.g., 4 RBs × 32 teams =
+  // 128, 2 QBs × 32 = 64), which is enough to resolve the shape of
+  // each position's active-age curve.
+  const teamIds = Array.from({ length: 32 }, (_, i) => `team-${i + 1}`);
+  const result = makeGenerator(777).generate({
+    leagueId: "league-large",
+    seasonId: "season-1",
+    teamIds,
+    rosterSize: 53,
+  });
+  const rostered = result.players.filter(
+    (p) => p.player.teamId !== null && p.player.status === "active",
+  );
+  const agesByBucket = new Map<NeutralBucket, number[]>();
+  for (const entry of rostered) {
+    const bucket = bucketOf(entry);
+    const [year] = entry.player.birthDate.split("-");
+    const age = 2026 - Number(year);
+    const list = agesByBucket.get(bucket) ?? [];
+    list.push(age);
+    agesByBucket.set(bucket, list);
+  }
+  const percentile = (vs: number[], p: number) => {
+    const sorted = [...vs].sort((a, b) => a - b);
+    const idx = Math.min(
+      sorted.length - 1,
+      Math.max(0, Math.floor((p / 100) * sorted.length)),
+    );
+    return sorted[idx];
+  };
+  // Broad bucket coverage — assert mean + p90 per bucket are near the
+  // curve prior. Tolerance is loose enough to absorb the classifier's
+  // bucket drift (the neutralBucket() result can disagree with the
+  // intended slot when signature/non-signature rolls are extreme) and
+  // the finite-sample noise on smaller bucket cohorts.
+  for (const [bucket, ages] of agesByBucket) {
+    if (ages.length < 20) continue;
+    const prior = AGE_CURVE_PRIORS[bucket];
+    const mean = ages.reduce((s, v) => s + v, 0) / ages.length;
+    assertEquals(
+      Math.abs(mean - prior.meanAge) <= 2,
+      true,
+      `${bucket} mean ${mean.toFixed(2)} off from prior ${
+        prior.meanAge.toFixed(2)
+      }`,
+    );
+    const p90 = percentile(ages, 90);
+    assertEquals(
+      Math.abs(p90 - prior.p90Age) <= 3,
+      true,
+      `${bucket} p90 ${p90} off from prior ${prior.p90Age}`,
+    );
+  }
+
+  // Acceptance shape checks: RB cliff, QB tail, specialist tail.
+  const rbAges = agesByBucket.get("RB") ?? [];
+  const qbAges = agesByBucket.get("QB") ?? [];
+  const rb30Plus = rbAges.filter((a) => a >= 30).length / rbAges.length;
+  const qb33Plus = qbAges.filter((a) => a >= 33).length / qbAges.length;
+  assertEquals(
+    rb30Plus <= 0.15,
+    true,
+    `RB 30+ share ${(rb30Plus * 100).toFixed(1)}% too high — cliff missing`,
+  );
+  assertEquals(
+    qb33Plus > rb30Plus * 0.5,
+    true,
+    `QB 33+ share ${(qb33Plus * 100).toFixed(1)}% not a meaningful tail`,
+  );
 });
 
 Deno.test("prospects fall into a draft-eligible age band", () => {

--- a/server/features/players/players-generator.ts
+++ b/server/features/players/players-generator.ts
@@ -17,6 +17,7 @@ import {
 } from "../../shared/name-generator.ts";
 import { DEFAULT_COLLEGES } from "../colleges/default-colleges.ts";
 import { DEFAULT_CITIES } from "../cities/default-cities.ts";
+import { sampleBucketAge } from "./age-curves.ts";
 import type { ContractGuaranteeType } from "@zone-blitz/shared";
 import type {
   ContractGeneratorInput,
@@ -422,8 +423,6 @@ export const SALARY_PER_QUALITY_POINT = 250_000;
 
 const ROOKIE_SCALE_AGE_THRESHOLD = 25;
 
-const VETERAN_AGE_MIN = 21;
-const VETERAN_AGE_MAX = 36;
 const PROSPECT_AGE_MIN = 20;
 const PROSPECT_AGE_MAX = 23;
 
@@ -577,14 +576,16 @@ function rollHeightWeight(rng: SeededRng, bucket: NeutralBucket): {
 function rollAge(
   rng: SeededRng,
   status: "rostered" | "free-agent" | "prospect",
+  bucket: NeutralBucket,
 ): number {
   if (status === "prospect") {
     return rng.int(PROSPECT_AGE_MIN, PROSPECT_AGE_MAX);
   }
-  // Triangular-ish around the middle of the playing-age band.
-  const raw = (rng.next() + rng.next()) / 2;
-  const span = VETERAN_AGE_MAX - VETERAN_AGE_MIN;
-  return VETERAN_AGE_MIN + Math.round(raw * span);
+  // Active / free-agent ages follow a position-conditioned cohort
+  // survival curve so RB/CB cliff near 28, OL plateau into mid-30s,
+  // QB keep a long tail past 36, and specialists (K/P/LS) extend past
+  // 40 — all real shapes the prior uniform 21–36 triangular erased.
+  return sampleBucketAge(rng.next, bucket);
 }
 
 function birthDateForAge(
@@ -1091,7 +1092,7 @@ export function createPlayersGenerator(
       rng,
       qualityTierForIndex(args.indexInBucket, args.bucketCount),
     );
-    const age = rollAge(rng, args.statusKind);
+    const age = rollAge(rng, args.statusKind, args.bucket);
     const { heightInches, weightPounds } = rollHeightWeight(rng, args.bucket);
     const attributes = rollAttributesFor(rng, args.bucket, quality);
     lockInBucket(attributes, args.bucket, heightInches, weightPounds);
@@ -1244,7 +1245,7 @@ export function createPlayersGenerator(
           );
           const tier = qualityTierForIndex(indexInBucket, bucketCount);
           const quality = rollQuality(rng, tier);
-          const age = rollAge(rng, "rostered");
+          const age = rollAge(rng, "rostered", bucket);
           return rollContract(
             rng,
             {


### PR DESCRIPTION
## Summary
- Replace the single 21–36 triangular `rollAge` with per-neutral-bucket weighted sampling driven by `p_active_by_age` survivorship curves from `data/bands/career-length.json`.
- New `server/features/players/age-curves.ts` encodes each bucket's active-age weights + precomputed mean / p50 / p90 priors, and exposes a constant-time `sampleBucketAge` sampler.
- Tests assert every bucket has a curve; sampled mean & p90 converge to the real-NFL priors (±0.5 / ±1); RB shows a post-28 cliff; QB and OL have meaningfully longer tails than RB; K/P/LS extend past 35. A large-league generator test checks rostered age histograms track priors end-to-end.

Closes #527