### PR TITLE
feat(sim): goal-line yardage conditioning (#571)

### DIFF
--- a/src/gamesimulator/java/app/zoneblitz/gamesimulator/resolver/run/GoalLineRunShift.java
+++ b/src/gamesimulator/java/app/zoneblitz/gamesimulator/resolver/run/GoalLineRunShift.java
@@ -1,0 +1,85 @@
+package app.zoneblitz.gamesimulator.resolver.run;
+
+import app.zoneblitz.gamesimulator.event.RunConcept;
+import app.zoneblitz.gamesimulator.resolver.run.MatchupRunResolver.RunMatchupShift;
+import app.zoneblitz.gamesimulator.rng.RandomSource;
+import java.util.Objects;
+
+/**
+ * Field-position contribution to the run matchup shift. Compresses probability mass away from
+ * {@code BREAKAWAY} and toward {@code STUFF}/{@code NORMAL} as the offense approaches the opponent
+ * goal line.
+ *
+ * <p>Calibration reference (nflfastR 2020–2024, regular season, rushes from {@code yardline_100}):
+ *
+ * <ul>
+ *   <li>1-yard line: TD% ≈ 58%, stuff% (≤0 yds) ≈ 42%, breakaway% (≥10 yds) ≈ 0%
+ *   <li>2-yard line: TD% ≈ 46%, breakaway% ≈ 0%
+ *   <li>3-yard line: TD% ≈ 37%, breakaway% ≈ 0%
+ *   <li>5-yard line: TD% ≈ 24%, breakaway% ≈ 0%
+ *   <li>10-yard line: breakaway% ≈ 11% (back at mid-field baseline)
+ * </ul>
+ *
+ * <p>The shipped run bands are league-average across all field positions, so at the 1 they still
+ * carry ~2% {@code BREAKAWAY} mass and no {@code STUFF} elevation. This shift applies a negative
+ * scalar inside the red zone — negative {@link RunMatchupShift} composes with the existing
+ * per-outcome β coefficients ({@code STUFF = -0.4}, {@code BREAKAWAY = +0.5}) to push probability
+ * mass from breakaway toward stuff/normal. End-zone clamping in the scoring path then converts most
+ * {@code NORMAL} gains from the 1 into rush TDs, matching the observed TD rate.
+ *
+ * <p>On short-yardage snaps ({@code yardsToGo ≤ 1}) concepts biased toward downhill push ({@code
+ * POWER}, {@code QB_SNEAK}) get a small positive offset so their conversion rate isn't
+ * over-penalised by the red-zone ramp. Situational play selection (who calls the sneak) is out of
+ * scope — issue #571 tracks this explicitly.
+ */
+public final class GoalLineRunShift implements RunMatchupShift {
+
+  /**
+   * Per-yard magnitude of the red-zone ramp. Kicks in at {@code yardsToGoal ≤ 10} and peaks at
+   * {@code yardsToGoal == 1}: {@code shift = -0.2 × (11 − yardsToGoal)} → {@code -2.0} at the 1,
+   * {@code -1.2} at the 5, {@code -0.2} at the 10. Zero outside the red zone.
+   */
+  public static final double DEFAULT_SHIFT_PER_YARD = 0.2;
+
+  /** Where the ramp turns on (yards from the opponent goal line, inclusive). */
+  public static final int DEFAULT_RED_ZONE_THRESHOLD = 10;
+
+  /**
+   * Offset applied when short-yardage ({@code yardsToGo ≤ 1}) meets {@code POWER}/{@code QB_SNEAK}.
+   * Partially counters the red-zone negative so short-yardage sneaks still convert at realistic
+   * rates inside the 5.
+   */
+  public static final double DEFAULT_SHORT_YARDAGE_POWER_BONUS = 0.4;
+
+  private final double shiftPerYard;
+  private final int redZoneThreshold;
+  private final double shortYardagePowerBonus;
+
+  public GoalLineRunShift() {
+    this(DEFAULT_SHIFT_PER_YARD, DEFAULT_RED_ZONE_THRESHOLD, DEFAULT_SHORT_YARDAGE_POWER_BONUS);
+  }
+
+  public GoalLineRunShift(
+      double shiftPerYard, int redZoneThreshold, double shortYardagePowerBonus) {
+    this.shiftPerYard = shiftPerYard;
+    this.redZoneThreshold = redZoneThreshold;
+    this.shortYardagePowerBonus = shortYardagePowerBonus;
+  }
+
+  @Override
+  public double compute(RunMatchupContext context, RandomSource rng) {
+    Objects.requireNonNull(context, "context");
+    Objects.requireNonNull(rng, "rng");
+    var yardsToGoal = context.yardsToGoal();
+    if (yardsToGoal > redZoneThreshold) {
+      return 0.0;
+    }
+    var redZone = -shiftPerYard * (redZoneThreshold + 1 - yardsToGoal);
+    var concept = context.concept();
+    if (context.yardsToGo() <= 1
+        && (concept == RunConcept.POWER || concept == RunConcept.QB_SNEAK)) {
+      return redZone + shortYardagePowerBonus;
+    }
+    return redZone;
+  }
+}

--- a/src/gamesimulator/java/app/zoneblitz/gamesimulator/resolver/run/MatchupRunResolver.java
+++ b/src/gamesimulator/java/app/zoneblitz/gamesimulator/resolver/run/MatchupRunResolver.java
@@ -132,7 +132,7 @@ public final class MatchupRunResolver implements RunResolver {
     var boxSampler = BandBoxCountSampler.load(repo);
     var composite =
         new CompositeRunMatchupShift(
-            new ClampedRunMatchupShift(), new BoxCountRunShift(boxSampler));
+            new ClampedRunMatchupShift(), new BoxCountRunShift(boxSampler), new GoalLineRunShift());
 
     return new MatchupRunResolver(
         sampler,
@@ -165,7 +165,13 @@ public final class MatchupRunResolver implements RunResolver {
                     new IllegalStateException(
                         "Offensive personnel has no rushing-eligible player"));
     var concept = call.runConcept();
-    var context = new RunMatchupContext(concept, roles, call.formation());
+    var context =
+        new RunMatchupContext(
+            concept,
+            roles,
+            call.formation(),
+            state.spot().yardLine(),
+            state.downAndDistance().yardsToGo());
     var shift = matchupShift.compute(context, rng);
     var kind = sampler.sampleRate(outcomeMix, shift, rng);
     var yardsBand = kind == RunOutcomeKind.FUMBLE ? fumbleYards : yardsByKind.get(kind);

--- a/src/gamesimulator/java/app/zoneblitz/gamesimulator/resolver/run/RunMatchupContext.java
+++ b/src/gamesimulator/java/app/zoneblitz/gamesimulator/resolver/run/RunMatchupContext.java
@@ -12,12 +12,33 @@ import java.util.Objects;
  * <p>Lives as a record — not a widening parameter list — so additional context (weather, field
  * zone, score differential) can be added without cascading signature changes through every
  * implementation.
+ *
+ * <p>{@code yardLine} is the offense's spot measured from their own goal line (0–100); the
+ * opponent's goal sits at 100, so {@code yardsToGoal = 100 - yardLine}. {@code yardsToGo} is the
+ * current down-and-distance yards-to-go. Both feed situational shifts like {@link
+ * GoalLineRunShift}; {@link MatchupRunResolver.RunMatchupShift} implementations that ignore field
+ * position simply don't read these fields.
  */
-public record RunMatchupContext(RunConcept concept, RunRoles roles, OffensiveFormation formation) {
+public record RunMatchupContext(
+    RunConcept concept, RunRoles roles, OffensiveFormation formation, int yardLine, int yardsToGo) {
 
   public RunMatchupContext {
     Objects.requireNonNull(concept, "concept");
     Objects.requireNonNull(roles, "roles");
     Objects.requireNonNull(formation, "formation");
+  }
+
+  /**
+   * Convenience constructor for call sites that don't care about field position (legacy tests,
+   * matchup-only shifts). Defaults to midfield ({@code yardLine = 50}) and a standard {@code
+   * yardsToGo = 10}.
+   */
+  public RunMatchupContext(RunConcept concept, RunRoles roles, OffensiveFormation formation) {
+    this(concept, roles, formation, 50, 10);
+  }
+
+  /** Yards from the offense's current spot to the opponent's goal line. */
+  public int yardsToGoal() {
+    return 100 - yardLine;
   }
 }

--- a/src/test/java/app/zoneblitz/gamesimulator/resolver/run/GoalLineRunShiftTests.java
+++ b/src/test/java/app/zoneblitz/gamesimulator/resolver/run/GoalLineRunShiftTests.java
@@ -1,0 +1,110 @@
+package app.zoneblitz.gamesimulator.resolver.run;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import app.zoneblitz.gamesimulator.event.RunConcept;
+import app.zoneblitz.gamesimulator.formation.OffensiveFormation;
+import app.zoneblitz.gamesimulator.resolver.RunRoles;
+import app.zoneblitz.gamesimulator.rng.SplittableRandomSource;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+
+class GoalLineRunShiftTests {
+
+  private static final RunRoles EMPTY_ROLES = new RunRoles(Optional.empty(), List.of(), List.of());
+
+  private static RunMatchupContext ctxAt(int yardLine, int yardsToGo, RunConcept concept) {
+    return new RunMatchupContext(
+        concept, EMPTY_ROLES, OffensiveFormation.SINGLEBACK, yardLine, yardsToGo);
+  }
+
+  @Test
+  void compute_outsideRedZone_returnsZero() {
+    var shift = new GoalLineRunShift();
+
+    assertThat(shift.compute(ctxAt(50, 10, RunConcept.INSIDE_ZONE), new SplittableRandomSource(0L)))
+        .isZero();
+    assertThat(shift.compute(ctxAt(89, 10, RunConcept.INSIDE_ZONE), new SplittableRandomSource(0L)))
+        .isZero();
+  }
+
+  @Test
+  void compute_atTheOne_returnsStrongNegative() {
+    var shift = new GoalLineRunShift();
+
+    var result =
+        shift.compute(ctxAt(99, 10, RunConcept.INSIDE_ZONE), new SplittableRandomSource(0L));
+
+    assertThat(result).isCloseTo(-2.0, org.assertj.core.data.Offset.offset(1e-12));
+  }
+
+  @Test
+  void compute_atTheFive_returnsModerateNegative() {
+    var shift = new GoalLineRunShift();
+
+    var result =
+        shift.compute(ctxAt(95, 10, RunConcept.INSIDE_ZONE), new SplittableRandomSource(0L));
+
+    assertThat(result).isCloseTo(-1.2, org.assertj.core.data.Offset.offset(1e-12));
+  }
+
+  @Test
+  void compute_atTheTen_returnsSmallNegative() {
+    var shift = new GoalLineRunShift();
+
+    var result =
+        shift.compute(ctxAt(90, 10, RunConcept.INSIDE_ZONE), new SplittableRandomSource(0L));
+
+    assertThat(result).isCloseTo(-0.2, org.assertj.core.data.Offset.offset(1e-12));
+  }
+
+  @Test
+  void compute_shortYardagePowerOrSneak_partiallyOffsetsRedZone() {
+    var shift = new GoalLineRunShift();
+
+    var power = shift.compute(ctxAt(99, 1, RunConcept.POWER), new SplittableRandomSource(0L));
+    var sneak = shift.compute(ctxAt(99, 1, RunConcept.QB_SNEAK), new SplittableRandomSource(0L));
+    var baseline =
+        shift.compute(ctxAt(99, 1, RunConcept.INSIDE_ZONE), new SplittableRandomSource(0L));
+
+    var offset = org.assertj.core.data.Offset.offset(1e-12);
+    assertThat(power).isCloseTo(-1.6, offset);
+    assertThat(sneak).isCloseTo(-1.6, offset);
+    assertThat(baseline).isCloseTo(-2.0, offset);
+  }
+
+  @Test
+  void compute_longerDistancePower_insideRedZone_noConceptBonus() {
+    var shift = new GoalLineRunShift();
+
+    var result = shift.compute(ctxAt(99, 5, RunConcept.POWER), new SplittableRandomSource(0L));
+
+    assertThat(result).isCloseTo(-2.0, org.assertj.core.data.Offset.offset(1e-12));
+  }
+
+  @Test
+  void compute_shortYardageNonPowerConcept_noBonus() {
+    var shift = new GoalLineRunShift();
+
+    var inside =
+        shift.compute(ctxAt(99, 1, RunConcept.INSIDE_ZONE), new SplittableRandomSource(0L));
+    var outside =
+        shift.compute(ctxAt(99, 1, RunConcept.OUTSIDE_ZONE), new SplittableRandomSource(0L));
+
+    var offset = org.assertj.core.data.Offset.offset(1e-12);
+    assertThat(inside).isCloseTo(-2.0, offset);
+    assertThat(outside).isCloseTo(-2.0, offset);
+  }
+
+  @Test
+  void compute_doesNotConsumeRng() {
+    var shift = new GoalLineRunShift();
+    var parent = new SplittableRandomSource(42L);
+    var twin = new SplittableRandomSource(42L);
+
+    shift.compute(ctxAt(99, 1, RunConcept.POWER), parent);
+
+    assertThat(parent.nextDouble()).isEqualTo(twin.nextDouble());
+  }
+}


### PR DESCRIPTION
Closes #571

## Summary
- Add `GoalLineRunShift`: a new `RunMatchupShift` component that reads `state.spot()` and `downAndDistance().yardsToGo()` (plumbed through `RunMatchupContext`) and applies a negative scalar inside the red zone. Composes with the existing per-outcome β coefficients (`STUFF=-0.4`, `NORMAL=0`, `BREAKAWAY=+0.5`, `FUMBLE=-0.2`) to redirect probability mass away from `BREAKAWAY` and toward `STUFF`/`NORMAL` as the offense approaches the opponent goal line.
- Short-yardage (`yardsToGo ≤ 1`) `POWER`/`QB_SNEAK` concepts get a small positive offset so the red-zone ramp doesn't over-penalise downhill conversion snaps.
- Wired into the default composite shift in `MatchupRunResolver.load` alongside `ClampedRunMatchupShift` and `BoxCountRunShift`. `RunOutcomeKind` stays package-private.

## Calibration (nflfastR 2020-2024, regular season)
| yardline_100 | rush TD% | stuff% (≤0) | breakaway% (≥10) |
| ---: | ---: | ---: | ---: |
| 1 | 58.0% | 42.0% | 0% |
| 2 | 45.8% | 26.5% | 0% |
| 3 | 36.9% | 27.7% | 0% |
| 5 | 23.8% | 21.3% | 0% |
| 10 | 10.8% | 17.2% | 10.8% (baseline) |

Ramp: `shift = -0.2 × (11 − yardsToGoal)` → `-2.0` at the 1, `-1.2` at the 5, `0` outside the 10. End-zone clamping converts the resulting `NORMAL` mass from the 1 into rush TDs.

## Out of scope
- Situational play selection (who calls `QB_SNEAK`) — tracked separately.
- Pass-side red-zone conditioning (fade routes, quick slants) — follow-up.
- Calibration drift relative to the full `rushing-plays.json` bands may require refinement once the run resolver is wired into the simulate-season loop; β coefficients and the ramp slope are the two tunable knobs.

## Test plan
- [x] `GoalLineRunShiftTests` — ramp values at the 1/5/10, red-zone off at 50/89, short-yardage POWER/QB_SNEAK bonus, non-POWER no-op, RNG preservation
- [x] `MatchupRunResolverTests` — baseline at midfield still green (composite adds zero shift outside the red zone)
- [x] `BoxCountRunShiftTests`, `CompositeRunMatchupShiftTests`, `ClampedRunMatchupShiftTests` — unchanged, use the 3-arg legacy `RunMatchupContext` constructor
- [x] `FullGameCalibrationTests` — unchanged
- [x] `./gradlew spotlessApply` + full `./gradlew test` green