### PR TITLE
calibration(coaches): modal contract length + age-gated first-time HC (closes #543)

### DIFF
--- a/server/features/coaches/coaches-generator.test.ts
+++ b/server/features/coaches/coaches-generator.test.ts
@@ -143,7 +143,8 @@ Deno.test("all coaches have the correct leagueId, non-empty names, plausible age
     assertEquals(coach.leagueId, INPUT.leagueId);
     assertEquals(coach.firstName.length > 0, true);
     assertEquals(coach.lastName.length > 0, true);
-    assertEquals(coach.age >= 30 && coach.age <= 75, true);
+    // Position-tier floor is 26 (TIER_BANDS.POSITION.ageMin); HC ceiling is 68.
+    assertEquals(coach.age >= 26 && coach.age <= 75, true);
     assertEquals(coach.contractYears >= 1, true);
     assertEquals(coach.isVacancy, false);
   }
@@ -957,3 +958,141 @@ Deno.test("generate leaves preference columns null for assigned staff", () => {
     assertEquals(coach.minimumThreshold, null);
   }
 });
+
+// ---- Contract length modal calibration (#543) ----
+
+// Large pool so the modal-length histogram is statistically meaningful.
+// 120 teams * 13 coaches = 1,560 coaches per role tier slice.
+const LENGTH_POOL_INPUT = {
+  leagueId: "league-length",
+  numberOfTeams: 120,
+};
+
+function modeOf(values: number[]): number {
+  const counts = new Map<number, number>();
+  for (const v of values) counts.set(v, (counts.get(v) ?? 0) + 1);
+  let best = values[0];
+  let bestCount = -1;
+  for (const [v, c] of counts) {
+    if (c > bestCount) {
+      best = v;
+      bestCount = c;
+    }
+  }
+  return best;
+}
+
+Deno.test("HC contract length has a visible mode at 5 years (#543)", () => {
+  const pool = createCoachesGenerator({
+    random: seededRandom(4321),
+    nameGenerator: fixedNameGenerator(),
+  }).generatePool(LENGTH_POOL_INPUT);
+  const hcYears = pool.filter((c) => c.role === "HC").map((c) =>
+    c.contractYears
+  );
+  assertEquals(hcYears.length > 100, true);
+  assertEquals(modeOf(hcYears), 5);
+  const fiveCount = hcYears.filter((y) => y === 5).length;
+  const share = fiveCount / hcYears.length;
+  // Weighted spec is 0.55 at 5 years; allow generous slack around that prior.
+  assertEquals(
+    share >= 0.45 && share <= 0.65,
+    true,
+    `expected 5yr share in [0.45,0.65], got ${share.toFixed(3)}`,
+  );
+  // Contract bounds: 3..6 inclusive (new weighted spec extends past old 5-cap).
+  for (const y of hcYears) {
+    assertEquals(y >= 3 && y <= 6, true, `unexpected HC contract years ${y}`);
+  }
+});
+
+Deno.test("Coordinator contract length is modal at 3 years (#543)", () => {
+  const pool = createCoachesGenerator({
+    random: seededRandom(4322),
+    nameGenerator: fixedNameGenerator(),
+  }).generatePool(LENGTH_POOL_INPUT);
+  const coordYears = pool
+    .filter((c) => c.role === "OC" || c.role === "DC" || c.role === "STC")
+    .map((c) => c.contractYears);
+  assertEquals(coordYears.length > 100, true);
+  assertEquals(modeOf(coordYears), 3);
+});
+
+Deno.test("Position coach contract length is modal at 2 years (#543)", () => {
+  const pool = createCoachesGenerator({
+    random: seededRandom(4323),
+    nameGenerator: fixedNameGenerator(),
+  }).generatePool(LENGTH_POOL_INPUT);
+  const positionRoles = new Set([
+    "QB",
+    "RB",
+    "WR",
+    "TE",
+    "OL",
+    "DL",
+    "LB",
+    "DB",
+    "ST_ASSISTANT",
+  ]);
+  const years = pool
+    .filter((c) => positionRoles.has(c.role))
+    .map((c) => c.contractYears);
+  assertEquals(years.length > 100, true);
+  assertEquals(modeOf(years), 2);
+});
+
+// ---- First-time HC age gating (#543) ----
+
+Deno.test(
+  "first-time HC rate is age-gated: young >> middle >> senior (#543)",
+  () => {
+    // Use generatePool (which rolls HCs) across many teams to get decent
+    // sample counts in each age band.
+    const pool = createCoachesGenerator({
+      random: seededRandom(7777),
+      nameGenerator: fixedNameGenerator(),
+    }).generatePool({ leagueId: "lg-age", numberOfTeams: 200 });
+    const hcs = pool.filter((c) => c.role === "HC");
+    const young = hcs.filter((c) => c.age < 45);
+    const middle = hcs.filter((c) => c.age >= 45 && c.age < 55);
+    const senior = hcs.filter((c) => c.age >= 55);
+    // With ageMode 51 and range 36–68, all three buckets should be populated.
+    assertEquals(young.length > 20, true, `young sample ${young.length}`);
+    assertEquals(middle.length > 20, true, `middle sample ${middle.length}`);
+    assertEquals(senior.length > 20, true, `senior sample ${senior.length}`);
+
+    const rate = (arr: typeof hcs) =>
+      arr.filter((c) => c.headCoachYears === 0).length / arr.length;
+    const youngRate = rate(young);
+    const middleRate = rate(middle);
+    const seniorRate = rate(senior);
+
+    // Spec: <45 = 0.50, 45–54 = 0.20, 55+ = 0.05.
+    assertEquals(
+      youngRate >= 0.35 && youngRate <= 0.65,
+      true,
+      `young first-time rate ${youngRate.toFixed(3)} outside [0.35,0.65]`,
+    );
+    assertEquals(
+      middleRate >= 0.10 && middleRate <= 0.32,
+      true,
+      `middle first-time rate ${middleRate.toFixed(3)} outside [0.10,0.32]`,
+    );
+    assertEquals(
+      seniorRate <= 0.15,
+      true,
+      `senior first-time rate ${seniorRate.toFixed(3)} above 0.15`,
+    );
+    // Ordering must hold: young strictly > middle > senior.
+    assertEquals(
+      youngRate > middleRate,
+      true,
+      `young ${youngRate} !> middle ${middleRate}`,
+    );
+    assertEquals(
+      middleRate > seniorRate,
+      true,
+      `middle ${middleRate} !> senior ${seniorRate}`,
+    );
+  },
+);

