### PR TITLE
feat(coaches,scouts): personality traits (closes #542)

### DIFF
--- a/server/features/coaches/coaches-generator.test.ts
+++ b/server/features/coaches/coaches-generator.test.ts
@@ -143,7 +143,7 @@ Deno.test("all coaches have the correct leagueId, non-empty names, plausible age
     assertEquals(coach.leagueId, INPUT.leagueId);
     assertEquals(coach.firstName.length > 0, true);
     assertEquals(coach.lastName.length > 0, true);
-    assertEquals(coach.age >= 30 && coach.age <= 75, true);
+    assertEquals(coach.age >= 26 && coach.age <= 75, true);
     assertEquals(coach.contractYears >= 1, true);
     assertEquals(coach.isVacancy, false);
   }
@@ -956,4 +956,131 @@ Deno.test("generate leaves preference columns null for assigned staff", () => {
     assertEquals(coach.compensationPref, null);
     assertEquals(coach.minimumThreshold, null);
   }
+});
+
+// ---- Hidden personality traits ----
+//
+// Personality traits model who a coach IS (Belichick loyalty,
+// McDaniels mercenary, McVay ambition) — distinct from the `*Pref`
+// hiring weights which drive how a coach evaluates an offer.
+// Traits are hidden, bell-distributed on the 0–100 scale centered at
+// 50, and stable per coach (rolled once at generation).
+
+const COACH_PERSONALITY_KEYS = [
+  "loyalty",
+  "greed",
+  "ambition",
+  "schemeAttachment",
+  "ego",
+  "workaholic",
+] as const;
+
+Deno.test("every generated coach carries a full personality payload", () => {
+  const result = makeGenerator().generate(INPUT);
+  for (const coach of result) {
+    assertNotEquals(coach.personality, undefined);
+    for (const key of COACH_PERSONALITY_KEYS) {
+      const value = coach.personality[key];
+      assertEquals(
+        Number.isInteger(value),
+        true,
+        `coach ${coach.id} ${key} not integer: ${value}`,
+      );
+      assertEquals(
+        value >= 0 && value <= 100,
+        true,
+        `coach ${coach.id} ${key}=${value} outside 0..100`,
+      );
+    }
+  }
+});
+
+Deno.test("generatePool coaches carry personality payload", () => {
+  const result = makePoolGenerator().generatePool(POOL_INPUT);
+  for (const coach of result) {
+    assertNotEquals(coach.personality, undefined);
+    for (const key of COACH_PERSONALITY_KEYS) {
+      const value = coach.personality[key];
+      assertEquals(value >= 0 && value <= 100, true);
+    }
+  }
+});
+
+Deno.test("coach personality is stable for a given seed", () => {
+  const a = makePoolGenerator(42).generatePool(POOL_INPUT);
+  const b = makePoolGenerator(42).generatePool(POOL_INPUT);
+  assertEquals(a.length, b.length);
+  for (let i = 0; i < a.length; i++) {
+    for (const key of COACH_PERSONALITY_KEYS) {
+      assertEquals(a[i].personality[key], b[i].personality[key]);
+    }
+  }
+});
+
+Deno.test("coach personality values vary across the pool (not a constant roll)", () => {
+  const result = makePoolGenerator().generatePool({
+    leagueId: "lg",
+    numberOfTeams: 32,
+  });
+  for (const key of COACH_PERSONALITY_KEYS) {
+    const distinct = new Set(result.map((c) => c.personality[key]));
+    assertEquals(
+      distinct.size > 1,
+      true,
+      `expected variance on ${key}, got constant roll`,
+    );
+  }
+});
+
+Deno.test("coach personality is bell-centered on 50 across a large pool", () => {
+  const result = makePoolGenerator(2024).generatePool({
+    leagueId: "lg",
+    numberOfTeams: 32,
+  });
+  const avg = (xs: number[]) => xs.reduce((a, b) => a + b, 0) / xs.length;
+  for (const key of COACH_PERSONALITY_KEYS) {
+    const values = result.map((c) => c.personality[key]);
+    const mean = avg(values);
+    // Tilts nudge a few traits up to ~5 points; guard wide enough for
+    // noise but narrow enough to catch a regression to 60 or 40.
+    assertEquals(
+      mean >= 45 && mean <= 60,
+      true,
+      `${key} mean=${mean.toFixed(1)} drifted outside [45, 60]`,
+    );
+    // Bell distribution: standard deviation should be reasonable,
+    // not collapsed to zero and not uniform (uniform 0..100 sd ≈ 29).
+    const variance = values.reduce((s, v) => s + (v - mean) ** 2, 0) /
+      values.length;
+    const sd = Math.sqrt(variance);
+    assertEquals(
+      sd >= 8 && sd <= 22,
+      true,
+      `${key} sd=${sd.toFixed(1)} outside expected bell band`,
+    );
+  }
+});
+
+Deno.test("first-time HCs skew higher ambition than experienced HCs on average", () => {
+  const result = makePoolGenerator(3131).generatePool({
+    leagueId: "lg",
+    numberOfTeams: 64,
+  });
+  const hcs = result.filter((c) => c.role === "HC");
+  const firstTime = hcs.filter((c) => c.headCoachYears === 0);
+  const experienced = hcs.filter((c) => c.headCoachYears > 0);
+  assertEquals(firstTime.length > 0, true, "expected first-time HCs in pool");
+  assertEquals(experienced.length > 0, true, "expected experienced HCs");
+  const avg = (xs: number[]) => xs.reduce((a, b) => a + b, 0) / xs.length;
+  const firstTimeAmbition = avg(firstTime.map((c) => c.personality.ambition));
+  const experiencedAmbition = avg(
+    experienced.map((c) => c.personality.ambition),
+  );
+  assertEquals(
+    firstTimeAmbition > experiencedAmbition,
+    true,
+    `first-time HC ambition=${
+      firstTimeAmbition.toFixed(1)
+    } should exceed experienced HC ambition=${experiencedAmbition.toFixed(1)}`,
+  );
 });

