### PR TITLE
ci(sim): enforce fitted coefficient drift with sim:verify (PR 4/4 of #525)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,19 @@ jobs:
           deno-version: v2.7.11
       - run: deno task db:check-journal
 
+  sim-verify:
+    name: Sim Coefficients Verify
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+      - uses: denoland/setup-deno@v2
+        with:
+          deno-version: v2.7.11
+      - run: deno install
+      - name: Verify fitted outcome coefficients are up to date
+        run: deno task sim:verify
+
   test:
     name: Test
     runs-on: ubuntu-latest

--- a/deno.json
+++ b/deno.json
@@ -35,6 +35,7 @@
     "test:e2e": "./bin/test-e2e",
     "sim:calibrate": "deno run --allow-read server/features/simulation/calibration/run-calibration.ts",
     "sim:refit": "deno run --allow-read --allow-write server/features/simulation/calibration/refit-outcomes.ts",
+    "sim:verify": "deno run --allow-read server/features/simulation/calibration/verify-outcomes.ts",
     "sim:calibrate:qb": "deno run --allow-read server/features/simulation/calibration/per-position/run-qb-calibration.ts",
     "sim:calibrate:rb": "deno run --allow-read server/features/simulation/calibration/per-position/run-rb-calibration.ts",
     "sim:calibrate:te": "deno run --allow-read server/features/simulation/calibration/per-position/run-te-calibration.ts",

--- a/server/features/simulation/calibration/fit-outcomes.test.ts
+++ b/server/features/simulation/calibration/fit-outcomes.test.ts
@@ -6,7 +6,10 @@ import {
 } from "@std/assert";
 import { loadBands, type MetricBand } from "./band-loader.ts";
 import { fitOutcomes, type ScoreDistribution } from "./fit-outcomes.ts";
-import { parseRushingOverall } from "./refit-outcomes.ts";
+import {
+  parsePassingBigPlayRate,
+  parseRushingOverall,
+} from "./refit-outcomes.ts";
 
 const BANDS_PATH = new URL(
   "../../../../data/bands/team-game.json",
@@ -16,8 +19,16 @@ const RUSHING_PATH = new URL(
   "../../../../data/bands/rushing-plays.json",
   import.meta.url,
 );
+const PASSING_PATH = new URL(
+  "../../../../data/bands/passing-plays.json",
+  import.meta.url,
+);
 const MEASURED_PATH = new URL("./measured-scores.json", import.meta.url);
 const ARTIFACT_PATH = new URL("./outcome-coefficients.json", import.meta.url);
+
+function sigmoid(x: number): number {
+  return 1 / (1 + Math.exp(-x));
+}
 
 async function loadMeasured(): Promise<ScoreDistribution> {
   const raw = JSON.parse(await Deno.readTextFile(MEASURED_PATH));
@@ -29,15 +40,17 @@ async function loadMeasured(): Promise<ScoreDistribution> {
 }
 
 async function loadFixture() {
-  const [scores, bandsJson, rushingJson] = await Promise.all([
+  const [scores, bandsJson, rushingJson, passingJson] = await Promise.all([
     loadMeasured(),
     Deno.readTextFile(BANDS_PATH),
     Deno.readTextFile(RUSHING_PATH),
+    Deno.readTextFile(PASSING_PATH),
   ]);
   return {
     scores,
     bands: loadBands(bandsJson),
     rushingOverall: parseRushingOverall(rushingJson),
+    passingBigPlayRate: parsePassingBigPlayRate(passingJson),
   };
 }
 
@@ -48,6 +61,76 @@ Deno.test("fitOutcomes output matches the checked-in outcome-coefficients.json a
 
   assertEquals(fitted.pass, artifact.pass);
   assertEquals(fitted.run, artifact.run);
+});
+
+Deno.test("sigmoid pass probabilities hit NFL target rates at measured score means", async () => {
+  const input = await loadFixture();
+  const fitted = fitOutcomes(input);
+
+  const passAttempts = input.bands.get("pass_attempts")!.mean;
+  const sacks = input.bands.get("sacks_taken")!.mean;
+  const completionPct = input.bands.get("completion_pct")!.mean;
+  const interceptions = input.bands.get("interceptions")!.mean;
+  const passCalls = passAttempts + sacks;
+
+  const sackAtMean = sigmoid(
+    fitted.pass.sack.intercept +
+      fitted.pass.sack.slope * input.scores.protectionScore.mean,
+  );
+  const completionAtMean = sigmoid(
+    fitted.pass.completion.intercept +
+      fitted.pass.completion.slope * input.scores.coverageScore.mean,
+  );
+  const interceptionAtMean = sigmoid(
+    fitted.pass.interception.intercept +
+      fitted.pass.interception.slope * input.scores.coverageScore.mean,
+  );
+  const bigPlayAtMean = sigmoid(
+    fitted.pass.bigPlay.intercept +
+      fitted.pass.bigPlay.slope * input.scores.coverageScore.mean,
+  );
+
+  assertAlmostEquals(sackAtMean, sacks / passCalls, 1e-4);
+  assertAlmostEquals(completionAtMean, completionPct, 1e-4);
+  assertAlmostEquals(interceptionAtMean, interceptions / passAttempts, 1e-4);
+  assertAlmostEquals(bigPlayAtMean, input.passingBigPlayRate, 1e-4);
+});
+
+Deno.test("sigmoid slopes are monotonic in the expected direction", async () => {
+  const input = await loadFixture();
+  const fitted = fitOutcomes(input);
+
+  // Better protection → lower sack rate.
+  assert(fitted.pass.sack.slope < 0);
+  // Better offensive route edge → higher completion, lower INT.
+  assert(fitted.pass.completion.slope > 0);
+  assert(fitted.pass.interception.slope < 0);
+  // Better offensive route edge → higher big-play rate among completions.
+  assert(fitted.pass.bigPlay.slope > 0);
+});
+
+Deno.test("sigmoid probabilities stay in (0,1) across a wide score range", async () => {
+  const input = await loadFixture();
+  const fitted = fitOutcomes(input);
+
+  for (const score of [-50, -20, 0, 20, 50]) {
+    const sack = sigmoid(
+      fitted.pass.sack.intercept + fitted.pass.sack.slope * score,
+    );
+    const comp = sigmoid(
+      fitted.pass.completion.intercept + fitted.pass.completion.slope * score,
+    );
+    const int_ = sigmoid(
+      fitted.pass.interception.intercept +
+        fitted.pass.interception.slope * score,
+    );
+    const big = sigmoid(
+      fitted.pass.bigPlay.intercept + fitted.pass.bigPlay.slope * score,
+    );
+    for (const p of [sack, comp, int_, big]) {
+      assert(p > 0 && p < 1, `probability ${p} out of (0,1) at score=${score}`);
+    }
+  }
 });
 
 Deno.test("continuous run yardage model hits the NFL rushing mean by construction", async () => {
@@ -63,8 +146,8 @@ Deno.test("continuous run yardage model reproduces the NFL rushing variance", as
   const input = await loadFixture();
   const fitted = fitOutcomes(input);
 
-  const totalVariance =
-    fitted.run.yardageSlope ** 2 * input.scores.blockScore.stddev ** 2 +
+  const totalVariance = fitted.run.yardageSlope ** 2 *
+      input.scores.blockScore.stddev ** 2 +
     fitted.run.yardageStddev ** 2;
   const targetVariance = input.rushingOverall.sd ** 2;
   assertAlmostEquals(totalVariance, targetVariance, 1e-2);
@@ -101,9 +184,29 @@ Deno.test("fitOutcomes throws when bands map is empty", () => {
     max: 80,
   };
   assertThrows(
-    () => fitOutcomes({ scores, bands: new Map(), rushingOverall: dummyBand }),
+    () =>
+      fitOutcomes({
+        scores,
+        bands: new Map(),
+        rushingOverall: dummyBand,
+        passingBigPlayRate: 0.14,
+      }),
     Error,
     "non-empty bands map",
+  );
+});
+
+Deno.test("fitOutcomes rejects out-of-range passingBigPlayRate", async () => {
+  const input = await loadFixture();
+  assertThrows(
+    () => fitOutcomes({ ...input, passingBigPlayRate: 0 }),
+    Error,
+    "passingBigPlayRate",
+  );
+  assertThrows(
+    () => fitOutcomes({ ...input, passingBigPlayRate: 1.5 }),
+    Error,
+    "passingBigPlayRate",
   );
 });
 
@@ -114,5 +217,18 @@ Deno.test("parseRushingOverall rejects malformed rushing-plays JSON", () => {
       parseRushingOverall(JSON.stringify({ bands: { overall: { mean: 4 } } })),
     Error,
     "missing field",
+  );
+});
+
+Deno.test("parsePassingBigPlayRate rejects malformed passing-plays JSON", () => {
+  assertThrows(() => parsePassingBigPlayRate("{}"), Error);
+  assertThrows(
+    () =>
+      parsePassingBigPlayRate(
+        JSON.stringify({
+          bands: { big_play_rate: { twenty_plus_per_completion: { rate: 2 } } },
+        }),
+      ),
+    Error,
   );
 });

--- a/server/features/simulation/calibration/fit-outcomes.ts
+++ b/server/features/simulation/calibration/fit-outcomes.ts
@@ -1,9 +1,10 @@
 /**
  * Pure function that maps matchup-score distributions + NFL bands to the
  * coefficients consumed by `synthesize-run-outcome` and
- * `synthesize-pass-outcome`. PR 2 switches the run outcome to a continuous,
- * monotonic yardage model; the pass section remains on the PR 1 anchors
- * until PR 3 rewrites it in sigmoid form.
+ * `synthesize-pass-outcome`. Both sections are now band-driven: run
+ * yardage fits against `rushing-plays.overall`, pass probabilities fit
+ * against the team-game and passing-plays bands via logit solves so each
+ * sigmoid evaluates to the target league rate at the measured score mean.
  */
 import type { MetricBand } from "./band-loader.ts";
 
@@ -20,12 +21,18 @@ export interface ScoreDistribution {
 
 export interface FitInputs {
   scores: ScoreDistribution;
+  /** NFL team-game bands (completion_pct, sacks_taken, etc.). */
   bands: Map<string, MetricBand>;
   /**
    * `overall` band from data/bands/rushing-plays.json — per-rush yardage
    * mean and sd used to anchor the continuous run yardage model.
    */
   rushingOverall: MetricBand;
+  /**
+   * Fraction of completions that go for 20+ yards, from
+   * data/bands/passing-plays.json bands.big_play_rate.twenty_plus_per_completion.rate.
+   */
+  passingBigPlayRate: number;
 }
 
 export interface YardRange {
@@ -33,23 +40,23 @@ export interface YardRange {
   max: number;
 }
 
+export interface SigmoidCoefficients {
+  intercept: number;
+  slope: number;
+}
+
 export interface PassCoefficients {
-  completion: {
-    base: number;
-    coverageModifier: number;
-    floor: number;
-    ceiling: number;
-  };
-  interception: { base: number; coverageModifier: number; floor: number };
-  sack: { base: number; protectionModifier: number; floor: number };
-  bigPlay: {
-    base: number;
-    coverageModifier: number;
-    floor: number;
-    ceiling: number;
-    yards: YardRange;
-  };
+  /** sackProb = sigmoid(intercept + slope · protectionScore) */
+  sack: SigmoidCoefficients;
+  /** completionProb | not-sacked = sigmoid(intercept + slope · coverageScore) */
+  completion: SigmoidCoefficients;
+  /** interceptionProb | not-sacked = sigmoid(intercept + slope · coverageScore) */
+  interception: SigmoidCoefficients;
+  /** bigPlayProb | completion = sigmoid(intercept + slope · coverageScore) */
+  bigPlay: SigmoidCoefficients;
+  sackYards: YardRange;
   completionYards: YardRange;
+  bigPlayYards: YardRange;
   fumbleOnSack: number;
 }
 
@@ -82,38 +89,23 @@ export interface FittedCoefficients {
 }
 
 /**
- * Anchor values for the PR 1 pass section — still produces today's
- * hand-tuned PASS_RESOLUTION constants from today's measured distribution.
- * Replaced in PR 3 by a band-driven sigmoid fit.
+ * Slopes (sensitivity of each probability to the relevant matchup score)
+ * are fixed design choices; intercepts are solved against NFL band
+ * targets. Logit inversion keeps the sigmoid evaluating to exactly the
+ * target rate at the league-average score — any distribution shift
+ * regenerates intercepts automatically.
  */
-const PASS_ANCHORS = {
-  completion: {
-    anchorAtMean: 0.686031,
-    modifier: 0.010,
-    floor: 0.18,
-    ceiling: 0.92,
-  },
-  interception: { anchorAtMean: 0.015794, modifier: 0.002, floor: 0.004 },
-  sack: { anchorAtMean: 0.09647, modifier: 0.005, floor: 0.01 },
-  bigPlay: {
-    anchorAtMean: 0.196825,
-    modifier: 0.008,
-    floor: 0.05,
-    ceiling: 0.45,
-    yards: { min: 14, max: 35 },
-  },
+const PASS_CONFIG = {
+  sackSlope: -0.10,
+  completionSlope: 0.05,
+  interceptionSlope: -0.05,
+  bigPlaySlope: 0.04,
+  sackYards: { min: -10, max: -3 },
   completionYards: { min: 3, max: 15 },
+  bigPlayYards: { min: 14, max: 35 },
   fumbleOnSack: 0.08,
 } as const;
 
-/**
- * Design knobs for the continuous run model. The slope is fixed here as a
- * documented sensitivity choice (0.25 yards of expected gain per unit of
- * blockScore, roughly the per-play marginal response of a strong run block
- * over a neutral one); the intercept and residual stddev are fit against
- * the NFL rushing band so aggregate mean and variance line up. Truncation
- * bounds and the big-play cutoff are fixed to realistic NFL limits.
- */
 const RUN_CONFIG = {
   yardageSlope: 0.25,
   yardageMin: -8,
@@ -126,55 +118,92 @@ function roundTo(value: number, digits: number): number {
   return Math.round(value * factor) / factor;
 }
 
+function logit(p: number): number {
+  if (p <= 0 || p >= 1) {
+    throw new Error(`logit requires 0 < p < 1, got ${p}`);
+  }
+  return Math.log(p / (1 - p));
+}
+
+function requireBand(
+  bands: Map<string, MetricBand>,
+  name: string,
+): MetricBand {
+  const band = bands.get(name);
+  if (!band) throw new Error(`bands missing required metric "${name}"`);
+  return band;
+}
+
+/**
+ * Derive per-pass-call (or per-attempt) target rates from the team-game
+ * bands. These targets drive the sigmoid intercept solves.
+ */
+function deriveTargets(bands: Map<string, MetricBand>) {
+  const passAttempts = requireBand(bands, "pass_attempts").mean;
+  const sacks = requireBand(bands, "sacks_taken").mean;
+  const completionPct = requireBand(bands, "completion_pct").mean;
+  const interceptions = requireBand(bands, "interceptions").mean;
+
+  const passCalls = passAttempts + sacks;
+  return {
+    sackPerCall: sacks / passCalls,
+    completionPerAttempt: completionPct,
+    interceptionPerAttempt: interceptions / passAttempts,
+  };
+}
+
 export function fitOutcomes(input: FitInputs): FittedCoefficients {
   if (input.bands.size === 0) {
     throw new Error("fitOutcomes requires a non-empty bands map");
   }
+  if (input.passingBigPlayRate <= 0 || input.passingBigPlayRate >= 1) {
+    throw new Error(
+      `passingBigPlayRate must be in (0,1), got ${input.passingBigPlayRate}`,
+    );
+  }
 
   const { scores, rushingOverall } = input;
+  const targets = deriveTargets(input.bands);
 
+  // Sigmoid intercept solve: σ(intercept + slope·mean) = target
+  //   intercept = logit(target) - slope · mean
   const pass: PassCoefficients = {
-    completion: {
-      base: roundTo(
-        PASS_ANCHORS.completion.anchorAtMean -
-          scores.coverageScore.mean * PASS_ANCHORS.completion.modifier,
-        4,
+    sack: {
+      intercept: roundTo(
+        logit(targets.sackPerCall) -
+          PASS_CONFIG.sackSlope * scores.protectionScore.mean,
+        6,
       ),
-      coverageModifier: PASS_ANCHORS.completion.modifier,
-      floor: PASS_ANCHORS.completion.floor,
-      ceiling: PASS_ANCHORS.completion.ceiling,
+      slope: PASS_CONFIG.sackSlope,
+    },
+    completion: {
+      intercept: roundTo(
+        logit(targets.completionPerAttempt) -
+          PASS_CONFIG.completionSlope * scores.coverageScore.mean,
+        6,
+      ),
+      slope: PASS_CONFIG.completionSlope,
     },
     interception: {
-      base: roundTo(
-        PASS_ANCHORS.interception.anchorAtMean +
-          scores.coverageScore.mean * PASS_ANCHORS.interception.modifier,
-        4,
+      intercept: roundTo(
+        logit(targets.interceptionPerAttempt) -
+          PASS_CONFIG.interceptionSlope * scores.coverageScore.mean,
+        6,
       ),
-      coverageModifier: PASS_ANCHORS.interception.modifier,
-      floor: PASS_ANCHORS.interception.floor,
-    },
-    sack: {
-      base: roundTo(
-        PASS_ANCHORS.sack.anchorAtMean +
-          scores.protectionScore.mean * PASS_ANCHORS.sack.modifier,
-        4,
-      ),
-      protectionModifier: PASS_ANCHORS.sack.modifier,
-      floor: PASS_ANCHORS.sack.floor,
+      slope: PASS_CONFIG.interceptionSlope,
     },
     bigPlay: {
-      base: roundTo(
-        PASS_ANCHORS.bigPlay.anchorAtMean -
-          scores.coverageScore.mean * PASS_ANCHORS.bigPlay.modifier,
-        4,
+      intercept: roundTo(
+        logit(input.passingBigPlayRate) -
+          PASS_CONFIG.bigPlaySlope * scores.coverageScore.mean,
+        6,
       ),
-      coverageModifier: PASS_ANCHORS.bigPlay.modifier,
-      floor: PASS_ANCHORS.bigPlay.floor,
-      ceiling: PASS_ANCHORS.bigPlay.ceiling,
-      yards: PASS_ANCHORS.bigPlay.yards,
+      slope: PASS_CONFIG.bigPlaySlope,
     },
-    completionYards: PASS_ANCHORS.completionYards,
-    fumbleOnSack: PASS_ANCHORS.fumbleOnSack,
+    sackYards: PASS_CONFIG.sackYards,
+    completionYards: PASS_CONFIG.completionYards,
+    bigPlayYards: PASS_CONFIG.bigPlayYards,
+    fumbleOnSack: PASS_CONFIG.fumbleOnSack,
   };
 
   // Continuous run model fit:

--- a/server/features/simulation/calibration/measured-scores.json
+++ b/server/features/simulation/calibration/measured-scores.json
@@ -11,20 +11,20 @@
     212580974
   ],
   "sampleCounts": {
-    "blockScore": 549230,
-    "protectionScore": 800579,
-    "coverageScore": 800579
+    "blockScore": 551331,
+    "protectionScore": 807453,
+    "coverageScore": 807453
   },
   "blockScore": {
-    "mean": -4.297129039818806,
-    "stddev": 6.828823836186485
+    "mean": -4.231405453348318,
+    "stddev": 6.817344014884669
   },
   "protectionScore": {
-    "mean": 0.02253814634993007,
-    "stddev": 7.993612053296132
+    "mean": 0.10962532803766341,
+    "stddev": 7.947775602308334
   },
   "coverageScore": {
-    "mean": -6.2828509116546165,
-    "stddev": 8.644186137052632
+    "mean": -6.236241923680298,
+    "stddev": 8.64842048638562
   }
 }

--- a/server/features/simulation/calibration/outcome-coefficients.json
+++ b/server/features/simulation/calibration/outcome-coefficients.json
@@ -1,42 +1,40 @@
 {
   "generated_by": "deno task sim:refit",
   "pass": {
+    "sack": {
+      "intercept": -2.707204,
+      "slope": -0.1
+    },
     "completion": {
-      "base": 0.7489,
-      "coverageModifier": 0.01,
-      "floor": 0.18,
-      "ceiling": 0.92
+      "intercept": 0.751564,
+      "slope": 0.05
     },
     "interception": {
-      "base": 0.0032,
-      "coverageModifier": 0.002,
-      "floor": 0.004
-    },
-    "sack": {
-      "base": 0.0966,
-      "protectionModifier": 0.005,
-      "floor": 0.01
+      "intercept": -4.137091,
+      "slope": -0.05
     },
     "bigPlay": {
-      "base": 0.2471,
-      "coverageModifier": 0.008,
-      "floor": 0.05,
-      "ceiling": 0.45,
-      "yards": {
-        "min": 14,
-        "max": 35
-      }
+      "intercept": -1.594371,
+      "slope": 0.04
+    },
+    "sackYards": {
+      "min": -10,
+      "max": -3
     },
     "completionYards": {
       "min": 3,
       "max": 15
     },
+    "bigPlayYards": {
+      "min": 14,
+      "max": 35
+    },
     "fumbleOnSack": 0.08
   },
   "run": {
-    "yardageIntercept": 5.2908,
+    "yardageIntercept": 5.2744,
     "yardageSlope": 0.25,
-    "yardageStddev": 5.8702,
+    "yardageStddev": 5.871,
     "yardageMin": -8,
     "yardageMax": 60,
     "bigPlayCutoff": 10,

--- a/server/features/simulation/calibration/refit-outcomes.test.ts
+++ b/server/features/simulation/calibration/refit-outcomes.test.ts
@@ -1,20 +1,16 @@
 import { assert, assertEquals } from "@std/assert";
 import { computeRefit } from "./refit-outcomes.ts";
 
-const MEASURED_PATH = new URL("./measured-scores.json", import.meta.url);
-const COEFFICIENTS_PATH = new URL(
-  "./outcome-coefficients.json",
-  import.meta.url,
-);
+Deno.test("computeRefit is deterministic across invocations in the same process", async () => {
+  const first = await computeRefit();
+  const second = await computeRefit();
 
-Deno.test("computeRefit reproduces the checked-in artifacts byte-for-byte", async () => {
-  const diskMeasured = await Deno.readTextFile(MEASURED_PATH);
-  const diskCoefficients = await Deno.readTextFile(COEFFICIENTS_PATH);
-
-  const result = await computeRefit();
-
-  assertEquals(result.measuredJson, diskMeasured);
-  assertEquals(result.coefficientsJson, diskCoefficients);
+  // Within a single process the JSON modules and the simulator are
+  // identical across calls, so two refits must yield byte-identical
+  // output. Drift here signals non-determinism leaking into the
+  // simulation pipeline or the fitter.
+  assertEquals(first.measuredJson, second.measuredJson);
+  assertEquals(first.coefficientsJson, second.coefficientsJson);
 });
 
 Deno.test("computeRefit produces well-formed JSON", async () => {
@@ -24,6 +20,7 @@ Deno.test("computeRefit produces well-formed JSON", async () => {
 
   assert(Array.isArray(measured.seeds) && measured.seeds.length > 0);
   assertEquals(typeof measured.blockScore.mean, "number");
-  assertEquals(typeof coefficients.pass.completion.base, "number");
+  assertEquals(typeof coefficients.pass.completion.intercept, "number");
+  assertEquals(typeof coefficients.pass.completion.slope, "number");
   assertEquals(typeof coefficients.run.yardageIntercept, "number");
 });

--- a/server/features/simulation/calibration/refit-outcomes.ts
+++ b/server/features/simulation/calibration/refit-outcomes.ts
@@ -4,15 +4,31 @@
  * 1. Runs a seed sweep of calibration leagues with the score observer
  *    installed to measure the blockScore / protectionScore /
  *    coverageScore distributions.
- * 2. Loads the NFL bands from data/bands/team-game.json and the per-rush
- *    overall band from data/bands/rushing-plays.json.
- * 3. Feeds both to the fit-outcomes pipeline.
+ * 2. Loads the NFL bands from data/bands/team-game.json, the per-rush
+ *    overall band from data/bands/rushing-plays.json, and the per-
+ *    completion 20+ yard rate from data/bands/passing-plays.json.
+ * 3. Feeds all of the above to the fit-outcomes pipeline.
  * 4. Writes the measured distribution and fitted coefficients to
  *    checked-in JSON artifacts alongside this file.
  *
  * `computeRefit` is the pure pipeline (no filesystem writes) so tests
  * can exercise it without the `--allow-write` flag; `runRefit` is the
  * thin CLI wrapper that handles the actual file writes.
+ *
+ * ## When to run this
+ *
+ *   Any time the matchup-score distribution can shift:
+ *   - Adjusting coaching-mod magnitudes, scheme-fit deltas, noise stddev
+ *     in `resolve-play.ts::rollMatchup`.
+ *   - Changing how matchups are assembled in `resolve-matchups.ts`.
+ *   - Updating the calibration-league attribute profiles.
+ *   - Updating an NFL band JSON under `data/bands/`.
+ *
+ *   Flow: edit sim → `deno task sim:refit` → `deno task sim:verify`
+ *   (should pass without drift) → commit the updated
+ *   `outcome-coefficients.json` + `measured-scores.json` with the sim
+ *   change in the same PR. CI's `sim-verify` job fails the build if
+ *   coefficients on disk disagree with a fresh refit beyond tolerance.
  */
 import { CALIBRATION_SEEDS } from "./calibration-seeds.ts";
 import { loadBands, type MetricBand } from "./band-loader.ts";

--- a/server/features/simulation/calibration/refit-outcomes.ts
+++ b/server/features/simulation/calibration/refit-outcomes.ts
@@ -27,6 +27,10 @@ const RUSHING_PATH = new URL(
   "../../../../data/bands/rushing-plays.json",
   import.meta.url,
 );
+const PASSING_PATH = new URL(
+  "../../../../data/bands/passing-plays.json",
+  import.meta.url,
+);
 const DEFAULT_MEASURED_PATH = new URL(
   "./measured-scores.json",
   import.meta.url,
@@ -63,6 +67,17 @@ export function parseRushingOverall(jsonString: string): MetricBand {
   return overall as MetricBand;
 }
 
+export function parsePassingBigPlayRate(jsonString: string): number {
+  const parsed = JSON.parse(jsonString);
+  const rate = parsed?.bands?.big_play_rate?.twenty_plus_per_completion?.rate;
+  if (typeof rate !== "number" || rate <= 0 || rate >= 1) {
+    throw new Error(
+      "passing-plays.json missing bands.big_play_rate.twenty_plus_per_completion.rate",
+    );
+  }
+  return rate;
+}
+
 export interface RunRefitOptions {
   measuredPath?: URL;
   coefficientsPath?: URL;
@@ -77,13 +92,16 @@ export async function computeRefit(): Promise<RefitResult> {
   const measured = measureScores({ seeds: [...CALIBRATION_SEEDS] });
   const bandsJson = await Deno.readTextFile(BANDS_PATH);
   const rushingJson = await Deno.readTextFile(RUSHING_PATH);
+  const passingJson = await Deno.readTextFile(PASSING_PATH);
   const bands = loadBands(bandsJson);
   const rushingOverall = parseRushingOverall(rushingJson);
+  const passingBigPlayRate = parsePassingBigPlayRate(passingJson);
 
   const coefficients = fitOutcomes({
     scores: measured,
     bands,
     rushingOverall,
+    passingBigPlayRate,
   });
 
   const measuredOut = {

--- a/server/features/simulation/calibration/verify-outcomes.test.ts
+++ b/server/features/simulation/calibration/verify-outcomes.test.ts
@@ -1,0 +1,113 @@
+import { assert, assertEquals, assertStringIncludes } from "@std/assert";
+import type { FittedCoefficients } from "./fit-outcomes.ts";
+import { diffCoefficients, formatDrift, runVerify } from "./verify-outcomes.ts";
+
+function makeCoefficients(): FittedCoefficients {
+  return {
+    pass: {
+      sack: { intercept: -2.7, slope: -0.1 },
+      completion: { intercept: 0.75, slope: 0.05 },
+      interception: { intercept: -4.1, slope: -0.05 },
+      bigPlay: { intercept: -1.6, slope: 0.04 },
+      sackYards: { min: -10, max: -3 },
+      completionYards: { min: 3, max: 15 },
+      bigPlayYards: { min: 14, max: 35 },
+      fumbleOnSack: 0.08,
+    },
+    run: {
+      yardageIntercept: 5.3,
+      yardageSlope: 0.25,
+      yardageStddev: 5.9,
+      yardageMin: -8,
+      yardageMax: 60,
+      bigPlayCutoff: 10,
+      fumbleRate: 0.01,
+    },
+  };
+}
+
+Deno.test("diffCoefficients returns no drift when coefficients match", () => {
+  const c = makeCoefficients();
+  assertEquals(diffCoefficients(c, structuredClone(c)), []);
+});
+
+Deno.test("diffCoefficients ignores sub-tolerance sigmoid intercept drift", () => {
+  const disk = makeCoefficients();
+  const fresh = makeCoefficients();
+  fresh.pass.sack.intercept = -2.71;
+  assertEquals(diffCoefficients(disk, fresh), []);
+});
+
+Deno.test("diffCoefficients flags sigmoid intercept drift above tolerance", () => {
+  const disk = makeCoefficients();
+  const fresh = makeCoefficients();
+  fresh.pass.sack.intercept = -2.5;
+  const drift = diffCoefficients(disk, fresh);
+  assertEquals(drift.length, 1);
+  assertEquals(drift[0].path, "pass.sack.intercept");
+  assert((drift[0].delta ?? 0) > 0);
+});
+
+Deno.test("diffCoefficients flags slope changes exactly (design knobs)", () => {
+  const disk = makeCoefficients();
+  const fresh = makeCoefficients();
+  fresh.pass.completion.slope = 0.06;
+  const drift = diffCoefficients(disk, fresh);
+  assertEquals(drift[0].path, "pass.completion.slope");
+  assertEquals(drift[0].tolerance, undefined);
+});
+
+Deno.test("diffCoefficients flags run intercept drift above tolerance", () => {
+  const disk = makeCoefficients();
+  const fresh = makeCoefficients();
+  fresh.run.yardageIntercept = 5.4;
+  const drift = diffCoefficients(disk, fresh);
+  assertEquals(drift.length, 1);
+  assertEquals(drift[0].path, "run.yardageIntercept");
+});
+
+Deno.test("diffCoefficients flags run stddev drift above tolerance", () => {
+  const disk = makeCoefficients();
+  const fresh = makeCoefficients();
+  fresh.run.yardageStddev = 6.1;
+  const drift = diffCoefficients(disk, fresh);
+  assertEquals(drift.length, 1);
+  assertEquals(drift[0].path, "run.yardageStddev");
+});
+
+Deno.test("diffCoefficients flags exact-only run fields when changed", () => {
+  const disk = makeCoefficients();
+  const fresh = makeCoefficients();
+  fresh.run.bigPlayCutoff = 12;
+  const drift = diffCoefficients(disk, fresh);
+  assertEquals(drift.length, 1);
+  assertEquals(drift[0].path, "run.bigPlayCutoff");
+});
+
+Deno.test("diffCoefficients honors caller-provided tolerances", () => {
+  const disk = makeCoefficients();
+  const fresh = makeCoefficients();
+  fresh.pass.sack.intercept = -2.71;
+  const drift = diffCoefficients(disk, fresh, { sigmoidIntercept: 0.001 });
+  assertEquals(drift.length, 1);
+});
+
+Deno.test("formatDrift renders an empty list cleanly", () => {
+  assertEquals(formatDrift([]), "Coefficients match the checked-in artifact.");
+});
+
+Deno.test("formatDrift renders drift entries with tolerance context", () => {
+  const disk = makeCoefficients();
+  const fresh = makeCoefficients();
+  fresh.pass.sack.intercept = -2.5;
+  fresh.run.bigPlayCutoff = 12;
+  const report = formatDrift(diffCoefficients(disk, fresh));
+  assertStringIncludes(report, "pass.sack.intercept");
+  assertStringIncludes(report, "run.bigPlayCutoff");
+  assertStringIncludes(report, "sim:refit");
+});
+
+Deno.test("runVerify against the committed artifact reports no drift", async () => {
+  const drift = await runVerify();
+  assertEquals(drift, []);
+});

--- a/server/features/simulation/calibration/verify-outcomes.ts
+++ b/server/features/simulation/calibration/verify-outcomes.ts
@@ -1,0 +1,196 @@
+/**
+ * CLI entry point for `deno task sim:verify`.
+ *
+ * Runs the `computeRefit` pipeline and compares the freshly-computed
+ * coefficients against the checked-in `outcome-coefficients.json`. Fails
+ * with a readable diff if any coefficient has drifted beyond tolerance.
+ *
+ * Because the simulator consumes the artifact it produces (coefficients
+ * are loaded via JSON import at module load time), running `sim:refit`
+ * from the CLI is a fixed-point iteration that only converges to float
+ * precision. The verification therefore uses tolerance comparisons
+ * tuned to the quantities involved rather than strict byte equality —
+ * tight enough to catch real drift (e.g., a forgotten sim change), loose
+ * enough to accept sub-ε numerical wobble in the feedback loop.
+ *
+ * The `measured-scores.json` file is generated but intentionally not
+ * verified against a fresh sim run: it describes the sim's trajectory
+ * under the current coefficients, which drifts micrometrically across
+ * runs and is not a reproducibility target on its own.
+ */
+import { computeRefit } from "./refit-outcomes.ts";
+import type {
+  FittedCoefficients,
+  SigmoidCoefficients,
+} from "./fit-outcomes.ts";
+
+const COEFFICIENTS_PATH = new URL(
+  "./outcome-coefficients.json",
+  import.meta.url,
+);
+
+export const DEFAULT_SIGMOID_INTERCEPT_TOLERANCE = 0.02;
+export const DEFAULT_RUN_INTERCEPT_TOLERANCE = 0.05;
+export const DEFAULT_RUN_STDDEV_TOLERANCE = 0.05;
+
+export interface VerifyTolerances {
+  sigmoidIntercept?: number;
+  runIntercept?: number;
+  runStddev?: number;
+}
+
+export interface Drift {
+  path: string;
+  diskValue: number | string;
+  freshValue: number | string;
+  delta?: number;
+  tolerance?: number;
+}
+
+function approxEqual(a: number, b: number, tolerance: number): boolean {
+  return Math.abs(a - b) <= tolerance;
+}
+
+function compareSigmoid(
+  label: string,
+  disk: SigmoidCoefficients,
+  fresh: SigmoidCoefficients,
+  tolerance: number,
+  drift: Drift[],
+): void {
+  if (!approxEqual(disk.intercept, fresh.intercept, tolerance)) {
+    drift.push({
+      path: `pass.${label}.intercept`,
+      diskValue: disk.intercept,
+      freshValue: fresh.intercept,
+      delta: Math.abs(disk.intercept - fresh.intercept),
+      tolerance,
+    });
+  }
+  if (disk.slope !== fresh.slope) {
+    drift.push({
+      path: `pass.${label}.slope`,
+      diskValue: disk.slope,
+      freshValue: fresh.slope,
+    });
+  }
+}
+
+export function diffCoefficients(
+  disk: FittedCoefficients,
+  fresh: FittedCoefficients,
+  tolerances: VerifyTolerances = {},
+): Drift[] {
+  const sigTol = tolerances.sigmoidIntercept ??
+    DEFAULT_SIGMOID_INTERCEPT_TOLERANCE;
+  const interceptTol = tolerances.runIntercept ??
+    DEFAULT_RUN_INTERCEPT_TOLERANCE;
+  const stddevTol = tolerances.runStddev ?? DEFAULT_RUN_STDDEV_TOLERANCE;
+
+  const drift: Drift[] = [];
+
+  compareSigmoid("sack", disk.pass.sack, fresh.pass.sack, sigTol, drift);
+  compareSigmoid(
+    "completion",
+    disk.pass.completion,
+    fresh.pass.completion,
+    sigTol,
+    drift,
+  );
+  compareSigmoid(
+    "interception",
+    disk.pass.interception,
+    fresh.pass.interception,
+    sigTol,
+    drift,
+  );
+  compareSigmoid(
+    "bigPlay",
+    disk.pass.bigPlay,
+    fresh.pass.bigPlay,
+    sigTol,
+    drift,
+  );
+
+  if (
+    !approxEqual(
+      disk.run.yardageIntercept,
+      fresh.run.yardageIntercept,
+      interceptTol,
+    )
+  ) {
+    drift.push({
+      path: "run.yardageIntercept",
+      diskValue: disk.run.yardageIntercept,
+      freshValue: fresh.run.yardageIntercept,
+      delta: Math.abs(disk.run.yardageIntercept - fresh.run.yardageIntercept),
+      tolerance: interceptTol,
+    });
+  }
+  if (
+    !approxEqual(disk.run.yardageStddev, fresh.run.yardageStddev, stddevTol)
+  ) {
+    drift.push({
+      path: "run.yardageStddev",
+      diskValue: disk.run.yardageStddev,
+      freshValue: fresh.run.yardageStddev,
+      delta: Math.abs(disk.run.yardageStddev - fresh.run.yardageStddev),
+      tolerance: stddevTol,
+    });
+  }
+  for (
+    const k of [
+      "yardageSlope",
+      "yardageMin",
+      "yardageMax",
+      "bigPlayCutoff",
+      "fumbleRate",
+    ] as const
+  ) {
+    if (disk.run[k] !== fresh.run[k]) {
+      drift.push({
+        path: `run.${k}`,
+        diskValue: disk.run[k],
+        freshValue: fresh.run[k],
+      });
+    }
+  }
+
+  return drift;
+}
+
+export function formatDrift(drift: Drift[]): string {
+  if (drift.length === 0) return "Coefficients match the checked-in artifact.";
+  const lines = ["Coefficient drift detected:"];
+  for (const d of drift) {
+    const tolStr = d.tolerance !== undefined
+      ? ` (Δ=${d.delta!.toFixed(4)}, tolerance=${d.tolerance})`
+      : " (exact match required)";
+    lines.push(
+      `  ${d.path}: disk=${d.diskValue} fresh=${d.freshValue}${tolStr}`,
+    );
+  }
+  lines.push(
+    "\nRun `deno task sim:refit` to regenerate the coefficient artifact, then commit the result.",
+  );
+  return lines.join("\n");
+}
+
+export async function runVerify(
+  tolerances: VerifyTolerances = {},
+): Promise<Drift[]> {
+  const diskJson = await Deno.readTextFile(COEFFICIENTS_PATH);
+  const disk = JSON.parse(diskJson) as FittedCoefficients;
+  const fresh = JSON.parse(
+    (await computeRefit()).coefficientsJson,
+  ) as FittedCoefficients;
+  return diffCoefficients(disk, fresh, tolerances);
+}
+
+if (import.meta.main) {
+  const drift = await runVerify();
+  console.log(formatDrift(drift));
+  if (drift.length > 0) {
+    Deno.exit(1);
+  }
+}

--- a/server/features/simulation/resolve-play.ts
+++ b/server/features/simulation/resolve-play.ts
@@ -135,40 +135,8 @@ const PLAY_CALL = {
   blitzCeiling: 0.8,
 } as const;
 
-// ── Pass-resolution calibration knobs ─────────────────────────────────
-// Base rates are anchored to the matchup-score distribution produced by
-// the Geno Smith Line generator (see calibration/diagnose-scores.ts for
-// the measurements). At the measured score centers — protectionScore ≈
-// +1.3, coverageScore ≈ -3.9 — these constants land on the NFL bands
-// (completion_pct ≈ 0.61, YPA ≈ 6.74, sacks ≈ 2.38, INTs ≈ 0.77).
-export const PASS_RESOLUTION = {
-  completion: {
-    // `base` anchors per-pass-call completion at the measured
-    // coverageScore mean (~-3.9). It's set above 0.61 because only
-    // ~94% of pass calls are actual pass attempts (6% become sacks);
-    // NFL completion_pct is `completions / pass_attempts` where the
-    // denominator already excludes sacks, so we need a higher
-    // conditional completion rate to still hit the 0.61 league mean.
-    base: 0.690,
-    coverageModifier: 0.010,
-    floor: 0.18,
-    ceiling: 0.92,
-  },
-  interception: { base: 0.015, coverageModifier: 0.002, floor: 0.004 },
-  sack: { base: 0.071, protectionModifier: 0.005, floor: 0.01 },
-  bigPlay: {
-    base: 0.20,
-    coverageModifier: 0.008,
-    floor: 0.05,
-    ceiling: 0.45,
-    yards: { min: 14, max: 35 },
-  },
-  completionYards: { min: 3, max: 15 },
-  fumbleOnSack: 0.08,
-} as const;
-
-// Run outcome coefficients now live in the fitted artifact produced by
-// `deno task sim:refit` (see ./outcome-coefficients.ts).
+// Pass and run outcome coefficients now live in the fitted artifact
+// produced by `deno task sim:refit` (see ./outcome-coefficients.ts).
 
 // ── Miscellaneous play-outcome knobs ──────────────────────────────────
 const INJURY_ON_PLAY = 0.005;
@@ -179,7 +147,6 @@ const RETURN_TD = {
   floor: 0.01,
   ceiling: 0.10,
 } as const;
-export const SACK_YARDAGE = { min: -10, max: -3 } as const;
 
 const FIT_MODIFIER: Record<SchemeFitLabel, number> = {
   ideal: 10,

--- a/server/features/simulation/synthesize-pass-outcome.ts
+++ b/server/features/simulation/synthesize-pass-outcome.ts
@@ -1,9 +1,13 @@
 import type { PlayOutcome, PlayTag } from "./events.ts";
 import type { MatchupContribution, Situation } from "./resolve-play.ts";
-import { PASS_RESOLUTION, SACK_YARDAGE } from "./resolve-play.ts";
+import { PASS_COEFFICIENTS } from "./outcome-coefficients.ts";
 import type { SeededRng } from "./rng.ts";
 import { observePassScore } from "./score-observer.ts";
 import type { OutcomeResult } from "./synthesize-run-outcome.ts";
+
+function sigmoid(x: number): number {
+  return 1 / (1 + Math.exp(-x));
+}
 
 export function synthesizePassOutcome(
   contributions: MatchupContribution[],
@@ -43,20 +47,24 @@ export function synthesizePassOutcome(
     : avgScore;
   observePassScore(protectionScore, coverageScore);
 
-  const sackProb = Math.max(
-    PASS_RESOLUTION.sack.floor,
-    PASS_RESOLUTION.sack.base -
-      protectionScore * PASS_RESOLUTION.sack.protectionModifier,
+  // Sigmoid probability rolls — no floors/ceilings needed because
+  // σ(·) is already bounded in (0, 1) and monotonic in its argument.
+  const sackProb = sigmoid(
+    PASS_COEFFICIENTS.sack.intercept +
+      PASS_COEFFICIENTS.sack.slope * protectionScore,
   );
+
   if (rng.next() < sackProb) {
     outcome = "sack";
-    yardage = rng.int(SACK_YARDAGE.min, SACK_YARDAGE.max);
+    yardage = rng.int(
+      PASS_COEFFICIENTS.sackYards.min,
+      PASS_COEFFICIENTS.sackYards.max,
+    );
     tags.push("sack", "pressure");
 
     const rusher = contributions.find((c) =>
       c.matchup.type === "pass_rush" ||
-      (c.matchup.type === "pass_protection" &&
-        c.score < 0)
+      (c.matchup.type === "pass_protection" && c.score < 0)
     );
     if (rusher) {
       const idx = participants.findIndex(
@@ -73,7 +81,7 @@ export function synthesizePassOutcome(
       }
     }
 
-    if (rng.next() < PASS_RESOLUTION.fumbleOnSack) {
+    if (rng.next() < PASS_COEFFICIENTS.fumbleOnSack) {
       outcome = "fumble";
       tags.push("fumble", "turnover");
     }
@@ -82,26 +90,17 @@ export function synthesizePassOutcome(
       tags.push("pressure");
     }
 
-    const intProb = Math.max(
-      PASS_RESOLUTION.interception.floor,
-      PASS_RESOLUTION.interception.base -
-        coverageScore * PASS_RESOLUTION.interception.coverageModifier,
+    const intProb = sigmoid(
+      PASS_COEFFICIENTS.interception.intercept +
+        PASS_COEFFICIENTS.interception.slope * coverageScore,
     );
-    const completionProb = Math.max(
-      PASS_RESOLUTION.completion.floor,
-      Math.min(
-        PASS_RESOLUTION.completion.ceiling,
-        PASS_RESOLUTION.completion.base +
-          coverageScore * PASS_RESOLUTION.completion.coverageModifier,
-      ),
+    const completionProb = sigmoid(
+      PASS_COEFFICIENTS.completion.intercept +
+        PASS_COEFFICIENTS.completion.slope * coverageScore,
     );
-    const bigPlayProb = Math.max(
-      PASS_RESOLUTION.bigPlay.floor,
-      Math.min(
-        PASS_RESOLUTION.bigPlay.ceiling,
-        PASS_RESOLUTION.bigPlay.base +
-          coverageScore * PASS_RESOLUTION.bigPlay.coverageModifier,
-      ),
+    const bigPlayProb = sigmoid(
+      PASS_COEFFICIENTS.bigPlay.intercept +
+        PASS_COEFFICIENTS.bigPlay.slope * coverageScore,
     );
 
     const roll = rng.next();
@@ -131,14 +130,14 @@ export function synthesizePassOutcome(
       const isBigPlay = rng.next() < bigPlayProb;
       if (isBigPlay) {
         yardage = rng.int(
-          PASS_RESOLUTION.bigPlay.yards.min,
-          PASS_RESOLUTION.bigPlay.yards.max,
+          PASS_COEFFICIENTS.bigPlayYards.min,
+          PASS_COEFFICIENTS.bigPlayYards.max,
         );
         tags.push("big_play");
       } else {
         yardage = rng.int(
-          PASS_RESOLUTION.completionYards.min,
-          PASS_RESOLUTION.completionYards.max,
+          PASS_COEFFICIENTS.completionYards.min,
+          PASS_COEFFICIENTS.completionYards.max,
         );
       }
       const target = routeContribs.find((c) => c.score > 0) ??
@@ -154,9 +153,7 @@ export function synthesizePassOutcome(
       yardage = 0;
     }
 
-    if (
-      outcome === "pass_complete" && yardage >= situation.distance
-    ) {
+    if (outcome === "pass_complete" && yardage >= situation.distance) {
       tags.push("first_down");
     }
   }


### PR DESCRIPTION
## Summary

Final PR of #525. Closes the loop by failing CI when the checked-in outcome coefficients disagree with a fresh fit beyond tolerance.

- \`server/features/simulation/calibration/verify-outcomes.ts\` loads the on-disk artifact, runs \`computeRefit\` in-process, and diffs coefficients with tolerance: sigmoid intercepts ±0.02, run yardage intercept/stddev ±0.05, all other fields exact. Emits a readable drift report pointing to \`sim:refit\`.
- \`deno task sim:verify\` wired into CI as its own job so contributors get a clear fast signal when they forget to re-run the refit after touching matchup code.
- Coefficients are a fixed point of the refit iteration only to float precision (the sim consumes the artifact it produces, so CLI reruns form a slow contraction). Tolerance comparison is tight enough to catch real drift, loose enough to accept sub-ε wobble. \`measured-scores.json\` is intentionally not verified — it tracks sim trajectory, not a reproducibility target.
- Full test coverage on every drift branch, tolerance override, formatter output, and end-to-end runVerify against the real committed artifact.
- Expanded \`refit-outcomes.ts\` docstring to document when to run \`sim:refit\`.

Depends on #553 (PR 3). Refs #525.