### PR TITLE
feat(gamesimulator): resolve fumble recoverer on run plays

### DIFF
--- a/src/gamesimulator/java/app/zoneblitz/gamesimulator/resolver/BaselineFumbleRecoveryModel.java
+++ b/src/gamesimulator/java/app/zoneblitz/gamesimulator/resolver/BaselineFumbleRecoveryModel.java
@@ -1,0 +1,66 @@
+package app.zoneblitz.gamesimulator.resolver;
+
+import app.zoneblitz.gamesimulator.event.FumbleOutcome;
+import app.zoneblitz.gamesimulator.event.PlayerId;
+import app.zoneblitz.gamesimulator.rng.RandomSource;
+import app.zoneblitz.gamesimulator.roster.Player;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+
+/**
+ * First-cut fumble-recovery model. Flips one weighted coin for "defense recovers vs offense
+ * recovers", then picks a recoverer uniformly at random from the winning pool. League-wide 2022-24
+ * play-by-play shows defense recovers a loose ball roughly half the time — the default rate is
+ * {@code 0.5}. Return yards on the recovery are zeroed; yardage modeling is a separate calibration
+ * target.
+ *
+ * <p>Offense recoveries draw from offensive teammates excluding the fumbler; defense recoveries
+ * draw from all defenders. Both pools use a role-agnostic uniform pick — proximity/role shaping
+ * will land in a later iteration without changing this interface.
+ */
+public final class BaselineFumbleRecoveryModel implements FumbleRecoveryModel {
+
+  public static final double DEFAULT_DEFENSE_RECOVERY_RATE = 0.5;
+
+  private final double defenseRecoveryRate;
+
+  public BaselineFumbleRecoveryModel() {
+    this(DEFAULT_DEFENSE_RECOVERY_RATE);
+  }
+
+  public BaselineFumbleRecoveryModel(double defenseRecoveryRate) {
+    if (defenseRecoveryRate < 0.0 || defenseRecoveryRate > 1.0) {
+      throw new IllegalArgumentException(
+          "defenseRecoveryRate must be in [0, 1]; got " + defenseRecoveryRate);
+    }
+    this.defenseRecoveryRate = defenseRecoveryRate;
+  }
+
+  @Override
+  public FumbleOutcome resolve(
+      PlayerId fumbledBy,
+      List<Player> offensiveTeammates,
+      List<Player> defenders,
+      RandomSource rng) {
+    Objects.requireNonNull(fumbledBy, "fumbledBy");
+    Objects.requireNonNull(offensiveTeammates, "offensiveTeammates");
+    Objects.requireNonNull(defenders, "defenders");
+    Objects.requireNonNull(rng, "rng");
+
+    var offenseCandidates =
+        offensiveTeammates.stream().filter(p -> !p.id().equals(fumbledBy)).toList();
+    if (offenseCandidates.isEmpty() && defenders.isEmpty()) {
+      throw new IllegalArgumentException("no recovery candidates available on either side");
+    }
+
+    var coin = rng.nextDouble();
+    var defenseWins =
+        offenseCandidates.isEmpty() || (!defenders.isEmpty() && coin < defenseRecoveryRate);
+    var pool = defenseWins ? defenders : offenseCandidates;
+    var index = Math.floorMod(rng.nextLong(), pool.size());
+    var recoverer = pool.get(index).id();
+
+    return new FumbleOutcome(fumbledBy, defenseWins, Optional.of(recoverer), 0);
+  }
+}

--- a/src/gamesimulator/java/app/zoneblitz/gamesimulator/resolver/FumbleRecoveryModel.java
+++ b/src/gamesimulator/java/app/zoneblitz/gamesimulator/resolver/FumbleRecoveryModel.java
@@ -1,0 +1,38 @@
+package app.zoneblitz.gamesimulator.resolver;
+
+import app.zoneblitz.gamesimulator.event.FumbleOutcome;
+import app.zoneblitz.gamesimulator.event.PlayerId;
+import app.zoneblitz.gamesimulator.rng.RandomSource;
+import app.zoneblitz.gamesimulator.roster.Player;
+import java.util.List;
+
+/**
+ * Strategy for resolving a loose ball into a concrete {@link FumbleOutcome}. Given the fumbler and
+ * the two candidate pools (offensive teammates and defenders), decides whether the defense recovers
+ * and which specific player comes up with the ball.
+ *
+ * <p>The returned outcome is the full surface a {@link app.zoneblitz.gamesimulator.event.PlayEvent}
+ * exposes: consumers must be able to render {@code "fumble recovered by Jones"} or {@code
+ * "recovered by own teammate Smith"} without any downstream imputation. That means the recoverer is
+ * never empty — callers should never invoke this model for a fumble that has no live recovery
+ * candidates.
+ */
+public interface FumbleRecoveryModel {
+
+  /**
+   * Resolve a loose ball into a full {@link FumbleOutcome}.
+   *
+   * @param fumbledBy the player who fumbled; must appear in {@code offensiveTeammates}
+   * @param offensiveTeammates the 11 offensive players on the field (including the fumbler); the
+   *     fumbler is excluded from recovery candidates
+   * @param defenders the 11 defensive players on the field — all eligible recovery candidates
+   * @param rng randomness source; drawn from for the recovery coin flip and the recoverer pick
+   * @return a fumble outcome with a non-empty {@code recoveredBy} player
+   * @throws IllegalArgumentException if there are no recovery candidates on either side
+   */
+  FumbleOutcome resolve(
+      PlayerId fumbledBy,
+      List<Player> offensiveTeammates,
+      List<Player> defenders,
+      RandomSource rng);
+}

