### PR TITLE
calibration(contracts): void years by position (closes #532)

### DIFF
--- a/server/features/players/players-generator.test.ts
+++ b/server/features/players/players-generator.test.ts
@@ -1251,6 +1251,126 @@ Deno.test(
   },
 );
 
+// ---- Void-year usage by position × tier (issue #532) ----
+//
+// OTC reporting (see `data/docs/contract-structure.md`): top-10 QB
+// contracts carry void years ~30%+ of the time, top-10 EDGE ~20%+,
+// top-10 IDL/WR/OT meaningful but lower, RB/S/CB/specialists rare.
+// The prior model drove void-year usage purely off the team cap
+// archetype; this suite pins the position × tier prior that layers
+// on top.
+
+function voidRate(bundles: ReturnType<typeof rollVeteranContract>[]): number {
+  return bundles.filter((b) => b.years.some((y) => y.isVoid)).length /
+    bundles.length;
+}
+
+Deno.test(
+  "top-10 QB contracts carry void years ~30%+ under a balanced archetype",
+  () => {
+    const bundles = sampleVeteranContracts({
+      bucket: "QB",
+      qualityTier: "star",
+      archetype: "balanced",
+      count: 600,
+      seed: 101,
+    });
+    const rate = voidRate(bundles);
+    assertEquals(
+      rate >= 0.25,
+      true,
+      `expected QB top-10 void-year rate >= 0.25; got ${rate.toFixed(3)}`,
+    );
+  },
+);
+
+Deno.test(
+  "top-10 EDGE contracts carry void years ~20%+ under a balanced archetype",
+  () => {
+    const bundles = sampleVeteranContracts({
+      bucket: "EDGE",
+      qualityTier: "star",
+      archetype: "balanced",
+      count: 600,
+      seed: 102,
+    });
+    const rate = voidRate(bundles);
+    assertEquals(
+      rate >= 0.15,
+      true,
+      `expected EDGE top-10 void-year rate >= 0.15; got ${rate.toFixed(3)}`,
+    );
+  },
+);
+
+Deno.test(
+  "top-10 QB void-year rate clearly exceeds top-10 RB / CB / S / specialists",
+  () => {
+    const qb = voidRate(sampleVeteranContracts({
+      bucket: "QB",
+      qualityTier: "star",
+      archetype: "balanced",
+      count: 600,
+      seed: 103,
+    }));
+    for (const bucket of ["RB", "CB", "S", "K"] as const) {
+      const other = voidRate(sampleVeteranContracts({
+        bucket,
+        qualityTier: "star",
+        archetype: "balanced",
+        count: 600,
+        seed: 103,
+      }));
+      assertEquals(
+        qb - other >= 0.15,
+        true,
+        `expected QB void rate (${qb.toFixed(3)}) to exceed ${bucket} (${
+          other.toFixed(3)
+        }) by >= 0.15`,
+      );
+    }
+  },
+);
+
+Deno.test(
+  "sub-top-10 tiers rarely carry void years regardless of position",
+  () => {
+    for (const bucket of ["QB", "EDGE", "WR"] as const) {
+      const rate = voidRate(sampleVeteranContracts({
+        bucket,
+        qualityTier: "depth",
+        archetype: "balanced",
+        count: 600,
+        seed: 104,
+      }));
+      assertEquals(
+        rate <= 0.1,
+        true,
+        `expected sub-top-10 ${bucket} void rate <= 0.10; got ${
+          rate.toFixed(3)
+        }`,
+      );
+    }
+  },
+);
+
+Deno.test(
+  "flush archetype zeroes void-year usage even for top-10 QBs",
+  () => {
+    // Flush teams never need cap tricks; the team archetype gates the
+    // position prior to preserve the existing cap-hell vs flush
+    // invariant (tested at generator scope above).
+    const bundles = sampleVeteranContracts({
+      bucket: "QB",
+      qualityTier: "star",
+      archetype: "flush",
+      count: 400,
+      seed: 105,
+    });
+    assertEquals(voidRate(bundles), 0);
+  },
+);
+
 Deno.test("default archetype (no teamArchetypes provided) still produces valid contracts", () => {
   const generator = makeGenerator();
   const players = Array.from({ length: 53 }, (_, i) => ({

--- a/server/features/players/players-generator.ts
+++ b/server/features/players/players-generator.ts
@@ -870,37 +870,162 @@ function rollOrigin(
  * Archetype-driven modifiers applied on top of the position × tier
  * contract-structure prior (see `contract-structure-bands.ts`). Real
  * NFL deals are shaped by position × market tier first; team cap
- * posture nudges the bonus share up/down and governs void-year usage.
+ * posture nudges the bonus share up/down and scales void-year usage.
+ *
+ * `voidYearMultiplier` and `maxVoidYearsCeiling` compose with the
+ * position × tier void-year prior (`VOID_YEAR_PRIOR_BY_POSITION`) so
+ * that team posture is a multiplier on a position-driven rate, not a
+ * replacement for it. A flush team zeroes the rate regardless of
+ * position — they have no cap reason to push cash forward.
  */
 interface ArchetypeModifier {
   /** Additive delta applied to the sampled signing-bonus share. */
   bonusShareDelta: number;
-  voidYearChance: number;
-  maxVoidYears: number;
+  voidYearMultiplier: number;
+  maxVoidYearsCeiling: number;
 }
 
 const ARCHETYPE_MODIFIER: Record<CapArchetype, ArchetypeModifier> = {
   "cap-hell": {
     bonusShareDelta: 0.20,
-    voidYearChance: 0.6,
-    maxVoidYears: 2,
+    voidYearMultiplier: 1.6,
+    maxVoidYearsCeiling: 3,
   },
   tight: {
     bonusShareDelta: 0.10,
-    voidYearChance: 0.3,
-    maxVoidYears: 1,
+    voidYearMultiplier: 1.3,
+    maxVoidYearsCeiling: 2,
   },
   balanced: {
     bonusShareDelta: 0.05,
-    voidYearChance: 0.15,
-    maxVoidYears: 1,
+    voidYearMultiplier: 1.0,
+    maxVoidYearsCeiling: 2,
   },
   flush: {
     bonusShareDelta: -0.10,
-    voidYearChance: 0,
-    maxVoidYears: 0,
+    voidYearMultiplier: 0,
+    maxVoidYearsCeiling: 0,
   },
 };
+
+/**
+ * Position × market-tier void-year priors. Sourced from the
+ * qualitative OTC tracking summarised in
+ * `data/docs/contract-structure.md` and issue #532: top-10 QB deals
+ * carry void years ~30%+ of the time, top-10 EDGE ~20%+, top-10
+ * IDL/WR/OT meaningful but lower, RB/S/CB/specialists rare. The
+ * published OTC feed does not mark void years directly — the band
+ * file's numeric `void_year_usage_rate_by_position` understates real
+ * usage by an order of magnitude. We use the qualitative priors
+ * instead, per the doc's "Known gaps" note.
+ *
+ * TODO(#557): restructure mechanics (post-Y2/Y3 base-to-bonus
+ * conversion, per-team post-June-1 designation) remain deferred —
+ * tracked separately as the restructure follow-up to #532.
+ */
+interface VoidYearPrior {
+  chance: number;
+  maxYears: number;
+}
+
+const VOID_YEAR_REST_PRIOR: VoidYearPrior = { chance: 0, maxYears: 0 };
+
+const VOID_YEAR_PRIOR_BY_POSITION: Record<
+  NeutralBucket,
+  Record<AavTier, VoidYearPrior>
+> = {
+  QB: {
+    top_10: { chance: 0.35, maxYears: 2 },
+    top_25: { chance: 0.18, maxYears: 2 },
+    top_50: { chance: 0.05, maxYears: 1 },
+    rest: VOID_YEAR_REST_PRIOR,
+  },
+  EDGE: {
+    top_10: { chance: 0.22, maxYears: 2 },
+    top_25: { chance: 0.1, maxYears: 2 },
+    top_50: { chance: 0.03, maxYears: 1 },
+    rest: VOID_YEAR_REST_PRIOR,
+  },
+  IDL: {
+    top_10: { chance: 0.12, maxYears: 2 },
+    top_25: { chance: 0.06, maxYears: 1 },
+    top_50: { chance: 0.02, maxYears: 1 },
+    rest: VOID_YEAR_REST_PRIOR,
+  },
+  WR: {
+    top_10: { chance: 0.12, maxYears: 2 },
+    top_25: { chance: 0.06, maxYears: 1 },
+    top_50: { chance: 0.02, maxYears: 1 },
+    rest: VOID_YEAR_REST_PRIOR,
+  },
+  OT: {
+    top_10: { chance: 0.1, maxYears: 2 },
+    top_25: { chance: 0.05, maxYears: 1 },
+    top_50: { chance: 0.02, maxYears: 1 },
+    rest: VOID_YEAR_REST_PRIOR,
+  },
+  IOL: {
+    top_10: { chance: 0.07, maxYears: 1 },
+    top_25: { chance: 0.03, maxYears: 1 },
+    top_50: { chance: 0.01, maxYears: 1 },
+    rest: VOID_YEAR_REST_PRIOR,
+  },
+  TE: {
+    top_10: { chance: 0.06, maxYears: 1 },
+    top_25: { chance: 0.03, maxYears: 1 },
+    top_50: { chance: 0.01, maxYears: 1 },
+    rest: VOID_YEAR_REST_PRIOR,
+  },
+  LB: {
+    top_10: { chance: 0.05, maxYears: 1 },
+    top_25: { chance: 0.02, maxYears: 1 },
+    top_50: { chance: 0.01, maxYears: 1 },
+    rest: VOID_YEAR_REST_PRIOR,
+  },
+  RB: {
+    top_10: { chance: 0.03, maxYears: 1 },
+    top_25: { chance: 0.01, maxYears: 1 },
+    top_50: VOID_YEAR_REST_PRIOR,
+    rest: VOID_YEAR_REST_PRIOR,
+  },
+  CB: {
+    top_10: { chance: 0.03, maxYears: 1 },
+    top_25: { chance: 0.01, maxYears: 1 },
+    top_50: VOID_YEAR_REST_PRIOR,
+    rest: VOID_YEAR_REST_PRIOR,
+  },
+  S: {
+    top_10: { chance: 0.03, maxYears: 1 },
+    top_25: { chance: 0.01, maxYears: 1 },
+    top_50: VOID_YEAR_REST_PRIOR,
+    rest: VOID_YEAR_REST_PRIOR,
+  },
+  K: {
+    top_10: { chance: 0.01, maxYears: 1 },
+    top_25: VOID_YEAR_REST_PRIOR,
+    top_50: VOID_YEAR_REST_PRIOR,
+    rest: VOID_YEAR_REST_PRIOR,
+  },
+  P: {
+    top_10: { chance: 0.01, maxYears: 1 },
+    top_25: VOID_YEAR_REST_PRIOR,
+    top_50: VOID_YEAR_REST_PRIOR,
+    rest: VOID_YEAR_REST_PRIOR,
+  },
+  LS: {
+    top_10: VOID_YEAR_REST_PRIOR,
+    top_25: VOID_YEAR_REST_PRIOR,
+    top_50: VOID_YEAR_REST_PRIOR,
+    rest: VOID_YEAR_REST_PRIOR,
+  },
+};
+
+export function getVoidYearPrior(
+  bucket: NeutralBucket,
+  tier: AavTier,
+): VoidYearPrior {
+  return VOID_YEAR_PRIOR_BY_POSITION[bucket][tier];
+}
 
 function clampRatio(value: number): number {
   return Math.max(0, Math.min(0.95, value));
@@ -1055,15 +1180,27 @@ export function rollVeteranContract(
   const signingBonus = Math.round(totalValue * bonusRatio);
   const remainingBase = totalValue - signingBonus;
 
-  // Void years are an archetype lever only — the league-wide per-
-  // position rate is effectively zero in the data (see
-  // void_year_usage_rate_by_position in contract-structure.json).
+  // Void-year usage is primarily position-driven: the issue #532
+  // qualitative priors (top-10 QB ~30%+, EDGE ~20%+, others lower,
+  // RB/CB/S/specialists rare) drive the base rate, and the team cap
+  // archetype acts as a multiplier and a ceiling on max void years.
+  // A flush team zeroes the multiplier and the ceiling — they have
+  // no cap reason to push cash forward regardless of position.
   let voidYears = 0;
+  const positionVoidPrior = getVoidYearPrior(args.bucket, args.marketTier);
+  const voidChance = Math.max(
+    0,
+    Math.min(0.95, positionVoidPrior.chance * modifier.voidYearMultiplier),
+  );
+  const effectiveMaxVoidYears = Math.min(
+    positionVoidPrior.maxYears,
+    modifier.maxVoidYearsCeiling,
+  );
   if (
-    modifier.maxVoidYears > 0 && realYears >= 2 &&
-    rng.next() < modifier.voidYearChance
+    effectiveMaxVoidYears > 0 && realYears >= 2 &&
+    rng.next() < voidChance
   ) {
-    voidYears = rng.int(1, modifier.maxVoidYears);
+    voidYears = rng.int(1, effectiveMaxVoidYears);
   }
   const totalYears = realYears + voidYears;
 


### PR DESCRIPTION
## Summary

- `rollVeteranContract` previously drove void-year usage purely off the team cap archetype, so every position had the same void-year rate at a given archetype. Real NFL usage is position-driven.
- Adds `VOID_YEAR_PRIOR_BY_POSITION` (neutral bucket × market tier) matching the qualitative OTC priors in `data/docs/contract-structure.md` and #532: top-10 QB ~35%, top-10 EDGE ~22%, top-10 IDL/WR/OT 10-12%, top-10 RB/CB/S ~3%, specialists near zero. Sub-top-10 tiers scale down; `rest` is zero.
- Restates the archetype lever as a multiplier (cap-hell 1.6×, tight 1.3×, balanced 1.0×, flush 0) + max-years ceiling that composes with the position prior. Flush teams still zero void-year usage regardless of position.
- Restructure mechanics and post-June-1 cut designation (Proposal items 2 and 3 of #532) remain deferred and are tracked in follow-up #557.