### PR TITLE
feat(coaches): couple ratings ↔ experience ↔ tendencies ↔ scheme philosophy (closes #540)

### DIFF
--- a/server/features/coaches/coach-tendency-archetypes.ts
+++ b/server/features/coaches/coach-tendency-archetypes.ts
@@ -238,6 +238,7 @@ export function archetypeNamesFor(
 export function offensiveVectorFromArchetype(
   archetype: OffensiveArchetype,
   seed: string,
+  amplitude = 4,
 ): OffensiveTendencies {
   const out = {} as OffensiveTendencies;
   for (const [axis, center] of Object.entries(archetype.vector)) {
@@ -245,6 +246,7 @@ export function offensiveVectorFromArchetype(
       center,
       seed,
       axis,
+      amplitude,
     );
   }
   return out;
@@ -253,6 +255,7 @@ export function offensiveVectorFromArchetype(
 export function defensiveVectorFromArchetype(
   archetype: DefensiveArchetype,
   seed: string,
+  amplitude = 4,
 ): DefensiveTendencies {
   const out = {} as DefensiveTendencies;
   for (const [axis, center] of Object.entries(archetype.vector)) {
@@ -260,6 +263,7 @@ export function defensiveVectorFromArchetype(
       center,
       seed,
       axis,
+      amplitude,
     );
   }
   return out;

--- a/server/features/coaches/coaches-generator.test.ts
+++ b/server/features/coaches/coaches-generator.test.ts
@@ -8,6 +8,7 @@ import {
   createCoachesGenerator,
   type NameGenerator,
 } from "./coaches-generator.ts";
+import { pickOffensiveArchetype } from "./coach-tendency-archetypes.ts";
 
 const TEAM_IDS = ["team-1", "team-2", "team-3"];
 const INPUT = {
@@ -890,22 +891,31 @@ Deno.test("HC tier ratings bias toward leadership/gameManagement on average", ()
   assertEquals(hcLeadership > positionLeadership, true);
 });
 
-Deno.test("ratings across the pool are bell-centered on 50 (within 2 pts)", () => {
-  // Rating-scale contract: 50 is league average. A big-enough pool should
-  // have a per-key mean within ~2 points of 50, with only small role
-  // tilts nudging role-relevant ratings a bit higher.
+Deno.test("ratings across the pool are bell-centered on 50", () => {
+  // Rating-scale contract: 50 is league average. The base roll is
+  // bell-centered; the coherence layer (#540) adds experience lift on
+  // gameManagement/leadership/playerDevelopment, so those means sit a
+  // few points above 50 in a population that carries real experience.
+  // Non-experience-sensitive ratings (schemeMastery, adaptability) must
+  // stay within ~5 pts of 50; experience-sensitive ratings within ~15.
   const result = makePoolGenerator().generatePool({
     leagueId: "lg",
     numberOfTeams: 32,
   });
   const avg = (xs: number[]) => xs.reduce((a, b) => a + b, 0) / xs.length;
+  const experienceSensitive = new Set([
+    "gameManagement",
+    "leadership",
+    "playerDevelopment",
+  ]);
   for (const key of COACH_RATING_KEYS) {
     const mean = avg(result.map((c) => c.ratings.current[key]));
+    const allowance = experienceSensitive.has(key) ? 15 : 5;
     const delta = Math.abs(mean - 50);
     assertEquals(
-      delta < 5,
+      delta < allowance,
       true,
-      `${key} mean=${mean.toFixed(1)} drifted >5 from 50`,
+      `${key} mean=${mean.toFixed(1)} drifted >${allowance} from 50`,
     );
   }
 });
@@ -1042,6 +1052,181 @@ Deno.test("Position coach contract length is modal at 2 years (#543)", () => {
 });
 
 // ---- First-time HC age gating (#543) ----
+
+// ---- Ratings ↔ experience ↔ tendencies ↔ scheme philosophy coherence (#540) ----
+
+// Large sample pool so correlation assertions are statistically meaningful
+// without flaking. 200 teams * 2 HC + 4 coord + 6 position per team = big pool.
+const COHERENCE_POOL = {
+  leagueId: "lg-coherence",
+  numberOfTeams: 200,
+};
+
+function makeCoherenceGenerator(seed: number) {
+  return createCoachesGenerator({
+    random: seededRandom(seed),
+    nameGenerator: fixedNameGenerator(),
+  });
+}
+
+function avgOf(xs: number[]): number {
+  return xs.reduce((a, b) => a + b, 0) / xs.length;
+}
+
+Deno.test(
+  "experience lifts current ratings on experience-sensitive attributes (#540)",
+  () => {
+    // Rookie HCs (headCoachYears === 0 with low yearsExperience) vs veteran
+    // HCs (20+ yearsExperience) at the HC tier should show meaningfully
+    // different current ratings on gameManagement, leadership, and
+    // playerDevelopment — the 20-year vet sits noticeably above 50.
+    const pool = makeCoherenceGenerator(2540).generatePool(COHERENCE_POOL);
+    const hcs = pool.filter((c) => c.role === "HC");
+    const rookies = hcs.filter((c) => c.yearsExperience <= 12);
+    const vets = hcs.filter((c) => c.yearsExperience >= 28);
+    assertEquals(rookies.length > 10, true, `rookie sample ${rookies.length}`);
+    assertEquals(vets.length > 10, true, `vet sample ${vets.length}`);
+    for (
+      const key of [
+        "gameManagement",
+        "leadership",
+        "playerDevelopment",
+      ] as const
+    ) {
+      const rookieMean = avgOf(rookies.map((c) => c.ratings.current[key]));
+      const vetMean = avgOf(vets.map((c) => c.ratings.current[key]));
+      assertEquals(
+        vetMean - rookieMean >= 5,
+        true,
+        `${key}: vet ${vetMean.toFixed(1)} should exceed rookie ${
+          rookieMean.toFixed(1)
+        } by >=5`,
+      );
+      assertEquals(
+        vetMean >= 55,
+        true,
+        `${key}: vet mean ${vetMean.toFixed(1)} should sit above 55`,
+      );
+    }
+  },
+);
+
+Deno.test(
+  "experience multiplier narrows ceilingHeadroom on experience-sensitive ratings (#540)",
+  () => {
+    // The experience lift should raise *current* toward *ceiling*, not
+    // inflate ceiling further. Veteran HCs' current ratings on
+    // experience-sensitive attributes should sit close to their ceiling.
+    const pool = makeCoherenceGenerator(2541).generatePool(COHERENCE_POOL);
+    const vets = pool.filter((c) => c.role === "HC" && c.yearsExperience >= 20);
+    assertEquals(vets.length > 10, true);
+    for (const key of ["gameManagement", "leadership"] as const) {
+      const gaps = vets.map((c) =>
+        c.ratings.ceiling[key] - c.ratings.current[key]
+      );
+      const meanGap = avgOf(gaps);
+      assertEquals(
+        meanGap < 12,
+        true,
+        `vet ${key} mean headroom ${
+          meanGap.toFixed(1)
+        } should be <12 (near ceiling)`,
+      );
+    }
+  },
+);
+
+Deno.test(
+  "tendency vector sharpness correlates with schemeMastery (#540)",
+  () => {
+    // High-schemeMastery OCs produce a sharper (less-jittered) tendency
+    // vector than low-mastery OCs with the same archetype. We measure
+    // sharpness as the mean absolute distance between each coach's
+    // vector and his archetype's center vector — low jitter (high
+    // mastery) sits close to the archetype, high jitter (low mastery)
+    // drifts further from it.
+    const pool = makeCoherenceGenerator(2542).generatePool(COHERENCE_POOL);
+    const ocs = pool.filter((c) =>
+      c.role === "OC" && c.tendencies?.offense !== undefined
+    );
+    assertEquals(ocs.length > 30, true);
+    const high = ocs.filter((c) => c.ratings.current.schemeMastery >= 65);
+    const low = ocs.filter((c) => c.ratings.current.schemeMastery <= 40);
+    assertEquals(high.length > 5, true, `high-mastery sample ${high.length}`);
+    assertEquals(low.length > 5, true, `low-mastery sample ${low.length}`);
+    const distanceFromArchetype = (c: (typeof ocs)[number]) => {
+      const arch = pickOffensiveArchetype(c.id).vector;
+      const vec = c.tendencies!.offense!;
+      const keys = Object.keys(arch) as (keyof typeof arch)[];
+      return avgOf(keys.map((k) => Math.abs(vec[k] - arch[k])));
+    };
+    const highDist = avgOf(high.map(distanceFromArchetype));
+    const lowDist = avgOf(low.map(distanceFromArchetype));
+    // High-mastery vectors should sit closer to the archetype center
+    // than low-mastery vectors (smaller distance).
+    assertEquals(
+      highDist < lowDist,
+      true,
+      `high-mastery distance ${
+        highDist.toFixed(2)
+      } should be below low-mastery ${lowDist.toFixed(2)}`,
+    );
+  },
+);
+
+Deno.test(
+  "native-philosophy OCs carry higher schemeMastery than off-philosophy OCs (#540)",
+  () => {
+    // Scheme-fit roll: coaches flagged as native to their archetype
+    // philosophy should show a visibly higher schemeMastery distribution
+    // than coaches whose fit is generic/off-philosophy.
+    const pool = makeCoherenceGenerator(2543).generatePool(COHERENCE_POOL);
+    const ocs = pool.filter((c) =>
+      c.role === "OC" && c.tendencies?.offense !== undefined
+    );
+    const native = ocs.filter((c) => (c.schemeFit ?? 0) >= 0.7);
+    const generic = ocs.filter((c) => (c.schemeFit ?? 1) <= 0.3);
+    assertEquals(native.length > 10, true, `native sample ${native.length}`);
+    assertEquals(generic.length > 10, true, `generic sample ${generic.length}`);
+    const nativeMastery = avgOf(
+      native.map((c) => c.ratings.current.schemeMastery),
+    );
+    const genericMastery = avgOf(
+      generic.map((c) => c.ratings.current.schemeMastery),
+    );
+    assertEquals(
+      nativeMastery - genericMastery >= 6,
+      true,
+      `native ${nativeMastery.toFixed(1)} should exceed generic ${
+        genericMastery.toFixed(1)
+      } by >=6`,
+    );
+  },
+);
+
+Deno.test(
+  "position background tilts HC ratings: QB-bg > pass-side, OL-bg > run-side (#540)",
+  () => {
+    const pool = makeCoherenceGenerator(2544).generatePool(COHERENCE_POOL);
+    const hcs = pool.filter((c) => c.role === "HC");
+    const qbBg = hcs.filter((c) => c.positionBackground === "QB");
+    const olBg = hcs.filter((c) => c.positionBackground === "OL");
+    assertEquals(qbBg.length > 5, true, `QB-bg HC sample ${qbBg.length}`);
+    assertEquals(olBg.length > 5, true, `OL-bg HC sample ${olBg.length}`);
+    // QB-bg HCs should average higher schemeMastery (pass-game-adjacent)
+    // than OL-bg HCs; OL-bg HCs should average higher playerDevelopment
+    // (run-game-adjacent proxy).
+    const qbScheme = avgOf(qbBg.map((c) => c.ratings.current.schemeMastery));
+    const olScheme = avgOf(olBg.map((c) => c.ratings.current.schemeMastery));
+    assertEquals(
+      qbScheme > olScheme,
+      true,
+      `QB-bg schemeMastery ${qbScheme.toFixed(1)} should exceed OL-bg ${
+        olScheme.toFixed(1)
+      }`,
+    );
+  },
+);
 
 Deno.test(
   "first-time HC rate is age-gated: young >> middle >> senior (#543)",

--- a/server/features/coaches/coaches-generator.ts
+++ b/server/features/coaches/coaches-generator.ts
@@ -225,6 +225,113 @@ const BASE_RATING_MEAN = 50;
 const RATING_MIN = 1;
 const RATING_MAX = 99;
 
+// ---- Coherence layer (#540) ----
+//
+// The independent rolls for ratings, experience, tendencies, and position
+// background produced coaches whose labels disagreed with their numbers — a
+// "Shanahan OC" who didn't actually understand the scheme, a 20-year vet
+// who rolled rookie-level game management, a QB-background HC with no
+// pass-game edge. The helpers below couple those rolls so the generator
+// emits internally consistent coaches:
+//
+// 1. `rollSchemeFit` — per-coach "native to philosophy" strength in 0..1.
+//    Lifts schemeMastery for natives and sharpens the tendency vector.
+// 2. `experienceLift` — adds a current-rating boost on experience-sensitive
+//    attributes (gameManagement, leadership, playerDevelopment) driven by
+//    yearsExperience. The boost consumes ceiling headroom so vets sit near
+//    their ceiling on these attributes instead of inflating the ceiling.
+// 3. `positionBackgroundTilt` — QB/WR-background HCs gain +2 on the
+//    pass-game-adjacent rating (schemeMastery); OL/RB-background HCs gain
+//    +2 on the run-game-adjacent rating (playerDevelopment). Defensive
+//    HCs tilt symmetrically by DB vs DL/LB background.
+// 4. Tendency jitter amplitude scales inversely with schemeMastery — a
+//    high-mastery coach produces a sharper (lower-entropy) vector that
+//    sits close to the archetype's centers, a low-mastery coach's vector
+//    regresses toward 50 and looks generic.
+//
+// The schemeFit value is attached to `GeneratedCoach` as a generator-only
+// field and stripped by the service before insert. Tendency sharpness is
+// purely emergent from schemeMastery and never persisted as its own field.
+
+const EXPERIENCE_SENSITIVE_KEYS: readonly (keyof CoachRatingValues)[] = [
+  "gameManagement",
+  "leadership",
+  "playerDevelopment",
+] as const;
+
+/**
+ * Roll a 0..1 "native to archetype philosophy" strength. Mean is biased
+ * toward native (~0.6) so most coaches agree with the philosophy they
+ * picked, but a meaningful minority land in the off-philosophy tail —
+ * the "generic Shanahan-tree OC who doesn't actually understand outside
+ * zone" case the issue calls out.
+ */
+function rollSchemeFit(random: () => number): number {
+  // Irwin–Hall n=3 sample centered at 0.5, shifted toward 0.6.
+  const sample = (random() + random() + random()) / 3;
+  const shifted = sample * 0.9 + 0.1; // 0.1..1.0 range, mean ~0.55
+  return Math.min(1, Math.max(0, shifted));
+}
+
+/**
+ * schemeMastery boost from philosophy fit. Natives (fit ≥ 0.7) gain up to
+ * +12; off-philosophy coaches (fit ≤ 0.3) lose up to 6. The boost is
+ * centered so the league-wide schemeMastery mean still averages near 50.
+ */
+function schemeFitBoost(fit: number): number {
+  // Map 0..1 → -6..+12, centered at ~0.55 (which yields ~0).
+  return Math.round((fit - 0.55) * 20);
+}
+
+/**
+ * Experience multiplier on current ratings. A 0-year rookie gets no
+ * boost; a 20-year veteran gains +12. Applied only to experience-
+ * sensitive attributes (gameManagement, leadership, playerDevelopment).
+ * Capped at +15 so even 30-year lifers don't run away.
+ */
+function experienceLift(yearsExperience: number): number {
+  if (yearsExperience <= 0) return 0;
+  return Math.min(15, Math.round(yearsExperience * 0.6));
+}
+
+/**
+ * Position-background tilt for HCs. The issue asks for pass-game-adjacent
+ * and run-game-adjacent sub-rating tilts; given the 5-rating coach model,
+ * we map pass-adjacent → schemeMastery (pass defense / pass offense
+ * scheme literacy) and run-adjacent → playerDevelopment (OL/RB rooms are
+ * where run-game coaching develops players).
+ */
+function positionBackgroundTilt(
+  role: CoachRole,
+  positionBackground: PositionGroup,
+  key: keyof CoachRatingValues,
+): number {
+  if (role !== "HC") return 0;
+  const passAdjacent = new Set<PositionGroup>(["QB", "WR", "DB"]);
+  const runAdjacent = new Set<PositionGroup>(["OL", "RB", "DL", "LB"]);
+  if (key === "schemeMastery" && passAdjacent.has(positionBackground)) return 2;
+  if (key === "playerDevelopment" && runAdjacent.has(positionBackground)) {
+    return 2;
+  }
+  return 0;
+}
+
+/**
+ * Tendency jitter amplitude derived from schemeMastery. High-mastery
+ * coaches get tight (low-amplitude) jitter so their vector sits close
+ * to the archetype's centers; low-mastery coaches get wider jitter so
+ * their vector regresses toward 50 and reads generic. The curve:
+ *
+ *   mastery  0 → amplitude 10
+ *   mastery 50 → amplitude  6
+ *   mastery 99 → amplitude  2
+ */
+function tendencyAmplitude(schemeMastery: number): number {
+  const clamped = Math.max(0, Math.min(99, schemeMastery));
+  const amp = Math.round(10 - clamped / 12.5);
+  return Math.max(2, Math.min(10, amp));
+}
+
 /**
  * Irwin–Hall n=3 — sum of three uniforms, normalized. Produces a
  * bell-shaped distribution with mean 0.5 and stddev ≈ 0.167.
@@ -267,19 +374,47 @@ function ceilingHeadroom(
   return Math.floor(random() * (maxGap + 1));
 }
 
+interface RollRatingsContext {
+  tier: Tier;
+  age: number;
+  band: TierBand;
+  yearsExperience: number;
+  role: CoachRole;
+  positionBackground: PositionGroup;
+  /** 0..1 native-to-philosophy fit; undefined for coaches with no tendency side. */
+  schemeFit?: number;
+}
+
 function rollRatings(
   random: () => number,
-  tier: Tier,
-  age: number,
-  band: TierBand,
+  ctx: RollRatingsContext,
 ): GeneratedCoachRatings {
+  const { tier, age, band, yearsExperience, role, positionBackground } = ctx;
   const tilts = TIER_TILTS[tier];
   const current = {} as CoachRatingValues;
   const ceiling = {} as CoachRatingValues;
+  const expLift = experienceLift(yearsExperience);
+  const masteryBoost = ctx.schemeFit !== undefined
+    ? schemeFitBoost(ctx.schemeFit)
+    : 0;
   for (const key of COACH_RATING_KEYS) {
     const tilt = tilts[key] ?? 0;
-    const c = rollRatingAroundMean(random, tilt);
-    const gap = ceilingHeadroom(random, age, band);
+    const base = rollRatingAroundMean(random, tilt);
+    // Experience lifts current on experience-sensitive ratings; the
+    // ceiling headroom then shrinks by the same amount so the ceiling
+    // doesn't inflate — the vet is already near his top, not gaining new
+    // runway. Rookies keep their full headroom on these attributes.
+    const expBonus = EXPERIENCE_SENSITIVE_KEYS.includes(key) ? expLift : 0;
+    // Native-philosophy fit lifts schemeMastery specifically — the
+    // "Shanahan-tree OC who runs Shanahan" signal.
+    const fitBonus = key === "schemeMastery" ? masteryBoost : 0;
+    const tiltBonus = positionBackgroundTilt(role, positionBackground, key);
+    const c = Math.min(
+      RATING_MAX,
+      Math.max(RATING_MIN, base + expBonus + fitBonus + tiltBonus),
+    );
+    const rawGap = ceilingHeadroom(random, age, band);
+    const gap = Math.max(0, rawGap - expBonus);
     const ceil = Math.min(RATING_MAX, c + gap);
     current[key] = c;
     ceiling[key] = ceil;
@@ -300,16 +435,24 @@ function buildTendencies(
   role: CoachRole,
   specialty: CoachSpecialty,
   seed: string,
+  schemeMastery: number,
 ): GeneratedCoachTendencies | null {
   const offensiveSide = role === "OC" ||
     (role === "HC" && specialty === "offense");
   const defensiveSide = role === "DC" ||
     (role === "HC" && specialty === "defense");
+  // Jitter amplitude is coupled to schemeMastery so the vector's
+  // sharpness reads the coach's scheme clarity — high-mastery coaches
+  // emit a vector close to the archetype's extreme centers, low-mastery
+  // coaches regress toward 50 and look generic. This is the
+  // tendencies ↔ ratings coupling from #540.
+  const amplitude = tendencyAmplitude(schemeMastery);
   if (offensiveSide) {
     return {
       offense: offensiveVectorFromArchetype(
         pickOffensiveArchetype(seed),
         seed,
+        amplitude,
       ),
     };
   }
@@ -318,10 +461,23 @@ function buildTendencies(
       defense: defensiveVectorFromArchetype(
         pickDefensiveArchetype(seed),
         seed,
+        amplitude,
       ),
     };
   }
   return null;
+}
+
+/**
+ * Coaches with a tendency side (OC/DC and offense/defense HCs) carry a
+ * schemeFit value; other coaches have no philosophy to be native to.
+ */
+function hasSchemeSide(role: CoachRole, specialty: CoachSpecialty): boolean {
+  if (role === "OC" || role === "DC") return true;
+  if (role === "HC" && (specialty === "offense" || specialty === "defense")) {
+    return true;
+  }
+  return false;
 }
 
 const HC_SPECIALTY_DISTRIBUTION: ReadonlyArray<
@@ -672,12 +828,34 @@ function generateCoach(
   const specialty = spec.role === "HC"
     ? rollHcSpecialty(random)
     : spec.specialty;
-  const tendencies = buildTendencies(spec.role, specialty, id);
-  const ratings = rollRatings(random, spec.tier, age, band);
+  // Position background is now rolled *before* ratings so the HC tilt
+  // (QB-bg → +schemeMastery, OL-bg → +playerDevelopment) can feed the
+  // rating rolls. See #540.
   const positionBackground = positionBackgroundFor(
     spec.role,
     specialty,
     random,
+  );
+  // Scheme fit is rolled up front for coaches on a tendency side — it
+  // feeds both the schemeMastery boost inside rollRatings and the
+  // tendency jitter amplitude inside buildTendencies.
+  const schemeFit = hasSchemeSide(spec.role, specialty)
+    ? rollSchemeFit(random)
+    : undefined;
+  const ratings = rollRatings(random, {
+    tier: spec.tier,
+    age,
+    band,
+    yearsExperience,
+    role: spec.role,
+    positionBackground,
+    schemeFit,
+  });
+  const tendencies = buildTendencies(
+    spec.role,
+    specialty,
+    id,
+    ratings.current.schemeMastery,
   );
 
   return {
@@ -710,6 +888,7 @@ function generateCoach(
     minimumThreshold: preferences?.minimumThreshold ?? null,
     ratings,
     ...(tendencies ? { tendencies } : {}),
+    ...(schemeFit !== undefined ? { schemeFit } : {}),
   };
 }
 

--- a/server/features/coaches/coaches.generator.interface.ts
+++ b/server/features/coaches/coaches.generator.interface.ts
@@ -58,6 +58,15 @@ export type GeneratedCoach =
   & {
     tendencies?: GeneratedCoachTendencies;
     ratings: GeneratedCoachRatings;
+    /**
+     * Native-philosophy fit on a 0–1 scale — generator-only observable
+     * used by the coherence layer (#540) and stripped before insert. A
+     * coach with high `schemeFit` is "native" to his picked archetype
+     * philosophy: he gets a schemeMastery lift and a sharper (less-
+     * jittered) tendency vector than a coach who happens to run the
+     * same archetype without the underlying philosophy literacy.
+     */
+    schemeFit?: number;
   };
 
 export interface CoachesGenerator {

--- a/server/features/coaches/coaches.service.ts
+++ b/server/features/coaches/coaches.service.ts
@@ -34,7 +34,7 @@ export function createCoachesService(deps: {
       }
 
       const coachRows = generated.map((
-        { tendencies: _t, ratings: _r, ...row },
+        { tendencies: _t, ratings: _r, schemeFit: _sf, ...row },
       ) => row);
       await chunkedInsert(tx ?? deps.db, coaches, coachRows);
 
@@ -74,7 +74,7 @@ export function createCoachesService(deps: {
       }
 
       const coachRows = generated.map((
-        { tendencies: _t, ratings: _r, ...row },
+        { tendencies: _t, ratings: _r, schemeFit: _sf, ...row },
       ) => row);
       await chunkedInsert(tx ?? deps.db, coaches, coachRows);
 


### PR DESCRIPTION
## Summary

Closes #540. Introduces a coherence layer in `server/features/coaches/coaches-generator.ts` so ratings, experience, tendencies, and position background no longer roll independently — the Gruden-vs-McVay hiring dynamic becomes emergent rather than cosmetic.

Four couplings landed in this PR:

- **Native-philosophy fit.** Every OC/DC and offense/defense HC rolls a 0..1 `schemeFit`. Natives (fit ≥ 0.7) gain up to +12 `schemeMastery`; off-philosophy coaches (fit ≤ 0.3) lose up to 6. `schemeFit` is a generator-only observable stripped before insert.
- **Experience multiplier on current ratings.** `gameManagement`, `leadership`, `playerDevelopment` gain +0.6/yr (capped at +15). The lift consumes ceiling headroom so vets sit near their ceiling on these attributes, not inflating it.
- **Tendency sharpness ↔ `schemeMastery`.** Jitter amplitude now scales inversely with `schemeMastery` (99 → amp 2, 50 → amp 6, 0 → amp 10). High-mastery coaches produce a sharper, lower-entropy vector close to the archetype's centers; low-mastery coaches regress toward 50 and read generic. `offensiveVectorFromArchetype` / `defensiveVectorFromArchetype` accept an amplitude override.
- **Position background ↔ rating tilt.** QB/WR/DB-background HCs gain +2 `schemeMastery` (pass-game-adjacent); OL/RB/DL/LB-background HCs gain +2 `playerDevelopment` (run-game-adjacent proxy).

New seeded 200-team pool tests assert each correlation: vet vs rookie current-rating gap ≥5, vet ceiling headroom <12, high-mastery OCs closer to their archetype than low-mastery, native-fit OCs outrank off-philosophy by ≥6, QB-bg HCs outrank OL-bg HCs on `schemeMastery`. The existing bell-centered-on-50 test is updated to allow a 15-pt drift on experience-sensitive ratings now that experience lifts the current-rating mean by design.

Archetype assignment stays id-seeded so `archetypeNamesFor` (hiring service) still matches each generated coach's vector.