### PR TITLE
refactor(sim): scaffold sim:refit for continuous outcome coefficients (PR 1/4 of #525)

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -34,6 +34,7 @@
     "test:coverage": "./bin/check-coverage",
     "test:e2e": "./bin/test-e2e",
     "sim:calibrate": "deno run --allow-read server/features/simulation/calibration/run-calibration.ts",
+    "sim:refit": "deno run --allow-read --allow-write server/features/simulation/calibration/refit-outcomes.ts",
     "sim:calibrate:qb": "deno run --allow-read server/features/simulation/calibration/per-position/run-qb-calibration.ts",
     "sim:calibrate:rb": "deno run --allow-read server/features/simulation/calibration/per-position/run-rb-calibration.ts",
     "sim:calibrate:te": "deno run --allow-read server/features/simulation/calibration/per-position/run-te-calibration.ts",

--- a/server/features/simulation/calibration/fit-outcomes.test.ts
+++ b/server/features/simulation/calibration/fit-outcomes.test.ts
@@ -1,0 +1,141 @@
+import { assertEquals, assertThrows } from "@std/assert";
+import { PASS_RESOLUTION, RUN_RESOLUTION } from "../resolve-play.ts";
+import { loadBands } from "./band-loader.ts";
+import { fitOutcomes, type ScoreDistribution } from "./fit-outcomes.ts";
+
+const BANDS_PATH = new URL(
+  "../../../../data/bands/team-game.json",
+  import.meta.url,
+);
+const MEASURED_PATH = new URL("./measured-scores.json", import.meta.url);
+
+async function loadMeasured(): Promise<ScoreDistribution> {
+  const raw = JSON.parse(await Deno.readTextFile(MEASURED_PATH));
+  return {
+    blockScore: raw.blockScore,
+    protectionScore: raw.protectionScore,
+    coverageScore: raw.coverageScore,
+  };
+}
+
+async function loadBandsFromDisk() {
+  return loadBands(await Deno.readTextFile(BANDS_PATH));
+}
+
+Deno.test("fitOutcomes reproduces PASS_RESOLUTION constants from current distribution", async () => {
+  const scores = await loadMeasured();
+  const bands = await loadBandsFromDisk();
+
+  const fitted = fitOutcomes({ scores, bands });
+
+  assertEquals(fitted.pass.completion.base, PASS_RESOLUTION.completion.base);
+  assertEquals(
+    fitted.pass.completion.coverageModifier,
+    PASS_RESOLUTION.completion.coverageModifier,
+  );
+  assertEquals(fitted.pass.completion.floor, PASS_RESOLUTION.completion.floor);
+  assertEquals(
+    fitted.pass.completion.ceiling,
+    PASS_RESOLUTION.completion.ceiling,
+  );
+
+  assertEquals(
+    fitted.pass.interception.base,
+    PASS_RESOLUTION.interception.base,
+  );
+  assertEquals(
+    fitted.pass.interception.coverageModifier,
+    PASS_RESOLUTION.interception.coverageModifier,
+  );
+  assertEquals(
+    fitted.pass.interception.floor,
+    PASS_RESOLUTION.interception.floor,
+  );
+
+  assertEquals(fitted.pass.sack.base, PASS_RESOLUTION.sack.base);
+  assertEquals(
+    fitted.pass.sack.protectionModifier,
+    PASS_RESOLUTION.sack.protectionModifier,
+  );
+  assertEquals(fitted.pass.sack.floor, PASS_RESOLUTION.sack.floor);
+
+  assertEquals(fitted.pass.bigPlay.base, PASS_RESOLUTION.bigPlay.base);
+  assertEquals(
+    fitted.pass.bigPlay.coverageModifier,
+    PASS_RESOLUTION.bigPlay.coverageModifier,
+  );
+  assertEquals(fitted.pass.bigPlay.floor, PASS_RESOLUTION.bigPlay.floor);
+  assertEquals(fitted.pass.bigPlay.ceiling, PASS_RESOLUTION.bigPlay.ceiling);
+  assertEquals(
+    fitted.pass.bigPlay.yards.min,
+    PASS_RESOLUTION.bigPlay.yards.min,
+  );
+  assertEquals(
+    fitted.pass.bigPlay.yards.max,
+    PASS_RESOLUTION.bigPlay.yards.max,
+  );
+
+  assertEquals(
+    fitted.pass.completionYards.min,
+    PASS_RESOLUTION.completionYards.min,
+  );
+  assertEquals(
+    fitted.pass.completionYards.max,
+    PASS_RESOLUTION.completionYards.max,
+  );
+  assertEquals(fitted.pass.fumbleOnSack, PASS_RESOLUTION.fumbleOnSack);
+});
+
+Deno.test("fitOutcomes reproduces RUN_RESOLUTION constants from current distribution", async () => {
+  const scores = await loadMeasured();
+  const bands = await loadBandsFromDisk();
+
+  const fitted = fitOutcomes({ scores, bands });
+
+  assertEquals(fitted.run.stuffThreshold, RUN_RESOLUTION.stuffThreshold);
+  assertEquals(
+    fitted.run.shortGainThreshold,
+    RUN_RESOLUTION.shortGainThreshold,
+  );
+  assertEquals(fitted.run.bigPlayThreshold, RUN_RESOLUTION.bigPlayThreshold);
+  assertEquals(fitted.run.stuffYards.min, RUN_RESOLUTION.stuffYards.min);
+  assertEquals(fitted.run.stuffYards.max, RUN_RESOLUTION.stuffYards.max);
+  assertEquals(
+    fitted.run.shortGainYards.min,
+    RUN_RESOLUTION.shortGainYards.min,
+  );
+  assertEquals(
+    fitted.run.shortGainYards.max,
+    RUN_RESOLUTION.shortGainYards.max,
+  );
+  assertEquals(fitted.run.bigPlayYards.min, RUN_RESOLUTION.bigPlayYards.min);
+  assertEquals(fitted.run.bigPlayYards.max, RUN_RESOLUTION.bigPlayYards.max);
+  assertEquals(fitted.run.normalYards.min, RUN_RESOLUTION.normalYards.min);
+  assertEquals(fitted.run.normalYards.max, RUN_RESOLUTION.normalYards.max);
+  assertEquals(fitted.run.fumbleRate, RUN_RESOLUTION.fumbleRate);
+});
+
+Deno.test("fitOutcomes matches the checked-in outcome-coefficients.json artifact", async () => {
+  const scores = await loadMeasured();
+  const bands = await loadBandsFromDisk();
+  const fitted = fitOutcomes({ scores, bands });
+
+  const artifactPath = new URL("./outcome-coefficients.json", import.meta.url);
+  const artifact = JSON.parse(await Deno.readTextFile(artifactPath));
+
+  assertEquals(fitted.pass, artifact.pass);
+  assertEquals(fitted.run, artifact.run);
+});
+
+Deno.test("fitOutcomes throws when bands map is empty", () => {
+  const scores: ScoreDistribution = {
+    blockScore: { mean: 0, stddev: 1 },
+    protectionScore: { mean: 0, stddev: 1 },
+    coverageScore: { mean: 0, stddev: 1 },
+  };
+  assertThrows(
+    () => fitOutcomes({ scores, bands: new Map() }),
+    Error,
+    "non-empty bands map",
+  );
+});

--- a/server/features/simulation/calibration/fit-outcomes.ts
+++ b/server/features/simulation/calibration/fit-outcomes.ts
@@ -1,0 +1,201 @@
+/**
+ * Pure function that maps matchup-score distributions + NFL bands to the
+ * coefficients consumed by `synthesize-run-outcome` and
+ * `synthesize-pass-outcome`. PR 1 scaffolding reproduces today's hand-tuned
+ * values from today's distribution; PR 2/3 will rewrite the math so
+ * coefficients are derived directly from the bands once the outcome
+ * mappings are continuous/sigmoid.
+ */
+import type { MetricBand } from "./band-loader.ts";
+
+export interface Stats {
+  mean: number;
+  stddev: number;
+}
+
+export interface ScoreDistribution {
+  blockScore: Stats;
+  protectionScore: Stats;
+  coverageScore: Stats;
+}
+
+export interface FitInputs {
+  scores: ScoreDistribution;
+  bands: Map<string, MetricBand>;
+}
+
+export interface YardRange {
+  min: number;
+  max: number;
+}
+
+export interface PassCoefficients {
+  completion: {
+    base: number;
+    coverageModifier: number;
+    floor: number;
+    ceiling: number;
+  };
+  interception: { base: number; coverageModifier: number; floor: number };
+  sack: { base: number; protectionModifier: number; floor: number };
+  bigPlay: {
+    base: number;
+    coverageModifier: number;
+    floor: number;
+    ceiling: number;
+    yards: YardRange;
+  };
+  completionYards: YardRange;
+  fumbleOnSack: number;
+}
+
+export interface RunCoefficients {
+  stuffThreshold: number;
+  stuffYards: YardRange;
+  shortGainThreshold: number;
+  shortGainYards: YardRange;
+  bigPlayThreshold: number;
+  bigPlayYards: YardRange;
+  normalYards: YardRange;
+  fumbleRate: number;
+}
+
+export interface FittedCoefficients {
+  pass: PassCoefficients;
+  run: RunCoefficients;
+}
+
+/**
+ * Anchor values chosen so that, given the current measured score
+ * distribution (see measured-scores.json), the fitter reproduces today's
+ * hand-tuned RUN_RESOLUTION / PASS_RESOLUTION constants to within rounding.
+ *
+ * Interpretation: each `anchorAtMean` is the probability the current engine
+ * lands at when the relevant matchup score equals the league-average score;
+ * each `sdMultiplier` places a run-yardage threshold a fixed number of
+ * standard deviations from the blockScore mean. Encoding these explicitly
+ * makes the regression test a straightforward back-substitution.
+ *
+ * PR 2/3 replace these anchors with a band-driven least-squares solve once
+ * the outcome mappings become continuous/sigmoid.
+ */
+const FIT_CONFIG = {
+  pass: {
+    completion: {
+      anchorAtMean: 0.686031,
+      modifier: 0.010,
+      floor: 0.18,
+      ceiling: 0.92,
+    },
+    interception: {
+      anchorAtMean: 0.015794,
+      modifier: 0.002,
+      floor: 0.004,
+    },
+    sack: { anchorAtMean: 0.09647, modifier: 0.005, floor: 0.01 },
+    bigPlay: {
+      anchorAtMean: 0.196825,
+      modifier: 0.008,
+      floor: 0.05,
+      ceiling: 0.45,
+      yards: { min: 14, max: 35 },
+    },
+    completionYards: { min: 3, max: 15 },
+    fumbleOnSack: 0.08,
+  },
+  run: {
+    stuffSdBelow: 4.59955,
+    shortGainSdBelow: 1.9267,
+    bigPlaySdAbove: 1.97964,
+    stuffYards: { min: -3, max: 0 },
+    shortGainYards: { min: 1, max: 5 },
+    bigPlayYards: { min: 9, max: 20 },
+    normalYards: { min: 2, max: 9 },
+    fumbleRate: 0.010,
+  },
+} as const;
+
+function roundTo(value: number, digits: number): number {
+  const factor = 10 ** digits;
+  return Math.round(value * factor) / factor;
+}
+
+function roundInt(value: number): number {
+  return Math.round(value);
+}
+
+export function fitOutcomes(input: FitInputs): FittedCoefficients {
+  // Bands are accepted as input for forward compatibility with PR 2/3; in the
+  // scaffolding phase coefficients are anchored to the measured distribution.
+  // Reference the map to keep the parameter non-unused.
+  if (input.bands.size === 0) {
+    throw new Error("fitOutcomes requires a non-empty bands map");
+  }
+
+  const { scores } = input;
+  const pc = FIT_CONFIG.pass;
+
+  // Each probability coefficient has the form `prob = base ± score · modifier`
+  // and must evaluate to `anchorAtMean` at the measured distribution mean.
+  // Solve for `base` symbolically so future distribution shifts regenerate
+  // coefficients without hand-retuning.
+  const pass: PassCoefficients = {
+    completion: {
+      base: roundTo(
+        pc.completion.anchorAtMean -
+          scores.coverageScore.mean * pc.completion.modifier,
+        4,
+      ),
+      coverageModifier: pc.completion.modifier,
+      floor: pc.completion.floor,
+      ceiling: pc.completion.ceiling,
+    },
+    interception: {
+      base: roundTo(
+        pc.interception.anchorAtMean +
+          scores.coverageScore.mean * pc.interception.modifier,
+        4,
+      ),
+      coverageModifier: pc.interception.modifier,
+      floor: pc.interception.floor,
+    },
+    sack: {
+      base: roundTo(
+        pc.sack.anchorAtMean +
+          scores.protectionScore.mean * pc.sack.modifier,
+        4,
+      ),
+      protectionModifier: pc.sack.modifier,
+      floor: pc.sack.floor,
+    },
+    bigPlay: {
+      base: roundTo(
+        pc.bigPlay.anchorAtMean -
+          scores.coverageScore.mean * pc.bigPlay.modifier,
+        4,
+      ),
+      coverageModifier: pc.bigPlay.modifier,
+      floor: pc.bigPlay.floor,
+      ceiling: pc.bigPlay.ceiling,
+      yards: pc.bigPlay.yards,
+    },
+    completionYards: pc.completionYards,
+    fumbleOnSack: pc.fumbleOnSack,
+  };
+
+  const rc = FIT_CONFIG.run;
+  const m = scores.blockScore.mean;
+  const sd = scores.blockScore.stddev;
+  const run: RunCoefficients = {
+    stuffThreshold: roundInt(m - rc.stuffSdBelow * sd),
+    stuffYards: rc.stuffYards,
+    shortGainThreshold: roundInt(m - rc.shortGainSdBelow * sd),
+    shortGainYards: rc.shortGainYards,
+    bigPlayThreshold: roundInt(m + rc.bigPlaySdAbove * sd),
+    bigPlayYards: rc.bigPlayYards,
+    normalYards: rc.normalYards,
+    fumbleRate: rc.fumbleRate,
+  };
+
+  return { pass, run };
+}

--- a/server/features/simulation/calibration/measure-scores.test.ts
+++ b/server/features/simulation/calibration/measure-scores.test.ts
@@ -1,0 +1,43 @@
+import { assert, assertEquals } from "@std/assert";
+import { CALIBRATION_SEED } from "./calibration-seed.ts";
+import { measureScores, summarizeSamples } from "./measure-scores.ts";
+
+Deno.test("summarizeSamples returns zeroed stats for empty samples", () => {
+  const summary = summarizeSamples({
+    blockScore: [],
+    protectionScore: [],
+    coverageScore: [],
+  });
+  assertEquals(summary, {
+    blockScore: { mean: 0, stddev: 0 },
+    protectionScore: { mean: 0, stddev: 0 },
+    coverageScore: { mean: 0, stddev: 0 },
+  });
+});
+
+Deno.test("summarizeSamples computes mean and population stddev", () => {
+  const summary = summarizeSamples({
+    blockScore: [2, 4, 4, 4, 5, 5, 7, 9],
+    protectionScore: [1, 1, 1, 1],
+    coverageScore: [0, 10],
+  });
+  assertEquals(summary.blockScore.mean, 5);
+  assertEquals(summary.blockScore.stddev, 2);
+  assertEquals(summary.protectionScore, { mean: 1, stddev: 0 });
+  assertEquals(summary.coverageScore, { mean: 5, stddev: 5 });
+});
+
+Deno.test("measureScores runs the simulator and produces non-empty distributions", () => {
+  // Single seed with default season shape is enough to prove wiring; the
+  // full 8-seed sweep is exercised by sim:refit.
+  const measured = measureScores({ seeds: [CALIBRATION_SEED] });
+  assertEquals(measured.seeds, [CALIBRATION_SEED]);
+  assert(measured.sampleCounts.blockScore > 0);
+  assert(measured.sampleCounts.protectionScore > 0);
+  assert(measured.sampleCounts.coverageScore > 0);
+  assert(Number.isFinite(measured.blockScore.mean));
+  assert(Number.isFinite(measured.blockScore.stddev));
+  assert(measured.blockScore.stddev > 0);
+  assert(measured.protectionScore.stddev > 0);
+  assert(measured.coverageScore.stddev > 0);
+});

--- a/server/features/simulation/calibration/measure-scores.ts
+++ b/server/features/simulation/calibration/measure-scores.ts
@@ -1,0 +1,72 @@
+/**
+ * Runs the simulator across a seed sweep with a score-observer installed,
+ * and returns summary statistics for the intermediate matchup scores
+ * consumed by the fit-outcomes pipeline.
+ */
+import {
+  createCollectingObserver,
+  type ScoreSamples,
+  setScoreObserver,
+} from "../score-observer.ts";
+import { simulateSeason } from "../simulate-season.ts";
+import type { ScoreDistribution, Stats } from "./fit-outcomes.ts";
+
+export interface MeasureScoresOptions {
+  seeds: number[];
+  teamCount?: number;
+  gamesPerTeam?: number;
+}
+
+export interface MeasuredDistribution extends ScoreDistribution {
+  sampleCounts: {
+    blockScore: number;
+    protectionScore: number;
+    coverageScore: number;
+  };
+  seeds: number[];
+}
+
+function toStats(values: number[]): Stats {
+  if (values.length === 0) return { mean: 0, stddev: 0 };
+  const mean = values.reduce((a, b) => a + b, 0) / values.length;
+  const variance = values.reduce((s, v) => s + (v - mean) ** 2, 0) /
+    values.length;
+  return { mean, stddev: Math.sqrt(variance) };
+}
+
+export function summarizeSamples(samples: ScoreSamples): ScoreDistribution {
+  return {
+    blockScore: toStats(samples.blockScore),
+    protectionScore: toStats(samples.protectionScore),
+    coverageScore: toStats(samples.coverageScore),
+  };
+}
+
+export function measureScores(
+  options: MeasureScoresOptions,
+): MeasuredDistribution {
+  const { samples, observer } = createCollectingObserver();
+  setScoreObserver(observer);
+  try {
+    for (const seed of options.seeds) {
+      simulateSeason({
+        leagueSeed: seed,
+        teamCount: options.teamCount,
+        gamesPerTeam: options.gamesPerTeam,
+      });
+    }
+  } finally {
+    setScoreObserver(null);
+  }
+
+  const summary = summarizeSamples(samples);
+  return {
+    ...summary,
+    sampleCounts: {
+      blockScore: samples.blockScore.length,
+      protectionScore: samples.protectionScore.length,
+      coverageScore: samples.coverageScore.length,
+    },
+    seeds: options.seeds,
+  };
+}

--- a/server/features/simulation/calibration/measured-scores.json
+++ b/server/features/simulation/calibration/measured-scores.json
@@ -1,0 +1,30 @@
+{
+  "generated_by": "deno task sim:refit",
+  "seeds": [
+    3390767137,
+    168939025,
+    3735928559,
+    4207869677,
+    3135097598,
+    3237998146,
+    4277009102,
+    212580974
+  ],
+  "sampleCounts": {
+    "blockScore": 139098,
+    "protectionScore": 123809,
+    "coverageScore": 123809
+  },
+  "blockScore": {
+    "mean": 2.371311273746237,
+    "stddev": 4.86389102168291
+  },
+  "protectionScore": {
+    "mean": -5.0937935314340645,
+    "stddev": 5.340522462194146
+  },
+  "coverageScore": {
+    "mean": -0.39691469207497626,
+    "stddev": 8.184379098286115
+  }
+}

--- a/server/features/simulation/calibration/outcome-coefficients.json
+++ b/server/features/simulation/calibration/outcome-coefficients.json
@@ -1,0 +1,58 @@
+{
+  "generated_by": "deno task sim:refit",
+  "pass": {
+    "completion": {
+      "base": 0.69,
+      "coverageModifier": 0.01,
+      "floor": 0.18,
+      "ceiling": 0.92
+    },
+    "interception": {
+      "base": 0.015,
+      "coverageModifier": 0.002,
+      "floor": 0.004
+    },
+    "sack": {
+      "base": 0.071,
+      "protectionModifier": 0.005,
+      "floor": 0.01
+    },
+    "bigPlay": {
+      "base": 0.2,
+      "coverageModifier": 0.008,
+      "floor": 0.05,
+      "ceiling": 0.45,
+      "yards": {
+        "min": 14,
+        "max": 35
+      }
+    },
+    "completionYards": {
+      "min": 3,
+      "max": 15
+    },
+    "fumbleOnSack": 0.08
+  },
+  "run": {
+    "stuffThreshold": -20,
+    "stuffYards": {
+      "min": -3,
+      "max": 0
+    },
+    "shortGainThreshold": -7,
+    "shortGainYards": {
+      "min": 1,
+      "max": 5
+    },
+    "bigPlayThreshold": 12,
+    "bigPlayYards": {
+      "min": 9,
+      "max": 20
+    },
+    "normalYards": {
+      "min": 2,
+      "max": 9
+    },
+    "fumbleRate": 0.01
+  }
+}

--- a/server/features/simulation/calibration/refit-outcomes.test.ts
+++ b/server/features/simulation/calibration/refit-outcomes.test.ts
@@ -1,0 +1,25 @@
+import { assertEquals } from "@std/assert";
+import { runRefit } from "./refit-outcomes.ts";
+
+const MEASURED_PATH = new URL("./measured-scores.json", import.meta.url);
+const COEFFICIENTS_PATH = new URL(
+  "./outcome-coefficients.json",
+  import.meta.url,
+);
+
+Deno.test("runRefit regenerates the checked-in artifacts deterministically", async () => {
+  const beforeMeasured = await Deno.readTextFile(MEASURED_PATH);
+  const beforeCoeffs = await Deno.readTextFile(COEFFICIENTS_PATH);
+
+  await runRefit();
+
+  const afterMeasured = await Deno.readTextFile(MEASURED_PATH);
+  const afterCoeffs = await Deno.readTextFile(COEFFICIENTS_PATH);
+
+  // Idempotent: rerunning the refit against the same code + bands must
+  // reproduce the committed artifacts byte-for-byte. Drift here signals
+  // either a sim-behavior change that wasn't accompanied by a re-commit of
+  // these files, or non-determinism leaking into the pipeline.
+  assertEquals(beforeMeasured, afterMeasured);
+  assertEquals(beforeCoeffs, afterCoeffs);
+});

--- a/server/features/simulation/calibration/refit-outcomes.test.ts
+++ b/server/features/simulation/calibration/refit-outcomes.test.ts
@@ -1,5 +1,5 @@
-import { assertEquals } from "@std/assert";
-import { runRefit } from "./refit-outcomes.ts";
+import { assert, assertEquals } from "@std/assert";
+import { computeRefit } from "./refit-outcomes.ts";
 
 const MEASURED_PATH = new URL("./measured-scores.json", import.meta.url);
 const COEFFICIENTS_PATH = new URL(
@@ -7,19 +7,27 @@ const COEFFICIENTS_PATH = new URL(
   import.meta.url,
 );
 
-Deno.test("runRefit regenerates the checked-in artifacts deterministically", async () => {
-  const beforeMeasured = await Deno.readTextFile(MEASURED_PATH);
-  const beforeCoeffs = await Deno.readTextFile(COEFFICIENTS_PATH);
+Deno.test("computeRefit reproduces the checked-in artifacts byte-for-byte", async () => {
+  const diskMeasured = await Deno.readTextFile(MEASURED_PATH);
+  const diskCoefficients = await Deno.readTextFile(COEFFICIENTS_PATH);
 
-  await runRefit();
+  const result = await computeRefit();
 
-  const afterMeasured = await Deno.readTextFile(MEASURED_PATH);
-  const afterCoeffs = await Deno.readTextFile(COEFFICIENTS_PATH);
+  // A fresh refit against the same simulator + bands + seeds must
+  // reproduce the committed JSON exactly. Drift signals that a sim
+  // behavior change was not followed by re-running `sim:refit`, or that
+  // non-determinism is leaking into the pipeline.
+  assertEquals(result.measuredJson, diskMeasured);
+  assertEquals(result.coefficientsJson, diskCoefficients);
+});
 
-  // Idempotent: rerunning the refit against the same code + bands must
-  // reproduce the committed artifacts byte-for-byte. Drift here signals
-  // either a sim-behavior change that wasn't accompanied by a re-commit of
-  // these files, or non-determinism leaking into the pipeline.
-  assertEquals(beforeMeasured, afterMeasured);
-  assertEquals(beforeCoeffs, afterCoeffs);
+Deno.test("computeRefit produces well-formed JSON", async () => {
+  const result = await computeRefit();
+  const measured = JSON.parse(result.measuredJson);
+  const coefficients = JSON.parse(result.coefficientsJson);
+
+  assert(Array.isArray(measured.seeds) && measured.seeds.length > 0);
+  assertEquals(typeof measured.blockScore.mean, "number");
+  assertEquals(typeof coefficients.pass.completion.base, "number");
+  assertEquals(typeof coefficients.run.stuffThreshold, "number");
 });

--- a/server/features/simulation/calibration/refit-outcomes.ts
+++ b/server/features/simulation/calibration/refit-outcomes.ts
@@ -21,13 +21,31 @@ const BANDS_PATH = new URL(
   "../../../../data/bands/team-game.json",
   import.meta.url,
 );
-const MEASURED_PATH = new URL("./measured-scores.json", import.meta.url);
-const COEFFICIENTS_PATH = new URL(
+const DEFAULT_MEASURED_PATH = new URL(
+  "./measured-scores.json",
+  import.meta.url,
+);
+const DEFAULT_COEFFICIENTS_PATH = new URL(
   "./outcome-coefficients.json",
   import.meta.url,
 );
 
-export async function runRefit(): Promise<void> {
+export interface RunRefitOptions {
+  measuredPath?: URL;
+  coefficientsPath?: URL;
+}
+
+export interface RefitResult {
+  measuredJson: string;
+  coefficientsJson: string;
+}
+
+/**
+ * Runs the measure → load bands → fit pipeline and returns the serialized
+ * outputs. Pure enough to be covered by tests without write permissions;
+ * the CLI wrapper below handles the actual file writes.
+ */
+export async function computeRefit(): Promise<RefitResult> {
   const measured = measureScores({ seeds: [...CALIBRATION_SEEDS] });
   const bandsJson = await Deno.readTextFile(BANDS_PATH);
   const bands = loadBands(bandsJson);
@@ -42,21 +60,27 @@ export async function runRefit(): Promise<void> {
     coverageScore: measured.coverageScore,
   };
 
-  await Deno.writeTextFile(
-    MEASURED_PATH,
-    JSON.stringify(measuredOut, null, 2) + "\n",
-  );
-  await Deno.writeTextFile(
-    COEFFICIENTS_PATH,
-    JSON.stringify(
+  return {
+    measuredJson: JSON.stringify(measuredOut, null, 2) + "\n",
+    coefficientsJson: JSON.stringify(
       { generated_by: "deno task sim:refit", ...coefficients },
       null,
       2,
     ) + "\n",
-  );
+  };
+}
 
-  console.log(`Wrote ${MEASURED_PATH.pathname}`);
-  console.log(`Wrote ${COEFFICIENTS_PATH.pathname}`);
+export async function runRefit(options: RunRefitOptions = {}): Promise<void> {
+  const measuredPath = options.measuredPath ?? DEFAULT_MEASURED_PATH;
+  const coefficientsPath = options.coefficientsPath ??
+    DEFAULT_COEFFICIENTS_PATH;
+
+  const result = await computeRefit();
+  await Deno.writeTextFile(measuredPath, result.measuredJson);
+  await Deno.writeTextFile(coefficientsPath, result.coefficientsJson);
+
+  console.log(`Wrote ${measuredPath.pathname}`);
+  console.log(`Wrote ${coefficientsPath.pathname}`);
 }
 
 if (import.meta.main) {

--- a/server/features/simulation/calibration/refit-outcomes.ts
+++ b/server/features/simulation/calibration/refit-outcomes.ts
@@ -1,0 +1,64 @@
+/**
+ * CLI entry point for `deno task sim:refit`.
+ *
+ * 1. Runs a seed sweep with the score observer installed to measure the
+ *    blockScore / protectionScore / coverageScore distributions.
+ * 2. Loads the NFL bands from data/bands/team-game.json.
+ * 3. Feeds both to the fit-outcomes pipeline.
+ * 4. Writes the measured distribution and fitted coefficients to
+ *    checked-in JSON artifacts alongside this file.
+ *
+ * The artifacts are regenerable and intended to be committed so CI can
+ * enforce agreement between the fitter and the on-disk constants (PR 4).
+ * In PR 1 the artifacts are produced but not yet consumed by resolve-play.
+ */
+import { CALIBRATION_SEEDS } from "./calibration-seeds.ts";
+import { loadBands } from "./band-loader.ts";
+import { fitOutcomes } from "./fit-outcomes.ts";
+import { measureScores } from "./measure-scores.ts";
+
+const BANDS_PATH = new URL(
+  "../../../../data/bands/team-game.json",
+  import.meta.url,
+);
+const MEASURED_PATH = new URL("./measured-scores.json", import.meta.url);
+const COEFFICIENTS_PATH = new URL(
+  "./outcome-coefficients.json",
+  import.meta.url,
+);
+
+export async function runRefit(): Promise<void> {
+  const measured = measureScores({ seeds: [...CALIBRATION_SEEDS] });
+  const bandsJson = await Deno.readTextFile(BANDS_PATH);
+  const bands = loadBands(bandsJson);
+  const coefficients = fitOutcomes({ scores: measured, bands });
+
+  const measuredOut = {
+    generated_by: "deno task sim:refit",
+    seeds: measured.seeds,
+    sampleCounts: measured.sampleCounts,
+    blockScore: measured.blockScore,
+    protectionScore: measured.protectionScore,
+    coverageScore: measured.coverageScore,
+  };
+
+  await Deno.writeTextFile(
+    MEASURED_PATH,
+    JSON.stringify(measuredOut, null, 2) + "\n",
+  );
+  await Deno.writeTextFile(
+    COEFFICIENTS_PATH,
+    JSON.stringify(
+      { generated_by: "deno task sim:refit", ...coefficients },
+      null,
+      2,
+    ) + "\n",
+  );
+
+  console.log(`Wrote ${MEASURED_PATH.pathname}`);
+  console.log(`Wrote ${COEFFICIENTS_PATH.pathname}`);
+}
+
+if (import.meta.main) {
+  await runRefit();
+}

--- a/server/features/simulation/score-observer.test.ts
+++ b/server/features/simulation/score-observer.test.ts
@@ -1,0 +1,47 @@
+import { assertEquals } from "@std/assert";
+import {
+  createCollectingObserver,
+  observePassScore,
+  observeRunScore,
+  setScoreObserver,
+} from "./score-observer.ts";
+
+Deno.test("score observer records run and pass scores while installed", () => {
+  const { samples, observer } = createCollectingObserver();
+  setScoreObserver(observer);
+  try {
+    observeRunScore(1.5);
+    observeRunScore(-2.25);
+    observePassScore(3.0, -4.0);
+    observePassScore(-1.0, 5.0);
+  } finally {
+    setScoreObserver(null);
+  }
+
+  assertEquals(samples.blockScore, [1.5, -2.25]);
+  assertEquals(samples.protectionScore, [3.0, -1.0]);
+  assertEquals(samples.coverageScore, [-4.0, 5.0]);
+});
+
+Deno.test("score observer is a no-op when not installed", () => {
+  setScoreObserver(null);
+  observeRunScore(42);
+  observePassScore(1, 2);
+  const { samples, observer } = createCollectingObserver();
+  setScoreObserver(observer);
+  try {
+    observeRunScore(99);
+  } finally {
+    setScoreObserver(null);
+  }
+  assertEquals(samples.blockScore, [99]);
+});
+
+Deno.test("setScoreObserver(null) detaches active observer", () => {
+  const { samples, observer } = createCollectingObserver();
+  setScoreObserver(observer);
+  observeRunScore(1);
+  setScoreObserver(null);
+  observeRunScore(2);
+  assertEquals(samples.blockScore, [1]);
+});

--- a/server/features/simulation/score-observer.ts
+++ b/server/features/simulation/score-observer.ts
@@ -1,0 +1,53 @@
+/**
+ * Module-level observer for the intermediate matchup scores produced during
+ * play synthesis. The fit-outcomes pipeline activates this observer to capture
+ * the `blockScore`, `protectionScore`, and `coverageScore` distributions
+ * without having to thread a new parameter through every simulation entry
+ * point. It has no effect when no observer is installed.
+ */
+export interface ScoreObserver {
+  onRun(blockScore: number): void;
+  onPass(protectionScore: number, coverageScore: number): void;
+}
+
+let current: ScoreObserver | null = null;
+
+export function setScoreObserver(observer: ScoreObserver | null): void {
+  current = observer;
+}
+
+export function observeRunScore(blockScore: number): void {
+  current?.onRun(blockScore);
+}
+
+export function observePassScore(
+  protectionScore: number,
+  coverageScore: number,
+): void {
+  current?.onPass(protectionScore, coverageScore);
+}
+
+export interface ScoreSamples {
+  blockScore: number[];
+  protectionScore: number[];
+  coverageScore: number[];
+}
+
+export function createCollectingObserver(): {
+  samples: ScoreSamples;
+  observer: ScoreObserver;
+} {
+  const samples: ScoreSamples = {
+    blockScore: [],
+    protectionScore: [],
+    coverageScore: [],
+  };
+  const observer: ScoreObserver = {
+    onRun: (s) => samples.blockScore.push(s),
+    onPass: (p, c) => {
+      samples.protectionScore.push(p);
+      samples.coverageScore.push(c);
+    },
+  };
+  return { samples, observer };
+}

--- a/server/features/simulation/synthesize-pass-outcome.ts
+++ b/server/features/simulation/synthesize-pass-outcome.ts
@@ -2,6 +2,7 @@ import type { PlayOutcome, PlayTag } from "./events.ts";
 import type { MatchupContribution, Situation } from "./resolve-play.ts";
 import { PASS_RESOLUTION, SACK_YARDAGE } from "./resolve-play.ts";
 import type { SeededRng } from "./rng.ts";
+import { observePassScore } from "./score-observer.ts";
 import type { OutcomeResult } from "./synthesize-run-outcome.ts";
 
 export function synthesizePassOutcome(
@@ -32,6 +33,15 @@ export function synthesizePassOutcome(
     ? protectionContribs.reduce((s, c) => s + c.score, 0) /
       protectionContribs.length
     : avgScore;
+
+  const routeContribs = contributions.filter(
+    (c) => c.matchup.type === "route_coverage",
+  );
+  const coverageScore = routeContribs.length > 0
+    ? routeContribs.reduce((s, c) => s + c.score, 0) /
+      routeContribs.length
+    : avgScore;
+  observePassScore(protectionScore, coverageScore);
 
   const sackProb = Math.max(
     PASS_RESOLUTION.sack.floor,
@@ -71,14 +81,6 @@ export function synthesizePassOutcome(
     if (protectionScore < -5) {
       tags.push("pressure");
     }
-
-    const routeContribs = contributions.filter(
-      (c) => c.matchup.type === "route_coverage",
-    );
-    const coverageScore = routeContribs.length > 0
-      ? routeContribs.reduce((s, c) => s + c.score, 0) /
-        routeContribs.length
-      : avgScore;
 
     const intProb = Math.max(
       PASS_RESOLUTION.interception.floor,

--- a/server/features/simulation/synthesize-run-outcome.ts
+++ b/server/features/simulation/synthesize-run-outcome.ts
@@ -2,6 +2,7 @@ import type { PlayOutcome, PlayTag } from "./events.ts";
 import type { MatchupContribution, Situation } from "./resolve-play.ts";
 import { RUN_RESOLUTION } from "./resolve-play.ts";
 import type { SeededRng } from "./rng.ts";
+import { observeRunScore } from "./score-observer.ts";
 
 export interface OutcomeResult {
   outcome: PlayOutcome;
@@ -34,6 +35,7 @@ export function synthesizeRunOutcome(
     ? blockingContribs.reduce((s, c) => s + c.score, 0) /
       blockingContribs.length
     : avgScore;
+  observeRunScore(blockScore);
 
   let yardage: number;
   if (blockScore < RUN_RESOLUTION.stuffThreshold) {


### PR DESCRIPTION
## Summary

PR 1 of 4 for #525. Scaffolds the fitter-driven outcome coefficient pipeline so later PRs can replace the hardcoded threshold/base constants with continuous/sigmoid models without touching the rest of the simulator.

- New module-level `score-observer` captures `blockScore` / `protectionScore` / `coverageScore` during play synthesis.
- `calibration/measure-scores.ts` runs a seed sweep with the observer and summarizes the distributions.
- `calibration/fit-outcomes.ts` is a pure fitter that maps measured distribution + NFL bands to PASS/RUN coefficients.
- `deno task sim:refit` runs the pipeline end-to-end and writes `measured-scores.json` + `outcome-coefficients.json` next to the calibration harness.
- Regression tests assert the fitter reproduces today's `PASS_RESOLUTION` / `RUN_RESOLUTION` constants from today's measured distribution, matches the checked-in artifact, and is idempotent.

No behavior change: `resolve-play.ts` still reads its hardcoded constants. Consumption of the fitted artifact lands in PR 2 (continuous run model) and PR 3 (sigmoid pass model); PR 4 adds `sim:verify` CI enforcement.

Refs #525.