### PR TITLE
feat(contracts): position × tier contract-structure priors

### DIFF
--- a/server/features/players/contract-structure-bands.test.ts
+++ b/server/features/players/contract-structure-bands.test.ts
@@ -1,0 +1,82 @@
+import { assertEquals } from "@std/assert";
+import {
+  bucketToContractPosition,
+  getContractStructurePrior,
+  qualityTierToContractTier,
+} from "./contract-structure-bands.ts";
+
+Deno.test("bucketToContractPosition maps specialist buckets to ST", () => {
+  assertEquals(bucketToContractPosition("K"), "ST");
+  assertEquals(bucketToContractPosition("P"), "ST");
+  assertEquals(bucketToContractPosition("LS"), "ST");
+});
+
+Deno.test("bucketToContractPosition passes through non-specialist buckets", () => {
+  assertEquals(bucketToContractPosition("QB"), "QB");
+  assertEquals(bucketToContractPosition("IOL"), "IOL");
+  assertEquals(bucketToContractPosition("CB"), "CB");
+});
+
+Deno.test("qualityTierToContractTier maps star/starter/depth to contract tiers", () => {
+  assertEquals(qualityTierToContractTier("star"), "top_10");
+  assertEquals(qualityTierToContractTier("starter"), "top_50");
+  assertEquals(qualityTierToContractTier("depth"), "rest");
+});
+
+Deno.test("QB top-10 mean length exceeds CB top-10 mean length", () => {
+  const qb = getContractStructurePrior("QB", "top_10");
+  const cb = getContractStructurePrior("CB", "top_10");
+  assertEquals(qb.lengthMean > cb.lengthMean, true);
+});
+
+Deno.test("IOL top-10 guarantee share exceeds OT top-10 guarantee share", () => {
+  const iol = getContractStructurePrior("IOL", "top_10");
+  const ot = getContractStructurePrior("OT", "top_10");
+  assertEquals(iol.guaranteeShareMean > ot.guaranteeShareMean, true);
+});
+
+Deno.test("cap-hit shape is normalised to sum ~1", () => {
+  const prior = getContractStructurePrior("QB", "top_10");
+  const sum = prior.capHitShape.reduce((s, v) => s + v, 0);
+  assertEquals(Math.abs(sum - 1) < 1e-9, true);
+});
+
+Deno.test("QB top-10 cap-hit shape is back-loaded (year 1 < year 5)", () => {
+  const prior = getContractStructurePrior("QB", "top_10");
+  assertEquals(prior.capHitShape[0] < prior.capHitShape[4], true);
+});
+
+Deno.test("rest-tier shape NaN year-5 values fall back to zero share", () => {
+  const prior = getContractStructurePrior("QB", "rest");
+  // The feed has NaN at year 5 for "rest"; our loader must coerce to 0
+  // so downstream samplers get a finite shape.
+  for (const v of prior.capHitShape) {
+    assertEquals(Number.isFinite(v), true);
+  }
+});
+
+Deno.test("every supported position × tier resolves without throwing", () => {
+  const positions = [
+    "QB",
+    "RB",
+    "WR",
+    "TE",
+    "OT",
+    "IOL",
+    "EDGE",
+    "IDL",
+    "LB",
+    "CB",
+    "S",
+    "ST",
+  ] as const;
+  const tiers = ["top_10", "top_25", "top_50", "rest"] as const;
+  for (const p of positions) {
+    for (const t of tiers) {
+      const prior = getContractStructurePrior(p, t);
+      assertEquals(Number.isFinite(prior.lengthMean), true);
+      assertEquals(Number.isFinite(prior.guaranteeShareMean), true);
+      assertEquals(Number.isFinite(prior.bonusShareMean), true);
+    }
+  }
+});

