### PR TITLE
feat(gamesimulator): emit Safety play event (#572)

### DIFF
--- a/src/gamesimulator/java/app/zoneblitz/gamesimulator/GameSimulator.java
+++ b/src/gamesimulator/java/app/zoneblitz/gamesimulator/GameSimulator.java
@@ -216,7 +216,9 @@ final class GameSimulator implements SimulateGame {
     }
     if (advance.safety()) {
       state = state.withScore(scoreAfter).withClock(clockAfter);
-      return state.withPossessionAndSpot(defenseSide, new FieldPosition(SAFETY_FREE_KICK_SPOT));
+      var freeKickSpot = new FieldPosition(SAFETY_FREE_KICK_SPOT);
+      out.add(safetyEvent(state, inputs.gameId(), seq[0]++, freeKickSpot, offenseSide));
+      return state.withPossessionAndSpot(defenseSide, freeKickSpot);
     }
     if (advance.turnover() != SnapAdvance.Turnover.NONE) {
       state = state.withScore(scoreAfter).withClock(clockAfter);
@@ -602,6 +604,27 @@ final class GameSimulator implements SimulateGame {
     state = state.withClock(tickKickClock(state, Kick.KICKOFF, rng));
     return state.withPossessionAndSpot(
         receivingSide, new FieldPosition(resolved.receivingSpotYardLine()));
+  }
+
+  private static PlayEvent.Safety safetyEvent(
+      GameState state,
+      GameId gameId,
+      int sequence,
+      FieldPosition freeKickSpot,
+      Side concedingSide) {
+    var id =
+        new PlayId(new UUID(gameId.value().getMostSignificantBits(), 0x5A00L | (long) sequence));
+    return new PlayEvent.Safety(
+        id,
+        gameId,
+        sequence,
+        state.downAndDistance(),
+        state.spot(),
+        state.clock(),
+        state.clock(),
+        state.score(),
+        freeKickSpot,
+        concedingSide);
   }
 
   private static PlayEvent.EndOfQuarter endOfQuarterEvent(

--- a/src/gamesimulator/java/app/zoneblitz/gamesimulator/event/PlayEvent.java
+++ b/src/gamesimulator/java/app/zoneblitz/gamesimulator/event/PlayEvent.java
@@ -21,6 +21,7 @@ public sealed interface PlayEvent
         PlayEvent.Punt,
         PlayEvent.Kickoff,
         PlayEvent.Penalty,
+        PlayEvent.Safety,
         PlayEvent.Kneel,
         PlayEvent.Spike,
         PlayEvent.Timeout,
@@ -245,6 +246,27 @@ public sealed interface PlayEvent
       int yards,
       boolean replayDown,
       Optional<PlayEvent> underlyingPlay)
+      implements PlayEvent {}
+
+  /**
+   * Emitted immediately after the triggering play event whenever that play resulted in a safety.
+   * The {@link #scoreAfter} matches the scoring math already applied on the triggering event (+2 to
+   * the defense). {@link #spot} is the free-kick spot awarded to the scoring team — today the ball
+   * is placed directly at that team's own 20 (a simplification; full free-kick modeling is a
+   * follow-up). {@link #concedingSide} is the side that gave up the two points (the offense on the
+   * triggering play).
+   */
+  record Safety(
+      PlayId id,
+      GameId gameId,
+      int sequence,
+      DownAndDistance preSnap,
+      FieldPosition preSnapSpot,
+      GameClock clockBefore,
+      GameClock clockAfter,
+      Score scoreAfter,
+      FieldPosition spot,
+      Side concedingSide)
       implements PlayEvent {}
 
   record Kneel(

--- a/src/gamesimulator/java/app/zoneblitz/gamesimulator/output/DefaultPlayNarrator.java
+++ b/src/gamesimulator/java/app/zoneblitz/gamesimulator/output/DefaultPlayNarrator.java
@@ -34,6 +34,7 @@ final class DefaultPlayNarrator implements PlayNarrator {
       case PlayEvent.Punt p -> punt(p, context);
       case PlayEvent.Kickoff k -> kickoff(k, context);
       case PlayEvent.Penalty p -> penalty(p, context);
+      case PlayEvent.Safety s -> safety(s, context);
       case PlayEvent.Kneel k -> "%s. Kneel down.".formatted(situation(k, context));
       case PlayEvent.Spike s -> "%s. Spike.".formatted(situation(s, context));
       case PlayEvent.Timeout t -> "Timeout, %s.".formatted(context.nameOf(t.team()));
@@ -180,6 +181,12 @@ final class DefaultPlayNarrator implements PlayNarrator {
     return "%s FLAG — %s on %s (%s), %d yards%s."
         .formatted(
             situation(p, ctx), type, against, ctx.nameOf(p.committedBy()), p.yards(), replay);
+  }
+
+  private String safety(PlayEvent.Safety s, NarrationContext ctx) {
+    return "SAFETY — 2 points awarded against %s. Free kick from own %d. %s"
+        .formatted(
+            ctx.nameOf(s.concedingSide()), s.spot().yardLine(), scoreLabel(s.scoreAfter(), ctx));
   }
 
   private String endOfQuarter(PlayEvent.EndOfQuarter e, NarrationContext ctx) {

--- a/src/test/java/app/zoneblitz/gamesimulator/GameSimulatorTests.java
+++ b/src/test/java/app/zoneblitz/gamesimulator/GameSimulatorTests.java
@@ -8,13 +8,20 @@ import app.zoneblitz.gamesimulator.clock.BandClockModel;
 import app.zoneblitz.gamesimulator.event.GameId;
 import app.zoneblitz.gamesimulator.event.PlayEvent;
 import app.zoneblitz.gamesimulator.event.PlayerId;
+import app.zoneblitz.gamesimulator.event.Side;
 import app.zoneblitz.gamesimulator.event.TeamId;
 import app.zoneblitz.gamesimulator.kickoff.TouchbackKickoffResolver;
 import app.zoneblitz.gamesimulator.penalty.BandPenaltyModel;
 import app.zoneblitz.gamesimulator.penalty.NoPenaltyModel;
+import app.zoneblitz.gamesimulator.personnel.DefensivePersonnel;
 import app.zoneblitz.gamesimulator.personnel.FakePersonnelSelector;
+import app.zoneblitz.gamesimulator.personnel.OffensivePersonnel;
 import app.zoneblitz.gamesimulator.personnel.TestPersonnel;
 import app.zoneblitz.gamesimulator.punt.DistanceCurvePuntResolver;
+import app.zoneblitz.gamesimulator.resolver.PassOutcome;
+import app.zoneblitz.gamesimulator.resolver.PlayOutcome;
+import app.zoneblitz.gamesimulator.resolver.PlayResolver;
+import app.zoneblitz.gamesimulator.rng.RandomSource;
 import app.zoneblitz.gamesimulator.roster.Coach;
 import app.zoneblitz.gamesimulator.roster.CoachId;
 import app.zoneblitz.gamesimulator.roster.Player;
@@ -140,6 +147,56 @@ class GameSimulatorTests {
     }
     // 10 games at ~13 flags/game average ≈ 130; a floor of 50 is a safe regression guard.
     assertThat(penalties).isGreaterThan(50);
+  }
+
+  @Test
+  void simulate_sackInOwnEndZone_emitsSafetyEventImmediatelyAfterTriggeringPlay() {
+    var personnel =
+        new FakePersonnelSelector(TestPersonnel.baselineOffense(), TestPersonnel.baselineDefense());
+    PlayResolver safetyResolver =
+        new PlayResolver() {
+          @Override
+          public PlayOutcome resolve(
+              PlayCaller.PlayCall call,
+              GameState state,
+              OffensivePersonnel offense,
+              DefensivePersonnel defense,
+              RandomSource rng) {
+            return new PassOutcome.Sack(QB_ID, List.of(), 50, Optional.empty());
+          }
+        };
+    var simulator =
+        new GameSimulator(
+            ScriptedPlayCaller.runs(1),
+            personnel,
+            safetyResolver,
+            BandClockModel.load(new ClasspathBandRepository(), new DefaultBandSampler()),
+            new TouchbackKickoffResolver(),
+            new FlatRateExtraPointResolver(),
+            new DistanceCurveFieldGoalResolver(),
+            new DistanceCurvePuntResolver(),
+            new NoPenaltyModel(),
+            app.zoneblitz.gamesimulator.playcalling.DefensiveCallSelector.neutral());
+
+    var events = simulator.simulate(inputs(Optional.of(7L))).toList();
+
+    var safetyIndex = -1;
+    for (var i = 0; i < events.size(); i++) {
+      if (events.get(i) instanceof PlayEvent.Safety) {
+        safetyIndex = i;
+        break;
+      }
+    }
+    assertThat(safetyIndex).as("expected a Safety event to be emitted").isGreaterThanOrEqualTo(1);
+    var safety = (PlayEvent.Safety) events.get(safetyIndex);
+    var trigger = events.get(safetyIndex - 1);
+    assertThat(trigger).isInstanceOf(PlayEvent.Sack.class);
+    assertThat(safety.sequence()).isEqualTo(trigger.sequence() + 1);
+    assertThat(safety.scoreAfter()).isEqualTo(trigger.scoreAfter());
+    assertThat(safety.concedingSide()).isEqualTo(Side.HOME);
+    assertThat(safety.spot().yardLine()).isEqualTo(20);
+    assertThat(safety.scoreAfter().away()).isEqualTo(2);
+    assertThat(safety.scoreAfter().home()).isZero();
   }
 
   @Test

--- a/src/test/java/app/zoneblitz/gamesimulator/event/PlayEventTests.java
+++ b/src/test/java/app/zoneblitz/gamesimulator/event/PlayEventTests.java
@@ -163,6 +163,8 @@ class PlayEventTests {
                 5,
                 true,
                 Optional.<PlayEvent>empty()),
+            new PlayEvent.Safety(
+                PLAY, GAME, 12, DD, SPOT, CLOCK, CLOCK, SCORE, new FieldPosition(20), Side.HOME),
             new PlayEvent.Kneel(PLAY, GAME, 12, DD, SPOT, CLOCK, CLOCK, SCORE),
             new PlayEvent.Spike(PLAY, GAME, 13, DD, SPOT, CLOCK, CLOCK, SCORE),
             new PlayEvent.Timeout(PLAY, GAME, 14, DD, SPOT, CLOCK, CLOCK, SCORE, Side.HOME),
@@ -184,6 +186,7 @@ class PlayEventTests {
             case PlayEvent.Punt p -> "punt";
             case PlayEvent.Kickoff k -> "kickoff";
             case PlayEvent.Penalty p -> "penalty";
+            case PlayEvent.Safety sf -> "safety";
             case PlayEvent.Kneel k -> "kneel";
             case PlayEvent.Spike s -> "spike";
             case PlayEvent.Timeout t -> "timeout";
@@ -192,6 +195,6 @@ class PlayEventTests {
           };
       assertThat(label).isNotBlank();
     }
-    assertThat(events).hasSize(17);
+    assertThat(events).hasSize(18);
   }
 }

--- a/src/test/java/app/zoneblitz/gamesimulator/output/DefaultPlayNarratorTests.java
+++ b/src/test/java/app/zoneblitz/gamesimulator/output/DefaultPlayNarratorTests.java
@@ -541,6 +541,26 @@ class DefaultPlayNarratorTests {
   }
 
   @Test
+  void narrate_safety_includesSafetyTagConcedingTeamAndScore() {
+    var event =
+        new PlayEvent.Safety(
+            PLAY,
+            GAME,
+            0,
+            FIRST_AND_TEN,
+            new FieldPosition(1),
+            Q1_OPEN,
+            Q1_OPEN,
+            new Score(0, 2),
+            new FieldPosition(20),
+            Side.HOME);
+
+    var line = narrator.narrate(event, context);
+
+    assertThat(line).contains("SAFETY").contains("Chiefs").contains("own 20").contains("0 – ");
+  }
+
+  @Test
   void narrate_goalLineRun_spotShownAsOpp() {
     var event =
         new PlayEvent.Run(


### PR DESCRIPTION
Closes #572

## Summary
- Adds `PlayEvent.Safety` variant (spot, concedingSide, scoreAfter) to the sealed `PlayEvent` hierarchy.
- `GameSimulator` now emits a `Safety` event immediately after the triggering play (sack or run tackled in own end zone) whenever `SnapAdvance.safety()` fires. The +2 score was already wired; this makes the safety visible in the event stream.
- `DefaultPlayNarrator` gains a "SAFETY — 2 points awarded against ..." line.
- Free-kick modeling unchanged: ball is spotted at the scoring team's own 20 (follow-up work).

## Test plan
- [x] `PlayEventTests` exhaustive-switch covers the new variant.
- [x] `DefaultPlayNarratorTests.narrate_safety_includesSafetyTagConcedingTeamAndScore` — asserts narrator tag, conceding team, free-kick spot, and score.
- [x] `GameSimulatorTests.simulate_sackInOwnEndZone_emitsSafetyEventImmediatelyAfterTriggeringPlay` — forces a 50-yard sack and asserts the Safety event is emitted at `sequence + 1` with the correct conceding side, free-kick spot (20), and +2 to the defense.
- [x] `./gradlew test` + `./gradlew spotlessCheck` green.