--- a/src/gamesimulator/java/app/zoneblitz/gamesimulator/resolver/run/MatchupRunResolver.java
+++ b/src/gamesimulator/java/app/zoneblitz/gamesimulator/resolver/run/MatchupRunResolver.java
@@ -7,10 +7,11 @@ import app.zoneblitz.gamesimulator.band.BandSampler;
 import app.zoneblitz.gamesimulator.band.DistributionalBand;
 import app.zoneblitz.gamesimulator.band.RateBand;
 import app.zoneblitz.gamesimulator.event.FumbleOutcome;
-import app.zoneblitz.gamesimulator.event.PlayerId;
 import app.zoneblitz.gamesimulator.formation.BandBoxCountSampler;
 import app.zoneblitz.gamesimulator.personnel.DefensivePersonnel;
 import app.zoneblitz.gamesimulator.personnel.OffensivePersonnel;
+import app.zoneblitz.gamesimulator.resolver.BaselineFumbleRecoveryModel;
+import app.zoneblitz.gamesimulator.resolver.FumbleRecoveryModel;
 import app.zoneblitz.gamesimulator.resolver.PositionBasedRunRoleAssigner;
 import app.zoneblitz.gamesimulator.resolver.RunOutcome;
 import app.zoneblitz.gamesimulator.resolver.RunRoleAssigner;