--- a/server/features/players/contract-structure-bands.ts
+++ b/server/features/players/contract-structure-bands.ts
@@ -1,0 +1,154 @@
+import type { NeutralBucket } from "@zone-blitz/shared";
+
+/**
+ * Position × tier priors for contract structure (length, guarantee
+ * share, signing-bonus share, per-year cap-hit shape), sourced from
+ * `data/bands/contract-structure.json`. Real NFL contracts are shaped
+ * by position × market-tier first; team cap archetype only modulates
+ * on top. Callers compose these priors with an archetype modifier.
+ */
+
+const BAND_URL = new URL(
+  "../../../data/bands/contract-structure.json",
+  import.meta.url,
+);
+
+interface RawLengthEntry {
+  mean_years: number;
+  p10_years: number;
+  p90_years: number;
+}
+interface RawGuaranteeEntry {
+  mean_share: number;
+  p10_share: number;
+  p90_share: number;
+}
+interface RawBonusEntry {
+  mean_signing_bonus_share: number;
+  p10_signing_bonus_share: number;
+  p90_signing_bonus_share: number;
+}
+interface RawShapeEntry {
+  mean_pct_year_1: number | string;
+  mean_pct_year_2: number | string;
+  mean_pct_year_3: number | string;
+  mean_pct_year_4: number | string;
+  mean_pct_year_5: number | string;
+}
+interface RawBandData {
+  bands: {
+    length_by_position_tier: Record<string, Record<string, RawLengthEntry>>;
+    guarantee_share_by_position_tier: Record<
+      string,
+      Record<string, RawGuaranteeEntry>
+    >;
+    signing_bonus_share_by_position_tier: Record<
+      string,
+      Record<string, RawBonusEntry>
+    >;
+    cap_hit_shape_by_position_tier: Record<
+      string,
+      Record<string, RawShapeEntry>
+    >;
+  };
+}
+
+const BAND_DATA: RawBandData = JSON.parse(
+  Deno.readTextFileSync(BAND_URL),
+) as RawBandData;
+
+export type ContractDataPosition =
+  | "QB"
+  | "RB"
+  | "WR"
+  | "TE"
+  | "OT"
+  | "IOL"
+  | "EDGE"
+  | "IDL"
+  | "LB"
+  | "CB"
+  | "S"
+  | "ST";
+
+export type ContractDataTier = "top_10" | "top_25" | "top_50" | "rest";
+
+export type QualityTier = "star" | "starter" | "depth";
+
+export interface ContractStructurePrior {
+  lengthMean: number;
+  lengthP10: number;
+  lengthP90: number;
+  guaranteeShareMean: number;
+  guaranteeShareP10: number;
+  guaranteeShareP90: number;
+  bonusShareMean: number;
+  bonusShareP10: number;
+  bonusShareP90: number;
+  /** Normalised 5-year cap-hit shape; sums to 1. */
+  capHitShape: readonly [number, number, number, number, number];
+}
+
+export function bucketToContractPosition(
+  bucket: NeutralBucket,
+): ContractDataPosition {
+  // Kickers / punters / long snappers roll into the "ST" group the OTC
+  // feed uses — it's the only cohort that represents these roles at all.
+  if (bucket === "K" || bucket === "P" || bucket === "LS") return "ST";
+  return bucket;
+}
+
+export function qualityTierToContractTier(
+  tier: QualityTier,
+): ContractDataTier {
+  if (tier === "star") return "top_10";
+  if (tier === "starter") return "top_50";
+  return "rest";
+}
+
+function readNumber(value: number | string): number {
+  return typeof value === "number" && Number.isFinite(value) ? value : 0;
+}
+
+export function getContractStructurePrior(
+  position: ContractDataPosition,
+  tier: ContractDataTier,
+): ContractStructurePrior {
+  const len = BAND_DATA.bands.length_by_position_tier[position][tier];
+  const guar = BAND_DATA.bands.guarantee_share_by_position_tier[position][tier];
+  const bonus =
+    BAND_DATA.bands.signing_bonus_share_by_position_tier[position][tier];
+  const shape = BAND_DATA.bands.cap_hit_shape_by_position_tier[position][tier];
+
+  const raw = [
+    readNumber(shape.mean_pct_year_1),
+    readNumber(shape.mean_pct_year_2),
+    readNumber(shape.mean_pct_year_3),
+    readNumber(shape.mean_pct_year_4),
+    readNumber(shape.mean_pct_year_5),
+  ];
+  const sum = raw.reduce((s, v) => s + v, 0);
+  const capHitShape =
+    (sum > 0
+      ? raw.map((v) => v / sum)
+      : [0.2, 0.2, 0.2, 0.2, 0.2]) as unknown as readonly [
+        number,
+        number,
+        number,
+        number,
+        number,
+      ];
+
+  return {
+    lengthMean: len.mean_years,
+    lengthP10: len.p10_years,
+    lengthP90: len.p90_years,
+    guaranteeShareMean: guar.mean_share,
+    guaranteeShareP10: guar.p10_share,
+    guaranteeShareP90: guar.p90_share,
+    bonusShareMean: bonus.mean_signing_bonus_share,
+    bonusShareP10: bonus.p10_signing_bonus_share,
+    bonusShareP90: bonus.p90_signing_bonus_share,
+    capHitShape,
+  };
+}

