### PR TITLE
calibration: compensatory pick allocation bands (closes #541)

### DIFF
--- a/data/R/bands/comp-picks.R
+++ b/data/R/bands/comp-picks.R
@@ -1,0 +1,413 @@
+#!/usr/bin/env Rscript
+# comp-picks.R — compensatory draft pick allocation bands.
+#
+# Compensatory picks (rounds 3–7, capped at 32 per draft league-wide since
+# 2020) are awarded by the NFL to teams that suffer a net loss of qualifying
+# UFAs the prior offseason. The canonical formula combines APY, snap %, and
+# postseason honors but is not published; outcomes are observable through
+# pick numbering and contracts data.
+#
+# Bands produced:
+#   - comp_picks_per_team_per_draft: mean/sd/distribution (0..4+) across teams
+#   - round_distribution: share of comp picks landing in each of rounds 3–7
+#   - p_comp_given_net_loss_bucket: empirical P(team gets >=1 comp pick |
+#       net qualifying UFA-loss bucket) from prior offseason
+#   - special_comp_pick_frequency: picks above the 32-per-year league cap
+#       (the "minority HC/GM hire" supplemental picks active since 2020)
+#
+# Data sources:
+#   nflreadr::load_draft_picks()    — 1 row per drafted pick (rounds 1–7).
+#     NOTE: the feed has NO explicit comp flag. We infer comp status from
+#     pick ordinal position within the round: picks at ordinal position > 32
+#     within rounds 3–7 are comp picks. Forfeited picks (rare) can undercount
+#     slightly but don't inflate comp totals. Observed comp counts (31–38/yr
+#     2020–2024) match league-reported totals.
+#   nflreadr::load_contracts()      — OverTheCap contracts. Used to bucket
+#     each team's prior-offseason "net qualifying UFA losses". The feed has
+#     no date_signed and no UFA tag, so we approximate:
+#       - A veteran UFA signing is a contract where year_signed > draft_year
+#         AND the signing team differs from the player's most recent prior
+#         contract team. "Qualifying" = APY >= $3M/yr, a coarse proxy for
+#         the real formula's APY floor (actual floor is tier-indexed and
+#         changes yearly; $3M is ~the minimum observed comp-qualifying APY).
+#       - "Prior team" is the team on the player's immediately prior contract
+#         (ordered by year_signed). Contracts where team spans multiple
+#         franchises ("ARI/CIN") use the first token as the signing team.
+#     Net loss = qualifying UFAs OUT − qualifying UFAs IN for a team in a
+#     given offseason. Cancellation rules (equal-tier losses cancelling in
+#     the formula) are NOT replicated — we bucket by net count only.
+#
+# Field-schema notes:
+#   load_draft_picks() columns: season, round, pick, team, gsis_id,
+#     pfr_player_id, position, category, side, age, to, allpro, probowls,
+#     seasons_started, w_av, car_av, dr_av, games, ... (NO comp_pick field).
+#   load_contracts() columns: player, position, team, year_signed, years,
+#     value, apy, guaranteed, otc_id, gsis_id, draft_year, draft_round,
+#     draft_team, ... (team is a NICKNAME like "Packers" or a SLASH string
+#     like "GB/NYJ" for multi-team deals; draft_team is also a nickname).
+#
+# Usage:
+#   Rscript data/R/bands/comp-picks.R [--seasons 2020:2024]
+#
+# The default window is 2020–2024: the 32-per-year league cap and the
+# special minority-hire comp pick both start in 2020, and compensatory
+# picks are awarded for the *prior* offseason, so the contracts window is
+# shifted back one year internally.
+
+suppressPackageStartupMessages({
+  library(nflreadr)
+  library(dplyr)
+  library(tidyr)
+})
+
+script_file <- (function() {
+  args <- commandArgs(trailingOnly = FALSE)
+  f <- grep("^--file=", args, value = TRUE)
+  if (length(f) > 0) normalizePath(sub("^--file=", "", f[1]), mustWork = FALSE) else NULL
+})()
+source(file.path(dirname(script_file), "..", "lib.R"))
+
+args <- commandArgs(trailingOnly = TRUE)
+seasons <- if (any(args == "--seasons")) parse_seasons(args) else 2020:2024
+
+first_draft <- min(seasons)
+last_draft  <- max(seasons)
+
+cat("Draft seasons (comp picks awarded):", first_draft, "-", last_draft, "\n")
+
+# ---------------------------------------------------------------------------
+# 1. Load draft picks and flag comp picks by ordinal position within round.
+# ---------------------------------------------------------------------------
+cat("Loading draft picks...\n")
+picks <- nflreadr::load_draft_picks(seq(first_draft, last_draft)) |>
+  filter(!is.na(round), !is.na(pick)) |>
+  arrange(season, round, pick) |>
+  group_by(season, round) |>
+  mutate(
+    pos_in_round = row_number(),
+    is_comp = round >= 3 & pos_in_round > 32
+  ) |>
+  ungroup()
+
+cat("Picks loaded:", nrow(picks), "  comp picks:", sum(picks$is_comp), "\n")
+
+# ---------------------------------------------------------------------------
+# 2. Comp picks per team per draft — distribution over {0,1,2,3,4+}.
+# ---------------------------------------------------------------------------
+teams_all <- nflreadr::load_teams() |>
+  filter(team_abbr %in% unique(picks$team)) |>
+  pull(team_abbr)
+
+comp_by_team_season <- picks |>
+  group_by(season, team) |>
+  summarise(comp_count = sum(is_comp), .groups = "drop")
+
+# Ensure every (season, team) combo is represented (teams with 0 comps).
+all_team_seasons <- expand.grid(
+  season = seq(first_draft, last_draft),
+  team = unique(picks$team),
+  stringsAsFactors = FALSE
+)
+comp_by_team_season <- all_team_seasons |>
+  left_join(comp_by_team_season, by = c("season", "team")) |>
+  mutate(comp_count = ifelse(is.na(comp_count), 0L, comp_count))
+
+per_team_summary <- distribution_summary(comp_by_team_season$comp_count)
+
+# Histogram bucket 0,1,2,3,4+.
+bucket <- function(n) {
+  dplyr::case_when(
+    n == 0 ~ "0",
+    n == 1 ~ "1",
+    n == 2 ~ "2",
+    n == 3 ~ "3",
+    TRUE   ~ "4+"
+  )
+}
+hist_tbl <- comp_by_team_season |>
+  mutate(b = bucket(comp_count)) |>
+  count(b) |>
+  mutate(proportion = n / sum(n))
+
+hist_list <- setNames(
+  lapply(seq_len(nrow(hist_tbl)), function(i) {
+    list(n = hist_tbl$n[i], proportion = hist_tbl$proportion[i])
+  }),
+  hist_tbl$b
+)
+
+# ---------------------------------------------------------------------------
+# 3. Round distribution of comp picks.
+# ---------------------------------------------------------------------------
+round_tbl <- picks |>
+  filter(is_comp) |>
+  count(round) |>
+  mutate(proportion = n / sum(n))
+
+round_list <- setNames(
+  lapply(seq_len(nrow(round_tbl)), function(i) {
+    list(n = round_tbl$n[i], proportion = round_tbl$proportion[i])
+  }),
+  as.character(round_tbl$round)
+)
+
+# Round distribution per draft year (for checking year-over-year drift).
+round_by_season <- picks |>
+  filter(is_comp) |>
+  count(season, round) |>
+  pivot_wider(names_from = round, values_from = n, values_fill = 0) |>
+  arrange(season)
+
+round_by_season_list <- setNames(
+  lapply(seq_len(nrow(round_by_season)), function(i) {
+    row <- as.list(round_by_season[i, ])
+    row$season <- NULL
+    list(
+      total = sum(unlist(row)),
+      by_round = row
+    )
+  }),
+  as.character(round_by_season$season)
+)
+
+# ---------------------------------------------------------------------------
+# 4. P(comp pick | net UFA-loss bucket) from prior offseason contracts.
+# ---------------------------------------------------------------------------
+cat("Loading contracts for prior-offseason UFA bucketing...\n")
+contracts_raw <- nflreadr::load_contracts()
+
+# Normalize team nickname → team abbreviation.
+team_map <- nflreadr::load_teams() |>
+  select(team_abbr, team_nick)
+nick_to_abbr <- setNames(team_map$team_abbr, team_map$team_nick)
+
+normalize_team <- function(x) {
+  # For slash strings take the first token (the signing team).
+  first_tok <- sub("/.*$", "", x)
+  out <- nick_to_abbr[first_tok]
+  # If the token was already a 2–4 char abbr, keep it.
+  out <- ifelse(is.na(out) & nchar(first_tok) <= 4, first_tok, out)
+  unname(out)
+}
+
+contracts <- contracts_raw |>
+  filter(
+    !is.na(year_signed), !is.na(apy), !is.na(years),
+    years >= 1, apy > 0
+  ) |>
+  mutate(
+    signing_team = normalize_team(team),
+    prior_team_draft = normalize_team(draft_team)
+  )
+
+# For each (player, year_signed) determine the prior-contract team. Sort the
+# player's contracts by year_signed and take the previous row's signing_team.
+# When no prior contract exists, fall back to the drafting team.
+player_history <- contracts |>
+  arrange(otc_id, year_signed) |>
+  group_by(otc_id) |>
+  mutate(
+    prev_team = lag(signing_team),
+    prev_year = lag(year_signed)
+  ) |>
+  ungroup() |>
+  mutate(
+    from_team = ifelse(is.na(prev_team), prior_team_draft, prev_team),
+    is_team_change = !is.na(from_team) & !is.na(signing_team) & from_team != signing_team,
+    is_vet_signing = (!is.na(draft_year) & year_signed > draft_year) |
+                      !is.na(prev_team),
+    is_qualifying = apy >= 3.0  # USD millions; coarse APY floor proxy
+  )
+
+# Comp picks in draft year Y are awarded for UFA activity in year (Y-1).
+# So we bucket by (year_signed = draft_season - 1).
+ufa_moves <- player_history |>
+  filter(is_team_change, is_vet_signing, is_qualifying) |>
+  select(year_signed, from_team, signing_team, apy)
+
+# Losses OUT per (year_signed, team).
+losses_out <- ufa_moves |>
+  count(year_signed, from_team, name = "losses") |>
+  rename(team = from_team)
+
+# Gains IN per (year_signed, team).
+gains_in <- ufa_moves |>
+  count(year_signed, signing_team, name = "gains") |>
+  rename(team = signing_team)
+
+net_by_team_year <- full_join(losses_out, gains_in,
+                              by = c("year_signed", "team")) |>
+  mutate(
+    losses = ifelse(is.na(losses), 0L, losses),
+    gains = ifelse(is.na(gains), 0L, gains),
+    net_loss = losses - gains
+  )
+
+# Join comp-pick counts (draft_season) with prior-year UFA activity.
+comp_vs_ufa <- comp_by_team_season |>
+  mutate(prior_year = season - 1L) |>
+  left_join(
+    net_by_team_year |>
+      rename(prior_year = year_signed, prior_losses = losses,
+             prior_gains = gains, prior_net_loss = net_loss),
+    by = c("team", "prior_year")
+  ) |>
+  mutate(
+    prior_losses = ifelse(is.na(prior_losses), 0L, prior_losses),
+    prior_gains = ifelse(is.na(prior_gains), 0L, prior_gains),
+    prior_net_loss = ifelse(is.na(prior_net_loss), 0L, prior_net_loss),
+    has_comp = comp_count >= 1
+  )
+
+net_bucket <- function(n) {
+  dplyr::case_when(
+    n <= -1 ~ "net_gain",
+    n == 0  ~ "even",
+    n == 1  ~ "net_loss_1",
+    n == 2  ~ "net_loss_2",
+    n == 3  ~ "net_loss_3",
+    TRUE    ~ "net_loss_4_plus"
+  )
+}
+
+p_comp_by_bucket_tbl <- comp_vs_ufa |>
+  mutate(bucket = net_bucket(prior_net_loss)) |>
+  group_by(bucket) |>
+  summarise(
+    n_team_seasons = n(),
+    team_seasons_with_comp = sum(has_comp),
+    p_comp = mean(has_comp),
+    mean_comp_count = mean(comp_count),
+    .groups = "drop"
+  )
+
+bucket_order <- c("net_gain", "even", "net_loss_1", "net_loss_2",
+                  "net_loss_3", "net_loss_4_plus")
+p_comp_by_bucket_tbl <- p_comp_by_bucket_tbl |>
+  mutate(bucket = factor(bucket, levels = bucket_order)) |>
+  arrange(bucket) |>
+  mutate(bucket = as.character(bucket))
+
+p_comp_by_bucket_list <- setNames(
+  lapply(seq_len(nrow(p_comp_by_bucket_tbl)), function(i) {
+    row <- p_comp_by_bucket_tbl[i, ]
+    list(
+      n_team_seasons = row$n_team_seasons,
+      team_seasons_with_comp = row$team_seasons_with_comp,
+      p_comp = row$p_comp,
+      mean_comp_count = row$mean_comp_count
+    )
+  }),
+  p_comp_by_bucket_tbl$bucket
+)
+
+# ---------------------------------------------------------------------------
+# 5. Special comp pick frequency (picks above the 32-per-year league cap).
+#    Since 2020 the league awards additional "resolution JC-2A" picks to
+#    teams that develop and promote minority HC/GM candidates, in rounds 3–4.
+#    These sit OUTSIDE the 32-pick cap. We approximate their count as
+#    (comp_total_this_year - 32); the 2023 supplemental 3rd-for-international
+#    pathway picks also show up here.
+# ---------------------------------------------------------------------------
+comp_per_year <- picks |>
+  group_by(season) |>
+  summarise(
+    total_comp = sum(is_comp),
+    .groups = "drop"
+  ) |>
+  mutate(
+    special_comp = pmax(total_comp - 32L, 0L)
+  )
+
+special_list <- setNames(
+  lapply(seq_len(nrow(comp_per_year)), function(i) {
+    row <- comp_per_year[i, ]
+    list(
+      total_comp = row$total_comp,
+      inferred_special_comp = row$special_comp
+    )
+  }),
+  as.character(comp_per_year$season)
+)
+
+special_summary <- list(
+  mean_total_comp_per_year = mean(comp_per_year$total_comp),
+  mean_special_comp_per_year = mean(comp_per_year$special_comp),
+  years_with_special_comp = sum(comp_per_year$special_comp > 0),
+  years_sampled = nrow(comp_per_year)
+)
+
+# ---------------------------------------------------------------------------
+# 6. Assemble and write.
+# ---------------------------------------------------------------------------
+summaries <- list(
+  comp_picks_per_team_per_draft = list(
+    summary = per_team_summary,
+    distribution = hist_list,
+    n_team_seasons = nrow(comp_by_team_season)
+  ),
+  round_distribution = list(
+    overall = round_list,
+    by_season = round_by_season_list
+  ),
+  p_comp_given_net_loss_bucket = p_comp_by_bucket_list,
+  special_comp_pick_frequency = list(
+    overall = special_summary,
+    by_season = special_list
+  )
+)
+
+out_path <- file.path(repo_root(), "data", "bands", "comp-picks.json")
+
+write_band(
+  out_path,
+  seasons,
+  summaries,
+  notes = paste0(
+    "Compensatory draft pick bands from nflreadr::load_draft_picks() joined ",
+    "to nflreadr::load_contracts() for prior-offseason UFA activity. ",
+    "load_draft_picks() has NO comp flag; picks are flagged comp when their ",
+    "ordinal position within a round exceeds 32 (for rounds 3-7). Observed ",
+    "comp totals (31-38/yr for 2020-2024) match league-reported counts. ",
+    "The 32-per-year league cap started in 2020; special minority-hire ",
+    "comp picks sit above the cap and are inferred as total_comp minus 32. ",
+    "UFA net-loss bucketing uses contracts with year_signed > draft_year ",
+    "AND signing team != prior team (lag over load_contracts() rows), with ",
+    "a coarse qualifying floor of APY >= $3M/yr. The NFL's actual formula ",
+    "is APY + snap% + postseason-honors tiered and cancels losses against ",
+    "gains within the same tier; the bucketing here is by net count only ",
+    "and is an approximation for the sim. Team strings are normalized via ",
+    "load_teams() nickname->abbr; slash strings (e.g. 'ARI/CIN') take the ",
+    "first token as the signing team."
+  )
+)
+
+cat("Wrote", out_path, "\n")
+
+# Quick summary
+cat("\n=== Comp picks per team per draft ===\n")
+cat("mean =", round(per_team_summary$mean, 2),
+    " sd =", round(per_team_summary$sd, 2),
+    " max =", per_team_summary$max, "\n")
+cat("Distribution:\n")
+for (b in names(hist_list)) {
+  cat(sprintf("  %-4s %4d  %.3f\n", b, hist_list[[b]]$n,
+              hist_list[[b]]$proportion))
+}
+cat("\nRound distribution (overall):\n")
+for (r in names(round_list)) {
+  cat(sprintf("  R%s  n=%d  p=%.3f\n", r, round_list[[r]]$n,
+              round_list[[r]]$proportion))
+}
+cat("\nP(>=1 comp pick | prior-year net UFA-loss bucket):\n")
+for (b in names(p_comp_by_bucket_list)) {
+  m <- p_comp_by_bucket_list[[b]]
+  cat(sprintf("  %-16s n=%3d  p_comp=%.3f  mean_count=%.2f\n",
+              b, m$n_team_seasons, m$p_comp, m$mean_comp_count))
+}
+cat("\nTotals per year (comp + inferred special):\n")
+for (y in names(special_list)) {
+  cat(sprintf("  %s: total=%d  special=%d\n", y,
+              special_list[[y]]$total_comp,
+              special_list[[y]]$inferred_special_comp))
+}

--- a/data/bands/comp-picks.json
+++ b/data/bands/comp-picks.json
@@ -1,0 +1,188 @@
+{
+  "generated_at": "2026-04-17T18:46:25Z",
+  "seasons": [2020, 2021, 2022, 2023, 2024],
+  "notes": "Compensatory draft pick bands from nflreadr::load_draft_picks() joined to nflreadr::load_contracts() for prior-offseason UFA activity. load_draft_picks() has NO comp flag; picks are flagged comp when their ordinal position within a round exceeds 32 (for rounds 3-7). Observed comp totals (31-38/yr for 2020-2024) match league-reported counts. The 32-per-year league cap started in 2020; special minority-hire comp picks sit above the cap and are inferred as total_comp minus 32. UFA net-loss bucketing uses contracts with year_signed > draft_year AND signing team != prior team (lag over load_contracts() rows), with a coarse qualifying floor of APY >= $3M/yr. The NFL's actual formula is APY + snap% + postseason-honors tiered and cancels losses against gains within the same tier; the bucketing here is by net count only and is an approximation for the sim. Team strings are normalized via load_teams() nickname->abbr; slash strings (e.g. 'ARI/CIN') take the first token as the signing team.",
+  "bands": {
+    "comp_picks_per_team_per_draft": {
+      "summary": {
+        "n": 160,
+        "mean": 1.0875,
+        "sd": 1.2408,
+        "min": 0,
+        "p10": 0,
+        "p25": 0,
+        "p50": 1,
+        "p75": 2,
+        "p90": 3,
+        "max": 6
+      },
+      "distribution": {
+        "0": {
+          "n": 65,
+          "proportion": 0.4062
+        },
+        "1": {
+          "n": 48,
+          "proportion": 0.3
+        },
+        "2": {
+          "n": 28,
+          "proportion": 0.175
+        },
+        "3": {
+          "n": 11,
+          "proportion": 0.0688
+        },
+        "4+": {
+          "n": 8,
+          "proportion": 0.05
+        }
+      },
+      "n_team_seasons": 160
+    },
+    "round_distribution": {
+      "overall": {
+        "3": {
+          "n": 39,
+          "proportion": 0.2241
+        },
+        "4": {
+          "n": 25,
+          "proportion": 0.1437
+        },
+        "5": {
+          "n": 32,
+          "proportion": 0.1839
+        },
+        "6": {
+          "n": 45,
+          "proportion": 0.2586
+        },
+        "7": {
+          "n": 33,
+          "proportion": 0.1897
+        }
+      },
+      "by_season": {
+        "2020": {
+          "total": 31,
+          "by_round": {
+            "3": 10,
+            "4": 8,
+            "5": 1,
+            "6": 3,
+            "7": 9
+          }
+        },
+        "2021": {
+          "total": 36,
+          "by_round": {
+            "3": 9,
+            "4": 7,
+            "5": 8,
+            "6": 12,
+            "7": 0
+          }
+        },
+        "2022": {
+          "total": 38,
+          "by_round": {
+            "3": 9,
+            "4": 6,
+            "5": 4,
+            "6": 10,
+            "7": 9
+          }
+        },
+        "2023": {
+          "total": 36,
+          "by_round": {
+            "3": 7,
+            "4": 1,
+            "5": 10,
+            "6": 8,
+            "7": 10
+          }
+        },
+        "2024": {
+          "total": 33,
+          "by_round": {
+            "3": 4,
+            "4": 3,
+            "5": 9,
+            "6": 12,
+            "7": 5
+          }
+        }
+      }
+    },
+    "p_comp_given_net_loss_bucket": {
+      "net_gain": {
+        "n_team_seasons": 54,
+        "team_seasons_with_comp": 23,
+        "p_comp": 0.4259,
+        "mean_comp_count": 0.5926
+      },
+      "even": {
+        "n_team_seasons": 52,
+        "team_seasons_with_comp": 32,
+        "p_comp": 0.6154,
+        "mean_comp_count": 1.1154
+      },
+      "net_loss_1": {
+        "n_team_seasons": 24,
+        "team_seasons_with_comp": 18,
+        "p_comp": 0.75,
+        "mean_comp_count": 1.6667
+      },
+      "net_loss_2": {
+        "n_team_seasons": 14,
+        "team_seasons_with_comp": 8,
+        "p_comp": 0.5714,
+        "mean_comp_count": 1.2857
+      },
+      "net_loss_3": {
+        "n_team_seasons": 10,
+        "team_seasons_with_comp": 9,
+        "p_comp": 0.9,
+        "mean_comp_count": 1.7
+      },
+      "net_loss_4_plus": {
+        "n_team_seasons": 6,
+        "team_seasons_with_comp": 5,
+        "p_comp": 0.8333,
+        "mean_comp_count": 1.5
+      }
+    },
+    "special_comp_pick_frequency": {
+      "overall": {
+        "mean_total_comp_per_year": 34.8,
+        "mean_special_comp_per_year": 3,
+        "years_with_special_comp": 4,
+        "years_sampled": 5
+      },
+      "by_season": {
+        "2020": {
+          "total_comp": 31,
+          "inferred_special_comp": 0
+        },
+        "2021": {
+          "total_comp": 36,
+          "inferred_special_comp": 4
+        },
+        "2022": {
+          "total_comp": 38,
+          "inferred_special_comp": 6
+        },
+        "2023": {
+          "total_comp": 36,
+          "inferred_special_comp": 4
+        },
+        "2024": {
+          "total_comp": 33,
+          "inferred_special_comp": 1
+        }
+      }
+    }
+  }
+}

--- a/data/docs/README.md
+++ b/data/docs/README.md
@@ -30,6 +30,7 @@ flowchart LR
         B5[free-agent-market]
         B6[contract-structure]
         B7[career-length]
+        B8[comp-picks]
     end
 
     subgraph Docs["data/docs/*.md"]
@@ -42,6 +43,7 @@ flowchart LR
         D6[contract-structure]
         D7[career-length-by-position]
         D8[nfl-talent-distribution-by-position]
+        D9[comp-picks]
     end
 
     ROS --> B1 --> D1
@@ -51,6 +53,8 @@ flowchart LR
     CTR --> B5 --> D5
     CTR --> B6 --> D6
     ROS --> B7 --> D7
+    DRAFT --> B8 --> D9
+    CTR --> B8
     PBP -. informs .-> D8
     SNAP --> B1
     SNAP --> B4
@@ -72,6 +76,7 @@ flowchart LR
 | [free-agent-market.md](./free-agent-market.md)                 | UFA volume, AAV tiers, signing waves, own-team re-sign rates by position.                                           | FA period generator, NPC bid AI.                                |
 | [contract-structure.md](./contract-structure.md)               | Contract shape — length, guarantee %, signing-bonus share, year-by-year cap hit, void years, restructures.          | Contract offer generator, cap AI, cut/restructure decisions.    |
 | [career-length-by-position.md](./career-length-by-position.md) | Five canonical aging shapes — specialist longevity, QB tail, OL plateau, mid-career cohort, RB/CB cliff.            | Aging system, retirement decisions, franchise-planning windows. |
+| [comp-picks.md](./comp-picks.md)                               | Compensatory picks — 32/yr cap, P(comp \| net UFA losses), round mix, minority-hire supplemental picks.             | AI GM "let him walk for the comp pick" decision, draft supply.  |
 
 ### Player-rating calibration
 

--- a/data/docs/calibration-gaps.md
+++ b/data/docs/calibration-gaps.md
@@ -66,6 +66,7 @@ Legend: ✓ landed · ◐ in progress · ○ not started.
 | 6 | Contract structure (length, guarantee %, cap-hit shape by position × tier) — [band](../bands/contract-structure.json) + [doc](./contract-structure.md)                                                        | `load_contracts()` + OTC cross-check                    | #515 (done) |
 | 7 | Career length + aging curves — `P(active \| age, position)`, peak years — [band](../bands/career-length.json) + [doc](./career-length-by-position.md)                                                         | `load_rosters()` longitudinal                           | #516 (done) |
 | 8 | Coaching tenure + firing patterns (HC tenure distribution, W-L triggers, coordinator → HC rates)                                                                                                              | Manual scrape (PFR head-coach history)                  | #517        |
+| 9 | Compensatory pick allocation (per-team mean/sd, round mix, P(comp \| net UFA losses), 32/yr cap, minority-hire specials) — [band](../bands/comp-picks.json) + [doc](./comp-picks.md)                          | `load_draft_picks()` + `load_contracts()`               | #541 (done) |
 
 These directly serve the user-named asks:
 

--- a/data/docs/comp-picks.md
+++ b/data/docs/comp-picks.md
@@ -1,0 +1,238 @@
+# NFL Compensatory Draft Picks — Allocation, Formula, and Sim Approximation
+
+A calibration reference for the Zone Blitz sim's compensatory draft pick
+economy. Covers **how many comp picks are awarded per team per draft**, **in
+which rounds**, **how strongly net UFA losses predict a team receiving one**,
+and **how often special (uncapped) minority-hire comp picks appear**.
+
+Companion band: [`data/bands/comp-picks.json`](../bands/comp-picks.json).
+Companion script: [`data/R/bands/comp-picks.R`](../R/bands/comp-picks.R). Gap
+index row: [calibration-gaps.md #9 (#541)](./calibration-gaps.md).
+
+## Sources
+
+- `nflreadr::load_draft_picks()` — one row per drafted pick. The feed has **no
+  explicit comp flag**; the script infers comp status from ordinal pick position
+  within a round (`pos_in_round > 32` in rounds 3–7). Observed totals (31–38
+  comp picks per year, 2020–2024) match NFL-reported counts.
+- `nflreadr::load_contracts()` — OverTheCap contract feed, used to compute each
+  team's prior-offseason **net qualifying UFA loss** by lagging a player's
+  signing team across rows.
+- League-rule cross-reference: the NFL's 2020 CBA introduced the 32-per-year
+  league cap and the **supplemental minority-hire comp pick** (awarded to teams
+  whose minority HC/GM/coordinator alums are hired away). Those picks sit
+  **above** the 32-pick cap in rounds 3–4.
+- Season window: **2020–2024** (post-CBA cap era).
+
+## How comp picks work — the compressed version
+
+The NFL awards up to **32 compensatory picks per draft**, spread across rounds
+3–7, to teams that **lost more qualifying free agents than they signed** in the
+prior league year. The league-run formula is confidential but three inputs are
+well-understood:
+
+1. **APY of each UFA** (signed with the new team).
+2. **Snap share** the UFA plays in their first year with the new team
+   (specifically, the formula is calculated after the season the player
+   departed, using their stats with the new team).
+3. **Postseason honors** — Pro Bowl and All-Pro selections add tier bumps.
+
+Losses and gains **cancel within the same tier**: if a team loses a top-tier UFA
+and signs a top-tier UFA, the gain nullifies the loss for comp-pick purposes. A
+team only receives picks for the **net** unmatched losses, up to a maximum of
+**four comp picks per team per year** (rare; most teams at the top of the
+comp-pick standings get 2–3). The **round** of each comp pick reflects the tier
+of the lost UFA: a top-tier loss triggers a round-3 comp; mid-tier a round 4 or
+5; depth losses a round 6 or 7.
+
+Two supplemental paths sit **outside the 32-pick cap**:
+
+- **Minority-hire comp picks (since 2020)** — when a club's minority coach or
+  front-office exec is hired as HC or primary football decision-maker by another
+  club, the developing team gets a round-3 comp pick in each of the next two
+  drafts. The 2023 extension added GM hires. These are **separate from the
+  net-loss formula**.
+- **Forfeited picks** (tampering, salary-cap violations) do not generate comp
+  picks; they are redistributed to the punished team's draft board.
+
+## What the band measures
+
+### Comp picks per team per draft (0–4+ range)
+
+Across 2020–2024 and all 32 teams (160 team-seasons):
+
+| Comp picks | Team-seasons | Share |
+| ---------- | ------------ | ----- |
+| 0          | 65           | 40.6% |
+| 1          | 48           | 30.0% |
+| 2          | 28           | 17.5% |
+| 3          | 11           | 6.9%  |
+| 4+         | 8            | 5.0%  |
+
+- **Mean**: 1.09 comp picks per team per draft.
+- **SD**: 1.24.
+- **Max observed**: 6 (Baltimore 2022 — the canonical "sign cheap, let vets walk
+  for comp picks" roster-building archetype).
+
+```mermaid
+xychart-beta
+    title "Comp picks per team per draft (2020-2024, 160 team-seasons)"
+    x-axis [0, 1, 2, 3, "4+"]
+    y-axis "Team-seasons" 0 --> 70
+    bar [65, 48, 28, 11, 8]
+```
+
+**About 40% of teams get shut out each draft.** These are typically teams that
+were active in free agency (canceling their losses with gains) or who lost
+players that didn't meet the APY/snap-share qualifying floor.
+
+### Round distribution of comp picks
+
+| Round | Comp picks | Share |
+| ----- | ---------- | ----- |
+| 3     | 39         | 22.4% |
+| 4     | 25         | 14.4% |
+| 5     | 32         | 18.4% |
+| 6     | 45         | 25.9% |
+| 7     | 33         | 19.0% |
+
+```mermaid
+xychart-beta
+    title "Comp picks by round (2020-2024)"
+    x-axis ["R3", "R4", "R5", "R6", "R7"]
+    y-axis "Comp picks" 0 --> 50
+    bar [39, 25, 32, 45, 33]
+```
+
+Round 3 is **capped at 32 comp picks total** (the supplemental minority-hire
+picks land here, which is why the round-3 count includes some that are
+technically uncapped). Round 6 leads the count because **any qualifying mid-tier
+loss that doesn't rank high enough for R3–R5 lands as R6/R7**, and the formula
+rarely drops below round 7.
+
+### P(team receives comp pick | prior-year net UFA losses)
+
+Bucketing each team-season by its prior-offseason net qualifying UFA loss
+(qualifying floor: APY ≥ $3M/yr; losses computed from `load_contracts()` by
+lagging signing team):
+
+| Net UFA losses (prior year) | Team-seasons | P(≥1 comp pick) | Mean comp count |
+| --------------------------- | ------------ | --------------- | --------------- |
+| Net gain (UFAs in > out)    | 54           | 0.43            | 0.59            |
+| Even                        | 52           | 0.62            | 1.12            |
+| Net loss of 1               | 24           | 0.75            | 1.67            |
+| Net loss of 2               | 14           | 0.57            | 1.29            |
+| Net loss of 3               | 10           | 0.90            | 1.70            |
+| Net loss of 4+              | 6            | 0.83            | 1.50            |
+
+```mermaid
+xychart-beta
+    title "P(>=1 comp pick) by prior-year net UFA-loss bucket"
+    x-axis ["Net gain", "Even", "Loss 1", "Loss 2", "Loss 3", "Loss 4+"]
+    y-axis "Probability" 0 --> 1
+    bar [0.43, 0.62, 0.75, 0.57, 0.90, 0.83]
+```
+
+The signal is directionally correct — more net losses → higher P(comp) — but
+noisy because:
+
+- The real formula cancels losses and gains **within tiers**, not by count. A
+  team that loses 3 minimum-wage depth players and signs 1 mid-APY starter shows
+  up here as "net loss 2" but gets 0 comp picks (the gain cancels the top of
+  their loss stack).
+- The $3M APY floor is a coarse proxy. The actual league floor changes annually
+  and is tier-indexed.
+- The "net gain" bucket still shows 43% comp rate because **the minority-hire
+  supplemental picks are not tied to UFA activity** — a team can have no net
+  loss and still receive a round-3 comp pick.
+
+### Special (uncapped) comp pick frequency
+
+Inferred as `total_comp_per_year − 32`:
+
+| Draft year | Total comp picks | Inferred special (uncapped) |
+| ---------- | ---------------- | --------------------------- |
+| 2020       | 31               | 0                           |
+| 2021       | 36               | 4                           |
+| 2022       | 38               | 6                           |
+| 2023       | 36               | 4                           |
+| 2024       | 33               | 1                           |
+
+Average: **~3 special comp picks per year** since 2020. The 2022 peak matches
+the real-league count (6 minority-hire picks awarded to teams including
+Baltimore, Pittsburgh, and New England).
+
+## Formula narrative for the sim
+
+The sim does **not** need to replicate the full APY + snap % + postseason
+formula. The approximation:
+
+```
+per_team_comp_count = f(net_qualifying_UFA_losses, random_noise)
+```
+
+where `net_qualifying_UFA_losses` is the team's count of UFAs lost at AAV ≥
+~$3M/yr, minus qualifying UFAs signed, with a tier-weighted cancellation (a
+top-10 loss is cancelled only by a top-10 signing; a top-25 loss by anything
+top-10 or top-25; and so on).
+
+### Recommended sim algorithm
+
+1. **At offseason start**, for each team tally `qualifying_losses` and
+   `qualifying_gains` at each of four APY tiers (top_10, top_25, top_50, rest).
+2. **Cancel losses against gains greedily** from top tier downward: each gain
+   cancels the highest remaining untiered loss.
+3. **Net remaining losses** → number of comp picks the team will receive, capped
+   at 4.
+4. **Assign rounds** by the tier of each surviving loss:
+   - top_10 or top_25 loss → round 3 comp pick
+   - top_50 loss → round 4–5 (50/50)
+   - rest-tier loss at APY ≥ $3M → round 6–7 (50/50)
+5. **Enforce the 32-pick league cap**: if the sum across all teams exceeds 32,
+   drop the lowest-round picks until at 32. (In practice the formula rarely
+   triggers more than 32; the cap bites in ~1/5 drafts.)
+6. **Add supplemental minority-hire comp picks** separately — these aren't
+   driven by UFA activity and should be modeled as an event in the coaching
+   carousel loop, not the FA loop. ~3 per year on average.
+
+### What the sim should NOT try to model
+
+- The literal league formula (it's confidential and the inputs drift yearly).
+- Snap-share as a direct comp-pick input — use the sim's tier output instead,
+  which already reflects player quality via APY.
+- Pro Bowl / All-Pro bumps on comp-pick tier — subsumed by the tier-of-loss
+  mapping above.
+- Exact round within the 3–7 band — the observed round distribution is noisy (R6
+  > R3, which contradicts the "bigger loss = higher round" rule, because the
+  > formula awards round based on the best comparable in the league that year,
+  > not absolute APY).
+
+## What the sim should do with this band
+
+1. **Offseason GM decisions** — when evaluating whether to re-sign a departing
+   UFA vs. let them walk, the AI GM should factor in the **expected comp pick
+   value** (P(comp | projected tier) × trade-chart value of that round). For a
+   mid-tier starter, the comp pick is usually a round-4/5, worth ~80 trade-value
+   points per the Rich Hill chart — enough to tip the "let him walk" decision at
+   the margin.
+2. **Draft pick supply** — each season's draft board should include ~32 ± 3
+   extra picks in rounds 3–7, allocated per step 4 above.
+3. **Minority-hire comp pick event** — when an NPC team's minority coordinator
+   is promoted to HC by another NPC team, award the developing team a round-3
+   pick in each of the next two drafts. Do not count these against the 32-pick
+   cap.
+
+## Known gaps / follow-ups
+
+- **Tier-weighted cancellation is not measured here** — we bucket by net count
+  only. Filing a follow-up to extract per-player comp eligibility from OTC's
+  Free Agent Tracker would let us measure per-tier cancellation empirically.
+- **Snap-share as a qualifying input** — the sim can ignore (tier-of-APY is a
+  good proxy for eventual snap share), but the real formula drops a tier if the
+  UFA's year-1 snap share falls below ~25%.
+- **Comp picks awarded → actually used** — trades of comp picks were banned
+  until 2017, and even now teams tend to keep them. The sim can treat comp picks
+  as tradable like any other pick; this mirrors post-2017 behavior.
+- **The 2023 international-player pathway picks** show up in the
+  uncapped-special total but are allocated by a different rule; they're rare
+  enough (1 pick in 2023) to ignore at sim scale.


### PR DESCRIPTION
## Summary

- Adds `data/R/bands/comp-picks.R`, `data/bands/comp-picks.json`, and
  `data/docs/comp-picks.md` to calibrate the sim's compensatory-pick
  economy against 2020–2024 NFL drafts.
- `load_draft_picks()` has no comp flag; the script infers comp status
  from ordinal pick position within the round (`pos_in_round > 32` in
  rounds 3–7). Observed totals (31–38/yr) match league-reported counts.
- Band reports per-team mean/sd/distribution (0..4+), round mix,
  P(≥1 comp pick | prior-year net UFA-loss bucket) via `load_contracts()`
  with a coarse $3M APY qualifying floor, and the inferred
  above-the-cap special (minority-hire) comp count per year.
- Doc captures the 32-pick league cap, tier-weighted cancellation
  rules, and a sim approximation that avoids replicating the NFL's
  confidential APY+snap+honors formula.
- Indexes the new doc in `data/docs/README.md` and adds row #9 to
  `data/docs/calibration-gaps.md`.