### PR TITLE
feat(sim): two-point conversion decision and resolver (#574)

### DIFF
--- a/src/gamesimulator/java/app/zoneblitz/gamesimulator/GameSimulator.java
+++ b/src/gamesimulator/java/app/zoneblitz/gamesimulator/GameSimulator.java
@@ -26,6 +26,8 @@ import app.zoneblitz.gamesimulator.rng.RandomSource;
 import app.zoneblitz.gamesimulator.rng.SplittableRandomSource;
 import app.zoneblitz.gamesimulator.scoring.ExtraPointResolver;
 import app.zoneblitz.gamesimulator.scoring.FieldGoalResolver;
+import app.zoneblitz.gamesimulator.scoring.TwoPointDecisionPolicy;
+import app.zoneblitz.gamesimulator.scoring.TwoPointResolver;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
@@ -52,6 +54,7 @@ final class GameSimulator implements SimulateGame {
   private static final int HARD_SNAP_CAP = 500;
   private static final long CLOCK_SPLIT_KEY = 0x3333_eeffL;
   private static final long PAT_SPLIT_KEY = 0xFA77_7777L;
+  private static final long TWO_POINT_SPLIT_KEY = 0xFB77_7777L;
   private static final long FG_SPLIT_KEY = 0xFB66_6666L;
   private static final long PUNT_SPLIT_KEY = 0xFC55_5555L;
   private static final long PENALTY_PRE_KEY = 0xFD44_4444L;
@@ -83,6 +86,8 @@ final class GameSimulator implements SimulateGame {
   private final PenaltyModel penaltyModel;
   private final DefensiveCallSelector defensiveCallSelector;
   private final HomeFieldModel homeFieldModel;
+  private final TwoPointDecisionPolicy twoPointPolicy;
+  private final TwoPointResolver twoPointResolver;
 
   GameSimulator(
       PlayCaller caller,
@@ -94,7 +99,9 @@ final class GameSimulator implements SimulateGame {
       FieldGoalResolver fieldGoalResolver,
       PuntResolver puntResolver,
       PenaltyModel penaltyModel,
-      DefensiveCallSelector defensiveCallSelector) {
+      DefensiveCallSelector defensiveCallSelector,
+      TwoPointDecisionPolicy twoPointPolicy,
+      TwoPointResolver twoPointResolver) {
     this(
         caller,
         personnel,
@@ -106,6 +113,8 @@ final class GameSimulator implements SimulateGame {
         puntResolver,
         penaltyModel,
         defensiveCallSelector,
+        twoPointPolicy,
+        twoPointResolver,
         HomeFieldModel.neutral());
   }
 
@@ -120,6 +129,8 @@ final class GameSimulator implements SimulateGame {
       PuntResolver puntResolver,
       PenaltyModel penaltyModel,
       DefensiveCallSelector defensiveCallSelector,
+      TwoPointDecisionPolicy twoPointPolicy,
+      TwoPointResolver twoPointResolver,
       HomeFieldModel homeFieldModel) {
     this.caller = Objects.requireNonNull(caller, "caller");
     this.personnel = Objects.requireNonNull(personnel, "personnel");
@@ -132,6 +143,8 @@ final class GameSimulator implements SimulateGame {
     this.penaltyModel = Objects.requireNonNull(penaltyModel, "penaltyModel");
     this.defensiveCallSelector =
         Objects.requireNonNull(defensiveCallSelector, "defensiveCallSelector");
+    this.twoPointPolicy = Objects.requireNonNull(twoPointPolicy, "twoPointPolicy");
+    this.twoPointResolver = Objects.requireNonNull(twoPointResolver, "twoPointResolver");
     this.homeFieldModel = Objects.requireNonNull(homeFieldModel, "homeFieldModel");
   }
 
@@ -511,6 +524,9 @@ final class GameSimulator implements SimulateGame {
       int[] seq,
       SplittableRandomSource root,
       long key) {
+    if (twoPointPolicy.goForTwo(state.score(), scoringSide, state.clock())) {
+      return emitTwoPointAttempt(out, state, inputs, scoringSide, seq, root, key);
+    }
     var sequence = seq[0]++;
     var kicking = scoringSide == Side.HOME ? inputs.home() : inputs.away();
     var rng = root.split(key ^ PAT_SPLIT_KEY ^ ((long) sequence << 32));
@@ -521,6 +537,24 @@ final class GameSimulator implements SimulateGame {
     return state
         .withScore(resolved.scoreAfter())
         .withClock(tickKickClock(state, Kick.EXTRA_POINT, rng));
+  }
+
+  private GameState emitTwoPointAttempt(
+      List<PlayEvent> out,
+      GameState state,
+      GameInputs inputs,
+      Side scoringSide,
+      int[] seq,
+      SplittableRandomSource root,
+      long key) {
+    var sequence = seq[0]++;
+    var scoring = scoringSide == Side.HOME ? inputs.home() : inputs.away();
+    var rng = root.split(key ^ TWO_POINT_SPLIT_KEY ^ ((long) sequence << 32));
+    var resolved =
+        twoPointResolver.resolve(
+            scoring, scoringSide, inputs.gameId(), sequence, state.clock(), state.score(), rng);
+    out.add(resolved.event());
+    return state.withScore(resolved.scoreAfter());
   }
 
   private GameClock tickKickClock(GameState state, Kick kick, RandomSource rng) {

--- a/src/gamesimulator/java/app/zoneblitz/gamesimulator/scoring/FlatRateTwoPointResolver.java
+++ b/src/gamesimulator/java/app/zoneblitz/gamesimulator/scoring/FlatRateTwoPointResolver.java
@@ -1,0 +1,81 @@
+package app.zoneblitz.gamesimulator.scoring;
+
+import app.zoneblitz.gamesimulator.event.DownAndDistance;
+import app.zoneblitz.gamesimulator.event.FieldPosition;
+import app.zoneblitz.gamesimulator.event.GameClock;
+import app.zoneblitz.gamesimulator.event.GameId;
+import app.zoneblitz.gamesimulator.event.PlayEvent;
+import app.zoneblitz.gamesimulator.event.PlayId;
+import app.zoneblitz.gamesimulator.event.Score;
+import app.zoneblitz.gamesimulator.event.Side;
+import app.zoneblitz.gamesimulator.event.TwoPointPlay;
+import app.zoneblitz.gamesimulator.rng.RandomSource;
+import app.zoneblitz.gamesimulator.roster.Team;
+import java.util.Objects;
+import java.util.UUID;
+
+/**
+ * Baseline two-point resolver: flat success rate regardless of personnel, plus an independent
+ * run-vs-pass sub-decision. Default rate is 0.48 — within the published 2015-2023 NFL league-wide
+ * conversion clip. Default run share is 0.40 — leaguewide two-point calls run slightly pass-heavy.
+ * Defensive return on a failed try (modern 2-point defensive score) is intentionally not modeled;
+ * see issue #574 out-of-scope note.
+ */
+public final class FlatRateTwoPointResolver implements TwoPointResolver {
+
+  public static final double DEFAULT_SUCCESS_RATE = 0.48;
+  public static final double DEFAULT_RUN_SHARE = 0.40;
+
+  private final double successRate;
+  private final double runShare;
+
+  public FlatRateTwoPointResolver() {
+    this(DEFAULT_SUCCESS_RATE, DEFAULT_RUN_SHARE);
+  }
+
+  public FlatRateTwoPointResolver(double successRate, double runShare) {
+    if (successRate < 0.0 || successRate > 1.0) {
+      throw new IllegalArgumentException("successRate must be in [0, 1], got " + successRate);
+    }
+    if (runShare < 0.0 || runShare > 1.0) {
+      throw new IllegalArgumentException("runShare must be in [0, 1], got " + runShare);
+    }
+    this.successRate = successRate;
+    this.runShare = runShare;
+  }
+
+  @Override
+  public Resolved resolve(
+      Team scoringTeam,
+      Side scoringSide,
+      GameId gameId,
+      int sequence,
+      GameClock clock,
+      Score scoreBeforeTry,
+      RandomSource rng) {
+    Objects.requireNonNull(scoringTeam, "scoringTeam");
+    Objects.requireNonNull(scoringSide, "scoringSide");
+    Objects.requireNonNull(gameId, "gameId");
+    Objects.requireNonNull(clock, "clock");
+    Objects.requireNonNull(scoreBeforeTry, "scoreBeforeTry");
+    Objects.requireNonNull(rng, "rng");
+
+    var play = rng.nextDouble() < runShare ? TwoPointPlay.RUN : TwoPointPlay.PASS;
+    var succeeded = rng.nextDouble() < successRate;
+    var scoreAfter = succeeded ? scoreBeforeTry.plus(scoringSide, 2) : scoreBeforeTry;
+    var id = new PlayId(new UUID(gameId.value().getMostSignificantBits(), 0xFB00L | sequence));
+    var event =
+        new PlayEvent.TwoPointAttempt(
+            id,
+            gameId,
+            sequence,
+            new DownAndDistance(0, 0),
+            new FieldPosition(98),
+            clock,
+            clock,
+            scoreAfter,
+            play,
+            succeeded);
+    return new Resolved(event, scoreAfter);
+  }
+}

--- a/src/gamesimulator/java/app/zoneblitz/gamesimulator/scoring/StandardTwoPointDecisionPolicy.java
+++ b/src/gamesimulator/java/app/zoneblitz/gamesimulator/scoring/StandardTwoPointDecisionPolicy.java
@@ -1,0 +1,56 @@
+package app.zoneblitz.gamesimulator.scoring;
+
+import app.zoneblitz.gamesimulator.event.GameClock;
+import app.zoneblitz.gamesimulator.event.Score;
+import app.zoneblitz.gamesimulator.event.Side;
+import java.util.Objects;
+import java.util.Set;
+
+/**
+ * Baseline {@link TwoPointDecisionPolicy}: always kick the PAT except in late-game catch-up
+ * situations. The "standard chart" used here is a simplified Vermeil-style rule — in the final five
+ * minutes of regulation (or any overtime period) the scoring team goes for two whenever its post-TD
+ * deficit is one of the canonical catch-up numbers: 1, 2, 4, 5, or 9 points. Every other situation
+ * kicks the extra point. Full coach aggressiveness / lead-protection variants are out of scope for
+ * v1 (see issue #574).
+ */
+public final class StandardTwoPointDecisionPolicy implements TwoPointDecisionPolicy {
+
+  /**
+   * Post-TD deficits (scoring team still trailing by this many) that warrant going for two in the
+   * late-game window. Hitting a 2 after one of these puts the team in a tying or one-score range
+   * that couldn't be reached with a PAT.
+   */
+  private static final Set<Integer> CATCH_UP_DEFICITS = Set.of(1, 2, 4, 5, 9);
+
+  /** Last five minutes of a regulation quarter (or any overtime period) count as "late game". */
+  private static final int LATE_GAME_SECONDS = 5 * 60;
+
+  @Override
+  public boolean goForTwo(Score scoreBeforeTry, Side scoringSide, GameClock clockAfterTd) {
+    Objects.requireNonNull(scoreBeforeTry, "scoreBeforeTry");
+    Objects.requireNonNull(scoringSide, "scoringSide");
+    Objects.requireNonNull(clockAfterTd, "clockAfterTd");
+
+    if (!isLateGame(clockAfterTd)) {
+      return false;
+    }
+
+    var scoring = pointsFor(scoreBeforeTry, scoringSide);
+    var opponent = pointsFor(scoreBeforeTry, scoringSide == Side.HOME ? Side.AWAY : Side.HOME);
+    var deficit = opponent - scoring;
+    return deficit > 0 && CATCH_UP_DEFICITS.contains(deficit);
+  }
+
+  private static boolean isLateGame(GameClock clock) {
+    var inFourthOrLater = clock.quarter() >= 4;
+    return inFourthOrLater && clock.secondsRemaining() <= LATE_GAME_SECONDS;
+  }
+
+  private static int pointsFor(Score score, Side side) {
+    return switch (side) {
+      case HOME -> score.home();
+      case AWAY -> score.away();
+    };
+  }
+}

--- a/src/gamesimulator/java/app/zoneblitz/gamesimulator/scoring/TwoPointDecisionPolicy.java
+++ b/src/gamesimulator/java/app/zoneblitz/gamesimulator/scoring/TwoPointDecisionPolicy.java
@@ -1,0 +1,22 @@
+package app.zoneblitz.gamesimulator.scoring;
+
+import app.zoneblitz.gamesimulator.event.GameClock;
+import app.zoneblitz.gamesimulator.event.Score;
+import app.zoneblitz.gamesimulator.event.Side;
+
+/**
+ * Decides whether the scoring team should attempt a two-point conversion or kick the extra point
+ * after a touchdown. Implementations should be pure functions of the supplied state so callers can
+ * reason deterministically about post-TD scoring sequences.
+ */
+public interface TwoPointDecisionPolicy {
+
+  /**
+   * @param scoreBeforeTry the running score with the touchdown's six points already applied but no
+   *     try-point applied yet
+   * @param scoringSide the side that just scored the touchdown
+   * @param clockAfterTd clock snapshot taken immediately after the touchdown
+   * @return {@code true} iff the scoring team should go for two; {@code false} means kick the PAT
+   */
+  boolean goForTwo(Score scoreBeforeTry, Side scoringSide, GameClock clockAfterTd);
+}

--- a/src/gamesimulator/java/app/zoneblitz/gamesimulator/scoring/TwoPointResolver.java
+++ b/src/gamesimulator/java/app/zoneblitz/gamesimulator/scoring/TwoPointResolver.java
@@ -1,0 +1,37 @@
+package app.zoneblitz.gamesimulator.scoring;
+
+import app.zoneblitz.gamesimulator.event.GameClock;
+import app.zoneblitz.gamesimulator.event.GameId;
+import app.zoneblitz.gamesimulator.event.PlayEvent;
+import app.zoneblitz.gamesimulator.event.Score;
+import app.zoneblitz.gamesimulator.event.Side;
+import app.zoneblitz.gamesimulator.rng.RandomSource;
+import app.zoneblitz.gamesimulator.roster.Team;
+
+/**
+ * Resolves a two-point conversion attempt from the opponent's two-yard line. Produces a {@link
+ * PlayEvent.TwoPointAttempt} and applies two points to the scoring side on success.
+ */
+public interface TwoPointResolver {
+
+  /**
+   * @param scoringTeam the team that just scored the touchdown and is attempting the conversion
+   * @param scoringSide which side of the game ledger the scoring team represents
+   * @param gameId current game id (for stable event id construction)
+   * @param sequence monotonic event sequence number
+   * @param clock clock snapshot — two-point attempts don't consume game time in this model
+   * @param scoreBeforeTry score after the TD itself but before the conversion points
+   * @param rng randomness source
+   */
+  Resolved resolve(
+      Team scoringTeam,
+      Side scoringSide,
+      GameId gameId,
+      int sequence,
+      GameClock clock,
+      Score scoreBeforeTry,
+      RandomSource rng);
+
+  /** The two-point event plus the score after the attempt. */
+  record Resolved(PlayEvent.TwoPointAttempt event, Score scoreAfter) {}
+}

--- a/src/main/java/app/zoneblitz/gamesimulator/GameSimEmulator.java
+++ b/src/main/java/app/zoneblitz/gamesimulator/GameSimEmulator.java
@@ -28,6 +28,8 @@ import app.zoneblitz.gamesimulator.roster.Position;
 import app.zoneblitz.gamesimulator.roster.Team;
 import app.zoneblitz.gamesimulator.scoring.DistanceCurveFieldGoalResolver;
 import app.zoneblitz.gamesimulator.scoring.FlatRateExtraPointResolver;
+import app.zoneblitz.gamesimulator.scoring.FlatRateTwoPointResolver;
+import app.zoneblitz.gamesimulator.scoring.StandardTwoPointDecisionPolicy;
 import app.zoneblitz.names.CuratedNameGenerator;
 import app.zoneblitz.names.NameGenerator;
 import java.util.ArrayList;
@@ -71,6 +73,8 @@ public final class GameSimEmulator {
             BandPuntResolver.load(repo, sampler),
             new BandPenaltyModel(),
             BaselineDefensiveCallSelector.load(repo),
+            new StandardTwoPointDecisionPolicy(),
+            new FlatRateTwoPointResolver(),
             new DefaultHomeFieldModel());
 
     var inputs =

--- a/src/test/java/app/zoneblitz/gamesimulator/FullGameCalibrationTests.java
+++ b/src/test/java/app/zoneblitz/gamesimulator/FullGameCalibrationTests.java
@@ -27,6 +27,8 @@ import app.zoneblitz.gamesimulator.roster.Team;
 import app.zoneblitz.gamesimulator.roster.Tendencies;
 import app.zoneblitz.gamesimulator.scoring.DistanceCurveFieldGoalResolver;
 import app.zoneblitz.gamesimulator.scoring.FlatRateExtraPointResolver;
+import app.zoneblitz.gamesimulator.scoring.FlatRateTwoPointResolver;
+import app.zoneblitz.gamesimulator.scoring.StandardTwoPointDecisionPolicy;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -89,7 +91,9 @@ class FullGameCalibrationTests {
               new DistanceCurveFieldGoalResolver(),
               BandPuntResolver.load(repo, sampler),
               new BandPenaltyModel(),
-              app.zoneblitz.gamesimulator.playcalling.DefensiveCallSelector.neutral());
+              app.zoneblitz.gamesimulator.playcalling.DefensiveCallSelector.neutral(),
+              new StandardTwoPointDecisionPolicy(),
+              new FlatRateTwoPointResolver());
       var inputs =
           new GameInputs(
               new GameId(new UUID(0xDEADBEEFL, seed)),
@@ -167,7 +171,9 @@ class FullGameCalibrationTests {
               new DistanceCurveFieldGoalResolver(),
               BandPuntResolver.load(repo, sampler),
               new BandPenaltyModel(),
-              app.zoneblitz.gamesimulator.playcalling.DefensiveCallSelector.neutral());
+              app.zoneblitz.gamesimulator.playcalling.DefensiveCallSelector.neutral(),
+              new StandardTwoPointDecisionPolicy(),
+              new FlatRateTwoPointResolver());
       var inputs =
           new GameInputs(
               new GameId(new UUID(0xF1A9BEEFL, seed)),
@@ -236,7 +242,9 @@ class FullGameCalibrationTests {
               new DistanceCurveFieldGoalResolver(),
               BandPuntResolver.load(repo, sampler),
               new BandPenaltyModel(),
-              app.zoneblitz.gamesimulator.playcalling.DefensiveCallSelector.neutral());
+              app.zoneblitz.gamesimulator.playcalling.DefensiveCallSelector.neutral(),
+              new StandardTwoPointDecisionPolicy(),
+              new FlatRateTwoPointResolver());
       var inputs =
           new GameInputs(
               new GameId(new UUID(0xE117E11L, seed)),
@@ -315,7 +323,9 @@ class FullGameCalibrationTests {
               new DistanceCurveFieldGoalResolver(),
               BandPuntResolver.load(repo, sampler),
               new BandPenaltyModel(),
-              app.zoneblitz.gamesimulator.playcalling.DefensiveCallSelector.neutral());
+              app.zoneblitz.gamesimulator.playcalling.DefensiveCallSelector.neutral(),
+              new StandardTwoPointDecisionPolicy(),
+              new FlatRateTwoPointResolver());
       var inputs =
           new GameInputs(
               new GameId(new UUID(0xBE1C4BEEFL, seed)),

--- a/src/test/java/app/zoneblitz/gamesimulator/GameSimulatorTests.java
+++ b/src/test/java/app/zoneblitz/gamesimulator/GameSimulatorTests.java
@@ -29,6 +29,8 @@ import app.zoneblitz.gamesimulator.roster.Position;
 import app.zoneblitz.gamesimulator.roster.Team;
 import app.zoneblitz.gamesimulator.scoring.DistanceCurveFieldGoalResolver;
 import app.zoneblitz.gamesimulator.scoring.FlatRateExtraPointResolver;
+import app.zoneblitz.gamesimulator.scoring.FlatRateTwoPointResolver;
+import app.zoneblitz.gamesimulator.scoring.StandardTwoPointDecisionPolicy;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
@@ -67,7 +69,9 @@ class GameSimulatorTests {
         new DistanceCurveFieldGoalResolver(),
         new DistanceCurvePuntResolver(),
         new NoPenaltyModel(),
-        app.zoneblitz.gamesimulator.playcalling.DefensiveCallSelector.neutral());
+        app.zoneblitz.gamesimulator.playcalling.DefensiveCallSelector.neutral(),
+        new StandardTwoPointDecisionPolicy(),
+        new FlatRateTwoPointResolver());
   }
 
   private static GameInputs inputs(Optional<Long> seed) {
@@ -134,7 +138,9 @@ class GameSimulatorTests {
             new DistanceCurveFieldGoalResolver(),
             new DistanceCurvePuntResolver(),
             new BandPenaltyModel(),
-            app.zoneblitz.gamesimulator.playcalling.DefensiveCallSelector.neutral());
+            app.zoneblitz.gamesimulator.playcalling.DefensiveCallSelector.neutral(),
+            new StandardTwoPointDecisionPolicy(),
+            new FlatRateTwoPointResolver());
 
     var penalties = 0;
     for (var seed = 1L; seed <= 10L; seed++) {
@@ -176,7 +182,9 @@ class GameSimulatorTests {
             new DistanceCurveFieldGoalResolver(),
             new DistanceCurvePuntResolver(),
             new NoPenaltyModel(),
-            app.zoneblitz.gamesimulator.playcalling.DefensiveCallSelector.neutral());
+            app.zoneblitz.gamesimulator.playcalling.DefensiveCallSelector.neutral(),
+            new StandardTwoPointDecisionPolicy(),
+            new FlatRateTwoPointResolver());
 
     var events = simulator.simulate(inputs(Optional.of(7L))).toList();
 
@@ -197,6 +205,46 @@ class GameSimulatorTests {
     assertThat(safety.spot().yardLine()).isEqualTo(20);
     assertThat(safety.scoreAfter().away()).isEqualTo(2);
     assertThat(safety.scoreAfter().home()).isZero();
+  }
+
+  @Test
+  void simulate_twoPointPolicyChoosesTwo_replacesExtraPointWithTwoPointAttempt() {
+    var personnel =
+        new FakePersonnelSelector(TestPersonnel.baselineOffense(), TestPersonnel.baselineDefense());
+    var simulator =
+        new GameSimulator(
+            ScriptedPlayCaller.runs(1),
+            personnel,
+            new ConstantPlayResolver(QB_ID, WR_ID),
+            BandClockModel.load(new ClasspathBandRepository(), new DefaultBandSampler()),
+            new TouchbackKickoffResolver(),
+            new FlatRateExtraPointResolver(),
+            new DistanceCurveFieldGoalResolver(),
+            new DistanceCurvePuntResolver(),
+            new NoPenaltyModel(),
+            app.zoneblitz.gamesimulator.playcalling.DefensiveCallSelector.neutral(),
+            (score, side, clock) -> true,
+            new app.zoneblitz.gamesimulator.scoring.FlatRateTwoPointResolver(1.0, 0.0));
+
+    var events = simulator.simulate(inputs(Optional.of(1L))).toList();
+
+    var firstTdIndex = -1;
+    for (var i = 0; i < events.size(); i++) {
+      if (events.get(i) instanceof PlayEvent.PassComplete pc && pc.touchdown()) {
+        firstTdIndex = i;
+        break;
+      }
+    }
+    assertThat(firstTdIndex)
+        .as("expected at least one offensive touchdown")
+        .isGreaterThanOrEqualTo(0);
+    assertThat(events.get(firstTdIndex + 1)).isInstanceOf(PlayEvent.TwoPointAttempt.class);
+    var twoPoint = (PlayEvent.TwoPointAttempt) events.get(firstTdIndex + 1);
+    assertThat(twoPoint.success()).isTrue();
+    var tdScore = events.get(firstTdIndex).scoreAfter();
+    assertThat(twoPoint.scoreAfter().home() + twoPoint.scoreAfter().away())
+        .isEqualTo(tdScore.home() + tdScore.away() + 2);
+    assertThat(events.get(firstTdIndex + 2)).isInstanceOf(PlayEvent.Kickoff.class);
   }
 
   @Test

--- a/src/test/java/app/zoneblitz/gamesimulator/HomeFieldAdvantageIntegrationTests.java
+++ b/src/test/java/app/zoneblitz/gamesimulator/HomeFieldAdvantageIntegrationTests.java
@@ -26,6 +26,8 @@ import app.zoneblitz.gamesimulator.roster.Position;
 import app.zoneblitz.gamesimulator.roster.Team;
 import app.zoneblitz.gamesimulator.scoring.DistanceCurveFieldGoalResolver;
 import app.zoneblitz.gamesimulator.scoring.FlatRateExtraPointResolver;
+import app.zoneblitz.gamesimulator.scoring.FlatRateTwoPointResolver;
+import app.zoneblitz.gamesimulator.scoring.StandardTwoPointDecisionPolicy;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
@@ -99,6 +101,8 @@ class HomeFieldAdvantageIntegrationTests {
               BandPuntResolver.load(repo, sampler),
               new BandPenaltyModel(),
               DefensiveCallSelector.neutral(),
+              new StandardTwoPointDecisionPolicy(),
+              new FlatRateTwoPointResolver(),
               new DefaultHomeFieldModel());
       var inputs =
           new GameInputs(

--- a/src/test/java/app/zoneblitz/gamesimulator/scoring/FlatRateTwoPointResolverTests.java
+++ b/src/test/java/app/zoneblitz/gamesimulator/scoring/FlatRateTwoPointResolverTests.java
@@ -1,0 +1,133 @@
+package app.zoneblitz.gamesimulator.scoring;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+
+import app.zoneblitz.gamesimulator.event.GameClock;
+import app.zoneblitz.gamesimulator.event.GameId;
+import app.zoneblitz.gamesimulator.event.PlayerId;
+import app.zoneblitz.gamesimulator.event.Score;
+import app.zoneblitz.gamesimulator.event.Side;
+import app.zoneblitz.gamesimulator.event.TeamId;
+import app.zoneblitz.gamesimulator.event.TwoPointPlay;
+import app.zoneblitz.gamesimulator.rng.SplittableRandomSource;
+import app.zoneblitz.gamesimulator.roster.Player;
+import app.zoneblitz.gamesimulator.roster.Position;
+import app.zoneblitz.gamesimulator.roster.Team;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+
+class FlatRateTwoPointResolverTests {
+
+  private static final Team TEAM =
+      new Team(
+          new TeamId(new UUID(1L, 1L)),
+          "T",
+          List.of(new Player(new PlayerId(new UUID(1L, 2L)), Position.QB, "QB")));
+  private static final GameId GAME = new GameId(new UUID(7L, 7L));
+
+  @Test
+  void resolve_certainSuccess_addsTwoToScoringSide() {
+    TwoPointResolver resolver = new FlatRateTwoPointResolver(1.0, 0.5);
+
+    var resolved =
+        resolver.resolve(
+            TEAM,
+            Side.HOME,
+            GAME,
+            0,
+            new GameClock(4, 60),
+            new Score(18, 21),
+            new SplittableRandomSource(42L));
+
+    assertThat(resolved.event().success()).isTrue();
+    assertThat(resolved.scoreAfter()).isEqualTo(new Score(20, 21));
+  }
+
+  @Test
+  void resolve_certainFailure_leavesScoreUnchanged() {
+    TwoPointResolver resolver = new FlatRateTwoPointResolver(0.0, 0.5);
+
+    var resolved =
+        resolver.resolve(
+            TEAM,
+            Side.AWAY,
+            GAME,
+            3,
+            new GameClock(4, 60),
+            new Score(21, 18),
+            new SplittableRandomSource(42L));
+
+    assertThat(resolved.event().success()).isFalse();
+    assertThat(resolved.scoreAfter()).isEqualTo(new Score(21, 18));
+  }
+
+  @Test
+  void resolve_certainRun_emitsRunPlay() {
+    TwoPointResolver resolver = new FlatRateTwoPointResolver(0.5, 1.0);
+
+    var resolved =
+        resolver.resolve(
+            TEAM,
+            Side.HOME,
+            GAME,
+            0,
+            new GameClock(4, 60),
+            new Score(18, 21),
+            new SplittableRandomSource(42L));
+
+    assertThat(resolved.event().play()).isEqualTo(TwoPointPlay.RUN);
+  }
+
+  @Test
+  void resolve_certainPass_emitsPassPlay() {
+    TwoPointResolver resolver = new FlatRateTwoPointResolver(0.5, 0.0);
+
+    var resolved =
+        resolver.resolve(
+            TEAM,
+            Side.HOME,
+            GAME,
+            0,
+            new GameClock(4, 60),
+            new Score(18, 21),
+            new SplittableRandomSource(42L));
+
+    assertThat(resolved.event().play()).isEqualTo(TwoPointPlay.PASS);
+  }
+
+  @Test
+  void resolve_defaultRate_approximatesLeagueAverageOverMany() {
+    TwoPointResolver resolver = new FlatRateTwoPointResolver();
+    var made = 0;
+    for (var i = 0; i < 5_000; i++) {
+      var r =
+          resolver.resolve(
+              TEAM,
+              Side.HOME,
+              GAME,
+              i,
+              new GameClock(4, 60),
+              new Score(18, 21),
+              new SplittableRandomSource(i));
+      if (r.event().success()) {
+        made++;
+      }
+    }
+    var rate = made / 5000.0;
+    assertThat(rate).isBetween(0.44, 0.52);
+  }
+
+  @Test
+  void construct_invalidSuccessRate_throws() {
+    assertThatIllegalArgumentException().isThrownBy(() -> new FlatRateTwoPointResolver(-0.1, 0.4));
+    assertThatIllegalArgumentException().isThrownBy(() -> new FlatRateTwoPointResolver(1.1, 0.4));
+  }
+
+  @Test
+  void construct_invalidRunShare_throws() {
+    assertThatIllegalArgumentException().isThrownBy(() -> new FlatRateTwoPointResolver(0.5, -0.1));
+    assertThatIllegalArgumentException().isThrownBy(() -> new FlatRateTwoPointResolver(0.5, 1.1));
+  }
+}

--- a/src/test/java/app/zoneblitz/gamesimulator/scoring/StandardTwoPointDecisionPolicyTests.java
+++ b/src/test/java/app/zoneblitz/gamesimulator/scoring/StandardTwoPointDecisionPolicyTests.java
@@ -1,0 +1,90 @@
+package app.zoneblitz.gamesimulator.scoring;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import app.zoneblitz.gamesimulator.event.GameClock;
+import app.zoneblitz.gamesimulator.event.Score;
+import app.zoneblitz.gamesimulator.event.Side;
+import org.junit.jupiter.api.Test;
+
+class StandardTwoPointDecisionPolicyTests {
+
+  private final TwoPointDecisionPolicy policy = new StandardTwoPointDecisionPolicy();
+
+  @Test
+  void goForTwo_earlyGame_returnsFalseEvenWhenTrailingByCatchUpNumber() {
+    // Home just scored a TD; now trailing by 2 (AWAY 8, HOME 6). Q1 — no late-game pressure.
+    var score = new Score(6, 8);
+
+    var result = policy.goForTwo(score, Side.HOME, new GameClock(1, 10 * 60));
+
+    assertThat(result).isFalse();
+  }
+
+  @Test
+  void goForTwo_lateFourthAndDownByTwo_returnsTrue() {
+    // Away trailing by 2 after TD in final 2 minutes — canonical "go for the tie".
+    var score = new Score(21, 19);
+
+    var result = policy.goForTwo(score, Side.AWAY, new GameClock(4, 90));
+
+    assertThat(result).isTrue();
+  }
+
+  @Test
+  void goForTwo_lateFourthAndDownByFive_returnsTrue() {
+    var score = new Score(14, 9);
+
+    var result = policy.goForTwo(score, Side.AWAY, new GameClock(4, 4 * 60));
+
+    assertThat(result).isTrue();
+  }
+
+  @Test
+  void goForTwo_lateFourthAndDownByNine_returnsTrue() {
+    var score = new Score(24, 15);
+
+    var result = policy.goForTwo(score, Side.AWAY, new GameClock(4, 60));
+
+    assertThat(result).isTrue();
+  }
+
+  @Test
+  void goForTwo_lateFourthAndLeading_returnsFalse() {
+    var score = new Score(21, 7);
+
+    var result = policy.goForTwo(score, Side.HOME, new GameClock(4, 90));
+
+    assertThat(result).isFalse();
+  }
+
+  @Test
+  void goForTwo_lateFourthButTrailingByNonCatchUpDeficit_returnsFalse() {
+    // Down 3 after TD is not a canonical catch-up number — a PAT keeps it a field-goal game.
+    var score = new Score(7, 10);
+
+    var result = policy.goForTwo(score, Side.HOME, new GameClock(4, 60));
+
+    assertThat(result).isFalse();
+  }
+
+  @Test
+  void goForTwo_lateOvertimeAndDownByTwo_returnsTrue() {
+    // Late-game window also applies to overtime periods.
+    var score = new Score(24, 22);
+
+    var result = policy.goForTwo(score, Side.AWAY, new GameClock(5, 60));
+
+    assertThat(result).isTrue();
+  }
+
+  @Test
+  void goForTwo_fourthQuarterButEarlyInIt_returnsFalse() {
+    // 10:00 left in Q4 is outside the "late-game" 5:00 window.
+    var score = new Score(6, 8);
+
+    var result = policy.goForTwo(score, Side.HOME, new GameClock(4, 10 * 60));
+
+    assertThat(result).isFalse();
+  }
+}


### PR DESCRIPTION
Closes #574
Closes #577

## Summary
- Adds `TwoPointDecisionPolicy` interface with a `StandardTwoPointDecisionPolicy` baseline: PAT by default, go for two only in the final 5:00 of Q4/OT when the post-TD deficit is a canonical catch-up number (1, 2, 4, 5, 9).
- Adds `TwoPointResolver` interface with a `FlatRateTwoPointResolver` baseline: flat ~0.48 success rate and ~0.40 run share, emitting `PlayEvent.TwoPointAttempt` with RUN/PASS sub-decision.
- Wires both seams into `GameSimulator.emitPat`: if the policy says go-for-two, a `TwoPointAttempt` is emitted in place of the `ExtraPoint`, crediting +2 on success; kickoff sequencing unchanged.

Out of scope (deferred): full coach aggressiveness tendency, defensive return on failed 2PT.

## Test plan
- [x] `./gradlew spotlessApply` / `spotlessCheck`
- [x] `./gradlew test` (full suite green)
- [x] Unit tests for `StandardTwoPointDecisionPolicy` (early-game, late catch-up at 2/5/9, leading, non-catch-up deficit, OT, early Q4)
- [x] Unit tests for `FlatRateTwoPointResolver` (success/failure, RUN/PASS determinism, long-run rate band, constructor validation)
- [x] Integration test in `GameSimulatorTests` confirming TD -> `TwoPointAttempt` -> Kickoff when policy forces go-for-two