### PR TITLE
calibration(free-agency): position-weighted FA pool + re-sign rate gating (closes #531)

### DIFF
--- a/data/R/bands/ufa-pool-composition.R
+++ b/data/R/bands/ufa-pool-composition.R
@@ -1,0 +1,400 @@
+#!/usr/bin/env Rscript
+# ufa-pool-composition.R — Position-weighted UFA pool composition and re-sign
+# rate gating from year-over-year roster transitions.
+#
+# The existing free-agent-market band counts *contract rows* where team !=
+# draft_team as "external UFA signings". That heuristic massively overcounts
+# because the OTC feed also carries minimum-salary depth churn, practice-squad
+# signings, futures contracts, ERFA tenders, and cut-day re-signings. Counts
+# like "425 WR external signings per offseason" are useful for relative shape
+# across positions but not for sizing the sim's FA pool.
+#
+# This band answers two tighter questions:
+#
+#   1. UFA pool composition — how many *distinct players* per position become
+#      UFAs each offseason, measured by year-over-year roster membership:
+#      a player who was on a roster in season N but whose contract term ended
+#      is a potential UFA in offseason N+1. The pool per position is what the
+#      generator should sample from.
+#
+#   2. Re-sign rate gating — of those potential UFAs, split outcomes three
+#      ways by comparing their season-N team to their season-(N+1) team:
+#        * re_sign_before_fa    = stayed on own team (extension, re-up, tag)
+#        * signed_elsewhere     = changed team (hit the open market and moved)
+#        * out_of_league        = no season-(N+1) roster appearance
+#      The sim gates the FA pool at re_sign_before_fa: those players never hit
+#      the market. The remaining pool is what NPC / user GMs bid on.
+#
+# Data sources:
+#   - nflreadr::load_rosters()   — player-season-team membership, years_exp,
+#                                   entry_year/rookie_year, draft_club
+#   - nflreadr::load_contracts() — used to enrich year-N-end players with a
+#                                   plausible signed contract in offseason N+1
+#                                   (optional — used for the by-tier resign-rate
+#                                   cross-check so the sim can distinguish
+#                                   top-10 retention from depth churn).
+#
+# UFA eligibility proxy: a player is treated as potentially-UFA-eligible in
+# offseason N+1 if they were on a season-N roster AND had years_exp >= 3 at
+# that point (CBA rule is 4 accrued seasons for true UFA status; using >= 3
+# here captures RFA/ERFA + true UFA and matches the sim's player lifecycle
+# which doesn't distinguish tender types).
+#
+# Output: data/bands/ufa-pool-composition.json
+#
+# Usage:
+#   Rscript data/R/bands/ufa-pool-composition.R [--seasons 2019:2024]
+
+suppressPackageStartupMessages({
+  library(nflreadr)
+  library(dplyr)
+  library(tidyr)
+})
+
+script_file <- (function() {
+  args <- commandArgs(trailingOnly = FALSE)
+  f <- grep("^--file=", args, value = TRUE)
+  if (length(f) > 0) normalizePath(sub("^--file=", "", f[1]), mustWork = FALSE) else NULL
+})()
+source(file.path(dirname(script_file), "..", "lib.R"))
+
+args <- commandArgs(trailingOnly = TRUE)
+seasons <- parse_seasons(args)
+
+# We need one extra leading season to establish the "season N roster" for the
+# earliest transition window, and we sample transitions N -> N+1 so we only
+# resolve transitions up through max(seasons) - 1.
+transition_seasons <- head(seasons, -1)
+cat("Resolving UFA transitions for offseasons ending in:",
+    paste(transition_seasons + 1L, collapse = ", "), "\n")
+
+# ---------------------------------------------------------------------------
+# 1. Load rosters for the window (one row per player-season-team-week-ish;
+#    dedupe to one row per player-season-team by keeping the modal team).
+# ---------------------------------------------------------------------------
+cat("Loading rosters for", paste(range(seasons), collapse = "-"), "\n")
+rosters_raw <- nflreadr::load_rosters(seasons)
+
+position_map <- function(pos, depth_chart) {
+  # Prefer depth_chart_position where it splits OL (T/G/C). Fall back to the
+  # general position label. Map into the sim's position groups.
+  p <- ifelse(!is.na(depth_chart) & depth_chart != "", depth_chart, pos)
+  case_when(
+    p %in% c("QB")                        ~ "QB",
+    p %in% c("RB", "FB", "HB")            ~ "RB",
+    p %in% c("WR")                        ~ "WR",
+    p %in% c("TE")                        ~ "TE",
+    p %in% c("T", "LT", "RT", "OT")       ~ "OT",
+    p %in% c("G", "LG", "RG", "C", "OG", "IOL") ~ "IOL",
+    p %in% c("DE", "OLB", "EDGE", "ED")   ~ "EDGE",
+    p %in% c("DT", "NT", "IDL", "DL")     ~ "IDL",
+    p %in% c("LB", "ILB", "MLB")          ~ "LB",
+    p %in% c("CB", "DB")                  ~ "CB",
+    p %in% c("S", "FS", "SS", "SAF")      ~ "S",
+    p %in% c("K", "P", "LS")              ~ "ST",
+    TRUE                                  ~ "other"
+  )
+}
+
+rosters <- rosters_raw |>
+  filter(!is.na(gsis_id), gsis_id != "") |>
+  mutate(position_group = position_map(position, depth_chart_position)) |>
+  # Pick one team per player-season (last week's team is a reasonable proxy
+  # for "end-of-season team", i.e. whose cap book they hit going into the
+  # offseason).
+  group_by(season, gsis_id) |>
+  slice_max(order_by = week, n = 1, with_ties = FALSE) |>
+  ungroup() |>
+  transmute(
+    season, gsis_id, team, position_group,
+    years_exp = as.integer(years_exp),
+    entry_year, rookie_year, draft_club
+  ) |>
+  filter(position_group != "other")
+
+cat("Roster rows (one per player-season):", nrow(rosters), "\n")
+
+# ---------------------------------------------------------------------------
+# 2. Build year-over-year transitions: for each (player, N) find (player, N+1).
+# ---------------------------------------------------------------------------
+next_year_lookup <- rosters |>
+  transmute(gsis_id,
+            season_n = season - 1L,   # so this row is the "next" season for season_n
+            team_next = team)
+
+transitions <- rosters |>
+  rename(season_n = season, team_n = team) |>
+  left_join(next_year_lookup,
+            by = c("gsis_id", "season_n"),
+            relationship = "one-to-one")
+
+# Restrict to transition_seasons (N such that N+1 is resolvable).
+transitions <- transitions |>
+  filter(season_n %in% transition_seasons) |>
+  # UFA-eligibility proxy: at least 3 accrued seasons at the end of season N.
+  # years_exp on rosters is "years entering this season" per nflreadr;
+  # so a rookie is years_exp = 0, a third-year vet is years_exp = 2.
+  # "Entering season N+1 with >= 3 accrued" = years_exp at season N >= 2.
+  # We widen to >= 2 to include RFA-eligible players who also move.
+  filter(!is.na(years_exp), years_exp >= 2L) |>
+  mutate(
+    outcome = case_when(
+      is.na(team_next)          ~ "out_of_league",
+      team_next == team_n       ~ "re_sign_before_fa",
+      TRUE                      ~ "signed_elsewhere"
+    )
+  )
+
+cat("Eligible-UFA transitions rows:", nrow(transitions), "\n")
+
+# ---------------------------------------------------------------------------
+# 3. UFA pool composition — distinct eligible UFAs per offseason, by position.
+#    "Pool" here = season-N roster members with >= 2 years_exp who were NOT
+#    re-signed before FA (i.e. signed_elsewhere + out_of_league would enter
+#    the open market, except out_of_league are retirees/cut depth who don't
+#    sign anywhere in the league). The effective FA pool the sim samples is
+#    signed_elsewhere + (subset of) out_of_league who could still sign.
+#    We report all three so the generator can choose the gate.
+# ---------------------------------------------------------------------------
+pool_by_pos_year <- transitions |>
+  mutate(outcome = factor(outcome,
+                          levels = c("re_sign_before_fa",
+                                     "signed_elsewhere",
+                                     "out_of_league"))) |>
+  count(season_n, position_group, outcome, name = "n", .drop = FALSE) |>
+  pivot_wider(names_from = outcome, values_from = n, values_fill = 0) |>
+  mutate(
+    eligible_ufas = re_sign_before_fa + signed_elsewhere + out_of_league,
+    open_market_pool = signed_elsewhere + out_of_league
+  )
+
+pool_summary <- pool_by_pos_year |>
+  group_by(position_group) |>
+  summarise(
+    seasons = n(),
+    mean_eligible_ufas = mean(eligible_ufas),
+    sd_eligible_ufas = stats::sd(eligible_ufas),
+    mean_open_market_pool = mean(open_market_pool),
+    sd_open_market_pool = stats::sd(open_market_pool),
+    mean_re_sign_before_fa = mean(re_sign_before_fa),
+    mean_signed_elsewhere = mean(signed_elsewhere),
+    mean_out_of_league = mean(out_of_league),
+    .groups = "drop"
+  ) |>
+  arrange(desc(mean_open_market_pool))
+
+total_open_market <- sum(pool_summary$mean_open_market_pool)
+
+pool_summary <- pool_summary |>
+  mutate(open_market_share = mean_open_market_pool / total_open_market)
+
+pool_list <- setNames(
+  lapply(seq_len(nrow(pool_summary)), function(i) {
+    row <- pool_summary[i, ]
+    list(
+      seasons_sampled = row$seasons,
+      mean_eligible_ufas_per_offseason = row$mean_eligible_ufas,
+      sd_eligible_ufas = row$sd_eligible_ufas,
+      mean_open_market_pool_per_offseason = row$mean_open_market_pool,
+      sd_open_market_pool = row$sd_open_market_pool,
+      open_market_pool_share = row$open_market_share,
+      mean_re_sign_before_fa = row$mean_re_sign_before_fa,
+      mean_signed_elsewhere = row$mean_signed_elsewhere,
+      mean_out_of_league = row$mean_out_of_league
+    )
+  }),
+  pool_summary$position_group
+)
+
+# ---------------------------------------------------------------------------
+# 4. Re-sign rate gating — three outcomes, by position.
+#    re_sign_rate = re_sign_before_fa / eligible_ufas
+#    signed_elsewhere_rate = signed_elsewhere / eligible_ufas
+#    out_of_league_rate = out_of_league / eligible_ufas
+#    (Matches the issue's ask: distinguish re-sign-before-FA from open-market
+#    outcomes.)
+# ---------------------------------------------------------------------------
+rate_by_pos <- transitions |>
+  group_by(position_group) |>
+  summarise(
+    eligible_ufas = n(),
+    re_sign_before_fa = sum(outcome == "re_sign_before_fa"),
+    signed_elsewhere = sum(outcome == "signed_elsewhere"),
+    out_of_league = sum(outcome == "out_of_league"),
+    .groups = "drop"
+  ) |>
+  mutate(
+    re_sign_rate = re_sign_before_fa / eligible_ufas,
+    signed_elsewhere_rate = signed_elsewhere / eligible_ufas,
+    out_of_league_rate = out_of_league / eligible_ufas
+  ) |>
+  arrange(desc(re_sign_rate))
+
+rate_list <- setNames(
+  lapply(seq_len(nrow(rate_by_pos)), function(i) {
+    row <- rate_by_pos[i, ]
+    list(
+      eligible_ufas = row$eligible_ufas,
+      re_sign_before_fa = row$re_sign_before_fa,
+      signed_elsewhere = row$signed_elsewhere,
+      out_of_league = row$out_of_league,
+      re_sign_rate = row$re_sign_rate,
+      signed_elsewhere_rate = row$signed_elsewhere_rate,
+      out_of_league_rate = row$out_of_league_rate
+    )
+  }),
+  rate_by_pos$position_group
+)
+
+# ---------------------------------------------------------------------------
+# 5. Re-sign rate by (position, tier) — enrich with OTC contracts so the sim
+#    can reproduce the tier multiplier (top-10 retention > top-25 > top-50 >
+#    rest). A player is placed in a tier by the APY of the contract they
+#    signed in offseason N+1; players without a signed contract (out-of-league
+#    / camp-body minimums) fall into "rest".
+# ---------------------------------------------------------------------------
+cat("Loading contracts\n")
+contracts_raw <- nflreadr::load_contracts()
+
+# Rank APYs within each position group across the full window so tiers are
+# stable (same convention as free-agent-market.R).
+position_tiers <- contracts_raw |>
+  filter(
+    !is.na(year_signed), !is.na(apy), !is.na(gsis_id), gsis_id != "",
+    year_signed %in% (transition_seasons + 1L)
+  ) |>
+  mutate(
+    position_group = case_when(
+      position == "QB"                       ~ "QB",
+      position %in% c("RB", "FB")            ~ "RB",
+      position == "WR"                       ~ "WR",
+      position == "TE"                       ~ "TE",
+      position %in% c("LT", "RT")            ~ "OT",
+      position %in% c("LG", "RG", "C")       ~ "IOL",
+      position %in% c("ED")                  ~ "EDGE",
+      position == "IDL"                      ~ "IDL",
+      position == "LB"                       ~ "LB",
+      position == "CB"                       ~ "CB",
+      position == "S"                        ~ "S",
+      position %in% c("K", "P", "LS")        ~ "ST",
+      TRUE                                   ~ "other"
+    )
+  ) |>
+  filter(position_group != "other") |>
+  group_by(position_group) |>
+  mutate(apy_rank = rank(-apy, ties.method = "first")) |>
+  ungroup() |>
+  mutate(tier = case_when(
+    apy_rank <= 10 ~ "top_10",
+    apy_rank <= 25 ~ "top_25",
+    apy_rank <= 50 ~ "top_50",
+    TRUE           ~ "rest"
+  )) |>
+  transmute(gsis_id, year_signed, position_group_c = position_group, tier)
+
+# Join transitions (keyed on player + offseason) to their signed contract.
+transitions_with_tier <- transitions |>
+  mutate(offseason = season_n + 1L) |>
+  left_join(
+    position_tiers,
+    by = c("gsis_id" = "gsis_id", "offseason" = "year_signed")
+  ) |>
+  mutate(tier = ifelse(is.na(tier), "rest", tier))
+
+rate_by_pos_tier <- transitions_with_tier |>
+  group_by(position_group, tier) |>
+  summarise(
+    eligible_ufas = n(),
+    re_sign_before_fa = sum(outcome == "re_sign_before_fa"),
+    signed_elsewhere = sum(outcome == "signed_elsewhere"),
+    out_of_league = sum(outcome == "out_of_league"),
+    .groups = "drop"
+  ) |>
+  mutate(
+    re_sign_rate = re_sign_before_fa / eligible_ufas,
+    signed_elsewhere_rate = signed_elsewhere / eligible_ufas
+  )
+
+rate_tier_nested <- split(rate_by_pos_tier, rate_by_pos_tier$position_group) |>
+  lapply(function(df) {
+    setNames(
+      lapply(seq_len(nrow(df)), function(i) {
+        list(
+          eligible_ufas = df$eligible_ufas[i],
+          re_sign_before_fa = df$re_sign_before_fa[i],
+          signed_elsewhere = df$signed_elsewhere[i],
+          out_of_league = df$out_of_league[i],
+          re_sign_rate = df$re_sign_rate[i],
+          signed_elsewhere_rate = df$signed_elsewhere_rate[i]
+        )
+      }),
+      df$tier
+    )
+  })
+
+# ---------------------------------------------------------------------------
+# 6. Assemble and write
+# ---------------------------------------------------------------------------
+summaries <- list(
+  pool_composition_by_position = pool_list,
+  resign_rate_by_position = rate_list,
+  resign_rate_by_position_tier = rate_tier_nested
+)
+
+out_path <- file.path(repo_root(), "data", "bands", "ufa-pool-composition.json")
+
+write_band(
+  out_path,
+  seasons,
+  summaries,
+  notes = paste0(
+    "UFA pool composition and re-sign-vs-open-market gating derived from ",
+    "year-over-year roster transitions (nflreadr::load_rosters()) rather than ",
+    "contract rows. A player on a season-N roster with years_exp >= 2 is ",
+    "counted as a potential UFA going into offseason N+1; outcome is ",
+    "classified by comparing team_N to team_(N+1): re_sign_before_fa (same ",
+    "team), signed_elsewhere (different team), out_of_league (no roster ",
+    "appearance). open_market_pool = signed_elsewhere + out_of_league, which ",
+    "is the effective sample space for the sim's FA generator AFTER applying ",
+    "the re-sign-before-FA gate. Tier enrichment joins nflreadr::load_contracts() ",
+    "on (gsis_id, offseason=year_signed) to place each transition in an APY ",
+    "tier (top_10 / top_25 / top_50 / rest); unsigned / minimum deals fall to ",
+    "rest. Position groups: QB, RB (incl FB/HB), WR, TE, OT (T/LT/RT), IOL ",
+    "(G/LG/RG/C/OG), EDGE (DE/OLB/ED), IDL (DT/NT/DL), LB (ILB/MLB), CB (incl ",
+    "DB), S (FS/SS/SAF), ST (K/P/LS)."
+  )
+)
+
+cat("Wrote", out_path, "\n")
+
+cat("\n=== Pool composition by position (mean per offseason) ===\n")
+for (pg in names(pool_list)) {
+  p <- pool_list[[pg]]
+  cat(sprintf("  %-6s elig=%.1f  open_market=%.1f (share %.1f%%)  resign=%.1f  oofl=%.1f\n",
+              pg,
+              p$mean_eligible_ufas_per_offseason,
+              p$mean_open_market_pool_per_offseason,
+              100 * p$open_market_pool_share,
+              p$mean_re_sign_before_fa,
+              p$mean_out_of_league))
+}
+
+cat("\n=== Re-sign vs open-market rates by position ===\n")
+for (pg in names(rate_list)) {
+  r <- rate_list[[pg]]
+  cat(sprintf("  %-6s  resign=%.1f%%  elsewhere=%.1f%%  oofl=%.1f%%  (n=%d)\n",
+              pg,
+              100 * r$re_sign_rate,
+              100 * r$signed_elsewhere_rate,
+              100 * r$out_of_league_rate,
+              r$eligible_ufas))
+}
+
+cat("\n=== Re-sign rate by (position, tier) ===\n")
+for (pg in names(rate_tier_nested)) {
+  for (t in names(rate_tier_nested[[pg]])) {
+    r <- rate_tier_nested[[pg]][[t]]
+    cat(sprintf("  %-6s %-7s resign=%.1f%%  (n=%d)\n",
+                pg, t, 100 * r$re_sign_rate, r$eligible_ufas))
+  }
+}

--- a/data/bands/ufa-pool-composition.json
+++ b/data/bands/ufa-pool-composition.json
@@ -1,0 +1,661 @@
+{
+  "generated_at": "2026-04-17T18:46:46Z",
+  "seasons": [2019, 2020, 2021, 2022, 2023, 2024],
+  "notes": "UFA pool composition and re-sign-vs-open-market gating derived from year-over-year roster transitions (nflreadr::load_rosters()) rather than contract rows. A player on a season-N roster with years_exp >= 2 is counted as a potential UFA going into offseason N+1; outcome is classified by comparing team_N to team_(N+1): re_sign_before_fa (same team), signed_elsewhere (different team), out_of_league (no roster appearance). open_market_pool = signed_elsewhere + out_of_league, which is the effective sample space for the sim's FA generator AFTER applying the re-sign-before-FA gate. Tier enrichment joins nflreadr::load_contracts() on (gsis_id, offseason=year_signed) to place each transition in an APY tier (top_10 / top_25 / top_50 / rest); unsigned / minimum deals fall to rest. Position groups: QB, RB (incl FB/HB), WR, TE, OT (T/LT/RT), IOL (G/LG/RG/C/OG), EDGE (DE/OLB/ED), IDL (DT/NT/DL), LB (ILB/MLB), CB (incl DB), S (FS/SS/SAF), ST (K/P/LS).",
+  "bands": {
+    "pool_composition_by_position": {
+      "EDGE": {
+        "seasons_sampled": 5,
+        "mean_eligible_ufas_per_offseason": 258.8,
+        "sd_eligible_ufas": 23.253,
+        "mean_open_market_pool_per_offseason": 145.6,
+        "sd_open_market_pool": 21.4429,
+        "open_market_pool_share": 0.136,
+        "mean_re_sign_before_fa": 113.2,
+        "mean_signed_elsewhere": 89.2,
+        "mean_out_of_league": 56.4
+      },
+      "WR": {
+        "seasons_sampled": 5,
+        "mean_eligible_ufas_per_offseason": 234.4,
+        "sd_eligible_ufas": 16.6072,
+        "mean_open_market_pool_per_offseason": 142,
+        "sd_open_market_pool": 20.2978,
+        "open_market_pool_share": 0.1327,
+        "mean_re_sign_before_fa": 92.4,
+        "mean_signed_elsewhere": 86.6,
+        "mean_out_of_league": 55.4
+      },
+      "CB": {
+        "seasons_sampled": 5,
+        "mean_eligible_ufas_per_offseason": 214.2,
+        "sd_eligible_ufas": 10.5214,
+        "mean_open_market_pool_per_offseason": 130,
+        "sd_open_market_pool": 12.9035,
+        "open_market_pool_share": 0.1214,
+        "mean_re_sign_before_fa": 84.2,
+        "mean_signed_elsewhere": 77.8,
+        "mean_out_of_league": 52.2
+      },
+      "IOL": {
+        "seasons_sampled": 5,
+        "mean_eligible_ufas_per_offseason": 191,
+        "sd_eligible_ufas": 3.0822,
+        "mean_open_market_pool_per_offseason": 100.4,
+        "sd_open_market_pool": 8.8487,
+        "open_market_pool_share": 0.0938,
+        "mean_re_sign_before_fa": 90.6,
+        "mean_signed_elsewhere": 60,
+        "mean_out_of_league": 40.4
+      },
+      "IDL": {
+        "seasons_sampled": 5,
+        "mean_eligible_ufas_per_offseason": 151.6,
+        "sd_eligible_ufas": 9.6592,
+        "mean_open_market_pool_per_offseason": 85.6,
+        "sd_open_market_pool": 5.8138,
+        "open_market_pool_share": 0.08,
+        "mean_re_sign_before_fa": 66,
+        "mean_signed_elsewhere": 57.8,
+        "mean_out_of_league": 27.8
+      },
+      "RB": {
+        "seasons_sampled": 5,
+        "mean_eligible_ufas_per_offseason": 142,
+        "sd_eligible_ufas": 6.2048,
+        "mean_open_market_pool_per_offseason": 83.2,
+        "sd_open_market_pool": 8.4083,
+        "open_market_pool_share": 0.0777,
+        "mean_re_sign_before_fa": 58.8,
+        "mean_signed_elsewhere": 46.6,
+        "mean_out_of_league": 36.6
+      },
+      "TE": {
+        "seasons_sampled": 5,
+        "mean_eligible_ufas_per_offseason": 131.4,
+        "sd_eligible_ufas": 2.9665,
+        "mean_open_market_pool_per_offseason": 72.8,
+        "sd_open_market_pool": 7.5631,
+        "open_market_pool_share": 0.068,
+        "mean_re_sign_before_fa": 58.6,
+        "mean_signed_elsewhere": 41.4,
+        "mean_out_of_league": 31.4
+      },
+      "OT": {
+        "seasons_sampled": 5,
+        "mean_eligible_ufas_per_offseason": 144.8,
+        "sd_eligible_ufas": 6.4962,
+        "mean_open_market_pool_per_offseason": 72.6,
+        "sd_open_market_pool": 8.2037,
+        "open_market_pool_share": 0.0678,
+        "mean_re_sign_before_fa": 72.2,
+        "mean_signed_elsewhere": 44.6,
+        "mean_out_of_league": 28
+      },
+      "S": {
+        "seasons_sampled": 5,
+        "mean_eligible_ufas_per_offseason": 143.6,
+        "sd_eligible_ufas": 10.4067,
+        "mean_open_market_pool_per_offseason": 72.4,
+        "sd_open_market_pool": 9.7877,
+        "open_market_pool_share": 0.0676,
+        "mean_re_sign_before_fa": 71.2,
+        "mean_signed_elsewhere": 43,
+        "mean_out_of_league": 29.4
+      },
+      "LB": {
+        "seasons_sampled": 5,
+        "mean_eligible_ufas_per_offseason": 121.4,
+        "sd_eligible_ufas": 5.8566,
+        "mean_open_market_pool_per_offseason": 71.4,
+        "sd_open_market_pool": 3.9115,
+        "open_market_pool_share": 0.0667,
+        "mean_re_sign_before_fa": 50,
+        "mean_signed_elsewhere": 45.2,
+        "mean_out_of_league": 26.2
+      },
+      "QB": {
+        "seasons_sampled": 5,
+        "mean_eligible_ufas_per_offseason": 88.2,
+        "sd_eligible_ufas": 4.4385,
+        "mean_open_market_pool_per_offseason": 47.8,
+        "sd_open_market_pool": 7.9812,
+        "open_market_pool_share": 0.0447,
+        "mean_re_sign_before_fa": 40.4,
+        "mean_signed_elsewhere": 33.8,
+        "mean_out_of_league": 14
+      },
+      "ST": {
+        "seasons_sampled": 5,
+        "mean_eligible_ufas_per_offseason": 109.2,
+        "sd_eligible_ufas": 8.8431,
+        "mean_open_market_pool_per_offseason": 46.6,
+        "sd_open_market_pool": 13.3154,
+        "open_market_pool_share": 0.0435,
+        "mean_re_sign_before_fa": 62.6,
+        "mean_signed_elsewhere": 28,
+        "mean_out_of_league": 18.6
+      }
+    },
+    "resign_rate_by_position": {
+      "ST": {
+        "eligible_ufas": 546,
+        "re_sign_before_fa": 313,
+        "signed_elsewhere": 140,
+        "out_of_league": 93,
+        "re_sign_rate": 0.5733,
+        "signed_elsewhere_rate": 0.2564,
+        "out_of_league_rate": 0.1703
+      },
+      "OT": {
+        "eligible_ufas": 724,
+        "re_sign_before_fa": 361,
+        "signed_elsewhere": 223,
+        "out_of_league": 140,
+        "re_sign_rate": 0.4986,
+        "signed_elsewhere_rate": 0.308,
+        "out_of_league_rate": 0.1934
+      },
+      "S": {
+        "eligible_ufas": 718,
+        "re_sign_before_fa": 356,
+        "signed_elsewhere": 215,
+        "out_of_league": 147,
+        "re_sign_rate": 0.4958,
+        "signed_elsewhere_rate": 0.2994,
+        "out_of_league_rate": 0.2047
+      },
+      "IOL": {
+        "eligible_ufas": 955,
+        "re_sign_before_fa": 453,
+        "signed_elsewhere": 300,
+        "out_of_league": 202,
+        "re_sign_rate": 0.4743,
+        "signed_elsewhere_rate": 0.3141,
+        "out_of_league_rate": 0.2115
+      },
+      "QB": {
+        "eligible_ufas": 441,
+        "re_sign_before_fa": 202,
+        "signed_elsewhere": 169,
+        "out_of_league": 70,
+        "re_sign_rate": 0.458,
+        "signed_elsewhere_rate": 0.3832,
+        "out_of_league_rate": 0.1587
+      },
+      "TE": {
+        "eligible_ufas": 657,
+        "re_sign_before_fa": 293,
+        "signed_elsewhere": 207,
+        "out_of_league": 157,
+        "re_sign_rate": 0.446,
+        "signed_elsewhere_rate": 0.3151,
+        "out_of_league_rate": 0.239
+      },
+      "EDGE": {
+        "eligible_ufas": 1294,
+        "re_sign_before_fa": 566,
+        "signed_elsewhere": 446,
+        "out_of_league": 282,
+        "re_sign_rate": 0.4374,
+        "signed_elsewhere_rate": 0.3447,
+        "out_of_league_rate": 0.2179
+      },
+      "IDL": {
+        "eligible_ufas": 758,
+        "re_sign_before_fa": 330,
+        "signed_elsewhere": 289,
+        "out_of_league": 139,
+        "re_sign_rate": 0.4354,
+        "signed_elsewhere_rate": 0.3813,
+        "out_of_league_rate": 0.1834
+      },
+      "RB": {
+        "eligible_ufas": 710,
+        "re_sign_before_fa": 294,
+        "signed_elsewhere": 233,
+        "out_of_league": 183,
+        "re_sign_rate": 0.4141,
+        "signed_elsewhere_rate": 0.3282,
+        "out_of_league_rate": 0.2577
+      },
+      "LB": {
+        "eligible_ufas": 607,
+        "re_sign_before_fa": 250,
+        "signed_elsewhere": 226,
+        "out_of_league": 131,
+        "re_sign_rate": 0.4119,
+        "signed_elsewhere_rate": 0.3723,
+        "out_of_league_rate": 0.2158
+      },
+      "WR": {
+        "eligible_ufas": 1172,
+        "re_sign_before_fa": 462,
+        "signed_elsewhere": 433,
+        "out_of_league": 277,
+        "re_sign_rate": 0.3942,
+        "signed_elsewhere_rate": 0.3695,
+        "out_of_league_rate": 0.2363
+      },
+      "CB": {
+        "eligible_ufas": 1071,
+        "re_sign_before_fa": 421,
+        "signed_elsewhere": 389,
+        "out_of_league": 261,
+        "re_sign_rate": 0.3931,
+        "signed_elsewhere_rate": 0.3632,
+        "out_of_league_rate": 0.2437
+      }
+    },
+    "resign_rate_by_position_tier": {
+      "CB": {
+        "rest": {
+          "eligible_ufas": 1695,
+          "re_sign_before_fa": 597,
+          "signed_elsewhere": 834,
+          "out_of_league": 264,
+          "re_sign_rate": 0.3522,
+          "signed_elsewhere_rate": 0.492
+        },
+        "top_10": {
+          "eligible_ufas": 10,
+          "re_sign_before_fa": 8,
+          "signed_elsewhere": 2,
+          "out_of_league": 0,
+          "re_sign_rate": 0.8,
+          "signed_elsewhere_rate": 0.2
+        },
+        "top_25": {
+          "eligible_ufas": 15,
+          "re_sign_before_fa": 8,
+          "signed_elsewhere": 7,
+          "out_of_league": 0,
+          "re_sign_rate": 0.5333,
+          "signed_elsewhere_rate": 0.4667
+        },
+        "top_50": {
+          "eligible_ufas": 25,
+          "re_sign_before_fa": 10,
+          "signed_elsewhere": 15,
+          "out_of_league": 0,
+          "re_sign_rate": 0.4,
+          "signed_elsewhere_rate": 0.6
+        }
+      },
+      "EDGE": {
+        "rest": {
+          "eligible_ufas": 1850,
+          "re_sign_before_fa": 698,
+          "signed_elsewhere": 869,
+          "out_of_league": 283,
+          "re_sign_rate": 0.3773,
+          "signed_elsewhere_rate": 0.4697
+        },
+        "top_10": {
+          "eligible_ufas": 12,
+          "re_sign_before_fa": 7,
+          "signed_elsewhere": 5,
+          "out_of_league": 0,
+          "re_sign_rate": 0.5833,
+          "signed_elsewhere_rate": 0.4167
+        },
+        "top_25": {
+          "eligible_ufas": 25,
+          "re_sign_before_fa": 15,
+          "signed_elsewhere": 10,
+          "out_of_league": 0,
+          "re_sign_rate": 0.6,
+          "signed_elsewhere_rate": 0.4
+        },
+        "top_50": {
+          "eligible_ufas": 33,
+          "re_sign_before_fa": 18,
+          "signed_elsewhere": 15,
+          "out_of_league": 0,
+          "re_sign_rate": 0.5455,
+          "signed_elsewhere_rate": 0.4545
+        }
+      },
+      "IDL": {
+        "rest": {
+          "eligible_ufas": 1192,
+          "re_sign_before_fa": 403,
+          "signed_elsewhere": 648,
+          "out_of_league": 141,
+          "re_sign_rate": 0.3381,
+          "signed_elsewhere_rate": 0.5436
+        },
+        "top_10": {
+          "eligible_ufas": 9,
+          "re_sign_before_fa": 9,
+          "signed_elsewhere": 0,
+          "out_of_league": 0,
+          "re_sign_rate": 1,
+          "signed_elsewhere_rate": 0
+        },
+        "top_25": {
+          "eligible_ufas": 11,
+          "re_sign_before_fa": 10,
+          "signed_elsewhere": 1,
+          "out_of_league": 0,
+          "re_sign_rate": 0.9091,
+          "signed_elsewhere_rate": 0.0909
+        },
+        "top_50": {
+          "eligible_ufas": 23,
+          "re_sign_before_fa": 14,
+          "signed_elsewhere": 9,
+          "out_of_league": 0,
+          "re_sign_rate": 0.6087,
+          "signed_elsewhere_rate": 0.3913
+        }
+      },
+      "IOL": {
+        "rest": {
+          "eligible_ufas": 1353,
+          "re_sign_before_fa": 566,
+          "signed_elsewhere": 582,
+          "out_of_league": 205,
+          "re_sign_rate": 0.4183,
+          "signed_elsewhere_rate": 0.4302
+        },
+        "top_10": {
+          "eligible_ufas": 10,
+          "re_sign_before_fa": 9,
+          "signed_elsewhere": 1,
+          "out_of_league": 0,
+          "re_sign_rate": 0.9,
+          "signed_elsewhere_rate": 0.1
+        },
+        "top_25": {
+          "eligible_ufas": 15,
+          "re_sign_before_fa": 10,
+          "signed_elsewhere": 5,
+          "out_of_league": 0,
+          "re_sign_rate": 0.6667,
+          "signed_elsewhere_rate": 0.3333
+        },
+        "top_50": {
+          "eligible_ufas": 23,
+          "re_sign_before_fa": 10,
+          "signed_elsewhere": 13,
+          "out_of_league": 0,
+          "re_sign_rate": 0.4348,
+          "signed_elsewhere_rate": 0.5652
+        }
+      },
+      "LB": {
+        "rest": {
+          "eligible_ufas": 930,
+          "re_sign_before_fa": 293,
+          "signed_elsewhere": 506,
+          "out_of_league": 131,
+          "re_sign_rate": 0.3151,
+          "signed_elsewhere_rate": 0.5441
+        },
+        "top_10": {
+          "eligible_ufas": 9,
+          "re_sign_before_fa": 6,
+          "signed_elsewhere": 3,
+          "out_of_league": 0,
+          "re_sign_rate": 0.6667,
+          "signed_elsewhere_rate": 0.3333
+        },
+        "top_25": {
+          "eligible_ufas": 9,
+          "re_sign_before_fa": 3,
+          "signed_elsewhere": 6,
+          "out_of_league": 0,
+          "re_sign_rate": 0.3333,
+          "signed_elsewhere_rate": 0.6667
+        },
+        "top_50": {
+          "eligible_ufas": 19,
+          "re_sign_before_fa": 9,
+          "signed_elsewhere": 10,
+          "out_of_league": 0,
+          "re_sign_rate": 0.4737,
+          "signed_elsewhere_rate": 0.5263
+        }
+      },
+      "OT": {
+        "rest": {
+          "eligible_ufas": 1000,
+          "re_sign_before_fa": 417,
+          "signed_elsewhere": 442,
+          "out_of_league": 141,
+          "re_sign_rate": 0.417,
+          "signed_elsewhere_rate": 0.442
+        },
+        "top_10": {
+          "eligible_ufas": 10,
+          "re_sign_before_fa": 10,
+          "signed_elsewhere": 0,
+          "out_of_league": 0,
+          "re_sign_rate": 1,
+          "signed_elsewhere_rate": 0
+        },
+        "top_25": {
+          "eligible_ufas": 15,
+          "re_sign_before_fa": 13,
+          "signed_elsewhere": 2,
+          "out_of_league": 0,
+          "re_sign_rate": 0.8667,
+          "signed_elsewhere_rate": 0.1333
+        },
+        "top_50": {
+          "eligible_ufas": 27,
+          "re_sign_before_fa": 19,
+          "signed_elsewhere": 8,
+          "out_of_league": 0,
+          "re_sign_rate": 0.7037,
+          "signed_elsewhere_rate": 0.2963
+        }
+      },
+      "QB": {
+        "rest": {
+          "eligible_ufas": 606,
+          "re_sign_before_fa": 221,
+          "signed_elsewhere": 315,
+          "out_of_league": 70,
+          "re_sign_rate": 0.3647,
+          "signed_elsewhere_rate": 0.5198
+        },
+        "top_10": {
+          "eligible_ufas": 10,
+          "re_sign_before_fa": 10,
+          "signed_elsewhere": 0,
+          "out_of_league": 0,
+          "re_sign_rate": 1,
+          "signed_elsewhere_rate": 0
+        },
+        "top_25": {
+          "eligible_ufas": 16,
+          "re_sign_before_fa": 11,
+          "signed_elsewhere": 5,
+          "out_of_league": 0,
+          "re_sign_rate": 0.6875,
+          "signed_elsewhere_rate": 0.3125
+        },
+        "top_50": {
+          "eligible_ufas": 22,
+          "re_sign_before_fa": 11,
+          "signed_elsewhere": 11,
+          "out_of_league": 0,
+          "re_sign_rate": 0.5,
+          "signed_elsewhere_rate": 0.5
+        }
+      },
+      "RB": {
+        "rest": {
+          "eligible_ufas": 1129,
+          "re_sign_before_fa": 391,
+          "signed_elsewhere": 555,
+          "out_of_league": 183,
+          "re_sign_rate": 0.3463,
+          "signed_elsewhere_rate": 0.4916
+        },
+        "top_10": {
+          "eligible_ufas": 10,
+          "re_sign_before_fa": 9,
+          "signed_elsewhere": 1,
+          "out_of_league": 0,
+          "re_sign_rate": 0.9,
+          "signed_elsewhere_rate": 0.1
+        },
+        "top_25": {
+          "eligible_ufas": 15,
+          "re_sign_before_fa": 12,
+          "signed_elsewhere": 3,
+          "out_of_league": 0,
+          "re_sign_rate": 0.8,
+          "signed_elsewhere_rate": 0.2
+        },
+        "top_50": {
+          "eligible_ufas": 24,
+          "re_sign_before_fa": 13,
+          "signed_elsewhere": 11,
+          "out_of_league": 0,
+          "re_sign_rate": 0.5417,
+          "signed_elsewhere_rate": 0.4583
+        }
+      },
+      "S": {
+        "rest": {
+          "eligible_ufas": 1055,
+          "re_sign_before_fa": 451,
+          "signed_elsewhere": 456,
+          "out_of_league": 148,
+          "re_sign_rate": 0.4275,
+          "signed_elsewhere_rate": 0.4322
+        },
+        "top_10": {
+          "eligible_ufas": 10,
+          "re_sign_before_fa": 8,
+          "signed_elsewhere": 2,
+          "out_of_league": 0,
+          "re_sign_rate": 0.8,
+          "signed_elsewhere_rate": 0.2
+        },
+        "top_25": {
+          "eligible_ufas": 15,
+          "re_sign_before_fa": 12,
+          "signed_elsewhere": 3,
+          "out_of_league": 0,
+          "re_sign_rate": 0.8,
+          "signed_elsewhere_rate": 0.2
+        },
+        "top_50": {
+          "eligible_ufas": 24,
+          "re_sign_before_fa": 13,
+          "signed_elsewhere": 11,
+          "out_of_league": 0,
+          "re_sign_rate": 0.5417,
+          "signed_elsewhere_rate": 0.4583
+        }
+      },
+      "ST": {
+        "rest": {
+          "eligible_ufas": 739,
+          "re_sign_before_fa": 299,
+          "signed_elsewhere": 347,
+          "out_of_league": 93,
+          "re_sign_rate": 0.4046,
+          "signed_elsewhere_rate": 0.4696
+        },
+        "top_10": {
+          "eligible_ufas": 9,
+          "re_sign_before_fa": 8,
+          "signed_elsewhere": 1,
+          "out_of_league": 0,
+          "re_sign_rate": 0.8889,
+          "signed_elsewhere_rate": 0.1111
+        },
+        "top_25": {
+          "eligible_ufas": 15,
+          "re_sign_before_fa": 14,
+          "signed_elsewhere": 1,
+          "out_of_league": 0,
+          "re_sign_rate": 0.9333,
+          "signed_elsewhere_rate": 0.0667
+        },
+        "top_50": {
+          "eligible_ufas": 24,
+          "re_sign_before_fa": 17,
+          "signed_elsewhere": 7,
+          "out_of_league": 0,
+          "re_sign_rate": 0.7083,
+          "signed_elsewhere_rate": 0.2917
+        }
+      },
+      "TE": {
+        "rest": {
+          "eligible_ufas": 955,
+          "re_sign_before_fa": 370,
+          "signed_elsewhere": 427,
+          "out_of_league": 158,
+          "re_sign_rate": 0.3874,
+          "signed_elsewhere_rate": 0.4471
+        },
+        "top_10": {
+          "eligible_ufas": 10,
+          "re_sign_before_fa": 10,
+          "signed_elsewhere": 0,
+          "out_of_league": 0,
+          "re_sign_rate": 1,
+          "signed_elsewhere_rate": 0
+        },
+        "top_25": {
+          "eligible_ufas": 14,
+          "re_sign_before_fa": 11,
+          "signed_elsewhere": 3,
+          "out_of_league": 0,
+          "re_sign_rate": 0.7857,
+          "signed_elsewhere_rate": 0.2143
+        },
+        "top_50": {
+          "eligible_ufas": 24,
+          "re_sign_before_fa": 9,
+          "signed_elsewhere": 15,
+          "out_of_league": 0,
+          "re_sign_rate": 0.375,
+          "signed_elsewhere_rate": 0.625
+        }
+      },
+      "WR": {
+        "rest": {
+          "eligible_ufas": 1936,
+          "re_sign_before_fa": 675,
+          "signed_elsewhere": 978,
+          "out_of_league": 283,
+          "re_sign_rate": 0.3487,
+          "signed_elsewhere_rate": 0.5052
+        },
+        "top_10": {
+          "eligible_ufas": 10,
+          "re_sign_before_fa": 8,
+          "signed_elsewhere": 2,
+          "out_of_league": 0,
+          "re_sign_rate": 0.8,
+          "signed_elsewhere_rate": 0.2
+        },
+        "top_25": {
+          "eligible_ufas": 15,
+          "re_sign_before_fa": 11,
+          "signed_elsewhere": 4,
+          "out_of_league": 0,
+          "re_sign_rate": 0.7333,
+          "signed_elsewhere_rate": 0.2667
+        },
+        "top_50": {
+          "eligible_ufas": 24,
+          "re_sign_before_fa": 19,
+          "signed_elsewhere": 5,
+          "out_of_league": 0,
+          "re_sign_rate": 0.7917,
+          "signed_elsewhere_rate": 0.2083
+        }
+      }
+    }
+  }
+}

--- a/data/docs/README.md
+++ b/data/docs/README.md
@@ -29,6 +29,7 @@ flowchart LR
         B3[draft-pick-value]
         B4[draft-hit-rates]
         B5[free-agent-market]
+        B5b[ufa-pool-composition]
         B6[contract-structure]
         B7[career-length]
         B8[comp-picks]
@@ -43,6 +44,7 @@ flowchart LR
         D3[draft-pick-trade-value]
         D4[draft-hit-rates-by-round]
         D5[free-agent-market]
+        D5b[ufa-pool-composition]
         D6[contract-structure]
         D7[career-length-by-position]
         D8[nfl-talent-distribution-by-position]
@@ -56,6 +58,8 @@ flowchart LR
     DRAFT --> B3 --> D3
     DRAFT --> B4 --> D4
     CTR --> B5 --> D5
+    ROS --> B5b --> D5b
+    CTR --> B5b
     CTR --> B6 --> D6
     ROS --> B7 --> D7
     DRAFT --> B8 --> D9
@@ -66,25 +70,26 @@ flowchart LR
     SCH --> B9 --> D10
     ROS --> B10 --> D11
 
-    D0 -. indexes .-> D1 & D2 & D3 & D4 & D5 & D6 & D7
+    D0 -. indexes .-> D1 & D2 & D3 & D4 & D5 & D5b & D6 & D7
 ```
 
 ## Index
 
 ### Meta-game (market & career)
 
-| Doc                                                            | What it covers                                                                                                      | Feeds                                                           |
-| -------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------- |
-| [calibration-gaps.md](./calibration-gaps.md)                   | Master index of what's done vs what's missing across play-level, game-level, and season/career realism.             | The roadmap.                                                    |
-| [position-market-sizing.md](./position-market-sizing.md)       | 53-man roster slots by position, meaningful contributors, clear starters. QB is 2, OL is 8, specialists are 1-deep. | Player generator, league init, depth-chart classification.      |
-| [draft-position-tendencies.md](./draft-position-tendencies.md) | Which positions go in which rounds. QB/WR/EDGE/OT/CB are ~65% of top-10; RB/LB double their R1 counts by R7.        | Draft class generator, NPC GM positional-value prior.           |
-| [draft-pick-trade-value.md](./draft-pick-trade-value.md)       | Jimmy Johnson vs Rich Hill vs Chase Stuart — three canonical trade-value charts and when they disagree.             | AI GM trade evaluator, user trade grade.                        |
-| [draft-hit-rates-by-round.md](./draft-hit-rates-by-round.md)   | P(multi-year starter \| round, position). 86% for R1, 7% for R7. Round 4 is the cliff.                              | Prospect generation, post-draft grade UI.                       |
-| [free-agent-market.md](./free-agent-market.md)                 | UFA volume, AAV tiers, signing waves, own-team re-sign rates by position.                                           | FA period generator, NPC bid AI.                                |
-| [contract-structure.md](./contract-structure.md)               | Contract shape — length, guarantee %, signing-bonus share, year-by-year cap hit, void years, restructures.          | Contract offer generator, cap AI, cut/restructure decisions.    |
-| [career-length-by-position.md](./career-length-by-position.md) | Five canonical aging shapes — specialist longevity, QB tail, OL plateau, mid-career cohort, RB/CB cliff.            | Aging system, retirement decisions, franchise-planning windows. |
-| [comp-picks.md](./comp-picks.md)                               | Compensatory picks — 32/yr cap, P(comp \| net UFA losses), round mix, minority-hire supplemental picks.             | AI GM "let him walk for the comp pick" decision, draft supply.  |
-| [ir-usage.md](./ir-usage.md)                                   | IR placements per team-season, ~30% return rate, ~5-week absence, position concentration (CB/OL/LB lead).           | In-season roster-slot pressure, waiver AI, PS elevations.       |
+| Doc                                                            | What it covers                                                                                                                   | Feeds                                                           |
+| -------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------- |
+| [calibration-gaps.md](./calibration-gaps.md)                   | Master index of what's done vs what's missing across play-level, game-level, and season/career realism.                          | The roadmap.                                                    |
+| [position-market-sizing.md](./position-market-sizing.md)       | 53-man roster slots by position, meaningful contributors, clear starters. QB is 2, OL is 8, specialists are 1-deep.              | Player generator, league init, depth-chart classification.      |
+| [draft-position-tendencies.md](./draft-position-tendencies.md) | Which positions go in which rounds. QB/WR/EDGE/OT/CB are ~65% of top-10; RB/LB double their R1 counts by R7.                     | Draft class generator, NPC GM positional-value prior.           |
+| [draft-pick-trade-value.md](./draft-pick-trade-value.md)       | Jimmy Johnson vs Rich Hill vs Chase Stuart — three canonical trade-value charts and when they disagree.                          | AI GM trade evaluator, user trade grade.                        |
+| [draft-hit-rates-by-round.md](./draft-hit-rates-by-round.md)   | P(multi-year starter \| round, position). 86% for R1, 7% for R7. Round 4 is the cliff.                                           | Prospect generation, post-draft grade UI.                       |
+| [free-agent-market.md](./free-agent-market.md)                 | UFA volume, AAV tiers, signing waves, own-team re-sign rates by position.                                                        | FA period generator, NPC bid AI.                                |
+| [ufa-pool-composition.md](./ufa-pool-composition.md)           | Distinct-player FA pool size per position via roster transitions; re-sign-before-FA vs signed-elsewhere vs out-of-league gating. | FA pool sampler, re-sign gate, attrition model.                 |
+| [contract-structure.md](./contract-structure.md)               | Contract shape — length, guarantee %, signing-bonus share, year-by-year cap hit, void years, restructures.                       | Contract offer generator, cap AI, cut/restructure decisions.    |
+| [career-length-by-position.md](./career-length-by-position.md) | Five canonical aging shapes — specialist longevity, QB tail, OL plateau, mid-career cohort, RB/CB cliff.                         | Aging system, retirement decisions, franchise-planning windows. |
+| [comp-picks.md](./comp-picks.md)                               | Compensatory picks — 32/yr cap, P(comp \| net UFA losses), round mix, minority-hire supplemental picks.                          | AI GM "let him walk for the comp pick" decision, draft supply.  |
+| [ir-usage.md](./ir-usage.md)                                   | IR placements per team-season, ~30% return rate, ~5-week absence, position concentration (CB/OL/LB lead).                        | In-season roster-slot pressure, waiver AI, PS elevations.       |
 
 ### Front-office market (coaches + scouts)
 

--- a/data/docs/free-agent-market.md
+++ b/data/docs/free-agent-market.md
@@ -11,6 +11,12 @@ Companion script:
 [`data/R/bands/free-agent-market.R`](../R/bands/free-agent-market.R). Gap index
 row: [calibration-gaps.md #5 (#514)](./calibration-gaps.md).
 
+**Related band**: [`ufa-pool-composition.md`](./ufa-pool-composition.md) sizes
+the FA pool per position using roster transitions (distinct-player counts, not
+contract-row counts) and gates re-sign-before-FA vs. open-market outcomes. Use
+this doc's AAV-tier bands for contract economics, and the pool-composition doc
+for pool sampling and the re-sign gate.
+
 ## Sources
 
 - `nflreadr::load_contracts()` — OverTheCap historical feed, one row per signed

--- a/data/docs/ufa-pool-composition.md
+++ b/data/docs/ufa-pool-composition.md
@@ -1,0 +1,248 @@
+# UFA Pool Composition & Re-sign Rate Gating
+
+How many **distinct veterans** hit free agency at each position each offseason,
+and what share of them re-sign with their own team **before** the market opens
+vs. sign elsewhere vs. fall out of the league entirely. Pairs with
+[`free-agent-market.md`](./free-agent-market.md) — the market doc answers "what
+do FA contracts look like once signed"; this doc answers "who is in the pool in
+the first place, and does the market ever get to bid on them".
+
+Companion band:
+[`data/bands/ufa-pool-composition.json`](../bands/ufa-pool-composition.json).
+Companion script:
+[`data/R/bands/ufa-pool-composition.R`](../R/bands/ufa-pool-composition.R).
+
+## Why a separate band
+
+`free-agent-market.json` counts **contract rows** where `team != draft_team` as
+"external UFA signings". That heuristic is fine for AAV-tier shape, but it
+over-samples the pool: every minimum-salary depth signing, practice-squad
+elevation, futures contract, ERFA tender, and cut-day re-signing is a row, and a
+single player can generate 3-4 rows a season as they get cycled through practice
+squads. A raw count of ~425 "WR external signings per offseason" is not the same
+thing as 425 WRs hitting the open market — it's closer to 80-90 distinct WRs
+plus a lot of roster churn.
+
+The sim's FA generator needs the **pool size per position**, not the churn
+count. Sampling a WR from a 425-sized pool produces implausible depth charts;
+sampling from a ~140-sized pool produces realistic ones.
+
+## Method
+
+1. **Roster membership** — `nflreadr::load_rosters(2019:2024)` gives one row per
+   player-season-team (we keep the last-week roster so cut-day moves settle).
+2. **Eligibility** — a player on a season-N roster with `years_exp >= 2`
+   (entering season N+1 with 3+ accrued seasons; RFA/UFA eligible) is a
+   _potential UFA_ going into offseason N+1.
+3. **Outcome classification** — compare `team_N` to `team_(N+1)`:
+   - `re_sign_before_fa` — same team in N+1. Captures extensions, re-ups, and
+     franchise/transition tags that keep the player off the open market.
+   - `signed_elsewhere` — different team in N+1. Hit the market and moved.
+   - `out_of_league` — no roster appearance in N+1. Retired, cut without
+     signing, career-ending injury, or washed out of the league.
+4. **Tier enrichment** — join `nflreadr::load_contracts()` on
+   `(gsis_id, year_signed == offseason)` so each transition can be placed in an
+   APY tier (`top_10 / top_25 / top_50 / rest`). Players without a signed
+   contract (min-deal UDFAs, practice-squad, out-of-league) fall into `rest`.
+
+## UFA pool composition by position
+
+Means across offseasons 2020–2024 (transitions resolved 2019-2024):
+
+| Position | Eligible UFAs | Re-sign before FA | Signed elsewhere | Out of league | Open-market pool | Share of open market |
+| -------- | ------------: | ----------------: | ---------------: | ------------: | ---------------: | -------------------: |
+| EDGE     |         258.8 |             113.2 |             89.2 |          56.4 |            145.6 |                13.6% |
+| WR       |         234.4 |              92.4 |             86.6 |          55.4 |            142.0 |                13.3% |
+| CB       |         214.2 |              84.2 |             77.8 |          52.2 |            130.0 |                12.1% |
+| IOL      |         191.0 |              90.6 |             60.0 |          40.4 |            100.4 |                 9.4% |
+| IDL      |         151.6 |              66.0 |             57.8 |          27.8 |             85.6 |                 8.0% |
+| RB       |         142.0 |              58.8 |             46.6 |          36.6 |             83.2 |                 7.8% |
+| TE       |         131.4 |              58.6 |             41.4 |          31.4 |             72.8 |                 6.8% |
+| OT       |         144.8 |              72.2 |             44.6 |          28.0 |             72.6 |                 6.8% |
+| S        |         143.6 |              71.2 |             43.0 |          29.4 |             72.4 |                 6.8% |
+| LB       |         121.4 |              50.0 |             45.2 |          26.2 |             71.4 |                 6.7% |
+| QB       |          88.2 |              40.4 |             33.8 |          14.0 |             47.8 |                 4.5% |
+| ST       |         109.2 |              62.6 |             28.0 |          18.6 |             46.6 |                 4.4% |
+
+**Open-market pool** = `signed_elsewhere + out_of_league` — the set of players
+who _could_ sign with any team once the league year opens. This is the
+sample-space the sim's FA generator should draw from, weighted by
+`open_market_pool_share`.
+
+```mermaid
+xychart-beta
+    title "Open-market UFA pool per offseason (mean 2020-2024)"
+    x-axis ["EDGE", "WR", "CB", "IOL", "IDL", "RB", "TE", "OT", "S", "LB", "QB", "ST"]
+    y-axis "Players" 0 --> 160
+    bar [145.6, 142.0, 130.0, 100.4, 85.6, 83.2, 72.8, 72.6, 72.4, 71.4, 47.8, 46.6]
+```
+
+### Sim implication — replace the uniform 50
+
+Today `server/features/players/players-generator.ts` generates a uniform 50-
+player pool round-robined across 15 buckets (~3.3 FAs per position). The table
+above shows the real shape is anything but uniform:
+
+- EDGE and WR each contribute ~13% of the open market (~140 each).
+- QB and ST each contribute ~4.5% (~47 each — and QB skews almost entirely
+  toward backup depth, not starters).
+- A sim FA generator sized to ~500 open-market slots should allocate roughly:
+  EDGE 68, WR 66, CB 60, IOL 47, IDL 40, RB 39, TE/OT/S/LB 33-34, QB/ST 22-22.
+
+Scaled down to the sim's current ~50-player pool, that's roughly:
+
+| Position      | Pool allocation (of ~50) |
+| ------------- | -----------------------: |
+| EDGE          |                        7 |
+| WR            |                        7 |
+| CB            |                        6 |
+| IOL           |                        5 |
+| IDL, RB       |                     4, 4 |
+| TE, OT, S, LB |                 3-4 each |
+| QB, ST        |                     2, 2 |
+
+Compared to the current uniform 3.3 per bucket: WR/EDGE/CB are under-represented
+by ~2× and QB/ST are over-represented by ~1.5×.
+
+## Re-sign rate gating (own-team retention before FA)
+
+Share of eligible UFAs per position that **never hit the market** because the
+drafting team re-signs/extends/tags them:
+
+| Position | Re-sign before FA | Signed elsewhere | Out of league |
+| -------- | ----------------: | ---------------: | ------------: |
+| ST       |             57.3% |            25.6% |         17.0% |
+| OT       |             49.9% |            30.8% |         19.3% |
+| S        |             49.6% |            29.9% |         20.5% |
+| IOL      |             47.4% |            31.4% |         21.2% |
+| QB       |             45.8% |            38.3% |         15.9% |
+| TE       |             44.6% |            31.5% |         23.9% |
+| EDGE     |             43.7% |            34.5% |         21.8% |
+| IDL      |             43.5% |            38.1% |         18.3% |
+| RB       |             41.4% |            32.8% |         25.8% |
+| LB       |             41.2% |            37.2% |         21.6% |
+| WR       |             39.4% |            36.9% |         23.6% |
+| CB       |             39.3% |            36.3% |         24.4% |
+
+```mermaid
+xychart-beta
+    title "Offseason outcome by position - share of eligible UFAs (%)"
+    x-axis ["ST", "OT", "S", "IOL", "QB", "TE", "EDGE", "IDL", "RB", "LB", "WR", "CB"]
+    y-axis "Re-sign before FA (%)" 0 --> 60
+    bar [57.3, 49.9, 49.6, 47.4, 45.8, 44.6, 43.7, 43.5, 41.4, 41.2, 39.4, 39.3]
+```
+
+**Why these numbers differ from `free-agent-market.md`:**
+
+The sibling doc reports re-sign rates of 9-23% based on contract rows; this doc
+reports 39-57% based on roster transitions. Both are "correct" for their
+denominator:
+
+- Contract-row denominator — includes cut-day minimums, practice-squad, and
+  futures deals where the "team" field flips constantly. Depresses the rate.
+- Roster-transition denominator — one observation per eligible player per
+  offseason. Matches PFF's ~35-45% headline number for "veteran UFAs who re-sign
+  with their own team on first trip".
+
+**The sim should use this doc's rates for the re-sign _gate_** (does this player
+hit the market?) and `free-agent-market.md`'s tiered AAV bands for contract
+economics (once they do hit the market, what do they sign for).
+
+### Position narratives
+
+- **Specialists (ST)** have the highest re-sign rate (57%) — K/P/LS churn on
+  1-year deals but churn _with their current team_ most often. Cheap to re-sign,
+  and teams rarely chase specialists on the market.
+- **OL (OT/IOL)** retain at 47-50% — continuity matters and teams bet on aging
+  curves; OL is also hardest to scout externally, so incumbents have a built-in
+  advantage.
+- **QB retention of 46% is skewed** by the "backup 1-year extension" pattern.
+  Starting QBs almost never hit free agency (tag or extension); the QB column
+  here is dominated by QB2/QB3 retention.
+- **WR and CB are the mobility leaders** (39% re-sign, ~37% signed elsewhere) —
+  these are the two positions where the open market actually gets the most shots
+  on high-end talent.
+- **RB has the highest attrition** (26% out-of-league) — brutal aging curve +
+  replaceable-at-minimum market. Matches the post-Barkley narrative.
+
+## Re-sign rate by tier
+
+The re-sign rate for the top of each position's market is meaningfully higher
+than for replacement-level players. Top-10-APY-tier retention runs 80-100%
+across positions (franchise tag + extend-before-FA is the dominant path for the
+elite); `rest`-tier retention sits at 31-50%.
+
+```mermaid
+xychart-beta
+    title "Re-sign rate by tier - QB / WR / EDGE / CB (%)"
+    x-axis ["QB", "WR", "EDGE", "CB"]
+    y-axis "Re-sign rate (%)" 0 --> 100
+    bar [100, 80, 58.3, 80]
+    bar [68.8, 73.3, 60, 53.3]
+    bar [50, 79.2, 54.5, 40]
+    bar [36.5, 34.9, 37.7, 35.2]
+```
+
+Legend: top_10 / top_25 / top_50 / rest bars, left-to-right per position.
+
+| Position | top_10 | top_25 | top_50 | rest |
+| -------- | -----: | -----: | -----: | ---: |
+| QB       |  100.0 |   68.8 |   50.0 | 36.5 |
+| WR       |   80.0 |   73.3 |   79.2 | 34.9 |
+| TE       |  100.0 |   78.6 |   37.5 | 38.7 |
+| OT       |  100.0 |   86.7 |   70.4 | 41.7 |
+| IOL      |   90.0 |   66.7 |   43.5 | 41.8 |
+| EDGE     |   58.3 |   60.0 |   54.5 | 37.7 |
+| IDL      |  100.0 |   90.9 |   60.9 | 33.8 |
+| LB       |   66.7 |   33.3 |   47.4 | 31.5 |
+| CB       |   80.0 |   53.3 |   40.0 | 35.2 |
+| S        |   80.0 |   80.0 |   54.2 | 42.7 |
+| RB       |   90.0 |   80.0 |   54.2 | 34.6 |
+| ST       |   88.9 |   93.3 |   70.8 | 40.5 |
+
+Top-10 sample sizes are small (9-12 per position across 5 offseasons) so
+individual numbers jitter; treat the **shape** (top_10 >> top_25 >~ top_50 >>
+rest) as the prior, not the exact percentage.
+
+## How the sim should use this band
+
+1. **Size the FA pool per position** — multiply a target pool size (e.g. 50) by
+   `pool_composition_by_position[*].open_market_pool_share`. The result is the
+   number of UFAs to generate per position, replacing the uniform round-robin.
+
+2. **Apply the re-sign gate per eligible veteran** — for each drafted /
+   previously-signed player nearing contract expiry:
+
+   ```
+   tier = tier_of(player)  // from their current contract's APY
+   P_resign = resign_rate_by_position_tier[pos][tier]
+   if random() < P_resign:
+     player stays on own team with an extension at tier mean_apy
+   else:
+     player enters the open-market FA pool
+   ```
+
+   This is the core mechanic the issue proposal calls for.
+
+3. **Attrition for out-of-league** — apply
+   `signed_elsewhere_rate + out_of_league_rate` together as "hits the market",
+   then within "hits the market" use `out_of_league_rate / (out_of_league_rate
+   - signed_elsewhere_rate)` as the probability of NOT getting a deal this cycle
+     (effective retirement / career-ending).
+
+4. **Contract economics, once signed** — delegate to
+   [`free-agent-market.md`](./free-agent-market.md) tier bands. This band
+   answers "does the player hit the market"; that band answers "what does the
+   contract look like".
+
+## Known gaps / follow-ups
+
+- `years_exp >= 2` is a proxy for "UFA-eligible under the CBA's 4-accrued-
+  seasons rule". Exact accrued-seasons data is not in the rosters feed.
+  RFA-eligible players (3 accrued) are blended in, which slightly inflates the
+  re-sign rate for the lower tiers (RFA tenders count as re-signs).
+- Franchise / transition tags are not flagged in either feed — they appear as
+  `re_sign_before_fa` with a 1-year contract in the contracts feed.
+- `out_of_league` mixes retirees, cuts, and injured-reserve-then-released
+  outcomes. Sim-side we should split these: retirement rate vs. genuine
+  "undrafted by the market" attrition.


### PR DESCRIPTION
## Summary

Adds a new `ufa-pool-composition` calibration band (R script + JSON + research doc) that sizes the free-agent pool by **distinct players per position** using year-over-year roster transitions from `nflreadr::load_rosters()`, and splits each offseason outcome three ways: `re_sign_before_fa`, `signed_elsewhere`, `out_of_league`. Tier enrichment via `load_contracts()` produces the `top_10 / top_25 / top_50 / rest` retention shape the sim's re-sign gate needs.

**Files**
- `data/R/bands/ufa-pool-composition.R` — script (seasons 2019:2024, resolves transitions for offseasons 2020-2024)
- `data/bands/ufa-pool-composition.json` — generated band artifact
- `data/docs/ufa-pool-composition.md` — research doc with sim implications
- `data/docs/README.md` — index + flowchart updated
- `data/docs/free-agent-market.md` — cross-link added at the top

**Why a new band rather than extending `free-agent-market`**

The existing `free-agent-market` band is contract-row based (`team != draft_team` → "external UFA"). That over-samples the pool — practice-squad, futures, cut-day minimums, and ERFA tenders each produce rows, so "425 WR external signings / yr" becomes "~140 distinct WRs on the open market / yr". Re-sign rates read 9-23% on that denominator; on a one-row-per-eligible-veteran roster-transition denominator they read **39-57%**, matching PFF's "first-trip UFA retention" priors.

The two bands coexist cleanly: `free-agent-market` owns **contract economics** (AAV tiers, years, guarantee share); `ufa-pool-composition` owns **who enters the pool** and **the re-sign gate**. Both are cross-linked in the docs.

**Output headline numbers**

- Open-market pool share per position: EDGE 13.6%, WR 13.3%, CB 12.1% down to QB 4.5%, ST 4.4%. Replaces the uniform 15-bucket round-robin in `players-generator.ts`.
- Re-sign-before-FA rates: ST 57%, OL 47-50%, QB 46%, RB 41%, WR/CB 39%.
- Out-of-league attrition: RB 26% (worst), QB 16% (best), matching aging-curve priors.
- Tier multiplier (e.g. OT): top_10 100%, top_25 87%, top_50 70%, rest 42%.

**Scope / follow-up**

This PR is calibration data only. Wiring the generator to consume the new band (replacing `FREE_AGENT_COUNT = 50` + uniform buckets, adding the re-sign roll) is a separate server change per the issue proposal.

Closes #531