--- a/server/features/players/players-generator.test.ts
+++ b/server/features/players/players-generator.test.ts
@@ -17,12 +17,14 @@ import {
   ELITES_PER_32_TEAMS,
   GENERATIONAL_OVERALL_THRESHOLD,
   type NameGenerator,
+  rollVeteranContract,
   ROSTER_BUCKET_COMPOSITION,
   SALARY_FLOOR,
   SALARY_PER_QUALITY_POINT,
   stubAttributesFor,
 } from "./players-generator.ts";
 import { AGE_CURVE_PRIORS } from "./age-curves.ts";
+import { createRng } from "@zone-blitz/shared";
 
 const TEAM_IDS = ["team-1", "team-2", "team-3"];
 const INPUT = {
@@ -920,6 +922,175 @@ Deno.test("contract totalYears includes void years, realYears excludes them", ()
     assertEquals(b.years.length, b.contract.totalYears);
   }
 });
+
+// ---- Issue #528: position × tier contract-structure priors ----
+//
+// These tests validate the position × market-tier shape governs
+// generated contracts (length / guarantee years / cap-hit curve).
+// We drive `rollVeteranContract` directly with explicit inputs
+// because the generator's per-slot tier assignment does not map
+// one-per-bucket for the 14 neutral buckets, and the acceptance
+// criteria specifically talk about position × tier comparisons.
+
+function sampleVeteranContracts(
+  args: {
+    bucket: NeutralBucket;
+    qualityTier: "star" | "starter" | "depth";
+    archetype: CapArchetype;
+    count: number;
+    seed?: number;
+  },
+) {
+  const rng = createRng(seededRandom(args.seed ?? 1));
+  const bundles: ReturnType<typeof rollVeteranContract>[] = [];
+  for (let i = 0; i < args.count; i++) {
+    bundles.push(
+      rollVeteranContract(
+        rng,
+        {
+          playerId: `p${i}`,
+          teamId: "team-1",
+          bucket: args.bucket,
+          quality: 85,
+          qualityTier: args.qualityTier,
+          age: 28, // veteran, not subject to age>=32 clamp
+          signedYear: 2026,
+          archetype: args.archetype,
+        },
+        positionalSalaryMultiplier,
+      ),
+    );
+  }
+  return bundles;
+}
+Deno.test(
+  "star-tier CB contracts are visibly shorter than star-tier QB contracts",
+  () => {
+    const qb = sampleVeteranContracts({
+      bucket: "QB",
+      qualityTier: "star",
+      archetype: "balanced",
+      count: 400,
+      seed: 42,
+    });
+    const cb = sampleVeteranContracts({
+      bucket: "CB",
+      qualityTier: "star",
+      archetype: "balanced",
+      count: 400,
+      seed: 42,
+    });
+    const avgLen = (arr: ReturnType<typeof rollVeteranContract>[]) =>
+      arr.reduce((s, b) => s + b.contract.realYears, 0) / arr.length;
+    const qbAvg = avgLen(qb);
+    const cbAvg = avgLen(cb);
+    assertEquals(
+      qbAvg - cbAvg >= 0.75,
+      true,
+      `expected QB avg length to exceed CB avg length by >= 0.75 yr; got qb=${
+        qbAvg.toFixed(2)
+      } cb=${cbAvg.toFixed(2)}`,
+    );
+  },
+);
+
+Deno.test(
+  "IOL top-10 guarantee share exceeds OT top-10 guarantee share in generated contracts",
+  () => {
+    const iol = sampleVeteranContracts({
+      bucket: "IOL",
+      qualityTier: "star",
+      archetype: "balanced",
+      count: 600,
+      seed: 7,
+    });
+    const ot = sampleVeteranContracts({
+      bucket: "OT",
+      qualityTier: "star",
+      archetype: "balanced",
+      count: 600,
+      seed: 7,
+    });
+    const guarRatio = (arr: ReturnType<typeof rollVeteranContract>[]) =>
+      arr.reduce((s, b) => {
+        const gy = b.years
+          .filter((y) => !y.isVoid && y.guaranteeType !== "none").length;
+        return s + gy / b.contract.realYears;
+      }, 0) / arr.length;
+    const iolAvg = guarRatio(iol);
+    const otAvg = guarRatio(ot);
+    assertEquals(
+      iolAvg > otAvg,
+      true,
+      `expected IOL guarantee share > OT; got iol=${iolAvg.toFixed(3)} ot=${
+        otAvg.toFixed(3)
+      }`,
+    );
+  },
+);
+
+Deno.test(
+  "star-tier QB contract cap-hit shape is back-loaded (y1 base share < last year base share)",
+  () => {
+    const bundles = sampleVeteranContracts({
+      bucket: "QB",
+      qualityTier: "star",
+      archetype: "balanced",
+      count: 400,
+      seed: 9,
+    });
+    const longDeals = bundles.filter((b) => b.contract.realYears >= 4);
+    assertEquals(longDeals.length > 20, true);
+    const avgY1 = longDeals.reduce((s, b) => {
+      const total = b.years
+        .filter((y) => !y.isVoid)
+        .reduce((t, y) => t + y.base, 0);
+      return s + b.years[0].base / total;
+    }, 0) / longDeals.length;
+    const avgYLast = longDeals.reduce((s, b) => {
+      const real = b.years.filter((y) => !y.isVoid);
+      const total = real.reduce((t, y) => t + y.base, 0);
+      return s + real[real.length - 1].base / total;
+    }, 0) / longDeals.length;
+    assertEquals(
+      avgY1 < avgYLast,
+      true,
+      `QB top-10 should be back-loaded: y1=${avgY1.toFixed(3)} yLast=${
+        avgYLast.toFixed(3)
+      }`,
+    );
+  },
+);
+
+Deno.test(
+  "cap-hell archetype lifts bonus share above balanced at the same position × tier",
+  () => {
+    // Confirms archetype remains a modifier on top of the position ×
+    // tier prior, not a replacement.
+    const balanced = sampleVeteranContracts({
+      bucket: "WR",
+      qualityTier: "star",
+      archetype: "balanced",
+      count: 400,
+      seed: 11,
+    });
+    const capHell = sampleVeteranContracts({
+      bucket: "WR",
+      qualityTier: "star",
+      archetype: "cap-hell",
+      count: 400,
+      seed: 11,
+    });
+    const avgBonus = (arr: ReturnType<typeof rollVeteranContract>[]) =>
+      arr.reduce((s, b) => {
+        const total = b.years
+          .filter((y) => !y.isVoid)
+          .reduce((t, y) => t + y.base, 0) + b.contract.signingBonus;
+        return total > 0 ? s + b.contract.signingBonus / total : s;
+      }, 0) / arr.length;
+    assertEquals(avgBonus(capHell) > avgBonus(balanced), true);
+  },
+);
 
 Deno.test("default archetype (no teamArchetypes provided) still produces valid contracts", () => {
   const generator = makeGenerator();

--- a/server/features/players/players-generator.ts
+++ b/server/features/players/players-generator.ts
@@ -29,6 +29,12 @@ import type {
   PlayersGenerator,
   PlayersGeneratorInput,
 } from "./players.generator.interface.ts";
+import {
+  bucketToContractPosition,
+  getContractStructurePrior,
+  type QualityTier,
+  qualityTierToContractTier,
+} from "./contract-structure-bands.ts";
 
 // Re-export the shared NameGenerator type for consumer tests that want to
 // mock a name source without reaching into server/shared directly.
@@ -648,39 +654,45 @@ function rollOrigin(
   };
 }
 
-interface ArchetypeShapeParams {
-  bonusRatioMin: number;
-  bonusRatioMax: number;
+/**
+ * Archetype-driven modifiers applied on top of the position × tier
+ * contract-structure prior (see `contract-structure-bands.ts`). Real
+ * NFL deals are shaped by position × market tier first; team cap
+ * posture nudges the bonus share up/down and governs void-year usage.
+ */
+interface ArchetypeModifier {
+  /** Additive delta applied to the sampled signing-bonus share. */
+  bonusShareDelta: number;
   voidYearChance: number;
   maxVoidYears: number;
 }
 
-const ARCHETYPE_SHAPE: Record<CapArchetype, ArchetypeShapeParams> = {
+const ARCHETYPE_MODIFIER: Record<CapArchetype, ArchetypeModifier> = {
   "cap-hell": {
-    bonusRatioMin: 0.45,
-    bonusRatioMax: 0.65,
+    bonusShareDelta: 0.20,
     voidYearChance: 0.6,
     maxVoidYears: 2,
   },
   tight: {
-    bonusRatioMin: 0.30,
-    bonusRatioMax: 0.50,
+    bonusShareDelta: 0.10,
     voidYearChance: 0.3,
     maxVoidYears: 1,
   },
   balanced: {
-    bonusRatioMin: 0.25,
-    bonusRatioMax: 0.45,
+    bonusShareDelta: 0.05,
     voidYearChance: 0.15,
     maxVoidYears: 1,
   },
   flush: {
-    bonusRatioMin: 0.08,
-    bonusRatioMax: 0.22,
-    voidYearChance: 0.0,
+    bonusShareDelta: -0.10,
+    voidYearChance: 0,
     maxVoidYears: 0,
   },
 };
+
+function clampRatio(value: number): number {
+  return Math.max(0, Math.min(0.95, value));
+}
 
 const ROOKIE_SLOTTED_MAX = 40_000_000;
 const ROOKIE_SLOTTED_MIN = 4_000_000;
@@ -713,6 +725,7 @@ function rollContract(
     teamId: string;
     bucket: NeutralBucket;
     quality: number;
+    qualityTier: QualityTier;
     age: number;
     signedYear: number;
     archetype: CapArchetype;
@@ -786,60 +799,109 @@ function rollRookieContract(
   };
 }
 
-function rollVeteranContract(
+export function rollVeteranContract(
   rng: SeededRng,
   args: {
     playerId: string;
     teamId: string;
     bucket: NeutralBucket;
     quality: number;
+    qualityTier: QualityTier;
     age: number;
     signedYear: number;
     archetype: CapArchetype;
   },
   multiplierFn: SalaryMultiplierFn,
 ): RolledContractBundle {
-  const shape = ARCHETYPE_SHAPE[args.archetype];
+  const modifier = ARCHETYPE_MODIFIER[args.archetype];
+  const prior = getContractStructurePrior(
+    bucketToContractPosition(args.bucket),
+    qualityTierToContractTier(args.qualityTier),
+  );
   const mult = multiplierFn(args.bucket, args.quality);
   const excess = Math.max(0, args.quality - 50);
   const baseSalary = SALARY_FLOOR + excess * SALARY_PER_QUALITY_POINT * mult;
   const jitter = 0.9 + rng.next() * 0.2;
   const annualBase = Math.max(SALARY_FLOOR, Math.round(baseSalary * jitter));
 
-  let realYears: number;
-  if (args.age >= 32) realYears = rng.int(1, 2);
-  else if (args.quality >= 80) realYears = rng.int(3, 5);
-  else if (args.quality >= 65) realYears = rng.int(2, 4);
-  else realYears = rng.int(1, 3);
+  // Sample length from the position × tier band. The p10/p90 window
+  // captures most of the real distribution and keeps CB contracts
+  // noticeably shorter than QB contracts at the same tier.
+  const lenMin = Math.max(1, Math.round(prior.lengthP10));
+  const lenMax = Math.max(lenMin, Math.round(prior.lengthP90));
+  let realYears = rng.int(lenMin, lenMax);
+  if (args.age >= 32) realYears = Math.min(realYears, 2);
 
   const totalValue = annualBase * realYears;
 
-  const bonusRatio = shape.bonusRatioMin +
-    rng.next() * (shape.bonusRatioMax - shape.bonusRatioMin);
+  // Signing-bonus share: position × tier baseline jittered around the
+  // mean, then nudged by archetype. Flush teams push cash flat, cap-
+  // hell teams push bonus-heavy to defer the hit.
+  const bonusSpread = Math.max(
+    0.05,
+    (prior.bonusShareP90 - prior.bonusShareP10) / 2,
+  );
+  const bonusSampled = prior.bonusShareMean +
+    (rng.next() * 2 - 1) * bonusSpread;
+  const bonusRatio = clampRatio(bonusSampled + modifier.bonusShareDelta);
   const signingBonus = Math.round(totalValue * bonusRatio);
   const remainingBase = totalValue - signingBonus;
 
+  // Void years are an archetype lever only — the league-wide per-
+  // position rate is effectively zero in the data (see
+  // void_year_usage_rate_by_position in contract-structure.json).
   let voidYears = 0;
   if (
-    shape.maxVoidYears > 0 && realYears >= 2 &&
-    rng.next() < shape.voidYearChance
+    modifier.maxVoidYears > 0 && realYears >= 2 &&
+    rng.next() < modifier.voidYearChance
   ) {
-    voidYears = rng.int(1, shape.maxVoidYears);
+    voidYears = rng.int(1, modifier.maxVoidYears);
   }
   const totalYears = realYears + voidYears;
 
-  const perYearBase = Math.max(1, Math.floor(remainingBase / realYears));
-  const baseResidue = remainingBase - perYearBase * realYears;
-
-  const guaranteedPct = args.quality >= 80
-    ? 0.5 + rng.next() * 0.2
-    : args.quality >= 65
-    ? 0.2 + rng.next() * 0.2
-    : 0.05 + rng.next() * 0.1;
+  // Guaranteed-year count derives from the position × tier guarantee
+  // share — IOL top-10 deals get the most guaranteed seasons, CB top-
+  // 10s the fewest, matching the research bands.
+  const guarSpread = Math.max(
+    0.05,
+    (prior.guaranteeShareP90 - prior.guaranteeShareP10) / 2,
+  );
+  const guarRatio = clampRatio(
+    prior.guaranteeShareMean + (rng.next() * 2 - 1) * guarSpread,
+  );
+  // Probabilistic rounding preserves the sampled share's expectation
+  // across a roster — deterministic `round` discards the fractional
+  // part and collapses neighbouring priors (IOL 0.53 vs OT 0.46) to
+  // the same integer for typical realYears, erasing the position
+  // signal the data encodes.
+  const guarYearsRaw = guarRatio * realYears;
+  const guarFloor = Math.floor(guarYearsRaw);
+  const guarFrac = guarYearsRaw - guarFloor;
   const guaranteedYears = Math.max(
     1,
-    Math.round(guaranteedPct * realYears),
+    guarFloor + (rng.next() < guarFrac ? 1 : 0),
   );
+
+  // Per-year base follows the cap-hit shape of real deals at this
+  // position × tier. Top-10 QB deals are back-loaded (Y1 ~15%, Y5
+  // ~34%); top-10 RB deals are front-loaded. Flat fallback is used
+  // only when the source shape is degenerate.
+  const shape = prior.capHitShape.slice(0, realYears);
+  const shapeSum = shape.reduce((s, v) => s + v, 0);
+  const yearBases: number[] = [];
+  if (shapeSum > 0) {
+    for (let i = 0; i < realYears; i++) {
+      yearBases.push(
+        Math.max(1, Math.floor(remainingBase * (shape[i] / shapeSum))),
+      );
+    }
+  } else {
+    const perYear = Math.max(1, Math.floor(remainingBase / realYears));
+    for (let i = 0; i < realYears; i++) yearBases.push(perYear);
+  }
+  const yearBaseSum = yearBases.reduce((s, v) => s + v, 0);
+  yearBases[realYears - 1] += remainingBase - yearBaseSum;
+  if (yearBases[realYears - 1] < 1) yearBases[realYears - 1] = 1;
 
   const years: GeneratedContractYear[] = [];
   for (let i = 0; i < realYears; i++) {
@@ -848,7 +910,7 @@ function rollVeteranContract(
       : "none";
     years.push({
       leagueYear: args.signedYear + i,
-      base: perYearBase + (i === realYears - 1 ? baseResidue : 0),
+      base: yearBases[i],
       rosterBonus: 0,
       workoutBonus: 0,
       perGameRosterBonus: 0,
@@ -1253,6 +1315,7 @@ export function createPlayersGenerator(
               teamId,
               bucket,
               quality,
+              qualityTier: tier,
               age,
               signedYear: currentYear,
               archetype,


### PR DESCRIPTION
## Summary

- Load position × tier priors from `data/bands/contract-structure.json` via a new `contract-structure-bands` module.
- `rollVeteranContract` now samples length, guarantee share, signing-bonus share, and per-year cap-hit shape from the `(bucket, tier)` prior; `ARCHETYPE_SHAPE` becomes an `ARCHETYPE_MODIFIER` that nudges bonus share and governs void-year usage on top of the position-tier baseline.
- Per-year base follows the `cap_hit_shape_by_position_tier` curve so top-10 QB deals back-load and top-10 RB deals front-load.

Closes #528