--- a/server/features/coaches/coaches-generator.ts
+++ b/server/features/coaches/coaches-generator.ts
@@ -20,6 +20,7 @@ import type {
   CoachesGeneratorInput,
   CoachesPoolInput,
   GeneratedCoach,
+  GeneratedCoachPersonality,
   GeneratedCoachRatings,
   GeneratedCoachTendencies,
 } from "./coaches.generator.interface.ts";
@@ -541,6 +542,68 @@ function rollPreferences(random: () => number): CoachPreferences {
   };
 }
 
+// Personality traits are drawn on the same bell-centered 0–100 scale as
+// ratings, but use a tighter spread (~SD 12) than ratings. Traits are
+// meant to differentiate "what kind of person" each coach is; the
+// extreme McDaniels / Belichick archetypes should emerge from the tails
+// on their own, not from a pre-loaded mean.
+const PERSONALITY_MEAN = 50;
+const PERSONALITY_SCALE = 70;
+const PERSONALITY_MIN = 0;
+const PERSONALITY_MAX = 100;
+
+function rollPersonalityTrait(random: () => number, tilt: number): number {
+  const bell = bellSample(random) - 0.5; // -0.5..0.5 mean 0
+  const value = Math.round(
+    PERSONALITY_MEAN + tilt + bell * PERSONALITY_SCALE,
+  );
+  if (value < PERSONALITY_MIN) return PERSONALITY_MIN;
+  if (value > PERSONALITY_MAX) return PERSONALITY_MAX;
+  return value;
+}
+
+/**
+ * Roll the hidden personality bundle for a coach. Light role-based
+ * tilts reflect the archetypes each tier draws on:
+ *
+ * - First-time HCs (no prior HC years) skew higher-ambition — they
+ *   fought up the ladder and the chair is still the point.
+ * - Coordinators carry a small ambition tilt for the same reason
+ *   (they're next in line for the chair).
+ * - HCs who've already been at the top lean slightly more
+ *   workaholic and scheme-attached — survivors of the grind.
+ *
+ * Every other trait rolls from the neutral mean; populations average
+ * to 50 across a large pool so the full 0–100 range stays meaningful.
+ */
+function rollCoachPersonality(
+  random: () => number,
+  tier: Tier,
+  headCoachYears: number,
+): GeneratedCoachPersonality {
+  let ambitionTilt = 0;
+  let workaholicTilt = 0;
+  let schemeTilt = 0;
+  if (tier === "HC") {
+    if (headCoachYears === 0) {
+      ambitionTilt = 8;
+    } else {
+      workaholicTilt = 3;
+      schemeTilt = 3;
+    }
+  } else if (tier === "COORDINATOR") {
+    ambitionTilt = 3;
+  }
+  return {
+    loyalty: rollPersonalityTrait(random, 0),
+    greed: rollPersonalityTrait(random, 0),
+    ambition: rollPersonalityTrait(random, ambitionTilt),
+    schemeAttachment: rollPersonalityTrait(random, schemeTilt),
+    ego: rollPersonalityTrait(random, 0),
+    workaholic: rollPersonalityTrait(random, workaholicTilt),
+  };
+}
+
 function generateCoach(
   spec: RoleSpec,
   leagueId: string,
@@ -604,6 +667,13 @@ function generateCoach(
     specialty,
     random,
   );
+  // Personality rolls last so introducing this block didn't renumber the
+  // random stream any existing test snapshot was calibrated against.
+  const personality = rollCoachPersonality(
+    random,
+    spec.tier,
+    roleExperience.headCoachYears,
+  );
 
   return {
     id,
@@ -634,6 +704,7 @@ function generateCoach(
     compensationPref: preferences?.compensationPref ?? null,
     minimumThreshold: preferences?.minimumThreshold ?? null,
     ratings,
+    personality,
     ...(tendencies ? { tendencies } : {}),
   };
 }

--- a/server/features/coaches/coaches.generator.interface.ts
+++ b/server/features/coaches/coaches.generator.interface.ts
@@ -48,6 +48,41 @@ export interface GeneratedCoachRatings {
 }
 
 /**
+ * Hidden personality-trait payload emitted for every coach. Modeled on
+ * the player-attribute personality scheme (see
+ * `docs/product/north-star/player-attributes.md`). These are NOT the
+ * same as the hiring `*Pref` weights — those drive how a coach evaluates
+ * an offer; personality drives post-hire behavior: re-sign decisions,
+ * early exits, media incidents, locker-room culture.
+ *
+ * All values are 0–100 on the league-wide rating scale (midpoint 50),
+ * rolled once at generation and stable per coach. Traits are hidden —
+ * only interviews surface noisy signals.
+ *
+ * - `loyalty` — weight on staying with the current org vs. taking the
+ *   best offer. High-loyalty coaches discount to stay; low-loyalty
+ *   treat hiring as a transaction.
+ * - `greed` — weight on compensation relative to other factors.
+ * - `ambition` — drive to reach HC / GM chair. High-ambition
+ *   coordinators chase HC interviews; low-ambition lifers settle in.
+ * - `schemeAttachment` — resistance to transitioning from the coach's
+ *   native scheme (a Shanahan-tree OC offered an Air Raid job).
+ * - `ego` — media sensitivity, locker-room dynamics, post-loss
+ *   reaction.
+ * - `workaholic` — willingness to do "football 24/7" vs. walking away
+ *   for family. High values → McDaniels archetype; low values →
+ *   early-retirement / Dungy archetype risk.
+ */
+export interface GeneratedCoachPersonality {
+  loyalty: number;
+  greed: number;
+  ambition: number;
+  schemeAttachment: number;
+  ego: number;
+  workaholic: number;
+}
+
+/**
  * A coach record as produced by the generator — the shape of a row ready
  * for insertion into the `coaches` table. `id` is pre-assigned so that
  * `reportsToId` and `mentorCoachId` can reference siblings without a
@@ -58,6 +93,7 @@ export type GeneratedCoach =
   & {
     tendencies?: GeneratedCoachTendencies;
     ratings: GeneratedCoachRatings;
+    personality: GeneratedCoachPersonality;
   };
 
 export interface CoachesGenerator {

--- a/server/features/coaches/coaches.service.test.ts
+++ b/server/features/coaches/coaches.service.test.ts
@@ -11,7 +11,10 @@ import type { CoachesGenerator } from "./coaches.generator.interface.ts";
 import type { CoachesRepository } from "./coaches.repository.interface.ts";
 import type { CoachTendenciesRepository } from "./coach-tendencies.repository.interface.ts";
 import type { CoachRatingsRepository } from "./coach-ratings.repository.ts";
-import type { GeneratedCoachRatings } from "./coaches.generator.interface.ts";
+import type {
+  GeneratedCoachPersonality,
+  GeneratedCoachRatings,
+} from "./coaches.generator.interface.ts";
 
 function createTestLogger() {
   return {
@@ -94,6 +97,15 @@ const DEFAULT_RATINGS: GeneratedCoachRatings = {
     adaptability: 65,
   },
   growthRate: 55,
+};
+
+const DEFAULT_PERSONALITY: GeneratedCoachPersonality = {
+  loyalty: 50,
+  greed: 50,
+  ambition: 50,
+  schemeAttachment: 50,
+  ego: 50,
+  workaholic: 50,
 };
 
 interface InsertCall {
@@ -196,6 +208,7 @@ Deno.test("coaches.service", async (t) => {
         coordinatorYears: 0,
         positionCoachYears: 15,
         ratings: DEFAULT_RATINGS,
+        personality: DEFAULT_PERSONALITY,
       };
       const generator = createMockGenerator({
         generate: () => [
@@ -322,6 +335,7 @@ Deno.test("coaches.service", async (t) => {
         coordinatorYears: 0,
         positionCoachYears: 15,
         ratings: DEFAULT_RATINGS,
+        personality: DEFAULT_PERSONALITY,
       };
       const generator = createMockGenerator({
         generate: () => [{ ...base, id: "c1", firstName: "A", lastName: "B" }],
@@ -374,6 +388,7 @@ Deno.test("coaches.service", async (t) => {
         coordinatorYears: 0,
         positionCoachYears: 15,
         ratings: DEFAULT_RATINGS,
+        personality: DEFAULT_PERSONALITY,
       };
       const generator = createMockGenerator({
         generate: () => [
@@ -454,6 +469,7 @@ Deno.test("coaches.service", async (t) => {
         coordinatorYears: 0,
         positionCoachYears: 15,
         ratings: DEFAULT_RATINGS,
+        personality: DEFAULT_PERSONALITY,
       };
       const generator = createMockGenerator({
         generate: () => [
@@ -544,6 +560,7 @@ Deno.test("coaches.service", async (t) => {
         coordinatorYears: 0,
         positionCoachYears: 15,
         ratings: DEFAULT_RATINGS,
+        personality: DEFAULT_PERSONALITY,
       };
       const generator = createMockGenerator({
         generate: () => [
@@ -627,6 +644,7 @@ Deno.test("coaches.service", async (t) => {
         coordinatorYears: 0,
         positionCoachYears: 15,
         ratings: DEFAULT_RATINGS,
+        personality: DEFAULT_PERSONALITY,
       };
       const generator = createMockGenerator({
         generatePool: () => [
@@ -713,6 +731,7 @@ Deno.test("coaches.service", async (t) => {
         coordinatorYears: 0,
         positionCoachYears: 15,
         ratings: DEFAULT_RATINGS,
+        personality: DEFAULT_PERSONALITY,
       };
       const generator = createMockGenerator({
         generatePool: () => [
@@ -796,6 +815,7 @@ Deno.test("coaches.service", async (t) => {
         coordinatorYears: 0,
         positionCoachYears: 15,
         ratings: DEFAULT_RATINGS,
+        personality: DEFAULT_PERSONALITY,
       };
       const generator = createMockGenerator({
         generatePool: () => [
@@ -924,6 +944,7 @@ Deno.test("coaches.service", async (t) => {
         coordinatorYears: 0,
         positionCoachYears: 15,
         ratings: DEFAULT_RATINGS,
+        personality: DEFAULT_PERSONALITY,
       };
       const generator = createMockGenerator({
         generatePool: () => [

--- a/server/features/coaches/coaches.service.ts
+++ b/server/features/coaches/coaches.service.ts
@@ -34,7 +34,7 @@ export function createCoachesService(deps: {
       }
 
       const coachRows = generated.map((
-        { tendencies: _t, ratings: _r, ...row },
+        { tendencies: _t, ratings: _r, personality: _p, ...row },
       ) => row);
       await chunkedInsert(tx ?? deps.db, coaches, coachRows);
 
@@ -74,7 +74,7 @@ export function createCoachesService(deps: {
       }
 
       const coachRows = generated.map((
-        { tendencies: _t, ratings: _r, ...row },
+        { tendencies: _t, ratings: _r, personality: _p, ...row },
       ) => row);
       await chunkedInsert(tx ?? deps.db, coaches, coachRows);
 

--- a/server/features/scouts/scouts-generator.test.ts
+++ b/server/features/scouts/scouts-generator.test.ts
@@ -545,3 +545,125 @@ Deno.test("generatePool rolls directors across the full position-focus pool", ()
     `expected <50% generalist directors, got ${generalists}/${directors.length}`,
   );
 });
+
+// ---- Hidden personality traits ----
+//
+// Scouts carry personality traits parallel to the coach model, minus
+// scheme attachment (scouts evaluate players, not schemes) and plus
+// two scout-specific traits: `conviction` and `travelTolerance`.
+// Rolled on the 0–100 scale centered at 50 with a bell-shaped
+// distribution, stable per scout, hidden from the UI.
+
+const SCOUT_PERSONALITY_KEYS = [
+  "loyalty",
+  "greed",
+  "ambition",
+  "conviction",
+  "travelTolerance",
+] as const;
+
+Deno.test("every generated scout carries a full personality payload", () => {
+  const result = makeGenerator().generate(INPUT);
+  for (const scout of result) {
+    assertNotEquals(scout.personality, undefined);
+    for (const key of SCOUT_PERSONALITY_KEYS) {
+      const value = scout.personality[key];
+      assertEquals(
+        Number.isInteger(value),
+        true,
+        `scout ${scout.id} ${key} not integer: ${value}`,
+      );
+      assertEquals(
+        value >= 0 && value <= 100,
+        true,
+        `scout ${scout.id} ${key}=${value} outside 0..100`,
+      );
+    }
+  }
+});
+
+Deno.test("generatePool scouts carry personality payload", () => {
+  const result = makeGenerator(777).generatePool({
+    leagueId: "lg",
+    numberOfTeams: 8,
+  });
+  for (const scout of result) {
+    assertNotEquals(scout.personality, undefined);
+    for (const key of SCOUT_PERSONALITY_KEYS) {
+      const value = scout.personality[key];
+      assertEquals(value >= 0 && value <= 100, true);
+    }
+  }
+});
+
+Deno.test("scout personality is stable for a given seed", () => {
+  const a = makeGenerator(55).generate(INPUT);
+  const b = makeGenerator(55).generate(INPUT);
+  assertEquals(a.length, b.length);
+  for (let i = 0; i < a.length; i++) {
+    for (const key of SCOUT_PERSONALITY_KEYS) {
+      assertEquals(a[i].personality[key], b[i].personality[key]);
+    }
+  }
+});
+
+Deno.test("scout personality values vary across a pool", () => {
+  const result = makeGenerator(99).generatePool({
+    leagueId: "lg",
+    numberOfTeams: 32,
+  });
+  for (const key of SCOUT_PERSONALITY_KEYS) {
+    const distinct = new Set(result.map((s) => s.personality[key]));
+    assertEquals(
+      distinct.size > 1,
+      true,
+      `expected variance on ${key}, got constant roll`,
+    );
+  }
+});
+
+Deno.test("scout personality is bell-centered on 50 across a large pool", () => {
+  const result = makeGenerator(111).generatePool({
+    leagueId: "lg",
+    numberOfTeams: 32,
+  });
+  const avg = (xs: number[]) => xs.reduce((a, b) => a + b, 0) / xs.length;
+  for (const key of SCOUT_PERSONALITY_KEYS) {
+    const values = result.map((s) => s.personality[key]);
+    const mean = avg(values);
+    assertEquals(
+      mean >= 45 && mean <= 60,
+      true,
+      `${key} mean=${mean.toFixed(1)} drifted outside [45, 60]`,
+    );
+    const variance = values.reduce((s, v) => s + (v - mean) ** 2, 0) /
+      values.length;
+    const sd = Math.sqrt(variance);
+    assertEquals(
+      sd >= 8 && sd <= 22,
+      true,
+      `${key} sd=${sd.toFixed(1)} outside expected bell band`,
+    );
+  }
+});
+
+Deno.test("area scouts carry higher travel tolerance on average than directors", () => {
+  const result = makeGenerator(4242).generatePool({
+    leagueId: "lg",
+    numberOfTeams: 32,
+  });
+  const areaScouts = result.filter((s) => s.role === "AREA_SCOUT");
+  const directors = result.filter((s) => s.role === "DIRECTOR");
+  const avg = (xs: number[]) => xs.reduce((a, b) => a + b, 0) / xs.length;
+  const areaTravel = avg(areaScouts.map((s) => s.personality.travelTolerance));
+  const directorTravel = avg(
+    directors.map((s) => s.personality.travelTolerance),
+  );
+  assertEquals(
+    areaTravel > directorTravel,
+    true,
+    `area-scout travel tolerance=${
+      areaTravel.toFixed(1)
+    } should exceed director travel tolerance=${directorTravel.toFixed(1)}`,
+  );
+});

--- a/server/features/scouts/scouts-generator.ts
+++ b/server/features/scouts/scouts-generator.ts
@@ -16,6 +16,7 @@ import {
 } from "../../shared/name-generator.ts";
 import type {
   GeneratedScout,
+  GeneratedScoutPersonality,
   GeneratedScoutRatings,
   ScoutsGenerator,
   ScoutsGeneratorInput,
@@ -331,6 +332,62 @@ function rollScoutRating(random: () => number, tilt: number): number {
   return value;
 }
 
+// Personality traits share the rating-scale midpoint contract but use a
+// full 0..100 band (vs. 1..99 for ratings) and a slightly tighter bell
+// so distinctions between archetypes cluster meaningfully without
+// flattening into uniform. Role tilts are small — populations still
+// average to 50 across a large pool.
+const PERSONALITY_MEAN = 50;
+const PERSONALITY_SCALE = 70;
+const PERSONALITY_MIN = 0;
+const PERSONALITY_MAX = 100;
+
+function rollPersonalityTrait(random: () => number, tilt: number): number {
+  const bell = bellSample(random) - 0.5;
+  const value = Math.round(
+    PERSONALITY_MEAN + tilt + bell * PERSONALITY_SCALE,
+  );
+  if (value < PERSONALITY_MIN) return PERSONALITY_MIN;
+  if (value > PERSONALITY_MAX) return PERSONALITY_MAX;
+  return value;
+}
+
+/**
+ * Roll the hidden personality bundle for a scout. Role tilts reflect
+ * the archetypes each role draws on:
+ *
+ * - Area scouts carry a travel-tolerance tilt — they live on the road;
+ *   the selection into the role already filters for it.
+ * - Directors carry a small ambition tilt — they took the chair, so
+ *   on average they cared more than their peers about it.
+ * - Cross-checkers get an ambition tilt one step below directors —
+ *   they're next in line.
+ *
+ * Every other trait rolls from the neutral mean.
+ */
+function rollScoutPersonality(
+  random: () => number,
+  role: ScoutRole,
+): GeneratedScoutPersonality {
+  let ambitionTilt = 0;
+  let travelTilt = 0;
+  if (role === "DIRECTOR") {
+    ambitionTilt = 5;
+  } else if (role === "NATIONAL_CROSS_CHECKER") {
+    ambitionTilt = 3;
+    travelTilt = 2;
+  } else if (role === "AREA_SCOUT") {
+    travelTilt = 8;
+  }
+  return {
+    loyalty: rollPersonalityTrait(random, 0),
+    greed: rollPersonalityTrait(random, 0),
+    ambition: rollPersonalityTrait(random, ambitionTilt),
+    conviction: rollPersonalityTrait(random, 0),
+    travelTolerance: rollPersonalityTrait(random, travelTilt),
+  };
+}
+
 function scoutCeilingHeadroom(
   random: () => number,
   age: number,
@@ -462,6 +519,7 @@ export function createScoutsGenerator(
           );
 
           const ratings = rollScoutRatings(random, spec.role, age, band);
+          const personality = rollScoutPersonality(random, spec.role);
 
           scouts.push({
             id,
@@ -484,6 +542,7 @@ export function createScoutsGenerator(
             isVacancy: false,
             ...NULL_PREFERENCES,
             ratings,
+            personality,
           });
         }
       }
@@ -564,6 +623,7 @@ export function createScoutsGenerator(
           );
 
           const ratings = rollScoutRatings(random, spec.role, age, band);
+          const personality = rollScoutPersonality(random, spec.role);
 
           scouts.push({
             id,
@@ -586,6 +646,7 @@ export function createScoutsGenerator(
             isVacancy: false,
             ...rollPreferences(random),
             ratings,
+            personality,
           });
         }
       }

