### PR TITLE
feat(calibration): position-conditioned age curves

### DIFF
--- a/server/features/players/players-generator.test.ts
+++ b/server/features/players/players-generator.test.ts
@@ -17,6 +17,7 @@ import {
   ELITES_PER_32_TEAMS,
   GENERATIONAL_OVERALL_THRESHOLD,
   type NameGenerator,
+  POSITION_AGE_BANDS,
   ROSTER_BUCKET_COMPOSITION,
   SALARY_FLOOR,
   SALARY_PER_QUALITY_POINT,
@@ -366,12 +367,143 @@ Deno.test("ages span a rookie-to-veteran curve", () => {
     return 2026 - Number(year);
   });
   const minAge = Math.min(...ages);
-  const maxAge = Math.max(...ages);
+  // Every bucket's band starts at >=21; upper end varies by position so no
+  // league-wide ceiling assertion (QB/K/P/LS tails run into the late 30s).
   assertEquals(minAge >= 21, true);
-  assertEquals(maxAge <= 36, true);
   // There should be both rookies (<=23) and veterans (>=30) in a 159-man pool.
   assertEquals(ages.some((a) => a <= 23), true);
   assertEquals(ages.some((a) => a >= 30), true);
+});
+
+function pooledRosteredByBucket(
+  seeds: readonly number[],
+): Map<NeutralBucket, number[]> {
+  const byBucket = new Map<NeutralBucket, number[]>();
+  for (const seed of seeds) {
+    const result = makeGenerator(seed).generate({
+      ...INPUT,
+      teamIds: Array.from({ length: 8 }, (_, i) => `team-${seed}-${i}`),
+    });
+    const rostered = result.players.filter(
+      (p) => p.player.teamId !== null && p.player.status === "active",
+    );
+    for (const entry of rostered) {
+      const bucket = bucketOf(entry);
+      const age = 2026 - Number(entry.player.birthDate.split("-")[0]);
+      const list = byBucket.get(bucket) ?? [];
+      list.push(age);
+      byBucket.set(bucket, list);
+    }
+  }
+  return byBucket;
+}
+
+function percentile(sortedAges: readonly number[], p: number): number {
+  if (sortedAges.length === 0) return NaN;
+  const idx = Math.min(
+    sortedAges.length - 1,
+    Math.floor(p * sortedAges.length),
+  );
+  return sortedAges[idx];
+}
+
+Deno.test("per-bucket rostered age distributions match career-length priors", () => {
+  const seeds = Array.from({ length: 12 }, (_, i) => 1000 + i);
+  const byBucket = pooledRosteredByBucket(seeds);
+  for (const [bucket, band] of Object.entries(POSITION_AGE_BANDS)) {
+    const ages = (byBucket.get(bucket as NeutralBucket) ?? []).slice().sort(
+      (a, b) => a - b,
+    );
+    // Even the rarest bucket (LS) accumulates ~96 samples across 12 leagues
+    // × 8 teams, plenty for stable mean/p90 estimates.
+    assertEquals(
+      ages.length >= 50,
+      true,
+      `bucket ${bucket} sample too small: ${ages.length}`,
+    );
+    const mean = ages.reduce((s, a) => s + a, 0) / ages.length;
+    const expectedMean = (band.min + band.mode + band.max) / 3;
+    assertEquals(
+      Math.abs(mean - expectedMean) <= 1.5,
+      true,
+      `bucket ${bucket} mean ${mean.toFixed(2)} drifted from ${
+        expectedMean.toFixed(2)
+      }`,
+    );
+    const p90 = percentile(ages, 0.9);
+    // Triangular p90 (closed form, valid when p=0.9 is above the mode,
+    // which holds for every band here).
+    const expectedP90 = band.max -
+      Math.sqrt(0.1 * (band.max - band.min) * (band.max - band.mode));
+    assertEquals(
+      Math.abs(p90 - expectedP90) <= 2,
+      true,
+      `bucket ${bucket} p90 ${p90} drifted from ${expectedP90.toFixed(2)}`,
+    );
+    assertEquals(
+      ages[0] >= band.min,
+      true,
+      `bucket ${bucket} min age ${ages[0]} below band min ${band.min}`,
+    );
+    assertEquals(
+      ages[ages.length - 1] <= band.max,
+      true,
+      `bucket ${bucket} max age ${
+        ages[ages.length - 1]
+      } above band max ${band.max}`,
+    );
+  }
+});
+
+Deno.test("RB ages show the post-28 cliff the NFL retirement data encodes", () => {
+  const seeds = Array.from({ length: 12 }, (_, i) => 2000 + i);
+  const byBucket = pooledRosteredByBucket(seeds);
+  const rbAges = byBucket.get("RB") ?? [];
+  const peakShare = rbAges.filter((a) => a >= 24 && a <= 27).length /
+    rbAges.length;
+  const cliffShare = rbAges.filter((a) => a >= 29 && a <= 32).length /
+    rbAges.length;
+  assertEquals(
+    peakShare > cliffShare * 1.5,
+    true,
+    `expected a visible RB cliff past 28: peak ${
+      peakShare.toFixed(2)
+    } vs cliff ${cliffShare.toFixed(2)}`,
+  );
+});
+
+Deno.test("QB ages keep a long tail past the skill-position cliff", () => {
+  const seeds = Array.from({ length: 12 }, (_, i) => 3000 + i);
+  const byBucket = pooledRosteredByBucket(seeds);
+  const qbAges = byBucket.get("QB") ?? [];
+  const lateTailShare = qbAges.filter((a) => a >= 33).length / qbAges.length;
+  assertEquals(
+    lateTailShare >= 0.05,
+    true,
+    `expected a non-trivial QB tail at 33+: ${lateTailShare.toFixed(3)}`,
+  );
+  const rbAges = byBucket.get("RB") ?? [];
+  const rbLateTailShare = rbAges.filter((a) => a >= 33).length / rbAges.length;
+  assertEquals(
+    lateTailShare > rbLateTailShare,
+    true,
+    "QB late-age tail should be strictly heavier than RB",
+  );
+});
+
+Deno.test("OL ages plateau into the mid-30s", () => {
+  const seeds = Array.from({ length: 12 }, (_, i) => 4000 + i);
+  const byBucket = pooledRosteredByBucket(seeds);
+  const olAges = [
+    ...(byBucket.get("OT") ?? []),
+    ...(byBucket.get("IOL") ?? []),
+  ];
+  const plateauShare = olAges.filter((a) => a >= 30).length / olAges.length;
+  assertEquals(
+    plateauShare >= 0.1,
+    true,
+    `expected OL plateau at 30+: ${plateauShare.toFixed(3)}`,
+  );
 });
 
 Deno.test("prospects fall into a draft-eligible age band", () => {

--- a/server/features/players/players-generator.ts
+++ b/server/features/players/players-generator.ts
@@ -422,10 +422,44 @@ export const SALARY_PER_QUALITY_POINT = 250_000;
 
 const ROOKIE_SCALE_AGE_THRESHOLD = 25;
 
-const VETERAN_AGE_MIN = 21;
-const VETERAN_AGE_MAX = 36;
 const PROSPECT_AGE_MIN = 20;
 const PROSPECT_AGE_MAX = 23;
+
+export interface PositionAgeBand {
+  /** Minimum active age — specialists debut slightly later than skill positions. */
+  min: number;
+  /** Modal (p50) active age, driving the peak of the triangular draw. */
+  mode: number;
+  /** Maximum active age (approximately p90 of retirement). */
+  max: number;
+}
+
+/**
+ * Per-position triangular (min, mode=p50, max=p90) age bands derived from
+ * `data/bands/career-length.json` retirement bands. Centralizing these here
+ * replaces the old single 21–36 triangular draw that blurred the RB cliff,
+ * the QB longevity tail, and the specialist ageless tail.
+ *
+ * Triangular(min, mode, max) has expected value (min + mode + max) / 3, so
+ * each bucket's mean lands within ~1 year of the underlying retirement
+ * mean without needing a separate parameter.
+ */
+export const POSITION_AGE_BANDS: Record<NeutralBucket, PositionAgeBand> = {
+  QB: { min: 21, mode: 27, max: 36 },
+  RB: { min: 21, mode: 26, max: 31 },
+  WR: { min: 21, mode: 25, max: 31 },
+  TE: { min: 21, mode: 26, max: 32 },
+  OT: { min: 21, mode: 27, max: 33 },
+  IOL: { min: 21, mode: 27, max: 33 },
+  EDGE: { min: 21, mode: 26, max: 32 },
+  IDL: { min: 21, mode: 26, max: 32 },
+  LB: { min: 21, mode: 26, max: 31 },
+  CB: { min: 21, mode: 26, max: 31 },
+  S: { min: 21, mode: 26, max: 31 },
+  K: { min: 22, mode: 29, max: 38 },
+  P: { min: 22, mode: 28, max: 38 },
+  LS: { min: 22, mode: 32, max: 38 },
+};
 
 /**
  * Rolls an overall-quality score anchored to the Geno Smith Line — the
@@ -574,17 +608,30 @@ function rollHeightWeight(rng: SeededRng, bucket: NeutralBucket): {
   return { heightInches, weightPounds };
 }
 
+function sampleTriangular(
+  rng: SeededRng,
+  min: number,
+  mode: number,
+  max: number,
+): number {
+  const u = rng.next();
+  const c = (mode - min) / (max - min);
+  if (u < c) {
+    return min + Math.sqrt(u * (max - min) * (mode - min));
+  }
+  return max - Math.sqrt((1 - u) * (max - min) * (max - mode));
+}
+
 function rollAge(
   rng: SeededRng,
+  bucket: NeutralBucket,
   status: "rostered" | "free-agent" | "prospect",
 ): number {
   if (status === "prospect") {
     return rng.int(PROSPECT_AGE_MIN, PROSPECT_AGE_MAX);
   }
-  // Triangular-ish around the middle of the playing-age band.
-  const raw = (rng.next() + rng.next()) / 2;
-  const span = VETERAN_AGE_MAX - VETERAN_AGE_MIN;
-  return VETERAN_AGE_MIN + Math.round(raw * span);
+  const band = POSITION_AGE_BANDS[bucket];
+  return Math.round(sampleTriangular(rng, band.min, band.mode, band.max));
 }
 
 function birthDateForAge(
@@ -1091,7 +1138,7 @@ export function createPlayersGenerator(
       rng,
       qualityTierForIndex(args.indexInBucket, args.bucketCount),
     );
-    const age = rollAge(rng, args.statusKind);
+    const age = rollAge(rng, args.bucket, args.statusKind);
     const { heightInches, weightPounds } = rollHeightWeight(rng, args.bucket);
     const attributes = rollAttributesFor(rng, args.bucket, quality);
     lockInBucket(attributes, args.bucket, heightInches, weightPounds);
@@ -1244,7 +1291,7 @@ export function createPlayersGenerator(
           );
           const tier = qualityTierForIndex(indexInBucket, bucketCount);
           const quality = rollQuality(rng, tier);
-          const age = rollAge(rng, "rostered");
+          const age = rollAge(rng, bucket, "rostered");
           return rollContract(
             rng,
             {


### PR DESCRIPTION
## Summary

- Replace the single 21–36 triangular `rollAge` with per-bucket triangular bands derived from `data/bands/career-length.json` retirement percentiles (min, mode=p50, max=p90).
- RB/CB/WR cliff around 28, OT/IOL plateau into the mid-30s, QB carries a long tail to 36, and K/P/LS reach the late-30s — matching the real NFL curves the position economy needs to key off.
- Tests assert per-bucket mean and p90 against the theoretical triangular targets, plus explicit shape checks for the RB cliff, QB late tail, and OL plateau.

Closes #527