### PR TITLE
feat(calibration): align roster composition with position market data

### DIFF
--- a/server/features/players/players-generator.test.ts
+++ b/server/features/players/players-generator.test.ts
@@ -69,10 +69,14 @@ Deno.test("generates correct number of rostered players per team", () => {
   const rostered = result.players.filter(
     (p) => p.player.teamId !== null && p.player.status === "active",
   );
-  assertEquals(rostered.length, TEAM_IDS.length * INPUT.rosterSize);
+  const expectedPerTeam = ROSTER_BUCKET_COMPOSITION.reduce(
+    (sum, entry) => sum + entry.count,
+    0,
+  );
+  assertEquals(rostered.length, TEAM_IDS.length * expectedPerTeam);
   for (const teamId of TEAM_IDS) {
     const teamPlayers = rostered.filter((p) => p.player.teamId === teamId);
-    assertEquals(teamPlayers.length, INPUT.rosterSize);
+    assertEquals(teamPlayers.length, expectedPerTeam);
   }
 });
 
@@ -228,13 +232,51 @@ Deno.test("signing bonus produces a bonus proration row with source 'signing'", 
   }
 });
 
-Deno.test("roster composition sums to 53 players", () => {
+Deno.test("roster composition sums to 48 players (NFL ACT mean)", () => {
   const total = ROSTER_BUCKET_COMPOSITION.reduce(
     (sum, entry) => sum + entry.count,
     0,
   );
-  assertEquals(total, 53);
+  assertEquals(total, 48);
 });
+
+Deno.test(
+  "roster composition matches position-market.json within ±0.5 slot per data bucket",
+  () => {
+    const counts = new Map<NeutralBucket, number>();
+    for (const { bucket, count } of ROSTER_BUCKET_COMPOSITION) {
+      counts.set(bucket, count);
+    }
+    const get = (b: NeutralBucket) => counts.get(b) ?? 0;
+
+    // Means from data/bands/position-market.json roster_slots_per_team_week.
+    const checks: { label: string; actual: number; data: number }[] = [
+      { label: "QB", actual: get("QB"), data: 2.0386 },
+      { label: "RB", actual: get("RB"), data: 3.5617 },
+      { label: "WR", actual: get("WR"), data: 5.2229 },
+      { label: "TE", actual: get("TE"), data: 3.1022 },
+      { label: "OL (OT+IOL)", actual: get("OT") + get("IOL"), data: 8.0223 },
+      {
+        label: "DL (EDGE+IDL)",
+        actual: get("EDGE") + get("IDL"),
+        data: 7.0316,
+      },
+      { label: "LB", actual: get("LB"), data: 6.8224 },
+      { label: "DB (CB+S)", actual: get("CB") + get("S"), data: 9.2181 },
+      { label: "K", actual: get("K"), data: 0.9959 },
+      { label: "P", actual: get("P"), data: 1.0059 },
+      { label: "LS", actual: get("LS"), data: 0.9996 },
+    ];
+    for (const { label, actual, data } of checks) {
+      const delta = Math.abs(actual - data);
+      assertEquals(
+        delta <= 0.5,
+        true,
+        `${label}: composition ${actual} diverges from data mean ${data} by ${delta} (>0.5)`,
+      );
+    }
+  },
+);
 
 Deno.test(
   "every generated player classifies into a known neutral bucket",
@@ -248,7 +290,7 @@ Deno.test(
 );
 
 Deno.test(
-  "per-team rostered neutral buckets match the 53-man composition",
+  "per-team rostered neutral buckets match the canonical composition",
   () => {
     const result = makeGenerator().generate(INPUT);
     for (const teamId of TEAM_IDS) {
@@ -369,7 +411,7 @@ Deno.test("ages span a rookie-to-veteran curve", () => {
   const maxAge = Math.max(...ages);
   assertEquals(minAge >= 21, true);
   assertEquals(maxAge <= 36, true);
-  // There should be both rookies (<=23) and veterans (>=30) in a 159-man pool.
+  // There should be both rookies (<=23) and veterans (>=30) in a 144-man pool.
   assertEquals(ages.some((a) => a <= 23), true);
   assertEquals(ages.some((a) => a >= 30), true);
 });
@@ -881,7 +923,7 @@ function signatureOverallOf(entry: {
 }
 
 function makeFullLeagueGenerator(seed: number) {
-  // 32 teams × 53 = 1696 rostered players — a realistic sample for
+  // 32 teams × 48 = 1536 rostered players — a realistic sample for
   // league-wide distribution assertions.
   return createPlayersGenerator({
     random: seededRandom(seed),
@@ -906,7 +948,7 @@ Deno.test("rostered signature overall distribution peaks in the backup band (35-
   const mean = overalls.reduce((s, v) => s + v, 0) / overalls.length;
   // Bin into 10-point buckets and find the modal bucket. The north-star
   // doc says the league peaks around 35-40; allow 30-50 for the mode so
-  // seed noise on a 1696-player sample doesn't turn this flaky.
+  // seed noise on a 1536-player sample doesn't turn this flaky.
   const bins = new Map<number, number>();
   for (const v of overalls) {
     const bucket = Math.floor(v / 10) * 10;

--- a/server/features/players/players-generator.ts
+++ b/server/features/players/players-generator.ts
@@ -388,22 +388,25 @@ export const BUCKET_PROFILES: Record<NeutralBucket, BucketProfile> = {
 };
 
 // Target roster composition by neutral bucket. FB is intentionally absent —
-// lead-blocking fullbacks classify as RB under the neutral lens.
+// lead-blocking fullbacks classify as RB under the neutral lens. Counts are
+// calibrated to `data/bands/position-market.json` (mean ACT slots per
+// team-week, 2020-2024) within ±0.5 per bucket: combined OL = 8 (data 8.02),
+// combined DL = 7 (data 7.03), combined DB = 9 (data 9.22).
 export const ROSTER_BUCKET_COMPOSITION: readonly {
   bucket: NeutralBucket;
   count: number;
 }[] = [
   { bucket: "QB", count: 2 },
   { bucket: "RB", count: 4 },
-  { bucket: "WR", count: 6 },
+  { bucket: "WR", count: 5 },
   { bucket: "TE", count: 3 },
   { bucket: "OT", count: 4 },
-  { bucket: "IOL", count: 5 },
+  { bucket: "IOL", count: 4 },
   { bucket: "EDGE", count: 4 },
-  { bucket: "IDL", count: 4 },
+  { bucket: "IDL", count: 3 },
   { bucket: "LB", count: 7 },
-  { bucket: "CB", count: 6 },
-  { bucket: "S", count: 5 },
+  { bucket: "CB", count: 5 },
+  { bucket: "S", count: 4 },
   { bucket: "K", count: 1 },
   { bucket: "P", count: 1 },
   { bucket: "LS", count: 1 },
@@ -1130,14 +1133,21 @@ export function createPlayersGenerator(
       const players: GeneratedPlayers["players"] = [];
       const rosteredEntries: typeof players = [];
 
+      // input.rosterSize is the league's roster cap (config), but the actual
+      // generated count is fixed by ROSTER_BUCKET_COMPOSITION — the data-
+      // calibrated 48-man composition. A larger cap leaves open slots; a
+      // zero cap (e.g. an empty league at creation time) skips entirely.
+      const rosteredCount = input.rosterSize > 0
+        ? ROSTER_BUCKET_SLOTS.length
+        : 0;
       for (const teamId of input.teamIds) {
         const bucketIndex = new Map<NeutralBucket, number>();
         const bucketTotal = new Map<NeutralBucket, number>();
         for (const { bucket, count } of ROSTER_BUCKET_COMPOSITION) {
           bucketTotal.set(bucket, count);
         }
-        for (let i = 0; i < input.rosterSize; i++) {
-          const bucket = ROSTER_BUCKET_SLOTS[i % ROSTER_BUCKET_SLOTS.length];
+        for (let i = 0; i < rosteredCount; i++) {
+          const bucket = ROSTER_BUCKET_SLOTS[i];
           const indexInBucket = bucketIndex.get(bucket) ?? 0;
           bucketIndex.set(bucket, indexInBucket + 1);
           const entry = buildPlayer({


### PR DESCRIPTION
## Summary

- `ROSTER_BUCKET_COMPOSITION` recalibrated to match `data/bands/position-market.json` (mean ACT slots 2020-2024) within ±0.5 per data bucket. Drops WR/IOL/IDL/CB/S by one slot each, total goes from 53 to 48.
- Generator's rostered loop now sizes off `ROSTER_BUCKET_SLOTS.length` instead of cycling `input.rosterSize`. A league cap of 53 leaves 5 open depth slots; `rosterSize=0` still skips entirely.
- Adds a parametric test pinning each combined-bucket count to its data mean ±0.5, so future drift fails fast.

Closes #530