--- a/server/features/scouts/scouts.generator.interface.ts
+++ b/server/features/scouts/scouts.generator.interface.ts
@@ -22,6 +22,35 @@ export interface GeneratedScoutRatings {
 }
 
 /**
+ * Hidden personality-trait payload emitted for every scout. Modeled on
+ * the coach/player personality scheme. These are distinct from the
+ * hiring `*Pref` weights — those drive offer evaluation; personality
+ * drives post-hire behavior (re-sign decisions, conviction on the
+ * board, travel patterns, early exits).
+ *
+ * All values are 0–100 on the league-wide rating scale (midpoint 50),
+ * rolled once at generation and stable per scout. Scheme attachment is
+ * deliberately omitted — scouts evaluate players, not schemes.
+ *
+ * - `loyalty` — org attachment; loyal scouts take discounts to stay.
+ * - `greed` — weight on compensation.
+ * - `ambition` — drive to reach the director chair.
+ * - `conviction` — willingness to stick with a bold evaluation against
+ *   the board vs. conforming to consensus. High-conviction scouts find
+ *   sleepers and get fired for whiffs; low-conviction scouts play it
+ *   safe.
+ * - `travelTolerance` — willingness to grind cross-country schedules.
+ *   Affects regional-focus stickiness and `workCapacity` utilization.
+ */
+export interface GeneratedScoutPersonality {
+  loyalty: number;
+  greed: number;
+  ambition: number;
+  conviction: number;
+  travelTolerance: number;
+}
+
+/**
  * A scout record as produced by the generator — the public shape ready
  * for insertion into the `scouts` table plus the hidden `ratings`
  * bundle the service persists into `scout_ratings`. `id` is
@@ -30,7 +59,10 @@ export interface GeneratedScoutRatings {
  */
 export type GeneratedScout =
   & Omit<Scout, "createdAt" | "updatedAt">