@@ -64,6 +65,7 @@ public final class MatchupRunResolver implements RunResolver {
   private final RateBand<RunOutcomeKind> outcomeMix;
   private final Map<RunOutcomeKind, DistributionalBand> yardsByKind;
   private final DistributionalBand fumbleYards;
+  private final FumbleRecoveryModel fumbleRecoveryModel;
 
   public MatchupRunResolver(
       BandSampler sampler,
@@ -72,10 +74,29 @@ public final class MatchupRunResolver implements RunResolver {
       RateBand<RunOutcomeKind> outcomeMix,
       Map<RunOutcomeKind, DistributionalBand> yardsByKind,
       DistributionalBand fumbleYards) {
+    this(
+        sampler,
+        roleAssigner,
+        matchupShift,
+        outcomeMix,
+        yardsByKind,
+        fumbleYards,
+        new BaselineFumbleRecoveryModel());
+  }
+
+  public MatchupRunResolver(
+      BandSampler sampler,
+      RunRoleAssigner roleAssigner,
+      RunMatchupShift matchupShift,
+      RateBand<RunOutcomeKind> outcomeMix,
+      Map<RunOutcomeKind, DistributionalBand> yardsByKind,
+      DistributionalBand fumbleYards,
+      FumbleRecoveryModel fumbleRecoveryModel) {
     this.sampler = Objects.requireNonNull(sampler, "sampler");
     this.roleAssigner = Objects.requireNonNull(roleAssigner, "roleAssigner");
     this.matchupShift = Objects.requireNonNull(matchupShift, "matchupShift");
     this.outcomeMix = Objects.requireNonNull(outcomeMix, "outcomeMix");
+    this.fumbleRecoveryModel = Objects.requireNonNull(fumbleRecoveryModel, "fumbleRecoveryModel");
     Objects.requireNonNull(yardsByKind, "yardsByKind");
     for (var kind :
         new RunOutcomeKind[] {
@@ -152,14 +173,12 @@ public final class MatchupRunResolver implements RunResolver {
 
     var fumble =
         kind == RunOutcomeKind.FUMBLE
-            ? Optional.of(fumble(carrier.id()))
+            ? Optional.of(
+                fumbleRecoveryModel.resolve(
+                    carrier.id(), offense.players(), defense.players(), rng))
             : Optional.<FumbleOutcome>empty();
 
     return new RunOutcome.Run(carrier.id(), concept, yards, Optional.empty(), fumble, false);
-  }
-
-  private static FumbleOutcome fumble(PlayerId carrier) {
-    return new FumbleOutcome(carrier, false, Optional.empty(), 0);
   }
 
   /**

--- a/src/test/java/app/zoneblitz/gamesimulator/resolver/BaselineFumbleRecoveryModelTests.java
+++ b/src/test/java/app/zoneblitz/gamesimulator/resolver/BaselineFumbleRecoveryModelTests.java
@@ -1,0 +1,162 @@
+package app.zoneblitz.gamesimulator.resolver;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import app.zoneblitz.gamesimulator.event.PlayerId;
+import app.zoneblitz.gamesimulator.rng.RandomSource;
+import app.zoneblitz.gamesimulator.rng.SplittableRandomSource;
+import app.zoneblitz.gamesimulator.roster.Player;
+import app.zoneblitz.gamesimulator.roster.Position;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.Test;
+
+class BaselineFumbleRecoveryModelTests {
+
+  private final FumbleRecoveryModel model = new BaselineFumbleRecoveryModel(0.5);
+
+  @Test
+  void resolve_defenseWinsCoinFlip_recovererIsADefender() {
+    var offense = players(Position.QB, "qb", "rb", "wr1");
+    var defense = players(Position.DL, "dl1", "dl2", "dl3");
+    var fumbler = offense.get(0).id();
+
+    var outcome = model.resolve(fumbler, offense, defense, scripted(0.1, 0.0));
+
+    assertThat(outcome.defenseRecovered()).isTrue();
+    assertThat(outcome.recoveredBy()).isPresent();
+    assertThat(defense).extracting(Player::id).contains(outcome.recoveredBy().get());
+    assertThat(outcome.fumbledBy()).isEqualTo(fumbler);
+  }
+
+  @Test
+  void resolve_offenseWinsCoinFlip_recovererIsAnOffensiveTeammateNotTheFumbler() {
+    var offense = players(Position.QB, "qb", "rb", "wr1");
+    var defense = players(Position.DL, "dl1", "dl2", "dl3");
+    var fumbler = offense.get(0).id();
+
+    var outcome = model.resolve(fumbler, offense, defense, scripted(0.9, 0.0));
+
+    assertThat(outcome.defenseRecovered()).isFalse();
+    assertThat(outcome.recoveredBy()).isPresent();
+    var recoverer = outcome.recoveredBy().get();
+    assertThat(recoverer).isNotEqualTo(fumbler);
+    assertThat(offense).extracting(Player::id).contains(recoverer);
+    assertThat(outcome.returnYards()).isZero();
+  }
+
+  @Test
+  void resolve_probabilityThresholdEdge_defenseRecoversStrictlyBelowRate() {
+    var offense = players(Position.QB, "qb", "rb");
+    var defense = players(Position.DL, "dl1", "dl2");
+    var fumbler = offense.get(0).id();
+
+    var belowThreshold = model.resolve(fumbler, offense, defense, scripted(0.4999, 0.0));
+    var aboveThreshold = model.resolve(fumbler, offense, defense, scripted(0.5000, 0.0));
+
+    assertThat(belowThreshold.defenseRecovered()).isTrue();
+    assertThat(aboveThreshold.defenseRecovered()).isFalse();
+  }
+
+  @Test
+  void resolve_overManyTrials_defenseRateConvergesToConfiguredProbability() {
+    var offense = players(Position.QB, "qb", "rb", "wr1", "wr2");
+    var defense = players(Position.DL, "dl1", "dl2", "dl3", "dl4");
+    var fumbler = offense.get(0).id();
+    var rng = new SplittableRandomSource(7L);
+
+    var trials = 10_000;
+    var defenseCount = 0;
+    for (var i = 0; i < trials; i++) {
+      if (model.resolve(fumbler, offense, defense, rng).defenseRecovered()) {
+        defenseCount++;
+      }
+    }
+
+    var rate = defenseCount / (double) trials;
+    assertThat(rate).as("configured rate = 0.5; ±3σ over 10k ≈ ±0.015").isBetween(0.475, 0.525);
+  }
+
+  @Test
+  void resolve_offenseRecovery_distributesAcrossNonFumblerTeammates() {
+    var offense = players(Position.QB, "qb", "rb", "wr1");
+    var defense = players(Position.DL, "dl1", "dl2", "dl3");
+    var fumbler = offense.get(0).id();
+    var rng = new SplittableRandomSource(21L);
+    var recoverers = new java.util.HashSet<PlayerId>();
+
+    for (var i = 0; i < 500; i++) {
+      var outcome = model.resolve(fumbler, offense, defense, rng);
+      if (!outcome.defenseRecovered()) {
+        recoverers.add(outcome.recoveredBy().get());
+      }
+    }
+
+    assertThat(recoverers)
+        .as("both non-fumbler teammates should appear over 500 trials")
+        .hasSize(2);
+    assertThat(recoverers).doesNotContain(fumbler);
+  }
+
+  @Test
+  void resolve_whenFumblerIsSoleOffensivePlayer_defenseAlwaysRecovers() {
+    var offense = List.of(player(Position.QB, "qb"));
+    var defense = players(Position.DL, "dl1", "dl2");
+    var fumbler = offense.get(0).id();
+
+    var outcome = model.resolve(fumbler, offense, defense, scripted(0.99, 0.0));
+
+    assertThat(outcome.defenseRecovered()).isTrue();
+    assertThat(defense).extracting(Player::id).contains(outcome.recoveredBy().get());
+  }
+
+  @Test
+  void resolve_emptyBothSides_throws() {
+    var fumbler = new PlayerId(new UUID(0L, 1L));
+    assertThatThrownBy(() -> model.resolve(fumbler, List.of(), List.of(), scripted(0.1, 0.0)))
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  private static List<Player> players(Position position, String... names) {
+    return java.util.Arrays.stream(names).map(n -> player(position, n)).toList();
+  }
+
+  private static Player player(Position position, String name) {
+    return new Player(new PlayerId(UUID.randomUUID()), position, name);
+  }
+
+  private static RandomSource scripted(double... doubles) {
+    return new ScriptedRandom(doubles);
+  }
+
+  private static final class ScriptedRandom implements RandomSource {
+    private final double[] doubles;
+    private final AtomicInteger cursor = new AtomicInteger();
+
+    ScriptedRandom(double[] doubles) {
+      this.doubles = doubles.clone();
+    }
+
+    @Override
+    public long nextLong() {
+      return 0L;
+    }
+
+    @Override
+    public double nextDouble() {
+      return doubles[cursor.getAndIncrement() % doubles.length];
+    }
+
+    @Override
+    public double nextGaussian() {
+      return 0.0;
+    }
+
+    @Override
+    public RandomSource split(long key) {
+      return this;
+    }
+  }
+}

--- a/src/test/java/app/zoneblitz/gamesimulator/resolver/run/MatchupRunResolverTests.java
+++ b/src/test/java/app/zoneblitz/gamesimulator/resolver/run/MatchupRunResolverTests.java
@@ -123,7 +123,37 @@ class MatchupRunResolverTests {
     for (var i = 0; i < 100; i++) {
       var run = (RunOutcome.Run) resolver.resolve(RUN_CALL, state(), offense, defense, rng);
       assertThat(run.fumble()).isPresent();
+      var fumble = run.fumble().get();
+      assertThat(fumble.recoveredBy())
+          .as("every fumble event must carry a non-null recoverer")
+          .isPresent();
+      assertThat(fumble.fumbledBy()).isEqualTo(run.carrier());
+      var recoverer = fumble.recoveredBy().get();
+      if (fumble.defenseRecovered()) {
+        assertThat(defense.players()).extracting(p -> p.id()).contains(recoverer);
+      } else {
+        assertThat(offense.players()).extracting(p -> p.id()).contains(recoverer);
+        assertThat(recoverer).isNotEqualTo(fumble.fumbledBy());
+      }
     }
+  }
+
+  @Test
+  void resolve_fumbleKind_defenseRecoveryRateMatchesModelBand() {
+    var resolver = buildResolver(forcedKind(RunOutcomeKind.FUMBLE), RunMatchupShift.ZERO);
+    var rng = new SplittableRandomSource(909L);
+    var trials = 5_000;
+    var defenseRecoveries = 0;
+    for (var i = 0; i < trials; i++) {
+      var run = (RunOutcome.Run) resolver.resolve(RUN_CALL, state(), offense, defense, rng);
+      if (run.fumble().orElseThrow().defenseRecovered()) {
+        defenseRecoveries++;
+      }
+    }
+    var rate = defenseRecoveries / (double) trials;
+    assertThat(rate)
+        .as("baseline recovery model flips ~50/50; ±3σ over 5k ≈ ±0.021")
+        .isBetween(0.46, 0.54);
   }
 
   @Test


### PR DESCRIPTION
## Summary
- Adds `FumbleRecoveryModel` interface + `BaselineFumbleRecoveryModel` (weighted coin flip, 50% default; uniform pick from winning pool, fumbler excluded from offense pool).
- Wires the model into `MatchupRunResolver` so run-play fumbles always carry a non-null `recoveredBy` and correct `defenseRecovered`.
- Pass-side fumbles (`Sack.fumble`) are always empty today; left untouched and flagged for the sack-modeling work in #581.
- `returnYards` zeroed for now — separate calibration target.

Closes #576.

## Test plan
- [x] 7 new unit tests for `BaselineFumbleRecoveryModel` (offense/defense branches, fumbler-exclusion, rate convergence).
- [x] `MatchupRunResolverTests` tightened to assert recoverer presence; added 5k-trial rate check (0.46–0.54 band).
- [x] `./gradlew test` green.
- [x] `./gradlew spotlessCheck` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)