### PR TITLE
feat(gamesimulator): sack rates from QB/OL/pass-rush attributes (#581)

### DIFF
--- a/src/gamesimulator/java/app/zoneblitz/gamesimulator/resolver/pass/MatchupPassResolver.java
+++ b/src/gamesimulator/java/app/zoneblitz/gamesimulator/resolver/pass/MatchupPassResolver.java
@@ -64,11 +64,14 @@ public final class MatchupPassResolver implements PassResolver {
           PassOutcomeKind.SACK, -0.5,
           PassOutcomeKind.SCRAMBLE, 0.1);
 
+  private static final long PRESSURE_SPLIT_KEY = 0x3333_eeffL;
+
   private final BandSampler sampler;
   private final PassRoleAssigner roleAssigner;
   private final PassMatchupShift matchupShift;
   private final CoverageShellSampler shellSampler;
   private final TargetSelector targetSelector;
+  private final PressureModel pressureModel;
   private final RateBand<PassOutcomeKind> outcomeMix;
   private final DistributionalBand completionYards;
   private final DistributionalBand sackYards;
@@ -81,6 +84,7 @@ public final class MatchupPassResolver implements PassResolver {
       PassMatchupShift matchupShift,
       CoverageShellSampler shellSampler,
       TargetSelector targetSelector,
+      PressureModel pressureModel,
       RateBand<PassOutcomeKind> outcomeMix,
       DistributionalBand completionYards,
       DistributionalBand sackYards,
@@ -91,6 +95,7 @@ public final class MatchupPassResolver implements PassResolver {
     this.matchupShift = Objects.requireNonNull(matchupShift, "matchupShift");
     this.shellSampler = Objects.requireNonNull(shellSampler, "shellSampler");
     this.targetSelector = Objects.requireNonNull(targetSelector, "targetSelector");
+    this.pressureModel = Objects.requireNonNull(pressureModel, "pressureModel");
     this.outcomeMix = Objects.requireNonNull(outcomeMix, "outcomeMix");
     this.completionYards = Objects.requireNonNull(completionYards, "completionYards");
     this.sackYards = Objects.requireNonNull(sackYards, "sackYards");
@@ -122,6 +127,7 @@ public final class MatchupPassResolver implements PassResolver {
         composite,
         shellSampler,
         new ScoreBasedTargetSelector(),
+        new QbPressureEscape(),
         outcomeMix,
         completionYards,
         sackYards,
@@ -161,10 +167,7 @@ public final class MatchupPassResolver implements PassResolver {
       case INCOMPLETE ->
           new PassOutcome.PassIncomplete(
               qb, target, 0, IncompleteReason.OVERTHROWN, Optional.empty());
-      case SACK -> {
-        var sampled = sampler.sampleDistribution(sackYards, shift, rng);
-        yield new PassOutcome.Sack(qb, List.of(), -sampled, Optional.empty());
-      }
+      case SACK -> resolvePressure(qb, target, roles, qbPlayer, shift, rng);
       case SCRAMBLE -> {
         var yards = sampler.sampleDistribution(scrambleYards, shift, rng);
         yield new PassOutcome.Scramble(qb, yards, Optional.empty(), false);
@@ -174,6 +177,30 @@ public final class MatchupPassResolver implements PassResolver {
         var returnYards = sampler.sampleDistribution(interceptionReturnYards, shift, rng);
         yield new PassOutcome.Interception(qb, target, interceptor, returnYards);
       }
+    };
+  }
+
+  private PassOutcome resolvePressure(
+      PlayerId qb,
+      PlayerId target,
+      PassRoles roles,
+      Player qbPlayer,
+      double shift,
+      RandomSource rng) {
+    var pressureRng = rng.split(PRESSURE_SPLIT_KEY);
+    var resolution = pressureModel.resolve(roles, qbPlayer, pressureRng);
+    return switch (resolution) {
+      case SACK -> {
+        var sampled = sampler.sampleDistribution(sackYards, shift, rng);
+        yield new PassOutcome.Sack(qb, List.of(), -sampled, Optional.empty());
+      }
+      case SCRAMBLE -> {
+        var yards = sampler.sampleDistribution(scrambleYards, shift, rng);
+        yield new PassOutcome.Scramble(qb, yards, Optional.empty(), false);
+      }
+      case THROWAWAY ->
+          new PassOutcome.PassIncomplete(
+              qb, target, 0, IncompleteReason.THROWN_AWAY, Optional.empty());
     };
   }
 

--- a/src/gamesimulator/java/app/zoneblitz/gamesimulator/resolver/pass/PressureModel.java
+++ b/src/gamesimulator/java/app/zoneblitz/gamesimulator/resolver/pass/PressureModel.java
@@ -1,0 +1,34 @@
+package app.zoneblitz.gamesimulator.resolver.pass;
+
+import app.zoneblitz.gamesimulator.resolver.PassRoles;
+import app.zoneblitz.gamesimulator.rng.RandomSource;
+import app.zoneblitz.gamesimulator.roster.Player;
+
+/**
+ * Resolves what happens to a QB when the pass rush has beaten protection. The outcome sampler draws
+ * a nominal {@link PassOutcomeKind#SACK} from the outcome-mix band; this model then decides whether
+ * the QB actually goes down, escapes for a scramble, or throws the ball away — using OL-vs-DL
+ * pressure strength and QB mobility / awareness.
+ *
+ * <p>Implementations must be identity at average attributes: when OL, DL, and QB all sit at average
+ * the model must return {@link PressureResolution#SACK} so the shipped outcome-mix stays
+ * structurally intact. Extreme attributes produce directional changes — a mobile QB sees more
+ * scrambles, an aware QB sees more throwaways, a dominant DL compresses both escape routes.
+ */
+@FunctionalInterface
+interface PressureModel {
+
+  /** No-op resolver — always returns SACK. Used to pin baseline parity in tests. */
+  PressureModel ALWAYS_SACK = (roles, qb, rng) -> PressureResolution.SACK;
+
+  /**
+   * Resolve a QB-under-pressure moment into an actual outcome kind.
+   *
+   * @param roles pre-snap role buckets (pass blockers vs pass rushers)
+   * @param qb the quarterback player
+   * @param rng randomness source
+   * @return one of {@link PressureResolution#SACK}, {@link PressureResolution#SCRAMBLE}, {@link
+   *     PressureResolution#THROWAWAY}
+   */
+  PressureResolution resolve(PassRoles roles, Player qb, RandomSource rng);
+}

--- a/src/gamesimulator/java/app/zoneblitz/gamesimulator/resolver/pass/PressureResolution.java
+++ b/src/gamesimulator/java/app/zoneblitz/gamesimulator/resolver/pass/PressureResolution.java
@@ -1,0 +1,15 @@
+package app.zoneblitz.gamesimulator.resolver.pass;
+
+/**
+ * What the quarterback does when the pass rush wins the protection matchup. Engine-internal
+ * classifier — never leaks onto the {@link app.zoneblitz.gamesimulator.resolver.PassOutcome} API.
+ *
+ * <p>{@link #SACK} is the nominal outcome: protection broke down and the QB went down. {@link
+ * #SCRAMBLE} represents a mobile QB escaping the pocket for yardage. {@link #THROWAWAY} represents
+ * an aware QB getting rid of the ball before the sack lands (scored as an incomplete pass).
+ */
+enum PressureResolution {
+  SACK,
+  SCRAMBLE,
+  THROWAWAY
+}

--- a/src/gamesimulator/java/app/zoneblitz/gamesimulator/resolver/pass/QbPressureEscape.java
+++ b/src/gamesimulator/java/app/zoneblitz/gamesimulator/resolver/pass/QbPressureEscape.java
@@ -1,0 +1,141 @@
+package app.zoneblitz.gamesimulator.resolver.pass;
+
+import app.zoneblitz.gamesimulator.resolver.PassRoles;
+import app.zoneblitz.gamesimulator.rng.RandomSource;
+import app.zoneblitz.gamesimulator.roster.Physical;
+import app.zoneblitz.gamesimulator.roster.Player;
+import app.zoneblitz.gamesimulator.roster.Skill;
+import app.zoneblitz.gamesimulator.roster.Tendencies;
+import java.util.List;
+import java.util.function.ToDoubleFunction;
+
+/**
+ * Pressure-gradient escape resolver.
+ *
+ * <p>Protection vs. pass-rush strength is computed as a symmetric [-1, +1] scalar: defense wins at
+ * +1, offense wins at -1, even matchup at 0. OL contributes {@code passSet} skill and strength /
+ * power / agility physical; DL contributes {@code passRushMoves + blockShedding} skill and a mirror
+ * physical mix. The scalar shapes how much pressure a QB absorbs.
+ *
+ * <p>Given a nominal sack, the model redistributes outcome mass toward scramble (QB mobility — a
+ * speed / acceleration / agility blend) and throwaway (QB awareness — {@code processing} tendency
+ * with a small {@code footballIq} lift). At average attributes and even matchup the redistribution
+ * is zero, so the shipped sack rate is preserved by construction.
+ *
+ * <p>Package-private: the pressure classifier drives sampling; outcome records never see it.
+ */
+final class QbPressureEscape implements PressureModel {
+
+  private static final double MAX_SCRAMBLE_REDIRECT = 0.55;
+  private static final double MAX_THROWAWAY_REDIRECT = 0.55;
+  private static final double MOBILITY_COEFFICIENT = 0.80;
+  private static final double AWARENESS_COEFFICIENT = 0.80;
+  private static final double PRESSURE_PENALTY = 0.35;
+
+  @Override
+  public PressureResolution resolve(PassRoles roles, Player qb, RandomSource rng) {
+    var pressure = pressureStrength(roles);
+    var mobility = qbMobilityEdge(qb.physical());
+    var awareness = qbAwarenessEdge(qb.tendencies(), qb.skill());
+
+    var scrambleRedirect =
+        clamp(MOBILITY_COEFFICIENT * mobility - PRESSURE_PENALTY * pressure, MAX_SCRAMBLE_REDIRECT);
+    var throwawayRedirect =
+        clamp(
+            AWARENESS_COEFFICIENT * awareness - PRESSURE_PENALTY * pressure,
+            MAX_THROWAWAY_REDIRECT);
+
+    var combined = scrambleRedirect + throwawayRedirect;
+    if (combined > 0.95) {
+      var scale = 0.95 / combined;
+      scrambleRedirect *= scale;
+      throwawayRedirect *= scale;
+    }
+
+    var roll = rng.nextDouble();
+    if (roll < scrambleRedirect) {
+      return PressureResolution.SCRAMBLE;
+    }
+    if (roll < scrambleRedirect + throwawayRedirect) {
+      return PressureResolution.THROWAWAY;
+    }
+    return PressureResolution.SACK;
+  }
+
+  private static double pressureStrength(PassRoles roles) {
+    var blockers = roles.passBlockers();
+    var rushers = roles.passRushers();
+    if (blockers.isEmpty() && rushers.isEmpty()) {
+      return 0.0;
+    }
+    var olSkill = aggregate(blockers, p -> p.skill().passSet());
+    var dlSkill =
+        aggregate(rushers, p -> (p.skill().passRushMoves() + p.skill().blockShedding()) / 2.0);
+    var olPhysical =
+        aggregate(
+            blockers,
+            p -> weightedPhysical(p.physical(), 0.20, 0.35, 0.25, 0.20, 0.0, 0.0, 0.0, 0.0));
+    var dlPhysical =
+        aggregate(
+            rushers,
+            p -> weightedPhysical(p.physical(), 0.25, 0.0, 0.0, 0.25, 0.25, 0.10, 0.0, 0.15));
+    var skillGap = centered(dlSkill) - centered(olSkill);
+    var physicalGap = centered(dlPhysical) - centered(olPhysical);
+    return clamp((skillGap + physicalGap) / 2.0, 1.0);
+  }
+
+  private static double qbMobilityEdge(Physical physical) {
+    var raw = (physical.speed() + physical.acceleration() + physical.agility()) / 3.0;
+    return centered(raw);
+  }
+
+  private static double qbAwarenessEdge(Tendencies tendencies, Skill ignoredSkill) {
+    var raw = 0.75 * tendencies.processing() + 0.25 * tendencies.footballIq();
+    return centered(raw);
+  }
+
+  private static double aggregate(List<Player> players, ToDoubleFunction<Player> score) {
+    if (players.isEmpty()) {
+      return 50.0;
+    }
+    var sum = 0.0;
+    for (var p : players) {
+      sum += score.applyAsDouble(p);
+    }
+    return sum / players.size();
+  }
+
+  private static double weightedPhysical(
+      Physical p,
+      double speed,
+      double acceleration,
+      double agility,
+      double strength,
+      double power,
+      double bend,
+      double stamina,
+      double explosiveness) {
+    return p.speed() * speed
+        + p.acceleration() * acceleration
+        + p.agility() * agility
+        + p.strength() * strength
+        + p.power() * power
+        + p.bend() * bend
+        + p.stamina() * stamina
+        + p.explosiveness() * explosiveness;
+  }
+
+  private static double centered(double zeroToHundred) {
+    return (zeroToHundred / 100.0 - 0.5) * 2.0;
+  }
+
+  private static double clamp(double value, double limit) {
+    if (value > limit) {
+      return limit;
+    }
+    if (value < -limit) {
+      return -limit;
+    }
+    return value;
+  }
+}

--- a/src/test/java/app/zoneblitz/gamesimulator/resolver/pass/MatchupPassResolverCalibrationTests.java
+++ b/src/test/java/app/zoneblitz/gamesimulator/resolver/pass/MatchupPassResolverCalibrationTests.java
@@ -337,6 +337,7 @@ class MatchupPassResolverCalibrationTests {
         shift,
         BandCoverageShellSampler.load(repo),
         new ScoreBasedTargetSelector(),
+        PressureModel.ALWAYS_SACK,
         outcomeMix,
         completionYards,
         sackYards,

--- a/src/test/java/app/zoneblitz/gamesimulator/resolver/pass/QbPressureEscapeTests.java
+++ b/src/test/java/app/zoneblitz/gamesimulator/resolver/pass/QbPressureEscapeTests.java
@@ -1,0 +1,344 @@
+package app.zoneblitz.gamesimulator.resolver.pass;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import app.zoneblitz.gamesimulator.event.PlayerId;
+import app.zoneblitz.gamesimulator.resolver.PassRoles;
+import app.zoneblitz.gamesimulator.rng.SplittableRandomSource;
+import app.zoneblitz.gamesimulator.roster.Physical;
+import app.zoneblitz.gamesimulator.roster.Player;
+import app.zoneblitz.gamesimulator.roster.Position;
+import app.zoneblitz.gamesimulator.roster.Skill;
+import app.zoneblitz.gamesimulator.roster.Tendencies;
+import java.util.List;
+import java.util.UUID;
+import java.util.function.Function;
+import org.junit.jupiter.api.Test;
+
+class QbPressureEscapeTests {
+
+  private static final int TRIALS = 20_000;
+
+  private final PressureModel model = new QbPressureEscape();
+
+  @Test
+  void resolve_averageAttributes_alwaysReturnsSack() {
+    var roles = rolesWith(averageOl(5), averageDl(4));
+    var qb = averageQb();
+    var rng = new SplittableRandomSource(1L);
+
+    var counts = sample(model, roles, qb, rng);
+
+    assertThat(counts.sack)
+        .as("average-everywhere roster must preserve nominal sack outcome by construction")
+        .isEqualTo(TRIALS);
+    assertThat(counts.scramble).isZero();
+    assertThat(counts.throwaway).isZero();
+  }
+
+  @Test
+  void resolve_mobileQbAgainstAverageProtection_raisesScrambleShare() {
+    var roles = rolesWith(averageOl(5), averageDl(4));
+    var averageCounts = sample(model, roles, averageQb(), new SplittableRandomSource(2L));
+    var mobileCounts = sample(model, roles, mobileQb(), new SplittableRandomSource(2L));
+
+    assertThat(mobileCounts.scramble)
+        .as("high-mobility QB must redirect sacks toward scrambles")
+        .isGreaterThan(averageCounts.scramble + TRIALS / 10);
+    assertThat(mobileCounts.sack).isLessThan(averageCounts.sack);
+  }
+
+  @Test
+  void resolve_awareQbAgainstAverageProtection_raisesThrowawayShare() {
+    var roles = rolesWith(averageOl(5), averageDl(4));
+    var averageCounts = sample(model, roles, averageQb(), new SplittableRandomSource(3L));
+    var awareCounts = sample(model, roles, awareQb(), new SplittableRandomSource(3L));
+
+    assertThat(awareCounts.throwaway)
+        .as("high-awareness QB must redirect sacks toward throwaways")
+        .isGreaterThan(averageCounts.throwaway + TRIALS / 10);
+    assertThat(awareCounts.sack).isLessThan(averageCounts.sack);
+  }
+
+  @Test
+  void resolve_dominantPassRushVsStatueQb_sackShareStaysHigh() {
+    var roles = rolesWith(weakOl(5), elitePassRush(4));
+    var counts = sample(model, roles, statueQb(), new SplittableRandomSource(4L));
+
+    assertThat(counts.sack)
+        .as("statue QB behind weak OL against elite rush cannot escape")
+        .isGreaterThan((int) (TRIALS * 0.95));
+  }
+
+  @Test
+  void resolve_weakPassRushAgainstEliteOl_pressureModelDoesNotInflateSacksAboveSampled() {
+    var roles = rolesWith(eliteOl(5), weakDl(4));
+    var counts = sample(model, roles, awareMobileQb(), new SplittableRandomSource(5L));
+
+    assertThat(counts.sack)
+        .as(
+            "with elite protection and an aware, mobile QB the initial sack sample should escape"
+                + " as scramble or throwaway the vast majority of the time")
+        .isLessThan(TRIALS / 2);
+  }
+
+  private static Counts sample(
+      PressureModel model, PassRoles roles, Player qb, SplittableRandomSource rng) {
+    var counts = new Counts();
+    for (var i = 0; i < TRIALS; i++) {
+      switch (model.resolve(roles, qb, rng)) {
+        case SACK -> counts.sack++;
+        case SCRAMBLE -> counts.scramble++;
+        case THROWAWAY -> counts.throwaway++;
+      }
+    }
+    return counts;
+  }
+
+  private static PassRoles rolesWith(List<Player> blockers, List<Player> rushers) {
+    return new PassRoles(rushers, blockers, List.of(), List.of());
+  }
+
+  private static List<Player> averageOl(int n) {
+    return generate(n, Position.OL, "ol", i -> Skill.average(), i -> Physical.average());
+  }
+
+  private static List<Player> eliteOl(int n) {
+    return generate(
+        n,
+        Position.OL,
+        "elite-ol",
+        i -> skillWith(sb -> sb.passSet(95)),
+        i -> physicalWith(pb -> pb.strength(95).power(95).agility(80).acceleration(80)));
+  }
+
+  private static List<Player> weakOl(int n) {
+    return generate(
+        n,
+        Position.OL,
+        "weak-ol",
+        i -> skillWith(sb -> sb.passSet(15)),
+        i -> physicalWith(pb -> pb.strength(25).power(25).agility(20).acceleration(20)));
+  }
+
+  private static List<Player> averageDl(int n) {
+    return generate(n, Position.DL, "dl", i -> Skill.average(), i -> Physical.average());
+  }
+
+  private static List<Player> elitePassRush(int n) {
+    return generate(
+        n,
+        Position.DL,
+        "elite-dl",
+        i -> skillWith(sb -> sb.passRushMoves(95).blockShedding(95)),
+        i -> physicalWith(pb -> pb.speed(90).strength(90).power(90).explosiveness(90).bend(90)));
+  }
+
+  private static List<Player> weakDl(int n) {
+    return generate(
+        n,
+        Position.DL,
+        "weak-dl",
+        i -> skillWith(sb -> sb.passRushMoves(15).blockShedding(15)),
+        i -> physicalWith(pb -> pb.speed(25).strength(25).power(25).explosiveness(25).bend(25)));
+  }
+
+  private static Player averageQb() {
+    return qb("avg-qb", Physical.average(), Skill.average(), Tendencies.average());
+  }
+
+  private static Player mobileQb() {
+    return qb(
+        "mobile-qb",
+        physicalWith(pb -> pb.speed(95).acceleration(95).agility(95)),
+        Skill.average(),
+        Tendencies.average());
+  }
+
+  private static Player awareQb() {
+    return qb(
+        "aware-qb",
+        Physical.average(),
+        Skill.average(),
+        tendenciesWith(tb -> tb.processing(95).footballIq(95)));
+  }
+
+  private static Player awareMobileQb() {
+    return qb(
+        "aware-mobile-qb",
+        physicalWith(pb -> pb.speed(95).acceleration(95).agility(95)),
+        Skill.average(),
+        tendenciesWith(tb -> tb.processing(95).footballIq(95)));
+  }
+
+  private static Player statueQb() {
+    return qb(
+        "statue-qb",
+        physicalWith(pb -> pb.speed(10).acceleration(10).agility(10)),
+        Skill.average(),
+        tendenciesWith(tb -> tb.processing(10).footballIq(10)));
+  }
+
+  private static Player qb(String name, Physical physical, Skill skill, Tendencies tendencies) {
+    return new Player(
+        new PlayerId(UUID.randomUUID()), Position.QB, name, physical, skill, tendencies);
+  }
+
+  private static List<Player> generate(
+      int count,
+      Position position,
+      String prefix,
+      Function<Integer, Skill> skill,
+      Function<Integer, Physical> physical) {
+    var players = new java.util.ArrayList<Player>(count);
+    for (var i = 0; i < count; i++) {
+      players.add(
+          new Player(
+              new PlayerId(UUID.randomUUID()),
+              position,
+              prefix + "-" + i,
+              physical.apply(i),
+              skill.apply(i),
+              Tendencies.average()));
+    }
+    return List.copyOf(players);
+  }
+
+  private static Skill skillWith(Function<SkillBuilder, SkillBuilder> customize) {
+    return customize.apply(new SkillBuilder()).build();
+  }
+
+  private static Physical physicalWith(Function<PhysicalBuilder, PhysicalBuilder> customize) {
+    return customize.apply(new PhysicalBuilder()).build();
+  }
+
+  private static Tendencies tendenciesWith(
+      Function<TendenciesBuilder, TendenciesBuilder> customize) {
+    return customize.apply(new TendenciesBuilder()).build();
+  }
+
+  private static final class Counts {
+    int sack;
+    int scramble;
+    int throwaway;
+  }
+
+  private static final class SkillBuilder {
+    private int passSet = 50;
+    private int routeRunning = 50;
+    private int coverageTechnique = 50;
+    private int passRushMoves = 50;
+    private int blockShedding = 50;
+    private int hands = 50;
+    private int runBlock = 50;
+    private int ballCarrierVision = 50;
+    private int breakTackle = 50;
+    private int tackling = 50;
+
+    SkillBuilder passSet(int v) {
+      this.passSet = v;
+      return this;
+    }
+
+    SkillBuilder passRushMoves(int v) {
+      this.passRushMoves = v;
+      return this;
+    }
+
+    SkillBuilder blockShedding(int v) {
+      this.blockShedding = v;
+      return this;
+    }
+
+    Skill build() {
+      return new Skill(
+          passSet,
+          routeRunning,
+          coverageTechnique,
+          passRushMoves,
+          blockShedding,
+          hands,
+          runBlock,
+          ballCarrierVision,
+          breakTackle,
+          tackling);
+    }
+  }
+
+  private static final class PhysicalBuilder {
+    private int speed = 50;
+    private int acceleration = 50;
+    private int agility = 50;
+    private int strength = 50;
+    private int power = 50;
+    private int bend = 50;
+    private int stamina = 50;
+    private int explosiveness = 50;
+
+    PhysicalBuilder speed(int v) {
+      this.speed = v;
+      return this;
+    }
+
+    PhysicalBuilder acceleration(int v) {
+      this.acceleration = v;
+      return this;
+    }
+
+    PhysicalBuilder agility(int v) {
+      this.agility = v;
+      return this;
+    }
+
+    PhysicalBuilder strength(int v) {
+      this.strength = v;
+      return this;
+    }
+
+    PhysicalBuilder power(int v) {
+      this.power = v;
+      return this;
+    }
+
+    PhysicalBuilder bend(int v) {
+      this.bend = v;
+      return this;
+    }
+
+    PhysicalBuilder explosiveness(int v) {
+      this.explosiveness = v;
+      return this;
+    }
+
+    Physical build() {
+      return new Physical(
+          speed, acceleration, agility, strength, power, bend, stamina, explosiveness);
+    }
+  }
+
+  private static final class TendenciesBuilder {
+    private int composure = 50;
+    private int discipline = 50;
+    private int footballIq = 50;
+    private int processing = 50;
+    private int toughness = 50;
+    private int clutch = 50;
+    private int consistency = 50;
+    private int motor = 50;
+
+    TendenciesBuilder footballIq(int v) {
+      this.footballIq = v;
+      return this;
+    }
+
+    TendenciesBuilder processing(int v) {
+      this.processing = v;
+      return this;
+    }
+
+    Tendencies build() {
+      return new Tendencies(
+          composure, discipline, footballIq, processing, toughness, clutch, consistency, motor);
+    }
+  }
+}


### PR DESCRIPTION
Closes #581

## Summary
- New `PressureModel` seam and `QbPressureEscape` implementation: given a nominal sack sampled from the outcome-mix band, redirects mass toward scrambles and throwaways based on OL-vs-DL skill/physical gap and QB mobility (speed/acceleration/agility) + awareness (`processing` tendency with a `footballIq` lift).
- Wired into `MatchupPassResolver` via constructor + `load` factory; uses `rng.split` so the pressure decision never bleeds into yardage sampling.
- Identity-at-average construction preserves the shipped ~6.29% league sack rate and all existing calibration tests untouched; tests use `PressureModel.ALWAYS_SACK` to pin baseline parity.

## Test plan
- [x] `./gradlew test` (full suite green)
- [x] `./gradlew spotlessCheck`
- [x] New `QbPressureEscapeTests`: average attrs => 100% sack (identity); mobile QB raises scramble share; aware QB raises throwaway share; weak OL vs elite DL + statue QB stays >95% sack; elite OL + aware/mobile QB lets most sack samples escape.