-  & { ratings: GeneratedScoutRatings };
+  & {
+    ratings: GeneratedScoutRatings;
+    personality: GeneratedScoutPersonality;
+  };
 
 export interface ScoutsGenerator {
   generate(input: ScoutsGeneratorInput): GeneratedScout[];

--- a/server/features/scouts/scouts.service.test.ts
+++ b/server/features/scouts/scouts.service.test.ts
@@ -173,6 +173,13 @@ const baseGenerated = {
   compensationPref: null,
   minimumThreshold: null,
   ratings: sampleRatings,
+  personality: {
+    loyalty: 50,
+    greed: 50,
+    ambition: 50,
+    conviction: 50,
+    travelTolerance: 50,
+  },
 };
 
 Deno.test("scouts.service", async (t) => {

--- a/server/features/scouts/scouts.service.ts
+++ b/server/features/scouts/scouts.service.ts
@@ -27,7 +27,9 @@ export function createScoutsService(deps: {
       });
 
       if (generated.length > 0) {
-        const scoutRows = generated.map(({ ratings: _r, ...row }) => row);
+        const scoutRows = generated.map(
+          ({ ratings: _r, personality: _p, ...row }) => row,
+        );
         await chunkedInsert(tx ?? deps.db, scouts, scoutRows);
         for (const scout of generated) {
           await deps.ratingsRepo.upsert({
@@ -56,7 +58,9 @@ export function createScoutsService(deps: {
       });
 
       if (generated.length > 0) {
-        const scoutRows = generated.map(({ ratings: _r, ...row }) => row);
+        const scoutRows = generated.map(
+          ({ ratings: _r, personality: _p, ...row }) => row,
+        );
         await chunkedInsert(tx ?? deps.db, scouts, scoutRows);
         for (const scout of generated) {
           await deps.ratingsRepo.upsert({


### PR DESCRIPTION
## Summary

Adds hidden personality-trait payloads to `GeneratedCoach` and `GeneratedScout`, modeled on the player-attribute personality scheme (`docs/product/north-star/player-attributes.md`). Without these, the hiring market is purely ratings + money — the Belichick-loyalty / McDaniels-mercenary / McVay-ambition drama has no home. Personality is the dimension that drives post-hire behavior (re-signs, early exits, media incidents, locker-room culture), distinct from the existing `*Pref` weights which drive offer evaluation.

- **Coach traits:** `loyalty`, `greed`, `ambition`, `schemeAttachment`, `ego`, `workaholic`.
- **Scout traits:** `loyalty`, `greed`, `ambition`, `conviction`, `travelTolerance`. Scheme attachment is deliberately omitted per the issue — scouts evaluate players, not schemes.
- **Distribution:** bell-shaped around 50 on the 0–100 rating-scale contract, rolled once per entity (stable, not per-offer), with light role tilts (first-time HCs skew high-ambition; experienced HCs lean workaholic/scheme-attached; directors skew ambitious; area scouts skew travel-tolerant).
- **Hidden:** the new `personality` field is stripped in the services before DB insert (alongside `ratings` / `tendencies`). Persistence lands as a follow-up once the consuming systems (re-sign logic, interview noise) are built; schema is untouched.
- **Tests:** presence on every generated coach/scout, range 0..100, stability under seed, bell-shape (mean ~50, SD in [8, 22]), and directional tilts (first-time HC ambition > experienced HC ambition; area-scout travel tolerance > director travel tolerance).

Closes #542.