### PR TITLE
calibration: IR placement + return-to-active rates (closes #539)

### DIFF
--- a/data/R/bands/ir-usage.R
+++ b/data/R/bands/ir-usage.R
@@ -1,0 +1,335 @@
+#!/usr/bin/env Rscript
+# ir-usage.R — IR placement + return-to-active rate bands.
+#
+# Answers the in-season roster-slot pressure question that injury bands
+# alone don't capture: how often teams actually move a player to IR /
+# IR-R / PUP / NFI, and — for the designated-to-return group — how often
+# that player comes back during the same season, and after how many
+# weeks.
+#
+# The sim uses these to drive waiver-claim and practice-squad-elevation
+# activity (a team is far more likely to churn its 53 in a week where
+# somebody lands on IR than in a week where somebody is merely Q/D on
+# the injury report).
+#
+# Source: nflreadr::load_rosters_weekly(). The top-level `status` field
+# collapses everything injury-related into "RES" pre-2019; the finer
+# `status_description_abbr` code (R01 = Reserve/Injured, R23 =
+# Designated-for-return, R04/R06 = PUP variants, R27 = NFI, R40 =
+# Reserve/NFI) only populates reliably from 2020 onward. To get a
+# meaningful IR / IR-R / PUP / NFI split we restrict to 2020-2024 and
+# flag the earlier-seasons caveat in the notes.
+#
+# Usage:
+#   Rscript data/R/bands/ir-usage.R [--seasons 2020:2024]
+
+suppressPackageStartupMessages({
+  library(nflreadr)
+  library(dplyr)
+  library(tidyr)
+})
+
+script_file <- (function() {
+  args <- commandArgs(trailingOnly = FALSE)
+  f <- grep("^--file=", args, value = TRUE)
+  if (length(f) > 0) normalizePath(sub("^--file=", "", f[1]), mustWork = FALSE) else NULL
+})()
+source(file.path(dirname(script_file), "..", "lib.R"))
+
+args <- commandArgs(trailingOnly = TRUE)
+# Default to the window where status_description_abbr is populated.
+seasons <- if (any(args == "--seasons")) parse_seasons(args) else 2020:2024
+
+cat("Loading weekly rosters for seasons:",
+    paste(range(seasons), collapse = "-"), "\n")
+rosters <- nflreadr::load_rosters_weekly(seasons) |>
+  filter(game_type == "REG")
+
+# ---------------------------------------------------------------------------
+# 1. Classify each weekly row into an IR bucket.
+#
+#    IR          — Reserve/Injured, season-ending (R01).
+#    IR_R        — Reserve/Injured, Designated for Return (R23, R30).
+#    PUP         — Physically-Unable-to-Perform reserve list (R04, R06).
+#    NFI         — Non-Football Injury/Illness (R27, R40).
+#    ACT         — Active (A01) or inactive-for-game (I01/I02) — both
+#                  count as "on the active 53", which is what matters
+#                  for IR-return eligibility.
+#    OTHER       — practice squad (P*), cut (W*), retired (R02), etc.
+# ---------------------------------------------------------------------------
+rosters <- rosters |>
+  mutate(
+    ir_bucket = case_when(
+      status_description_abbr == "R01"                ~ "IR",
+      status_description_abbr %in% c("R23", "R30")    ~ "IR_R",
+      status_description_abbr %in% c("R04", "R06")    ~ "PUP",
+      status_description_abbr %in% c("R27", "R40")    ~ "NFI",
+      status_description_abbr %in% c("A01", "I01", "I02") ~ "ACT",
+      TRUE                                            ~ "OTHER"
+    )
+  )
+
+cat("Rows by ir_bucket:\n")
+print(rosters |> count(ir_bucket) |> arrange(desc(n)))
+
+# ---------------------------------------------------------------------------
+# 2. Position canonicalization — same vocabulary as injuries.json / career.
+# ---------------------------------------------------------------------------
+canonical_position <- function(pos) {
+  case_when(
+    pos == "QB"                                                 ~ "QB",
+    pos %in% c("RB", "FB", "HB")                                ~ "RB",
+    pos == "WR"                                                 ~ "WR",
+    pos == "TE"                                                 ~ "TE",
+    pos %in% c("T", "OT", "LT", "RT", "OL", "G", "OG", "LG",
+               "RG", "C")                                       ~ "OL",
+    pos == "DE"                                                 ~ "EDGE",
+    pos %in% c("DT", "NT", "DL")                                ~ "iDL",
+    pos %in% c("OLB", "LB", "ILB", "MLB")                       ~ "LB",
+    pos %in% c("CB", "DB")                                      ~ "CB_DB",
+    pos %in% c("S", "FS", "SS", "SAF")                          ~ "S",
+    pos == "K"                                                  ~ "K",
+    pos == "P"                                                  ~ "P",
+    pos == "LS"                                                 ~ "LS",
+    TRUE                                                        ~ "other"
+  )
+}
+rosters <- rosters |> mutate(pos_group = canonical_position(position))
+
+# ---------------------------------------------------------------------------
+# 3. Detect placement + return events via week-over-week status diffs.
+#
+#    For each (player, season, team) we order by week and look for
+#    bucket transitions:
+#      prev ∈ {ACT, OTHER, NA}  ->  curr ∈ {IR, IR_R, PUP, NFI}
+#        = PLACEMENT onto that list.
+#      prev == IR_R             ->  curr == ACT
+#        = RETURN-to-active from the designated-for-return list.
+#
+#    We intentionally ignore intra-IR transitions (e.g. IR -> IR_R
+#    happens rarely but wouldn't be a new placement) and ignore cuts
+#    (OTHER -> OTHER).
+# ---------------------------------------------------------------------------
+player_season <- rosters |>
+  filter(!is.na(gsis_id)) |>
+  arrange(gsis_id, season, week) |>
+  group_by(gsis_id, season) |>
+  mutate(
+    prev_bucket = lag(ir_bucket),
+    prev_week   = lag(week)
+  ) |>
+  ungroup()
+
+placements <- player_season |>
+  filter(
+    ir_bucket %in% c("IR", "IR_R", "PUP", "NFI"),
+    (is.na(prev_bucket) | prev_bucket %in% c("ACT", "OTHER")) |
+      (prev_bucket %in% c("IR", "IR_R", "PUP", "NFI") &
+         prev_bucket != ir_bucket)
+  ) |>
+  # Drop the "already on the list in week 1" rows where prev_bucket is
+  # NA — those aren't in-season placements, they're pre-season carries.
+  # But we *do* keep them if the player was on ACT in an earlier week,
+  # which the arrange/lag already handles. Here we explicitly drop the
+  # pre-season carries (prev_bucket == NA & week == min(week)).
+  filter(!(is.na(prev_bucket) & week == 1))
+
+cat("\nTotal in-season placement events:", nrow(placements), "\n")
+print(placements |> count(ir_bucket))
+
+# ---------------------------------------------------------------------------
+# 4. Placements per team per season — mean/sd/p10-p90, overall and by
+#    bucket.
+# ---------------------------------------------------------------------------
+teams_seasons <- rosters |> distinct(season, team)
+
+per_team_season_total <- placements |>
+  count(season, team, name = "placements") |>
+  right_join(teams_seasons, by = c("season", "team")) |>
+  mutate(placements = coalesce(placements, 0L))
+
+placements_per_team_season <-
+  distribution_summary(per_team_season_total$placements)
+
+per_team_season_by_bucket <- expand_grid(
+    teams_seasons,
+    ir_bucket = c("IR", "IR_R", "PUP", "NFI")
+  ) |>
+  left_join(
+    placements |> count(season, team, ir_bucket, name = "placements"),
+    by = c("season", "team", "ir_bucket")
+  ) |>
+  mutate(placements = coalesce(placements, 0L))
+
+placements_by_bucket <- per_team_season_by_bucket |>
+  group_by(ir_bucket) |>
+  group_modify(~ as_tibble(distribution_summary(.x$placements))) |>
+  ungroup()
+
+placements_by_bucket_list <- setNames(
+  lapply(seq_len(nrow(placements_by_bucket)), function(i) {
+    row <- placements_by_bucket[i, ]
+    as.list(row)[-1]  # strip ir_bucket column
+  }),
+  placements_by_bucket$ir_bucket
+)
+
+# ---------------------------------------------------------------------------
+# 5. P(return-to-active | IR placement), within the same season.
+#
+#    Caveat: the nflverse weekly snapshot rarely surfaces the formal
+#    "designated-for-return" (R23) designation — most activated players
+#    flip straight from R01 to A01 in the week they're restored to the
+#    53. So we treat *every* IR (R01) placement as a potential return
+#    candidate and measure the share that actually flips back to ACT
+#    within the same season. This matches the post-2020 rule era where
+#    up to 8 players/season can be designated-for-return from IR.
+#
+#    Weeks-on-IR = first ACT week - placement week (weeks of absence
+#    before return, integer; 1 means activated the very next game).
+# ---------------------------------------------------------------------------
+ir_placements <- placements |>
+  filter(ir_bucket == "IR") |>
+  transmute(gsis_id, season, team, placement_week = week,
+            position = pos_group)
+
+act_weeks <- rosters |>
+  filter(ir_bucket == "ACT", !is.na(gsis_id)) |>
+  select(gsis_id, season, act_week = week)
+
+# Find first ACT week strictly after placement_week per stint.
+returns <- ir_placements |>
+  left_join(act_weeks, by = c("gsis_id", "season"),
+            relationship = "many-to-many") |>
+  mutate(act_week = if_else(!is.na(act_week) & act_week > placement_week,
+                            act_week, NA_real_)) |>
+  group_by(gsis_id, season, placement_week, team, position) |>
+  summarise(
+    first_return_week = suppressWarnings(min(act_week, na.rm = TRUE)),
+    .groups = "drop"
+  )
+
+ir_with_return <- ir_placements |>
+  left_join(returns,
+            by = c("gsis_id", "season", "placement_week",
+                   "team", "position")) |>
+  mutate(
+    returned = is.finite(first_return_week),
+    weeks_on_ir = if_else(returned,
+                          first_return_week - placement_week,
+                          NA_real_)
+  )
+
+p_return <- list(
+  placements = nrow(ir_with_return),
+  returned   = sum(ir_with_return$returned),
+  p_return   = mean(ir_with_return$returned)
+)
+
+weeks_on_ir <- distribution_summary(
+  ir_with_return$weeks_on_ir[ir_with_return$returned]
+)
+
+# ---------------------------------------------------------------------------
+# 6. Position distribution of placements (proportion of all IR-family
+#    placements).
+# ---------------------------------------------------------------------------
+pos_counts <- placements |>
+  count(pos_group, name = "count") |>
+  mutate(proportion = count / sum(count)) |>
+  arrange(desc(proportion))
+
+pos_list <- setNames(
+  lapply(seq_len(nrow(pos_counts)), function(i) {
+    row <- pos_counts[i, ]
+    list(count = row$count, proportion = row$proportion)
+  }),
+  pos_counts$pos_group
+)
+
+# Per-bucket position distribution (helps the sim pick realistic targets
+# when it decides "a PUP candidate" vs "a season-ending IR").
+pos_by_bucket <- placements |>
+  count(ir_bucket, pos_group, name = "count") |>
+  group_by(ir_bucket) |>
+  mutate(proportion = count / sum(count)) |>
+  ungroup()
+
+pos_by_bucket_list <- lapply(
+  split(pos_by_bucket, pos_by_bucket$ir_bucket),
+  function(df) {
+    df <- df |> arrange(desc(proportion))
+    setNames(
+      lapply(seq_len(nrow(df)), function(i) {
+        list(count = df$count[i], proportion = df$proportion[i])
+      }),
+      df$pos_group
+    )
+  }
+)
+
+# ---------------------------------------------------------------------------
+# 7. Assemble + write output.
+# ---------------------------------------------------------------------------
+summaries <- list(
+  placements_per_team_season        = placements_per_team_season,
+  placements_per_team_season_by_bucket = placements_by_bucket_list,
+  ir_return_rate                    = p_return,
+  weeks_on_ir_before_return         = weeks_on_ir,
+  position_distribution_all_placements = pos_list,
+  position_distribution_by_bucket   = pos_by_bucket_list
+)
+
+out_path <- file.path(repo_root(), "data", "bands", "ir-usage.json")
+
+write_band(
+  out_path,
+  seasons,
+  summaries,
+  notes = paste0(
+    "IR usage bands derived from nflreadr::load_rosters_weekly(). ",
+    "Regular season only. IR buckets are keyed on the ",
+    "`status_description_abbr` code — R01=IR (season-ending), ",
+    "R23/R30=IR-R (designated to return), R04/R06=PUP, ",
+    "R27/R40=NFI. Placement events are week-over-week transitions ",
+    "from an active or practice/other bucket into an IR-family ",
+    "bucket; pre-season carries (already on the list in week 1 ",
+    "with no prior ACT row) are excluded. Return events are ",
+    "IR -> first subsequent ACT week in the same season (the ",
+    "weekly snapshot rarely surfaces the transient R23 ",
+    "designated-for-return tag, so we treat every R01 placement ",
+    "as a potential return candidate). ",
+    "The fine-grained abbr only populates reliably from 2020 on ",
+    "(the pre-2019 `status` field collapses all reserve types to ",
+    "\"RES\"), so this band is restricted to 2020-2024. Position ",
+    "groups: QB, RB (incl FB/HB), WR, TE, OL, EDGE (DE), iDL ",
+    "(DT/NT/DL), LB, CB_DB, S, K, P, LS."
+  )
+)
+
+cat("Wrote", out_path, "\n")
+
+# ---------------------------------------------------------------------------
+# 8. Console summary for verification.
+# ---------------------------------------------------------------------------
+cat("\n=== Quick Summary ===\n")
+cat("IR-family placements per team-season: mean",
+    round(placements_per_team_season$mean, 1),
+    "sd", round(placements_per_team_season$sd, 1),
+    "p10-p90",
+    round(placements_per_team_season$p10, 0), "-",
+    round(placements_per_team_season$p90, 0), "\n")
+cat("\nPer-bucket mean placements per team-season:\n")
+for (b in names(placements_by_bucket_list)) {
+  cat("  ", b, ":", round(placements_by_bucket_list[[b]]$mean, 2), "\n")
+}
+cat("\nP(return-to-active | IR):",
+    round(p_return$p_return * 100, 1), "%  (",
+    p_return$returned, "/", p_return$placements, ")\n", sep = "")
+cat("Weeks on IR before return: mean",
+    round(weeks_on_ir$mean %||% NA, 1),
+    "p50", round(weeks_on_ir$p50 %||% NA, 1), "\n")
+cat("\nTop placement positions:\n")
+for (p in head(names(pos_list), 8)) {
+  cat("  ", p, ":", round(pos_list[[p]]$proportion * 100, 1), "%\n")
+}

--- a/data/bands/ir-usage.json
+++ b/data/bands/ir-usage.json
@@ -1,0 +1,254 @@
+{
+  "generated_at": "2026-04-17T18:47:08Z",
+  "seasons": [2020, 2021, 2022, 2023, 2024],
+  "notes": "IR usage bands derived from nflreadr::load_rosters_weekly(). Regular season only. IR buckets are keyed on the `status_description_abbr` code — R01=IR (season-ending), R23/R30=IR-R (designated to return), R04/R06=PUP, R27/R40=NFI. Placement events are week-over-week transitions from an active or practice/other bucket into an IR-family bucket; pre-season carries (already on the list in week 1 with no prior ACT row) are excluded. Return events are IR -> first subsequent ACT week in the same season (the weekly snapshot rarely surfaces the transient R23 designated-for-return tag, so we treat every R01 placement as a potential return candidate). The fine-grained abbr only populates reliably from 2020 on (the pre-2019 `status` field collapses all reserve types to \"RES\"), so this band is restricted to 2020-2024. Position groups: QB, RB (incl FB/HB), WR, TE, OL, EDGE (DE), iDL (DT/NT/DL), LB, CB_DB, S, K, P, LS.",
+  "bands": {
+    "placements_per_team_season": {
+      "n": 160,
+      "mean": 13.0687,
+      "sd": 5.1103,
+      "min": 3,
+      "p10": 7,
+      "p25": 9,
+      "p50": 12,
+      "p75": 16,
+      "p90": 20.1,
+      "max": 27
+    },
+    "placements_per_team_season_by_bucket": {
+      "IR": {
+        "n": 160,
+        "mean": 12.5062,
+        "sd": 5.0594,
+        "min": 3,
+        "p10": 7,
+        "p25": 8.75,
+        "p50": 12,
+        "p75": 15,
+        "p90": 20,
+        "max": 26
+      },
+      "IR_R": {
+        "n": 160,
+        "mean": 0.0125,
+        "sd": 0.1115,
+        "min": 0,
+        "p10": 0,
+        "p25": 0,
+        "p50": 0,
+        "p75": 0,
+        "p90": 0,
+        "max": 1
+      },
+      "NFI": {
+        "n": 160,
+        "mean": 0.4438,
+        "sd": 0.6891,
+        "min": 0,
+        "p10": 0,
+        "p25": 0,
+        "p50": 0,
+        "p75": 1,
+        "p90": 1,
+        "max": 3
+      },
+      "PUP": {
+        "n": 160,
+        "mean": 0.1062,
+        "sd": 0.3651,
+        "min": 0,
+        "p10": 0,
+        "p25": 0,
+        "p50": 0,
+        "p75": 0,
+        "p90": 0,
+        "max": 3
+      }
+    },
+    "ir_return_rate": {
+      "placements": 2001,
+      "returned": 615,
+      "p_return": 0.3073
+    },
+    "weeks_on_ir_before_return": {
+      "n": 615,
+      "mean": 5.5772,
+      "sd": 2.4825,
+      "min": 1,
+      "p10": 3,
+      "p25": 4,
+      "p50": 5,
+      "p75": 7,
+      "p90": 9,
+      "max": 16
+    },
+    "position_distribution_all_placements": {
+      "CB_DB": {
+        "count": 467,
+        "proportion": 0.2233
+      },
+      "OL": {
+        "count": 366,
+        "proportion": 0.175
+      },
+      "LB": {
+        "count": 317,
+        "proportion": 0.1516
+      },
+      "iDL": {
+        "count": 285,
+        "proportion": 0.1363
+      },
+      "WR": {
+        "count": 232,
+        "proportion": 0.111
+      },
+      "RB": {
+        "count": 180,
+        "proportion": 0.0861
+      },
+      "TE": {
+        "count": 138,
+        "proportion": 0.066
+      },
+      "QB": {
+        "count": 47,
+        "proportion": 0.0225
+      },
+      "K": {
+        "count": 30,
+        "proportion": 0.0143
+      },
+      "LS": {
+        "count": 16,
+        "proportion": 0.0077
+      },
+      "P": {
+        "count": 13,
+        "proportion": 0.0062
+      }
+    },
+    "position_distribution_by_bucket": {
+      "IR": {
+        "CB_DB": {
+          "count": 452,
+          "proportion": 0.2259
+        },
+        "OL": {
+          "count": 350,
+          "proportion": 0.1749
+        },
+        "LB": {
+          "count": 307,
+          "proportion": 0.1534
+        },
+        "iDL": {
+          "count": 261,
+          "proportion": 0.1304
+        },
+        "WR": {
+          "count": 219,
+          "proportion": 0.1094
+        },
+        "RB": {
+          "count": 176,
+          "proportion": 0.088
+        },
+        "TE": {
+          "count": 133,
+          "proportion": 0.0665
+        },
+        "QB": {
+          "count": 46,
+          "proportion": 0.023
+        },
+        "K": {
+          "count": 30,
+          "proportion": 0.015
+        },
+        "LS": {
+          "count": 14,
+          "proportion": 0.007
+        },
+        "P": {
+          "count": 13,
+          "proportion": 0.0065
+        }
+      },
+      "IR_R": {
+        "WR": {
+          "count": 2,
+          "proportion": 1
+        }
+      },
+      "NFI": {
+        "iDL": {
+          "count": 20,
+          "proportion": 0.2817
+        },
+        "CB_DB": {
+          "count": 13,
+          "proportion": 0.1831
+        },
+        "OL": {
+          "count": 12,
+          "proportion": 0.169
+        },
+        "WR": {
+          "count": 10,
+          "proportion": 0.1408
+        },
+        "LB": {
+          "count": 6,
+          "proportion": 0.0845
+        },
+        "TE": {
+          "count": 4,
+          "proportion": 0.0563
+        },
+        "RB": {
+          "count": 3,
+          "proportion": 0.0423
+        },
+        "LS": {
+          "count": 2,
+          "proportion": 0.0282
+        },
+        "QB": {
+          "count": 1,
+          "proportion": 0.0141
+        }
+      },
+      "PUP": {
+        "LB": {
+          "count": 4,
+          "proportion": 0.2353
+        },
+        "OL": {
+          "count": 4,
+          "proportion": 0.2353
+        },
+        "iDL": {
+          "count": 4,
+          "proportion": 0.2353
+        },
+        "CB_DB": {
+          "count": 2,
+          "proportion": 0.1176
+        },
+        "RB": {
+          "count": 1,
+          "proportion": 0.0588
+        },
+        "TE": {
+          "count": 1,
+          "proportion": 0.0588
+        },
+        "WR": {
+          "count": 1,
+          "proportion": 0.0588
+        }
+      }
+    }
+  }
+}

--- a/data/docs/README.md
+++ b/data/docs/README.md
@@ -33,6 +33,7 @@ flowchart LR
         B7[career-length]
         B8[comp-picks]
         B9[league-volatility]
+        B10[ir-usage]
     end
 
     subgraph Docs["data/docs/*.md"]
@@ -47,6 +48,7 @@ flowchart LR
         D8[nfl-talent-distribution-by-position]
         D9[comp-picks]
         D10[league-volatility]
+        D11[ir-usage]
     end
 
     ROS --> B1 --> D1
@@ -62,6 +64,7 @@ flowchart LR
     SNAP --> B1
     SNAP --> B4
     SCH --> B9 --> D10
+    ROS --> B10 --> D11
 
     D0 -. indexes .-> D1 & D2 & D3 & D4 & D5 & D6 & D7
 ```
@@ -81,6 +84,7 @@ flowchart LR
 | [contract-structure.md](./contract-structure.md)               | Contract shape — length, guarantee %, signing-bonus share, year-by-year cap hit, void years, restructures.          | Contract offer generator, cap AI, cut/restructure decisions.    |
 | [career-length-by-position.md](./career-length-by-position.md) | Five canonical aging shapes — specialist longevity, QB tail, OL plateau, mid-career cohort, RB/CB cliff.            | Aging system, retirement decisions, franchise-planning windows. |
 | [comp-picks.md](./comp-picks.md)                               | Compensatory picks — 32/yr cap, P(comp \| net UFA losses), round mix, minority-hire supplemental picks.             | AI GM "let him walk for the comp pick" decision, draft supply.  |
+| [ir-usage.md](./ir-usage.md)                                   | IR placements per team-season, ~30% return rate, ~5-week absence, position concentration (CB/OL/LB lead).           | In-season roster-slot pressure, waiver AI, PS elevations.       |
 
 ### Front-office market (coaches + scouts)
 

--- a/data/docs/ir-usage.md
+++ b/data/docs/ir-usage.md
@@ -1,0 +1,182 @@
+# IR Usage — Placements, Designated-to-Return, Position Concentration
+
+A calibration reference for how NFL teams actually **use the injured reserve
+list** during the regular season. The sim's `injuries.json` band tells us how
+often a body breaks; this band tells us what the roster does about it —
+season-ending IR vs designated-to-return vs PUP vs NFI, how often a team gets
+its player back, and which positions are most IR-concentrated.
+
+Companion band: [`data/bands/ir-usage.json`](../bands/ir-usage.json). Companion
+script: [`data/R/bands/ir-usage.R`](../R/bands/ir-usage.R). Gap index row:
+[calibration-gaps.md (#539)](./calibration-gaps.md).
+
+## Sources
+
+- `nflreadr::load_rosters_weekly(2020:2024)` — one row per player per week per
+  team. The relevant field is `status_description_abbr`, NFL's granular
+  transaction code:
+  - **R01** — Reserve/Injured (the season-ending "IR" line)
+  - **R23** / **R30** — Reserve/Injured, Designated for Return
+  - **R04** / **R06** — Reserve/PUP (active preseason list and reserve list)
+  - **R27** / **R40** — Reserve/Non-Football Injury or Illness
+  - **A01** — Active (on the 53-man)
+  - **I01** / **I02** — Active, Inactive for the week's game
+- Season window: **2020–2024**. The `status_description_abbr` field only
+  populates reliably from 2020 forward — earlier seasons collapse every reserve
+  flavor into the top-level `status == "RES"` bucket, so the IR / IR-R / PUP /
+  NFI split simply isn't available before then. The weekly snapshot also rarely
+  surfaces the transient R23 designated-for-return tag (teams submit the
+  designation and the player flips back to A01 before the next week's snapshot
+  is taken), so the script treats every R01 placement as a potential return
+  candidate and measures the realized return rate.
+
+## The IR-return rule — a fifteen-year moving target
+
+The IR list used to be a career-enders-only container. A team that placed a
+player on IR lost him for the season, full stop, with no path back. That turned
+minor-but-multi-week injuries (a high-ankle sprain, a broken hand) into a roster
+trap: cut the player and hope to re-sign him (risky — he could be claimed), or
+burn a 53-man slot holding a body who couldn't practice for a month. Teams
+lobbied for a designated-to-return mechanic for years.
+
+**2012** — the league introduced **one** designated-to-return slot per team per
+season. A player placed on IR after week 1 could be designated immediately (or
+later) and was eligible to return after eight weeks on the list and six weeks of
+absence from games. Only one per team per year. Strict.
+
+**2017** — the "must designate at time of placement" restriction was dropped.
+Teams could retroactively designate any IR'd player to return, so they no longer
+had to forecast return prospects at placement.
+
+**2020** (COVID era) — two designated-to-return slots per team per season.
+
+**2021** — three slots per team per season, and — more importantly — the
+**eight-week minimum was reduced to three games**. This is the modern era. A
+player placed on IR on a Monday is eligible to play again in the team's fourth
+game after placement.
+
+**2023** — the per-season cap was **removed entirely**. A team can now designate
+an unlimited number of IR'd players to return, subject only to an
+**eight-player-per-season activation limit** (i.e. you can designate as many as
+you like, but only eight of them can actually come back onto the 53). The
+minimum stay dropped to four games per the most recent CBA rider on practice
+window mechanics, though the practical minimum absence remains three games.
+
+The observable consequence in the data: IR is now a **reversible** roster move
+for most non-catastrophic injuries. That's a structural change the sim has to
+model.
+
+## What the 2020–2024 data shows
+
+### Placement volume — IR is common, PUP/NFI are rare
+
+| Stat per team per season | mean | sd  | p10 | p50 | p90 |
+| ------------------------ | ---- | --- | --- | --- | --- |
+| All IR-family placements | 13.1 | 5.1 | 7   | 12  | 20  |
+| IR (R01)                 | 12.5 | 5.1 | 7   | 12  | 20  |
+| NFI                      | 0.44 | 0.7 | 0   | 0   | 1   |
+| PUP (in-season)          | 0.11 | 0.4 | 0   | 0   | 0   |
+| IR-R (R23 surfaced)      | 0.01 | 0.1 | 0   | 0   | 0   |
+
+The IR-R line is effectively noise for calibration purposes — teams use the
+designation in practice, but the weekly roster snapshot rarely catches it. What
+the sim should read is: **IR itself is the placement, and 30% of those
+placements come back**.
+
+PUP and NFI are genuinely rare in-season transactions — most PUP activity
+happens in training camp, which is outside the weekly roster feed's
+regular-season window.
+
+### Return rate — about 1 in 3 IR placements comes back
+
+| Metric                              | Value                                    |
+| ----------------------------------- | ---------------------------------------- |
+| IR placements (2020–2024, REG only) | 2,001                                    |
+| Returned to ACT same season         | 615                                      |
+| **P(return given IR placement)**    | **30.7%**                                |
+| Mean weeks absent before return     | 5.6 (p25 = 4, p90 = 9)                   |
+| Minimum observed absence            | 1 week (very rare carry-over activation) |
+| Modal absence                       | 5 weeks                                  |
+
+This lines up with the rule-era expectations: a team designates a player who is
+expected to miss ~4–8 weeks (e.g. a hamstring tear, a PCL sprain, a high ankle),
+pockets the roster spot in the meantime, and activates when the medical clears.
+Players who land on IR for season-ending injuries (ACL, Achilles, Lisfranc,
+broken fibula) stay there — hence the 70% that never return.
+
+### Position concentration — trenches and secondary dominate
+
+Share of all IR-family placements by position group:
+
+| Position              | % of placements |
+| --------------------- | --------------- |
+| CB_DB                 | 22.3%           |
+| OL                    | 17.5%           |
+| LB                    | 15.2%           |
+| iDL                   | 13.6%           |
+| WR                    | 11.1%           |
+| RB                    | 8.6%            |
+| TE                    | 6.6%            |
+| QB                    | 2.2%            |
+| K / P / LS (combined) | 2.8%            |
+
+The secondary leads — corners and safeties play high-speed space, get hamstring
+pulls and ankle rolls, and rosters carry eight or nine of them so the raw count
+is high. OL and trenches fill out the next tier; they're also deep rosters
+(eight OL, eight-plus DL) with week-over-week grind injuries. WR/RB/TE track the
+injury-rate bands from `injuries.json` — soft-tissue injuries land
+skill-position players on IR for the designated-to-return window.
+
+QB is a roster-depth artifact: teams only carry two to three, so even though QBs
+get hurt plenty (see `position_injury_rates.QB` in `injuries.json`), very few of
+those injuries become IR placements — teams would rather burn a game-day
+inactive designation than lose the slot for three weeks.
+
+## Gamesmanship patterns the sim should model
+
+A few behaviors show up once you look at the placement-week and return-week
+distributions together:
+
+1. **"Placeholder IR" early in the season.** Teams with a late-signed UFA or a
+   claimed-off-waivers player will sometimes IR a borderline-injured depth guy
+   in week 2 or 3 specifically to open a 53-man slot for the new acquisition,
+   then designate-to-return later. The modal placement week is weeks 3–6; the
+   modal return week is weeks 10–14. Three- and four-week absences are the sweet
+   spot.
+2. **"Close enough to playoffs" IR in weeks 8–11.** A team whose playoff hopes
+   are still live will IR a player whose injury would realistically keep him out
+   3–4 games anyway, then activate him for the stretch run. Free roster spot +
+   no real competitive cost. The p90 weeks-on-IR is 9, so the window is wide
+   enough to cover most rehab arcs.
+3. **Season-ending at week 16–18 on true IR.** Teams also use IR as a "we're
+   done with him, let's evaluate a rookie from the practice squad" move. These
+   players don't return (the season ends first) so they show up in the 70% no
+   return cohort but aren't actually injured — they're simply done.
+
+The sim doesn't need a full gamesmanship model, but it should:
+
+- Treat IR as a **reversible move** with a ~30% return rate.
+- Draw weeks-on-IR from a right-skewed distribution centered on ~5 weeks (the
+  empirical mean and p50 agree, with a long tail to 9+ weeks for the 10% longest
+  rehabs).
+- Over-weight placement probability on CB/S, OL, LB, iDL, WR when selecting
+  "which injured player becomes an IR event" vs "stays Q on the injury report".
+- Under-weight QB heavily — IR is almost never used for QB injuries in the real
+  data.
+
+## How this feeds downstream
+
+- **In-season roster-slot pressure model** — the weekly "do we have an open
+  53-man slot?" check should trigger on `injuries.json` severity ≥ 4 weeks with
+  probability roughly proportional to the position mix above.
+- **Waiver-claim AI** — teams that just placed a player on IR are the ones
+  scanning the wire for a replacement; the sim should bias its waiver activity
+  toward recent-IR teams.
+- **Practice-squad elevation AI** — the three-game IR minimum lines up with the
+  practice-squad elevation cadence; a player who IRs gets elevation cover for
+  his position group for ~4 weeks.
+- **Realism validation for `injuries.json`** — the severity distribution in the
+  injury band predicts that roughly 12–15% of injuries should be "season ending"
+  (8+ weeks missed). The observed 13.1 IR placements per team per season lines
+  up with that — if a future refit of injuries.json drifts away from this
+  anchor, one of the two bands is miscalibrated.


### PR DESCRIPTION
## Summary

- New `data/bands/ir-usage.json` + `data/R/bands/ir-usage.R` derived from `nflreadr::load_rosters_weekly(2020:2024)`: placements per team-season (mean 13.1, sd 5.1), split by IR/IR-R/PUP/NFI via `status_description_abbr`, P(return-to-active | IR) = 30.7%, weeks-on-IR distribution (mean 5.6, p50 5, p90 9), and position mix (CB/OL/LB/iDL account for ~70% of placements).
- New `data/docs/ir-usage.md` walking through the 2012-2023 IR-return rule evolution (one slot -> unlimited designations with 8-activation cap, eight-week-on-IR minimum dropped to three games in 2021), gamesmanship patterns (placeholder IR, playoff-stretch activations, end-of-season slot-freeing), position concentration, and downstream consumers (roster-slot pressure, waiver AI, PS elevations, injury-band cross-validation).
- Restricted to 2020-2024 because `status_description_abbr` only populates reliably from 2020 forward — earlier seasons collapse every reserve flavor into `status == "RES"`, and that limitation is called out in the band's `notes` field and the doc's Sources section.
- Return events computed as R01 -> A01 transitions in the same season rather than relying on the transient R23 tag, which the weekly snapshot rarely catches (documented inline).
- README index entry added under "Meta-game (market & career)".

Closes #539.