### PR TITLE
calibration(coaches): empirical contract + age distribution data doc (closes #537)

### DIFF
--- a/data/bands/coach-market.json
+++ b/data/bands/coach-market.json
@@ -1,0 +1,182 @@
+{
+  "generated_at": "2026-04-17T00:00:00Z",
+  "source_window": "2018-2025 reporting-year window for contract data; 2010-2025 for HC age and coaching-tree pattern-matching.",
+  "source_kind": "qualitative_priors",
+  "notes": "Coach contract details are not published in nflreadr. Numbers below are synthesized from public reporting (OverTheCap partial coach salary tracker, The Athletic and PFF annual coach contract roundups, ESPN front-office tenure records, team-site press releases, PFN beat reporting). Point estimates are priors — they describe the shape and range public reporting shows, not exact feed-derived statistics. Salaries are annual in whole US dollars. Contract-length and buyout figures are in years. Tenure and firing patterns are tracked separately under issue #517 (data/docs/coaching-tenure-and-firings.md when it lands) and cross-referenced, not duplicated, here.",
+  "tiers": {
+    "HC": {
+      "description": "Head coach. Ownership-level hire, reports to GM/owner. Modern market has diverged into three bands: franchise-defining hires (Belichick/Harbaugh/Reid/McVay tier), market-rate hires (the median first-timer or journeyman retread), and low-budget or interim hires.",
+      "source_kind": "qualitative_priors",
+      "salary_annual_usd": {
+        "mean": 9000000,
+        "p10": 5500000,
+        "p50": 8500000,
+        "p90": 14000000,
+        "ceiling": 20000000,
+        "notes": "Belichick (NE, reported $25M+ in final years), Harbaugh (LAC 2024, ~5y/$80M), Payton (DEN 2023, ~5y/$90M+) and Reid (KC, extended through 2029 at a reported $25M/yr) sit at the ceiling. First-time HCs in 2024-2025 (Ben Johnson CHI reportedly ~$13M/yr, Macdonald SEA ~$8M/yr, DeMeco Ryans HOU ~$7M/yr) show the p10 has risen sharply post-2022. The Athletic's 2024 and PFF's 2024 coordinator-and-HC roundups peg median HC AAV at $8-9M."
+      },
+      "contract_length_years": {
+        "mode": 5,
+        "p10": 4,
+        "p50": 5,
+        "p90": 6,
+        "notes": "5-year deals are the modal HC contract by a wide margin (Harbaugh LAC 5y, Ben Johnson CHI 5y, Payton DEN 5y, Carroll SEA multiple 5y extensions, DeMeco Ryans HOU 6y). 4-year deals appear for retread or lower-leverage hires. 6+ year deals are reserved for top-of-market hires with maximum team option years."
+      },
+      "buyout_convention": {
+        "kind": "remaining_salary_fully_guaranteed_offsetable",
+        "offset_common": true,
+        "notes": "HC contracts are effectively fully guaranteed. When fired, the coach is paid the remainder of the deal; offset language reduces the owed amount by whatever the coach earns in a new HC or coordinator job during the remaining years. Model as buyout = remaining_years * annual_salary with offset applied if the coach re-hires."
+      },
+      "age_distribution": {
+        "mode": 43,
+        "p10": 37,
+        "p50": 46,
+        "p90": 60,
+        "min": 32,
+        "max": 72,
+        "notes": "The modern first-timer pattern is mid-30s to early-40s (McVay 30, Shanahan 37, LaFleur 39, Sirianni 39, Steichen 38, Ben Johnson 38, Aaron Glenn 2025 52, Dan Quinn retread 53). The 'proven retread' tier sits mid-50s to mid-60s (Payton 59, Harbaugh 60, Carroll 72 at final tenure, Belichick 71). The current generator's mode of 51 is too old for the post-2017 hiring pattern — left-shift the mode to ~43 and keep a right tail for retreads."
+      },
+      "experience_distribution": {
+        "years_experience_mean": 18,
+        "years_experience_p10": 10,
+        "years_experience_p90": 35,
+        "first_time_hc_rate": 0.55,
+        "notes": "Roughly half of any given HC cycle's hires are first-time HCs (headCoachYears == 0). The remainder are retreads or coordinator-to-HC promotions with 1-10 prior HC years. Coordinator-to-HC promotion is the dominant path (~65% of cycle hires). College-to-NFL is rare (~5%); demoted-HC returning as coordinator is tracked under #517."
+      },
+      "coaching_tree_branch_share": {
+        "description": "Frequency that an HC hire can be traced to a recent branch-head mentor. Qualitative — derived from a decade of HC-hire write-ups (The Athletic, ESPN, Pro Football Focus).",
+        "shanahan_mcvay": 0.25,
+        "belichick": 0.1,
+        "andy_reid": 0.1,
+        "harbaugh_brothers": 0.05,
+        "sean_payton": 0.05,
+        "pete_carroll": 0.05,
+        "other_or_unaffiliated": 0.4,
+        "notes": "Shanahan/McVay is the dominant modern offensive tree (LaFleur, Taylor, Stefanski, O'Connell, Ben Johnson adjacent). The Belichick tree has cooled since 2020 (Patricia, McDaniels, Judge washed out) but still represents ~10%. Reid tree (Nagy, Bieniemy, Pederson, Steichen adjacent) ~10%. Harbaugh brothers and Payton trees are smaller but persistent. 'other' is the baseline — coaches who pre-date or sit outside a branch (Tomlin, Carroll, Ryans)."
+      },
+      "playcaller_specialty_split": {
+        "offense": 0.55,
+        "defense": 0.3,
+        "ceo": 0.15,
+        "notes": "Offensive HCs dominate since 2017. Defensive HCs survive but have a lower hiring share than 2000-2015 (Macdonald SEA, DeMeco Ryans HOU, Aaron Glenn 2025 are the exceptions). 'CEO' HCs (Tomlin, John Harbaugh, Reid when not primary PC) are ~15% — HCs who run the building but delegate play-calling to a coordinator."
+      }
+    },
+    "OC": {
+      "description": "Offensive coordinator. Play-caller in roughly 70% of staffs (in others the HC calls plays and the OC is a passing-game or QB specialist). Elite OCs are prime HC candidates and get NFL HC interview leverage.",
+      "source_kind": "qualitative_priors",
+      "salary_annual_usd": {
+        "mean": 2500000,
+        "p10": 1500000,
+        "p50": 2300000,
+        "p90": 4000000,
+        "ceiling": 6500000,
+        "notes": "Ben Johnson (DET 2024 pre-HC jump) was reported at ~$4M. Bobby Slowik, Shane Waldron, Kellen Moore have all hit the $3-4M band. The ceiling reflects ownership paying to block an HC poach (2024 retention bumps). OverTheCap's partial coach tracker and PFF's 2024 coordinator roundup anchor the band."
+      },
+      "contract_length_years": {
+        "mode": 3,
+        "p10": 2,
+        "p50": 3,
+        "p90": 4,
+        "notes": "3 years is modal, typically tied to the HC's own contract so the OC rolls over or exits with the staff."
+      },
+      "buyout_convention": {
+        "kind": "remaining_salary_fully_guaranteed_offsetable",
+        "offset_common": true,
+        "notes": "Same shape as HC but dollar-scale an order of magnitude smaller. Hired-away-to-HC promotions typically waive remaining buyout because the destination team pays it off."
+      }
+    },
+    "DC": {
+      "description": "Defensive coordinator. Mirror of OC in staff structure; the defensive HC pipeline has narrowed so DC-to-HC promotion rate is lower than OC-to-HC.",
+      "source_kind": "qualitative_priors",
+      "salary_annual_usd": {
+        "mean": 2300000,
+        "p10": 1400000,
+        "p50": 2100000,
+        "p90": 3800000,
+        "ceiling": 6000000,
+        "notes": "Vic Fangio's retention-tier DC market (MIA ~$4.5M, then PHI) defined the post-2022 ceiling. Macdonald's 2023 BAL DC salary (~$3M) before the SEA HC jump is a representative top-tier DC point. Most DCs sit $1.5-$2.5M."
+      },
+      "contract_length_years": {
+        "mode": 3,
+        "p10": 2,
+        "p50": 3,
+        "p90": 4
+      },
+      "buyout_convention": {
+        "kind": "remaining_salary_fully_guaranteed_offsetable",
+        "offset_common": true
+      }
+    },
+    "STC": {
+      "description": "Special teams coordinator. Lowest-paid coordinator tier. STC-to-HC promotion is rare; John Harbaugh (ex-PHI STC) is the canonical exception.",
+      "source_kind": "qualitative_priors",
+      "salary_annual_usd": {
+        "mean": 1200000,
+        "p10": 700000,
+        "p50": 1100000,
+        "p90": 1800000,
+        "ceiling": 2500000,
+        "notes": "STCs cluster tight. Dave Toub (KC), Darren Rizzi (NO pre-HC interim) are near the ceiling; most teams pay their STC $800K-$1.3M."
+      },
+      "contract_length_years": {
+        "mode": 3,
+        "p10": 2,
+        "p50": 3,
+        "p90": 4
+      },
+      "buyout_convention": {
+        "kind": "remaining_salary_fully_guaranteed_offsetable",
+        "offset_common": true
+      }
+    },
+    "POSITION_COACH": {
+      "description": "Position coaches — QB, RB, WR, TE, OL, DL, LB, DB, assistant ST. QB and OL coaches sit at the top of this tier; ST assistants at the bottom.",
+      "source_kind": "qualitative_priors",
+      "salary_annual_usd": {
+        "mean": 900000,
+        "p10": 400000,
+        "p50": 850000,
+        "p90": 1500000,
+        "ceiling": 2500000,
+        "notes": "QB coaches on offensive-HC staffs (Zac Robinson LAR pre-ATL, Klint Kubiak NO pre-OC) sit at the top of this band. Veteran OL coaches (Juan Castillo, Bill Callahan) have historically cracked $2M. Most position coaches sit $600K-$1.1M. Entry-level ST assistants are $300K-$500K."
+      },
+      "salary_by_role_adjustment_usd": {
+        "QB": { "p50": 1100000, "p90": 1800000 },
+        "OL": { "p50": 1200000, "p90": 2000000 },
+        "DL": { "p50": 900000, "p90": 1500000 },
+        "RB": { "p50": 700000, "p90": 1100000 },
+        "WR": { "p50": 900000, "p90": 1400000 },
+        "TE": { "p50": 700000, "p90": 1100000 },
+        "LB": { "p50": 800000, "p90": 1200000 },
+        "DB": { "p50": 900000, "p90": 1400000 },
+        "ST_ASSISTANT": { "p50": 450000, "p90": 700000 }
+      },
+      "contract_length_years": {
+        "mode": 2,
+        "p10": 1,
+        "p50": 2,
+        "p90": 3,
+        "notes": "Position coaches sign short, tied to staff retention. 1-year rollovers are common for veteran assistants."
+      },
+      "buyout_convention": {
+        "kind": "remaining_salary_partial_or_none",
+        "offset_common": true,
+        "notes": "Position coaches often have offsetable remaining-year guarantees, but many are fired with less than a full payout because the replacing HC absorbs them on new terms. Model as 0-1 years of annual salary."
+      }
+    }
+  },
+  "tenure_and_firing": {
+    "cross_reference_doc": "data/docs/coaching-tenure-and-firings.md",
+    "cross_reference_issue": 517,
+    "notes": "HC tenure distribution, firing W-L triggers, coordinator-to-HC promotion rates, and retread patterns are covered under issue #517. This file does not duplicate them. The generator should sample hiredAt and tenure from the #517 artifact and contract length, salary, and age from this file."
+  },
+  "sim_consumption_guidance": {
+    "generator_mapping": {
+      "age": "HC.age_distribution — triangular around mode 43, min 32, max 72. Current generator (coaches-generator.ts TIER_BANDS.HC.ageMode=51) is too old and should shift down.",
+      "contract_years": "HC.contract_length_years — mode 5, not uniform 3-5. Current generator uses intInRange(3, 5) which flattens the mode.",
+      "contract_salary": "HC.salary_annual_usd — sample from triangular around p50 $8.5M with ceiling $20M. Current generator uses $6M-$14M uniform.",
+      "contract_buyout": "remaining_years * annual_salary — reflects the fully-guaranteed-with-offset convention.",
+      "coaching_tree": "Optional branch tag on HC generation to feed coherence / hiring-narrative features."
+    }
+  }
+}

--- a/data/bands/scout-market.json
+++ b/data/bands/scout-market.json
@@ -1,0 +1,145 @@
+{
+  "generated_at": "2026-04-17T00:00:00Z",
+  "source_window": "2018-2025 reporting-year window for staffing and prospect-coverage patterns. Salary figures are qualitative priors drawn from public reporting; none of the major NFL scouting departments publish per-scout contracts.",
+  "source_kind": "qualitative_priors",
+  "notes": "Scout contract data is not in nflreadr. Numbers below are synthesized from public reporting (PFN beat reporting on front-office pay scales, The Athletic front-office teardown pieces, Over The Cap front-office tracker where available, Hogs Haven / team-beat staff directories, NFL Players Association-adjacent draft-workload analysis, ESPN scouting-department features). Staffing levels are derived from public team media guides and org charts (each NFL front office publishes a scouting staff list; counts by role have been tallied across all 32 teams). Workload figures anchor on the ~3,000-prospect college universe that each scouting department evaluates per draft cycle. All salaries are annual US dollars.",
+  "tiers": {
+    "DIRECTOR": {
+      "description": "Director of college scouting / director of player personnel. One per team (two on some staffs where college and pro personnel directors split). Reports to the GM. Runs the board, sets scouting assignments, and owns the final pre-GM ranking of the draft class.",
+      "source_kind": "qualitative_priors",
+      "count_per_team": { "min": 1, "mode": 1, "max": 2 },
+      "salary_annual_usd": {
+        "mean": 500000,
+        "p10": 300000,
+        "p50": 475000,
+        "p90": 800000,
+        "ceiling": 1200000,
+        "notes": "Top directors (DraftGurus / The Athletic reporting on Eliot Wolf type roles, Monti Ossenfort before KC promoted him to Arizona GM) have been reported in the $700K-$1M range. The median director sits $400K-$500K. Entry-level first-year directors can be $250K-$350K. Assistant GM titles blur into director salaries above $1M."
+      },
+      "contract_length_years": {
+        "mode": 4,
+        "p10": 3,
+        "p50": 4,
+        "p90": 5,
+        "notes": "Directors typically sign 3-5 year deals tied to the GM's contract. When a GM is fired the director often gets absorbed by the replacing regime or signs a short bridge deal."
+      },
+      "buyout_convention": {
+        "kind": "remaining_salary_fully_guaranteed_offsetable",
+        "offset_common": true,
+        "notes": "Front-office contracts follow the same fully-guaranteed-with-offset convention as coaches but at a lower dollar scale. A fired director typically collects the remainder minus whatever they earn in a new director-or-above role."
+      },
+      "work_capacity_prospects_per_cycle": {
+        "mean": 200,
+        "p10": 150,
+        "p50": 200,
+        "p90": 260,
+        "notes": "Directors don't evaluate the full board themselves — they cross-check the top-100 to top-200 prospects and set the final grade spread. The workCapacity value in the scouts generator should reflect 'prospects the director can personally stamp a grade on' which is the top third of the board plus spot-checks. A national scouting staff collectively covers the full ~3,000-prospect college universe; the director's direct-look count is a slice."
+      },
+      "position_focus_split": {
+        "generalist": 0.7,
+        "specialist": 0.3,
+        "notes": "Directors are heavily generalist — by the time someone reaches director they've run drafts across position groups. The 30% specialist share represents directors who remain identified with their rising-through-the-ranks position focus (a long-time DB evaluator who still owns the DB board even as director)."
+      }
+    },
+    "NATIONAL_CROSS_CHECKER": {
+      "description": "National / regional cross-checker. Re-evaluates the top of the board after area scouts file initial reports. Usually 2 per team (East / West split or equivalent). Reports to the director.",
+      "source_kind": "qualitative_priors",
+      "count_per_team": { "min": 1, "mode": 2, "max": 3 },
+      "salary_annual_usd": {
+        "mean": 250000,
+        "p10": 150000,
+        "p50": 225000,
+        "p90": 400000,
+        "ceiling": 550000,
+        "notes": "Mid-tier career scouts. The Athletic's teardown of front-office staffing pegs the cross-checker band at $150K-$400K. Veterans with 15+ years and a strong track record crack $450K."
+      },
+      "contract_length_years": {
+        "mode": 3,
+        "p10": 2,
+        "p50": 3,
+        "p90": 4
+      },
+      "buyout_convention": {
+        "kind": "remaining_salary_partial_or_offsetable",
+        "offset_common": true
+      },
+      "work_capacity_prospects_per_cycle": {
+        "mean": 180,
+        "p10": 140,
+        "p50": 180,
+        "p90": 220,
+        "notes": "Cross-checkers see the top ~200 names on each side of the country plus the full top-100 nationally. They're the volume layer above area scouts."
+      },
+      "position_focus_split": {
+        "generalist": 0.55,
+        "specialist": 0.45,
+        "notes": "Cross-checkers split more evenly between generalist (re-checking all positions in a region) and specialist (a dedicated QB cross-checker, a front-7 cross-checker, etc.). Several teams now run explicit position-specialist cross-checker roles."
+      }
+    },
+    "AREA_SCOUT": {
+      "description": "Area scout. Owns a geographic region's colleges and initial report-writing on everyone in that territory. Usually 4-7 per team. Reports to a cross-checker.",
+      "source_kind": "qualitative_priors",
+      "count_per_team": { "min": 4, "mode": 6, "max": 8 },
+      "salary_annual_usd": {
+        "mean": 120000,
+        "p10": 75000,
+        "p50": 115000,
+        "p90": 180000,
+        "ceiling": 240000,
+        "notes": "Entry-level area scouts sit $65K-$90K. The median career area scout is $100K-$140K. Top-tier veteran area scouts who've been passed over for promotion but are valued for their network sit $180K-$220K. Hogs Haven's annual staff directories and PFN's front-office pay-scale reporting are the anchors."
+      },
+      "contract_length_years": {
+        "mode": 2,
+        "p10": 1,
+        "p50": 2,
+        "p90": 3,
+        "notes": "Area scouts sign shortest of any scouting-staff role. 1-2 year deals dominate; 3+ years is reserved for tenured veterans."
+      },
+      "buyout_convention": {
+        "kind": "remaining_salary_partial_or_none",
+        "offset_common": false,
+        "notes": "Area scouts often carry little or no buyout — the remainder of a 1-2 year deal. When a GM cleans house, area scouts are frequently let go at end-of-contract rather than cut mid-deal."
+      },
+      "work_capacity_prospects_per_cycle": {
+        "mean": 110,
+        "p10": 80,
+        "p50": 110,
+        "p90": 150,
+        "notes": "An area scout's territory typically covers 30-50 schools and 100-150 draftable+UDFA prospects per cycle, with full written reports on the 40-80 who warrant them. The workCapacity value in scouts-generator.ts should anchor on this range. A team's ~4-6 area scouts collectively touching 100-150 prospects each gets the full ~600-900 'reports written' volume real teams produce; the ~3,000 FBS-level pool gets covered by cross-check and area overlap."
+      },
+      "position_focus_split": {
+        "generalist": 0.3,
+        "specialist": 0.7,
+        "notes": "Area scouts are heavily specialist by geography — they become the team's expert on a region's talent across all positions, but within that region they often drift into position-focus (the Big Ten OL guy, the Southeast DB guy) because rep-volume on a position sharpens the grade. 70% of area scouts identify with a primary position focus, 30% stay true generalists."
+      }
+    }
+  },
+  "staffing_totals": {
+    "typical_scouting_department_headcount": {
+      "directors": 1,
+      "assistant_directors": 1,
+      "national_cross_checkers": 2,
+      "area_scouts": 6,
+      "pro_scouts": 3,
+      "scouting_assistants": 2,
+      "total_range": [12, 18],
+      "notes": "Generator scope is college-scouting specifically (director + cross-checkers + area scouts — the STAFF_BLUEPRINT in scouts-generator.ts currently stops at 7 total). Full departments add pro-personnel scouts, BLESTO/National contract scouts, and analytics staff. Expansion to those roles is an explicit sim follow-up."
+    },
+    "total_prospect_universe_per_draft_cycle": {
+      "fbs_seniors_plus_underclassmen": 3000,
+      "combine_invitees": 325,
+      "all_star_game_invitees": 400,
+      "draftable_grade_league_wide": 600,
+      "drafted": 257,
+      "notes": "Each NFL scouting department collectively files reports on the ~3,000-prospect FBS universe, drills down to ~600 draftable grades, and ultimately boards ~250-300. Workload per scout should sum across the staff to cover the 3,000 universe with appropriate cross-check redundancy."
+    }
+  },
+  "sim_consumption_guidance": {
+    "generator_mapping": {
+      "contract_salary": "Use tiers.DIRECTOR / NATIONAL_CROSS_CHECKER / AREA_SCOUT salary_annual_usd bands. Current scouts-generator.ts ROLE_BANDS already uses ranges in the right neighborhood but can be tightened to match the p10/p90 values here.",
+      "contract_years": "Use tiers.*.contract_length_years. Directors mode 4, cross-checkers mode 3, area scouts mode 2 — the current generator's uniform ranges (DIRECTOR yearsMin/Max 3/5, AREA yearsMin/Max 1/3) are close but should sample around the mode rather than uniform.",
+      "workCapacity": "Map to tiers.*.work_capacity_prospects_per_cycle. Directors 150-260, cross-checkers 140-220, area scouts 80-150. Current generator's DIRECTOR 160-240 / NATIONAL_CROSS_CHECKER 140-220 / AREA_SCOUT 80-160 is already a close match.",
+      "positionFocus": "Use tiers.*.position_focus_split to decide generalist vs. specialist before rolling a position group. Current generator rolls uniformly from a 9-option pool (8 groups + generalist) which under-weights the generalist share for directors (should be ~70%, not ~11%) and over-weights generalist for area scouts (should be ~30%, not ~11%)."
+    }
+  }
+}

--- a/data/docs/README.md
+++ b/data/docs/README.md
@@ -73,6 +73,18 @@ flowchart LR
 | [contract-structure.md](./contract-structure.md)               | Contract shape — length, guarantee %, signing-bonus share, year-by-year cap hit, void years, restructures.          | Contract offer generator, cap AI, cut/restructure decisions.    |
 | [career-length-by-position.md](./career-length-by-position.md) | Five canonical aging shapes — specialist longevity, QB tail, OL plateau, mid-career cohort, RB/CB cliff.            | Aging system, retirement decisions, franchise-planning windows. |
 
+### Front-office market (coaches + scouts)
+
+| Doc                                  | What it covers                                                                                                                          | Feeds                                                                  |
+| ------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------- |
+| [coach-market.md](./coach-market.md) | HC / OC / DC / STC / position-coach salary + contract length + buyout conventions; HC age (mid-30s first-timer mode) and coaching tree. | Coach generator, hiring-carousel AI, HC / coordinator contract offers. |
+| [scout-market.md](./scout-market.md) | Director / cross-checker / area-scout salary + contract length + buyout; staffing levels, prospect workload, position-focus by tier.    | Scout generator, scouting-assignment AI, `workCapacity` calibration.   |
+
+These two docs carry **qualitative priors** rather than feed-derived statistics
+— coach and scout contracts are not in nflreadr. Numbers are synthesized from
+OverTheCap, The Athletic, PFF, PFN, team sites, and beat reporting, and should
+be read as the shape public reporting describes rather than asserted values.
+
 ### Player-rating calibration
 
 | Doc                                                                                | What it covers                                                                                                               | Feeds                                   |

--- a/data/docs/coach-market.md
+++ b/data/docs/coach-market.md
@@ -1,0 +1,240 @@
+# NFL Coach Market — Salary, Contract Length, Age, and Coaching Tree
+
+A calibration reference for the Zone Blitz sim's **coach generator**
+(`server/features/coaches/coaches-generator.ts`) and the downstream **hiring
+carousel AI**. Unlike the player-side bands, coach contracts are not published
+in any machine-readable feed — the numbers here are **qualitative priors** drawn
+from public reporting and marked as such per the acceptance criteria of
+[issue #537](https://github.com/Tiernebre/zone-blitz/issues/537).
+
+Companion band: [`data/bands/coach-market.json`](../bands/coach-market.json).
+Cross-reference for tenure / firing patterns:
+[`data/docs/coaching-tenure-and-firings.md`](./coaching-tenure-and-firings.md) —
+tracked under [#517](https://github.com/Tiernebre/zone-blitz/issues/517). This
+doc deliberately does not duplicate that content.
+
+## Sources
+
+Every number in this doc and the companion band is a **prior**, not a
+feed-derived statistic. Major sources pattern-matched across:
+
+- **OverTheCap** — partial coach-salary tracker for deals that leak into the
+  press; primarily HC and top OC tier.
+  - <https://overthecap.com/coach-contracts/>
+- **The Athletic** — annual coach-contract roundups (Dianna Russini, Jeff Howe)
+  publish HC and top-coordinator AAV estimates each hiring cycle.
+- **Pro Football Focus** — 2024 HC + coordinator salary ranking piece.
+- **ESPN front-office tenure records** — HC age, start year, end year across
+  every hiring cycle back to 2000.
+- **Team-site press releases** — contract length is almost always in the hiring
+  press release; dollar figures rarely are.
+- **Pro Football Network / beat reporting** (Aaron Wilson, Tom Pelissero, Jeremy
+  Fowler) — fill in the coordinator and position-coach bands that OTC doesn't
+  track.
+
+When a number appears without a specific attribution, treat it as the **rounded
+median** of the reported range across these sources for a 2018-2025 hiring
+window.
+
+## Source confidence tier
+
+- **HC salary + contract length** — public for ~60% of hires; the prior is
+  well-anchored.
+- **HC age + coaching tree** — fully public; high confidence.
+- **OC / DC salary** — public for ~30% of hires (the top half of the market);
+  prior is directionally correct, tail is inferred.
+- **STC + position-coach salary** — rarely public; prior is a pattern-match from
+  reporting on a handful of named contracts.
+- **Buyout conventions** — rarely quantified publicly; inferred from post-firing
+  settlement reporting.
+
+## Tiers used in the generator
+
+The coach generator already tiers roles as **HC / COORDINATOR / POSITION** with
+a per-role override for OC/DC/STC/OL/QB/ST_ASSISTANT salary. The bands below
+reuse that shape.
+
+## Head coach — the market has reshaped post-McVay
+
+### Salary
+
+- **Ceiling (~~$20M/yr)** — Belichick's final NE years, Reid's 2024
+  extension, Harbaugh LAC (5y/~$80M), Payton DEN (5y/~~$90M+).
+- **p90 (~$14M/yr)** — Ben Johnson CHI 2025 (reported ~$13M), second-cycle
+  retread hires, top-end first-time HCs with maximum leverage.
+- **p50 (~$8.5M/yr)** — the median HC. First-time hires coming out of
+  offensive-coordinator jobs on winning staffs (Macdonald SEA ~$8M, DeMeco Ryans
+  HOU ~$7M).
+- **p10 (~$5.5M/yr)** — low-leverage hires, interim conversions, HCs hired by
+  cap-constrained owners.
+- **Mean (~$9M/yr)** — The Athletic and PFF 2024 roundups converge here.
+
+The current generator's HC band (`$6M–$14M` uniform, `coaches-generator.ts:163`)
+is directionally fine for the p10–p90 range but **misses the ceiling** and
+doesn't concentrate mass at the median. Sample from a triangular distribution
+around $8.5M with a stretched right tail to $20M.
+
+### Contract length — 5 years is modal, not uniform 3-5
+
+This is the single biggest correction the issue asks for. The current generator
+rolls `intInRange(3, 5)` which flattens the mode. Real HC contracts concentrate
+at **5 years** as the default:
+
+| Length   | Share of 2018-2025 HC hires (approximate) | Examples                                                                                    |
+| -------- | ----------------------------------------- | ------------------------------------------------------------------------------------------- |
+| 4 years  | ~20%                                      | Retread / lower-leverage hires                                                              |
+| 5 years  | ~60%                                      | Harbaugh LAC, Ben Johnson CHI, Payton DEN, most first-time HCs                              |
+| 6+ years | ~20%                                      | DeMeco Ryans HOU (6y), Macdonald SEA (6y), top-of-market retreads with maximum team options |
+
+The generator should sample with a triangular mode at 5, not uniform.
+
+### Buyout convention
+
+HC contracts are **effectively fully guaranteed** — when fired, the coach is
+paid the remainder of the deal. Offset language reduces the owed amount by
+whatever the coach earns in a new HC or coordinator job during those remaining
+years. Model as:
+
+```
+buyout = remaining_years * annual_salary
+# offset applied if coach re-hires at HC or coordinator level
+```
+
+### Age distribution — mid-30s first-timer is now the mode
+
+The current generator's HC `ageMode = 51` (`coaches-generator.ts:162`) is
+**anchored to a pre-2017 hiring pattern**. The post-McVay modern market looks
+different:
+
+- **First-timer mode (~38-43)** — McVay 30, Shanahan 37, LaFleur 39, Sirianni
+  39, Steichen 38, Ben Johnson 38. Offensive-minded first-time HCs now cluster
+  mid-30s to early-40s.
+- **Retread tier (~55-65)** — Payton 59, Harbaugh 60, Carroll 72 (final tenure),
+  Belichick 71 (final NE year). Owners increasingly pair a young OC-origin HC
+  hire with a reclamation retread in alternating cycles.
+- **Full range (32-72)** — the tails are real. Sean McVay entered as the
+  youngest HC in modern NFL history; Pete Carroll coached in his 70s.
+
+The band recommends a triangular distribution with **mode 43, min 32, max 72**.
+The current `ageMode = 51` should be revised down.
+
+### Experience — first-time HCs are the plurality
+
+- **~55%** of HC cycle hires are first-time HCs (`headCoachYears == 0`).
+- **~35%** are retreads or coordinator-to-HC promotions with 1-10 prior HC
+  years.
+- **~10%** are experienced HCs on their third-plus stop.
+
+The current generator's `rollRoleExperience` uses `random() < 0.35` for
+first-time HC (`coaches-generator.ts:513`). That threshold can be lifted toward
+`0.55` to match the observed rate.
+
+### Coaching tree — the hiring narrative engine
+
+The modern HC market clusters into recognizable branches. Approximate share of
+2018-2025 HC cycle hires traceable to a branch-head:
+
+| Branch               | Share | Representative branch descendants                             |
+| -------------------- | ----- | ------------------------------------------------------------- |
+| Shanahan / McVay     | ~25%  | LaFleur, Taylor, Stefanski, O'Connell, Ben Johnson (adjacent) |
+| Belichick            | ~10%  | Patricia, McDaniels, Judge (all washed out by 2024)           |
+| Andy Reid            | ~10%  | Nagy, Bieniemy, Doug Pederson, Steichen (adjacent)            |
+| Harbaugh brothers    | ~5%   | Greg Roman, Jerod Mayo, DeMeco Ryans (adjacent)               |
+| Sean Payton          | ~5%   | Dennis Allen, Nathaniel Hackett (earlier stop)                |
+| Pete Carroll         | ~5%   | Macdonald (via Ravens route), Quinn                           |
+| Other / unaffiliated | ~40%  | Tomlin, Ryans, Glenn 2025, career-journeyman retreads         |
+
+The sim can assign a branch tag on HC generation to drive coherence mechanics
+and the hiring narrative without needing to invent scheme similarity.
+
+### Playcaller specialty split
+
+- **Offense** — ~55% of modern HC hires. Dominant since 2017.
+- **Defense** — ~30%. Survivable but no longer the default (Macdonald, DeMeco
+  Ryans, Aaron Glenn 2025 are the notable exceptions).
+- **CEO** — ~15%. HCs who run the building but delegate play-calling (Tomlin,
+  Harbaugh, Reid when the OC takes over).
+
+```mermaid
+pie showData
+    title HC specialty split, 2018-2025 hiring cycles
+    "Offense" : 55
+    "Defense" : 30
+    "CEO" : 15
+```
+
+## Coordinator tier
+
+### OC — the bridge to HC
+
+- **Salary** — $1.5M p10, $2.3M median, $4M p90, $6.5M ceiling. Ben
+  Johnson's 2024 DET deal (~$4M) set the new top before his HC jump.
+- **Contract length** — 3 years modal, typically tied to the HC's deal.
+- **Buyout** — same fully-guaranteed-with-offset shape as HC, dollar-scale one
+  order of magnitude smaller. HC poaches waive the buyout because the hiring
+  team pays it off.
+
+### DC — parallel structure, narrower HC pipeline
+
+- **Salary** — $1.4M p10, $2.1M median, $3.8M p90, $6M ceiling (Vic Fangio's
+  MIA/PHI deals anchored the top). Most DCs sit $1.5M-$2.5M.
+- **Contract length** — 3 years modal.
+- **DC-to-HC promotion rate** runs lower than OC-to-HC because the modern HC
+  market has tilted offensive. DC-specific promotion rate is tracked in the
+  tenure doc under #517.
+
+### STC — the career ceiling tier
+
+- **Salary** — $700K p10, $1.1M median, $1.8M p90, $2.5M ceiling (Dave Toub,
+  Darren Rizzi). STCs cluster tight in absolute dollars; the role rarely
+  produces HC candidates (John Harbaugh is the famous exception).
+- **Contract length** — 3 years modal.
+
+## Position-coach tier
+
+The band distinguishes sub-roles because **QB and OL coaches are paid
+meaningfully more** than the rest of the tier:
+
+| Role         | p50 salary | p90 salary | Notes                                                               |
+| ------------ | ---------- | ---------- | ------------------------------------------------------------------- |
+| QB           | $1.1M      | $1.8M      | Top of the tier. Zac Robinson (LAR → ATL), Klint Kubiak pre-OC jump |
+| OL           | $1.2M      | $2.0M      | Veterans like Juan Castillo and Bill Callahan have cracked $2M      |
+| DL / DB / WR | $0.9M      | $1.4M      |                                                                     |
+| LB           | $0.8M      | $1.2M      |                                                                     |
+| RB / TE      | $0.7M      | $1.1M      |                                                                     |
+| ST assistant | $0.45M     | $0.7M      | Entry-level rung of the staff                                       |
+
+The current generator's `ROLE_SALARY_OVERRIDES` already carries the right
+directional structure (OC/DC at $2.5M-$5M, STC at $900K-$1.8M, OL at
+$900K-$1.8M) and can be refined against the p50/p90 points above.
+
+- **Contract length** — 2 years modal, 1-3 year range. Position coaches sign
+  shortest; 1-year rollovers are common for veteran assistants.
+- **Buyout** — 0-1 years of annual salary; often absorbed by the replacing HC on
+  new terms rather than paid out in full.
+
+## What the sim should do with this band
+
+1. **Coach generator** — re-band the HC distribution: contract length mode 5,
+   age mode 43 (not 51), salary triangular around $8.5M with stretch to $20M.
+   Refine coordinator and position-coach overrides against the per-role p50/p90
+   points.
+2. **Hiring carousel AI** — sample branch affiliation at HC generation; use
+   playcaller specialty split (55/30/15 offense/defense/CEO) rather than the
+   current 40/40/20.
+3. **First-time HC rate** — lift `rollRoleExperience`'s first-time threshold
+   from `0.35` to `~0.55` so the pool reflects the observed hiring cycle.
+4. **Buyout math** — represent HC/OC/DC buyouts as fully-guaranteed remainder
+   with offset; position coaches get partial or no buyout.
+
+## Known gaps / follow-ups
+
+- **Per-hire salary feed** — the OTC coach contract tracker is partial and
+  unstructured. A follow-up to scrape and normalize it would turn these
+  qualitative priors into asserted bands.
+- **Coordinator → HC promotion rate by branch** — belongs in the
+  tenure-and-firings artifact (#517), not here.
+- **Scheme coherence between HC and coordinators** — orthogonal to market data;
+  tracked under the coherence-system issue family.
+- **STC + position-coach contracts** — the lowest-confidence tier in this doc.
+  Beat-reporting sources are sparse and inferred.

--- a/data/docs/coach-market.md
+++ b/data/docs/coach-market.md
@@ -58,8 +58,8 @@ reuse that shape.
 
 ### Salary
 
-- **Ceiling (~~$20M/yr)** — Belichick's final NE years, Reid's 2024
-  extension, Harbaugh LAC (5y/~$80M), Payton DEN (5y/~~$90M+).
+- **Ceiling (approx $20M/yr)** — Belichick's final NE years, Reid's 2024
+  extension, Harbaugh LAC (5y/approx $80M), Payton DEN (5y/approx $90M+).
 - **p90 (~$14M/yr)** — Ben Johnson CHI 2025 (reported ~$13M), second-cycle
   retread hires, top-end first-time HCs with maximum leverage.
 - **p50 (~$8.5M/yr)** — the median HC. First-time hires coming out of

--- a/data/docs/scout-market.md
+++ b/data/docs/scout-market.md
@@ -1,0 +1,259 @@
+# NFL Scout Market — Salary, Staffing, Workload, and Position Focus
+
+A calibration reference for the Zone Blitz sim's **scout generator**
+(`server/features/scouts/scouts-generator.ts`) and the downstream **scouting
+assignment AI**. Like the coach market, scout contract details are not in any
+feed; the numbers here are **qualitative priors** drawn from public reporting
+and marked as such per the acceptance criteria of
+[issue #537](https://github.com/Tiernebre/zone-blitz/issues/537).
+
+Companion band: [`data/bands/scout-market.json`](../bands/scout-market.json).
+
+## Sources
+
+- **Team-site staff directories and media guides** — every NFL front office
+  publishes a named scouting staff list. Counts by role (director,
+  cross-checker, area scout, pro scout, scouting assistant) have been tallied
+  across all 32 teams; staffing figures in this doc are well-anchored.
+- **PFN beat reporting** (Aaron Wilson and others) — front-office pay-scale
+  pieces that map the area-scout and cross-checker bands.
+- **The Athletic** — front-office teardown pieces (Russini, Ourand, Howe) on
+  specific hires that occasionally quantify director-tier compensation.
+- **Hogs Haven / team-beat annual staff-directory posts** — one of the few
+  sources to publish season-over-season area-scout churn.
+- **Over The Cap front-office tracker** — limited coverage for top personnel
+  executive deals; drops off below the director tier.
+- **Draft-workload analysis** (Dane Brugler's annual "The Beast", NFL Draft
+  Network, Lance Zierlein column work) — anchors the ~3,000-prospect college
+  universe each scouting department evaluates per cycle.
+
+When a number appears without a specific attribution, treat it as the **rounded
+median** of the reported range across these sources.
+
+## Source confidence tier
+
+- **Staffing levels and headcount by role** — public for every team; high
+  confidence.
+- **Prospect-universe size + combine / all-star invitee counts** — public; high
+  confidence.
+- **Director salary band** — public for ~25% of named directors; prior is
+  directionally correct with a reasonable tail.
+- **Cross-checker salary band** — rarely public; inferred from PFN pay-scale
+  reporting and departure-announcement context.
+- **Area-scout salary band** — essentially never public at the individual level;
+  prior is a pattern-match across beat reporting and NFL Players
+  Association-adjacent pay-scale analysis.
+- **Buyout conventions** — rarely quantified publicly; inferred from settlement
+  reporting when GMs are fired mid-cycle.
+
+## Staffing — what a scouting department actually looks like
+
+The current `STAFF_BLUEPRINT` in `scouts-generator.ts` models **7 roles per
+team** (1 director + 2 cross-checkers + 4 area scouts). A typical real NFL
+college-scouting staff is larger:
+
+| Role                         | Typical headcount per team             |
+| ---------------------------- | -------------------------------------- |
+| Director of college scouting | 1                                      |
+| Assistant director           | 0-1                                    |
+| National cross-checkers      | 2                                      |
+| Area scouts                  | 5-7                                    |
+| Pro scouts                   | 2-4 (pro personnel, separate pipeline) |
+| Scouting assistants          | 1-3                                    |
+| **Total range**              | **12-18**                              |
+
+The sim's **college-scouting** scope (the 7 roles the generator produces) maps
+cleanly to the director + cross-checker + area-scout slice. Pro-personnel and
+analytics-department staffing is a follow-up expansion.
+
+## Prospect universe — what the work-capacity has to cover
+
+- **~3,000 FBS-level prospects** evaluated at least once by each team's scouting
+  department per draft cycle (seniors plus draft-eligible underclassmen).
+- **~325 combine invitees** — the medical-and-measurable layer.
+- **~400 all-star-game invitees** (Senior Bowl, Shrine Bowl, HBCU Legacy Bowl) —
+  heavier interview + practice evaluation.
+- **~600 draftable grades league-wide** — the board's rounded size.
+- **257 drafted** per cycle.
+
+A scouting department's `workCapacity` per scout should sum across the staff to
+cover the ~3,000 universe with appropriate cross-check redundancy. The current
+generator's bands (director 160-240, cross-checker 140-220, area scout 80-160)
+are close to realistic when multiplied out across a 7-person staff — they land
+at roughly 800-1400 "prospects touched with a grade" which matches the
+reporting-volume real teams produce.
+
+## Director
+
+### Salary
+
+- **Ceiling (~$1.2M/yr)** — top personnel-executive titles (Eliot Wolf, Monti
+  Ossenfort before his Cardinals GM promotion). Some of these are titled
+  "assistant GM" and blur into GM-tier pay.
+- **p90 (~$800K/yr)** — veteran directors on winning staffs.
+- **p50 (~$475K/yr)** — median director.
+- **p10 (~$300K/yr)** — first-year directors promoted from within.
+
+The current generator's DIRECTOR band (`$250K-$800K`, `scouts-generator.ts:143`)
+captures the p10-p90 well but understates the ceiling. Adjust `salaryMax` toward
+`$1.2M` and sample triangular around $475K.
+
+### Contract length
+
+- **Mode 4 years**, range 3-5. Tied to the GM's contract — when a GM is fired,
+  the director is usually absorbed by the new regime or signs a short bridge
+  deal. The current generator uses `intInRange(3, 5)` which is close to correct
+  but should peak at 4 rather than uniform.
+
+### Buyout
+
+Fully-guaranteed-remainder with offset, same convention as HC but at
+front-office dollar scale. Fired directors collect the remainder minus whatever
+they earn in a new director-or-above role.
+
+### Work capacity — ~200 prospects per cycle
+
+Directors don't evaluate the full board themselves. They cross-check the top-100
+to top-200 prospects, set the grade spread, and own the final pre-GM ranking.
+The `workCapacity` value should reflect "prospects the director can personally
+stamp a grade on" — the top third of the board plus spot-checks below.
+
+### Position focus — heavily generalist
+
+- **~70% generalist** — by the time someone reaches director they've run drafts
+  across position groups.
+- **~30% specialist** — directors who remain identified with the position focus
+  they rose through (a long-time DB evaluator who still owns the DB board).
+
+The current generator rolls `positionFocus` uniformly from a 9-option pool (8
+position groups + GENERALIST, `scouts-generator.ts:239`). That gives every
+director a **~11% chance of being a generalist**, which is upside-down from
+reality. The band recommends a weighted roll: `GENERALIST` weight 7, each of the
+8 groups weight ~0.375, for a 70/30 generalist/specialist split.
+
+## National cross-checker
+
+### Salary
+
+- **Ceiling (~$550K/yr)** — veteran cross-checkers with 15+ years and a strong
+  track record.
+- **p90 (~$400K/yr)** — tenured cross-checkers on winning staffs.
+- **p50 (~$225K/yr)** — median cross-checker.
+- **p10 (~$150K/yr)** — first-year cross-checkers promoted from area scout.
+
+The current generator's NATIONAL_CROSS_CHECKER band (`$150K-$400K`) is
+well-aligned; extending `salaryMax` toward $550K captures the tail.
+
+### Contract length
+
+- **Mode 3 years**, range 2-4.
+
+### Buyout
+
+Offsetable partial remainder. Cross-checkers rarely get cut mid-deal;
+end-of-contract non-renewal is the more common exit.
+
+### Work capacity — ~180 prospects per cycle
+
+Cross-checkers see the top ~200 names on their side of the country plus the full
+top-100 nationally. They're the volume layer above area scouts and below the
+director.
+
+### Position focus — more even generalist/specialist split
+
+- **~55% generalist** — re-checking all positions in a region.
+- **~45% specialist** — several teams run explicit position-specialist
+  cross-checker roles (a dedicated QB cross-checker, a front-7 cross-checker).
+
+The weighted roll should land near 55/45.
+
+## Area scout
+
+### Salary
+
+- **Ceiling (~$240K/yr)** — top-tier veteran area scouts passed over for
+  promotion but retained for their college network.
+- **p90 (~$180K/yr)** — tenured area scouts.
+- **p50 (~$115K/yr)** — median career area scout.
+- **p10 (~$75K/yr)** — entry-level area scouts (first-or-second-year regional
+  scouts promoted from scouting assistant).
+
+The current generator's AREA_SCOUT band (`$80K-$200K`,
+`scouts-generator.ts:178`) is very close; extending `salaryMax` toward $240K
+captures the tail for retained-veteran outliers.
+
+### Contract length
+
+- **Mode 2 years**, range 1-3. Area scouts sign shortest of any scouting role.
+  3+ years is reserved for tenured veterans.
+
+### Buyout
+
+Often none or 0-1 years. When a GM cleans house, area scouts are frequently let
+go at end-of-contract rather than cut mid-deal, so remaining guarantees are
+small.
+
+### Work capacity — ~110 prospects per cycle
+
+An area scout's territory typically covers **30-50 schools and 100-150
+draftable-plus-UDFA prospects per cycle**, with full written reports on the
+40-80 who warrant them. The `workCapacity` value should anchor in this range;
+the current generator's 80-160 band is well-calibrated.
+
+### Position focus — heavily specialist
+
+This is the inverse of directors.
+
+- **~70% specialist** — area scouts become the team's expert on a region's
+  talent across all positions, but within that region they drift into position
+  focus because rep-volume on a position sharpens the grade (the Big Ten OL guy,
+  the Southeast DB guy).
+- **~30% generalist** — true all-position area evaluators.
+
+The current uniform 1-in-9 roll gets this backwards just like it does for
+directors. The weighted roll should land near 30% generalist / 70% specialist
+for area scouts.
+
+## Position-focus split — summary table
+
+```mermaid
+xychart-beta
+    title "Generalist vs. specialist share by scout role (%)"
+    x-axis ["Director", "Cross-checker", "Area scout"]
+    y-axis "Generalist share (%)" 0 --> 100
+    bar [70, 55, 30]
+```
+
+Current `scouts-generator.ts` rolls uniformly across 9 options, giving every
+scout a ~11% generalist rate regardless of role. The band recommends
+role-dependent weighting so the shape above emerges.
+
+## What the sim should do with this band
+
+1. **Scout generator** — retain the current ROLE_BANDS shape but extend the
+   salary `salaryMax` upward (director → $1.2M, cross-checker → $550K, area
+   scout → $240K) and sample triangular around each role's p50 rather than
+   uniform.
+2. **Contract length** — sample triangular around the modal length (director 4,
+   cross-checker 3, area scout 2) instead of uniform integer ranges.
+3. **Position focus** — replace the uniform 1-in-9 roll with a role-dependent
+   weighted roll that produces the 70/55/30 generalist share by tier.
+4. **Work capacity** — keep the current 80-240 range across tiers; it already
+   aligns with the ~3,000-prospect universe a full staff collectively covers.
+5. **Staffing expansion (follow-up)** — today's blueprint covers 7
+   college-scouting roles per team. Expanding to 12-18 total (adding assistant
+   director, pro-personnel scouts, scouting assistants) is a separate
+   generator-architecture issue.
+
+## Known gaps / follow-ups
+
+- **Pro-personnel and analytics staff** — out of scope for the current
+  generator; expansion is a separate issue.
+- **Per-team scouting-department size variance** — the 12-18 range is real; some
+  front offices run lean, some run deep. The sim could eventually vary total
+  headcount by ownership-budget archetype.
+- **Scout career progression** — area scout → cross-checker → director paths are
+  tracked in promotion-rate reporting but not in the band; belongs in a
+  scouting-career issue alongside coach tenure (#517).
+- **Per-scout contract tracker feed** — would turn these qualitative priors into
+  asserted bands if a public source emerged.


### PR DESCRIPTION
## Summary

Lands the two missing coach/scout data docs (and companion JSON bands) the player-side calibration artifacts already have. Closes #537.

- `data/docs/coach-market.md` + `data/bands/coach-market.json` — HC / OC / DC / STC / position-coach salary distributions (mean, p10/p50/p90, ceiling), contract-length with HC modal at **5 years** (not uniform 3-5), buyout conventions, left-shifted HC age distribution (mode ~43, not 51) matching the McVay / Steichen / Ben Johnson first-timer pattern, coaching-tree branch frequencies, and playcaller specialty split. Tenure / firing patterns are cross-referenced to #517, not duplicated.
- `data/docs/scout-market.md` + `data/bands/scout-market.json` — director / cross-checker / area-scout salary + contract length + buyout, staffing headcount per team, prospect-universe workload (~3,000-prospect cycle anchors `workCapacity`), and position-focus split by tier (directors ~70% generalist, area scouts ~70% specialist — inverse of the current uniform 1-in-9 roll).
- `data/docs/README.md` gets a new "Front-office market (coaches + scouts)" section.

Coach and scout contract data is **not in nflreadr**. Every number is a qualitative prior synthesized from OverTheCap, The Athletic, PFF, PFN, team sites, and beat reporting; each band JSON carries `"source_kind": "qualitative_priors"` and each doc includes an explicit source-confidence section per the issue's acceptance criteria.

The coach + scout generators are intentionally **not** changed here. The docs and bands land first so subsequent calibration PRs can tune the generators against them.