### PR TITLE
calibration(players): align roster composition with position-market data

### DIFF
--- a/server/features/players/players-generator.test.ts
+++ b/server/features/players/players-generator.test.ts
@@ -64,15 +64,20 @@ function bucketOf(entry: {
   });
 }
 
+const COMPOSITION_TOTAL = ROSTER_BUCKET_COMPOSITION.reduce(
+  (sum, entry) => sum + entry.count,
+  0,
+);
+
 Deno.test("generates correct number of rostered players per team", () => {
   const result = makeGenerator().generate(INPUT);
   const rostered = result.players.filter(
     (p) => p.player.teamId !== null && p.player.status === "active",
   );
-  assertEquals(rostered.length, TEAM_IDS.length * INPUT.rosterSize);
+  assertEquals(rostered.length, TEAM_IDS.length * COMPOSITION_TOTAL);
   for (const teamId of TEAM_IDS) {
     const teamPlayers = rostered.filter((p) => p.player.teamId === teamId);
-    assertEquals(teamPlayers.length, INPUT.rosterSize);
+    assertEquals(teamPlayers.length, COMPOSITION_TOTAL);
   }
 });
 
@@ -228,13 +233,52 @@ Deno.test("signing bonus produces a bonus proration row with source 'signing'", 
   }
 });
 
-Deno.test("roster composition sums to 53 players", () => {
-  const total = ROSTER_BUCKET_COMPOSITION.reduce(
-    (sum, entry) => sum + entry.count,
-    0,
-  );
-  assertEquals(total, 53);
-});
+Deno.test(
+  "roster composition matches position-market data within ±0.5 per bucket",
+  () => {
+    // Means from data/bands/position-market.json roster_slots_per_team_week.
+    // OL/DL/DB are split between sub-buckets (OT+IOL, EDGE+IDL, CB+S) and
+    // checked as combined totals against the data's combined means.
+    const PER_BUCKET_MEANS: Record<string, number> = {
+      QB: 2.0386,
+      RB: 3.5617,
+      WR: 5.2229,
+      TE: 3.1022,
+      LB: 6.8224,
+      K: 0.9959,
+      P: 1.0059,
+      LS: 0.9996,
+    };
+    const COMBINED_MEANS: Record<string, [readonly string[], number]> = {
+      OL: [["OT", "IOL"], 8.0223],
+      DL: [["EDGE", "IDL"], 7.0316],
+      DB: [["CB", "S"], 9.2181],
+    };
+    const counts = new Map<string, number>(
+      ROSTER_BUCKET_COMPOSITION.map(({ bucket, count }) => [bucket, count]),
+    );
+    for (const [bucket, mean] of Object.entries(PER_BUCKET_MEANS)) {
+      const count = counts.get(bucket) ?? 0;
+      const delta = Math.abs(count - mean);
+      assertEquals(
+        delta <= 0.5,
+        true,
+        `${bucket} count ${count} drifted ${
+          delta.toFixed(2)
+        } from mean ${mean}`,
+      );
+    }
+    for (const [group, [members, mean]] of Object.entries(COMBINED_MEANS)) {
+      const total = members.reduce((s, b) => s + (counts.get(b) ?? 0), 0);
+      const delta = Math.abs(total - mean);
+      assertEquals(
+        delta <= 0.5,
+        true,
+        `${group} total ${total} drifted ${delta.toFixed(2)} from mean ${mean}`,
+      );
+    }
+  },
+);
 
 Deno.test(
   "every generated player classifies into a known neutral bucket",

--- a/server/features/players/players-generator.ts
+++ b/server/features/players/players-generator.ts
@@ -387,7 +387,11 @@ export const BUCKET_PROFILES: Record<NeutralBucket, BucketProfile> = {
   },
 };
 
-// Target roster composition by neutral bucket. FB is intentionally absent —
+// Target roster composition by neutral bucket, calibrated to the
+// `roster_slots_per_team_week` means in `data/bands/position-market.json`
+// (NFL active-roster slots, 2020-2024). Each bucket sits within ±0.5 of
+// its data mean, so the simulated league mirrors real per-team position
+// distribution rather than the prior backup-padded mix. FB is absent —
 // lead-blocking fullbacks classify as RB under the neutral lens.
 export const ROSTER_BUCKET_COMPOSITION: readonly {
   bucket: NeutralBucket;
@@ -395,15 +399,15 @@ export const ROSTER_BUCKET_COMPOSITION: readonly {
 }[] = [
   { bucket: "QB", count: 2 },
   { bucket: "RB", count: 4 },
-  { bucket: "WR", count: 6 },
+  { bucket: "WR", count: 5 },
   { bucket: "TE", count: 3 },
   { bucket: "OT", count: 4 },
-  { bucket: "IOL", count: 5 },
+  { bucket: "IOL", count: 4 },
   { bucket: "EDGE", count: 4 },
-  { bucket: "IDL", count: 4 },
+  { bucket: "IDL", count: 3 },
   { bucket: "LB", count: 7 },
-  { bucket: "CB", count: 6 },
-  { bucket: "S", count: 5 },
+  { bucket: "CB", count: 5 },
+  { bucket: "S", count: 4 },
   { bucket: "K", count: 1 },
   { bucket: "P", count: 1 },
   { bucket: "LS", count: 1 },
@@ -1136,8 +1140,13 @@ export function createPlayersGenerator(
         for (const { bucket, count } of ROSTER_BUCKET_COMPOSITION) {
           bucketTotal.set(bucket, count);
         }
-        for (let i = 0; i < input.rosterSize; i++) {
-          const bucket = ROSTER_BUCKET_SLOTS[i % ROSTER_BUCKET_SLOTS.length];
+        // Iterate over composition slots directly — `input.rosterSize`
+        // is informational (see league config); the per-team mix is
+        // pinned by `ROSTER_BUCKET_COMPOSITION` so position counts stay
+        // aligned with the position-market data instead of cycling and
+        // overflowing into the first few buckets.
+        for (let i = 0; i < ROSTER_BUCKET_SLOTS.length; i++) {
+          const bucket = ROSTER_BUCKET_SLOTS[i];
           const indexInBucket = bucketIndex.get(bucket) ?? 0;
           bucketIndex.set(bucket, indexInBucket + 1);
           const entry = buildPlayer({


### PR DESCRIPTION
## Summary

- Recalibrates `ROSTER_BUCKET_COMPOSITION` so each bucket sits within ±0.5 of the per-team active-roster mean from `data/bands/position-market.json` (WR 6→5, IOL 5→4, IDL 4→3, CB 6→5, S 5→4). Previous mix overweighted DBs by ~2 slots and IOL by ~1 versus 2020-2024 NFL data.
- Generator now iterates over composition slots directly instead of `input.rosterSize`, so per-team distribution stays pinned to the calibrated mix instead of cycling and overflowing the leading buckets.
- Adds a data-anchored guard test that asserts every bucket (and OL/DL/DB combined groupings) stays within ±0.5 of the position-market mean, catching future drift at build time.

Closes #530