--- a/server/features/coaches/coaches-generator.ts
+++ b/server/features/coaches/coaches-generator.ts
@@ -162,8 +162,11 @@ const TIER_BANDS: Record<Tier, TierBand> = {
     ageMode: 51,
     salaryMin: 6_000_000,
     salaryMax: 14_000_000,
+    // Contract length for coaches is rolled via CONTRACT_LENGTH_WEIGHTS
+    // (weighted mode-aware), not by uniform intInRange on this band. These
+    // bounds are retained as documentation of the realistic range. See #543.
     yearsMin: 3,
-    yearsMax: 5,
+    yearsMax: 6,
     buyoutYearsMin: 1,
     buyoutYearsMax: 2,
     tenureMin: 0,
@@ -480,10 +483,79 @@ interface RoleExperienceSplit {
  *
  * The three returned fields always sum to `yearsExperience`.
  */
+/**
+ * Contract length distributions per tier. Real NFL contracts cluster
+ * heavily at modal lengths rather than spreading uniformly across the
+ * tier's min/max band: HCs are almost always signed to 5-year deals,
+ * coordinators to 3-year deals, and position coaches to 2-year deals.
+ * A uniform roll across `yearsMin..yearsMax` underweighted the mode and
+ * overproduced short contracts — e.g., ~33% of HCs on 3-year deals,
+ * which is essentially unseen in the modern league. These weights honor
+ * the mode while still leaving tails for the occasional longer or
+ * shorter deal. See #543.
+ */
+const CONTRACT_LENGTH_WEIGHTS: Record<
+  Tier,
+  ReadonlyArray<{ years: number; weight: number }>
+> = {
+  HC: [
+    { years: 3, weight: 0.10 },
+    { years: 4, weight: 0.20 },
+    { years: 5, weight: 0.55 },
+    { years: 6, weight: 0.15 },
+  ],
+  COORDINATOR: [
+    { years: 2, weight: 0.25 },
+    { years: 3, weight: 0.55 },
+    { years: 4, weight: 0.20 },
+  ],
+  POSITION: [
+    { years: 1, weight: 0.20 },
+    { years: 2, weight: 0.55 },
+    { years: 3, weight: 0.25 },
+  ],
+};
+
+function pickWeighted<T>(
+  random: () => number,
+  options: ReadonlyArray<{ value: T; weight: number }>,
+): T {
+  const total = options.reduce((sum, o) => sum + o.weight, 0);
+  let roll = random() * total;
+  for (const option of options) {
+    roll -= option.weight;
+    if (roll <= 0) return option.value;
+  }
+  return options[options.length - 1].value;
+}
+
+function pickContractYears(tier: Tier, random: () => number): number {
+  const weights = CONTRACT_LENGTH_WEIGHTS[tier];
+  return pickWeighted(
+    random,
+    weights.map((w) => ({ value: w.years, weight: w.weight })),
+  );
+}
+
+/**
+ * First-time HC probability by age bucket. Modern NFL first-time HCs
+ * overwhelmingly come from the mid-30s to mid-40s coaching tree — McVay
+ * (30), Steichen (37), Ben Johnson (38), LaFleur (39), Shanahan (37).
+ * First-timers in their 50s exist but are rare; first-timers 55+ are
+ * effectively unheard of. A flat 35% roll produced 65-year-old first-
+ * time HCs, which is not a realistic hiring market. See #543.
+ */
+function firstTimeHcProbability(age: number): number {
+  if (age < 45) return 0.50;
+  if (age < 55) return 0.20;
+  return 0.05;
+}
+
 function rollRoleExperience(
   tier: Tier,
   yearsExperience: number,
   random: () => number,
+  age: number,
 ): RoleExperienceSplit {
   if (yearsExperience <= 0) {
     return { headCoachYears: 0, coordinatorYears: 0, positionCoachYears: 0 };
@@ -509,10 +581,12 @@ function rollRoleExperience(
     };
   }
   const maxHc = Math.min(yearsExperience, 18);
-  // ~35% of HC candidates are first-time head coaches (0 HC years); the rest
-  // have at least one season in the chair. Keeps the hiring market's
-  // "proven vs unproven" spread realistic — the pool always carries both.
-  const headCoachYears = random() < 0.35
+  // First-time HC probability is age-gated (see firstTimeHcProbability).
+  // Young candidates are overwhelmingly first-timers; older candidates have
+  // almost certainly already been in the chair somewhere. This preserves a
+  // realistic "proven vs unproven" pool shape while eliminating the
+  // implausible 60+-year-old first-time HC. See #543.
+  const headCoachYears = random() < firstTimeHcProbability(age)
     ? 0
     : triangularInt(random, 1, Math.min(3, maxHc), Math.max(1, maxHc));
   const remaining = yearsExperience - headCoachYears;
@@ -561,7 +635,7 @@ function generateCoach(
   const salaryMax = salaryOverride?.salaryMax ?? band.salaryMax;
 
   const age = triangularInt(random, band.ageMin, band.ageMode, band.ageMax);
-  const contractYears = intInRange(random, band.yearsMin, band.yearsMax);
+  const contractYears = pickContractYears(spec.tier, random);
   const salarySteps = Math.max(
     1,
     Math.floor((salaryMax - salaryMin) / 50_000),
@@ -588,6 +662,7 @@ function generateCoach(
     spec.tier,
     yearsExperience,
     random,
+    age,
   );
 
   const collegeId = collegeIds.length > 0


### PR DESCRIPTION
## Summary

- Replace uniform `intInRange` contract length with a weighted picker per tier so HC deals mode at 5yr (0.55), coordinators at 3yr (0.55), and position coaches at 2yr (0.55) — eliminating the ~33% of HCs shipped on 3-year deals under the old uniform roll.
- Age-gate the first-time HC roll in `rollRoleExperience`: `<45` → 50%, `45–54` → 20%, `55+` → 5%, replacing the flat 35% that could generate 65-year-old first-time HCs.
- Add seeded tests that assert modal frequency across a 120-team pool and age-banded first-time rates with strict ordering (young > middle > senior) across a 200-team pool.

Closes #543.