### PR TITLE
feat(gamesimulator): NFL-compliant overtime rules (#582)

### DIFF
--- a/src/gamesimulator/java/app/zoneblitz/gamesimulator/GameInputs.java
+++ b/src/gamesimulator/java/app/zoneblitz/gamesimulator/GameInputs.java
@@ -10,6 +10,10 @@ import java.util.Optional;
  * All inputs required to simulate a single game. Rosters and coaches are pre-fetched by the caller
  * from the roster feature's public use case — the sim never touches persistence. {@link
  * PreGameContext} is a stub today; later tasks fill in weather, surface, and home-field context.
+ *
+ * <p>{@link #gameType()} drives overtime rules: regular-season games use modified sudden death with
+ * a single 10-minute period that may end tied; playoff games play indefinite 15-minute sudden-death
+ * periods until a winner is determined.
  */
 public record GameInputs(
     GameId gameId,
@@ -18,6 +22,7 @@ public record GameInputs(
     Coach homeCoach,
     Coach awayCoach,
     PreGameContext preGameContext,
+    GameType gameType,
     Optional<Long> seed) {
 
   public GameInputs {
@@ -27,7 +32,22 @@ public record GameInputs(
     Objects.requireNonNull(homeCoach, "homeCoach");
     Objects.requireNonNull(awayCoach, "awayCoach");
     Objects.requireNonNull(preGameContext, "preGameContext");
+    Objects.requireNonNull(gameType, "gameType");
     Objects.requireNonNull(seed, "seed");
+  }
+
+  /**
+   * Convenience constructor that defaults {@link #gameType()} to {@link GameType#REGULAR_SEASON}.
+   */
+  public GameInputs(
+      GameId gameId,
+      Team home,
+      Team away,
+      Coach homeCoach,
+      Coach awayCoach,
+      PreGameContext preGameContext,
+      Optional<Long> seed) {
+    this(gameId, home, away, homeCoach, awayCoach, preGameContext, GameType.REGULAR_SEASON, seed);
   }
 
   /**

--- a/src/gamesimulator/java/app/zoneblitz/gamesimulator/GameSimulator.java
+++ b/src/gamesimulator/java/app/zoneblitz/gamesimulator/GameSimulator.java
@@ -48,8 +48,10 @@ import java.util.stream.Stream;
 final class GameSimulator implements SimulateGame {
 
   private static final int REGULATION_QUARTER_SECONDS = 15 * 60;
-  private static final int OVERTIME_PERIOD_SECONDS = 10 * 60;
+  private static final int REGULAR_SEASON_OT_PERIOD_SECONDS = 10 * 60;
+  private static final int PLAYOFF_OT_PERIOD_SECONDS = 15 * 60;
   private static final int HARD_SNAP_CAP = 500;
+  private static final long OT_COIN_TOSS_KEY = 0xC0DE_CAFEL;
   private static final long CLOCK_SPLIT_KEY = 0x3333_eeffL;
   private static final long PAT_SPLIT_KEY = 0xFA77_7777L;
   private static final long FG_SPLIT_KEY = 0xFB66_6666L;
@@ -243,12 +245,20 @@ final class GameSimulator implements SimulateGame {
 
     if (advance.touchdown()) {
       state = state.withScore(scoreAfter).withClock(clockAfter);
+      state = concludeOvertimePossession(state, offenseSide);
+      if (state.phase() == GameState.Phase.FINAL) {
+        return state;
+      }
       state = emitPat(out, state, inputs, offenseSide, seq, root, gameKey ^ sequence);
       return emitKickoff(
           out, state, inputs, defenseSide, seq, root.split(gameKey ^ sequence ^ 0x5C01DL));
     }
     if (advance.defensiveTouchdown()) {
       state = state.withScore(scoreAfter).withClock(clockAfter);
+      state = concludeOvertimePossession(state, offenseSide);
+      if (state.phase() == GameState.Phase.FINAL) {
+        return state;
+      }
       state = emitPat(out, state, inputs, defenseSide, seq, root, gameKey ^ sequence);
       return emitKickoff(
           out, state, inputs, offenseSide, seq, root.split(gameKey ^ sequence ^ 0x5C02DL));
@@ -257,10 +267,18 @@ final class GameSimulator implements SimulateGame {
       state = state.withScore(scoreAfter).withClock(clockAfter);
       var freeKickSpot = new FieldPosition(SAFETY_FREE_KICK_SPOT);
       out.add(safetyEvent(state, inputs.gameId(), seq[0]++, freeKickSpot, offenseSide));
+      state = concludeOvertimePossession(state, offenseSide);
+      if (state.phase() == GameState.Phase.FINAL) {
+        return state;
+      }
       return state.withPossessionAndSpot(defenseSide, freeKickSpot);
     }
     if (advance.turnover() != SnapAdvance.Turnover.NONE) {
       state = state.withScore(scoreAfter).withClock(clockAfter);
+      state = concludeOvertimePossession(state, offenseSide);
+      if (state.phase() == GameState.Phase.FINAL) {
+        return state;
+      }
       return state.withPossessionAndSpot(defenseSide, new FieldPosition(advance.endYardLine()));
     }
 
@@ -268,6 +286,10 @@ final class GameSimulator implements SimulateGame {
     if (newDd == null) {
       // Turnover on downs.
       state = state.withClock(clockAfter);
+      state = concludeOvertimePossession(state, offenseSide);
+      if (state.phase() == GameState.Phase.FINAL) {
+        return state;
+      }
       return state.withPossessionAndSpot(
           defenseSide, new FieldPosition(100 - advance.endYardLine()));
     }
@@ -397,7 +419,8 @@ final class GameSimulator implements SimulateGame {
               state.homeTimeouts(),
               state.awayTimeouts(),
               state.phase(),
-              state.overtimeRound());
+              state.overtimeRound(),
+              state.overtime());
       case PenaltyEnforcer.Applied.TurnoverOnDowns t ->
           state
               .withClock(clockAfter)
@@ -464,6 +487,10 @@ final class GameSimulator implements SimulateGame {
             .withScore(resolved.scoreAfter())
             .withClock(tickKickClock(state, Kick.FIELD_GOAL, rng));
 
+    state = concludeOvertimePossession(state, offenseSide);
+    if (state.phase() == GameState.Phase.FINAL) {
+      return state;
+    }
     if (resolved.made()) {
       return emitKickoff(
           out, state, inputs, defenseSide, seq, root.split(gameKey ^ sequence ^ 0x5C03DL));
@@ -499,6 +526,10 @@ final class GameSimulator implements SimulateGame {
             rng);
     out.add(resolved.event());
     state = state.withClock(tickKickClock(state, Kick.PUNT, rng));
+    state = concludeOvertimePossession(state, offenseSide);
+    if (state.phase() == GameState.Phase.FINAL) {
+      return state;
+    }
     return state.withPossessionAndSpot(
         defenseSide, new FieldPosition(resolved.receivingTakeoverYardLine()));
   }
@@ -546,6 +577,32 @@ final class GameSimulator implements SimulateGame {
 
   private static Side otherSide(Side side) {
     return side == Side.HOME ? Side.AWAY : Side.HOME;
+  }
+
+  /**
+   * Marks that {@code possessingSide} just finished a possession in overtime and evaluates whether
+   * the game has ended. Applies modified sudden death: both teams are guaranteed a possession in
+   * the opening OT period (even if the opener is a TD); once both have possessed, pure sudden death
+   * applies and any lead finalizes the result. Returns the updated state (possibly {@link
+   * GameState.Phase#FINAL}); callers must honor {@code FINAL} and skip any follow-up PAT/kickoff.
+   */
+  static GameState concludeOvertimePossession(GameState state, Side possessingSide) {
+    if (state.phase() != GameState.Phase.OVERTIME) {
+      return state;
+    }
+    var ot = state.overtime().withPossessed(possessingSide);
+    var tied = state.score().home() == state.score().away();
+    if (ot.suddenDeath() && !tied) {
+      return state.withOvertime(ot).withPhase(GameState.Phase.FINAL);
+    }
+    if (ot.bothPossessed()) {
+      var enteredSd = ot.enterSuddenDeath();
+      if (!tied) {
+        return state.withOvertime(enteredSd).withPhase(GameState.Phase.FINAL);
+      }
+      return state.withOvertime(enteredSd);
+    }
+    return state.withOvertime(ot);
   }
 
   private static Score scoreAfterPlay(
@@ -600,13 +657,11 @@ final class GameSimulator implements SimulateGame {
       if (state.score().home() != state.score().away()) {
         return state.withPhase(GameState.Phase.FINAL);
       }
-      var otClock = new GameClock(5, OVERTIME_PERIOD_SECONDS);
-      var withOt = state.withPhase(GameState.Phase.OVERTIME).withClock(otClock);
-      return emitKickoff(out, withOt, inputs, Side.HOME, seq, root.split(gameKey ^ 0xD1AABBL));
+      return startOvertimePeriod(out, state, inputs, seq, root, gameKey, 1);
     }
 
     if (quarter >= 5) {
-      return state.withPhase(GameState.Phase.FINAL);
+      return endOfOvertimePeriod(out, state, inputs, seq, root, gameKey);
     }
 
     var nextClock = new GameClock(quarter + 1, REGULATION_QUARTER_SECONDS);
@@ -617,6 +672,46 @@ final class GameSimulator implements SimulateGame {
           out, advanced, inputs, secondHalfReceiver, seq, root.split(gameKey ^ 0xB00BL));
     }
     return advanced;
+  }
+
+  private GameState startOvertimePeriod(
+      List<PlayEvent> out,
+      GameState state,
+      GameInputs inputs,
+      int[] seq,
+      SplittableRandomSource root,
+      long gameKey,
+      int round) {
+    var periodSeconds =
+        inputs.gameType() == GameType.PLAYOFFS
+            ? PLAYOFF_OT_PERIOD_SECONDS
+            : REGULAR_SEASON_OT_PERIOD_SECONDS;
+    var otClock = new GameClock(4 + round, periodSeconds);
+    var coinTossRng = root.split(gameKey ^ OT_COIN_TOSS_KEY ^ (long) round);
+    var receiver = coinTossRng.nextDouble() < 0.5 ? Side.HOME : Side.AWAY;
+    var withOt =
+        state
+            .withPhase(GameState.Phase.OVERTIME)
+            .withClock(otClock)
+            .withOvertimeRound(round)
+            .withOvertime(GameState.OvertimeState.notStarted());
+    return emitKickoff(out, withOt, inputs, receiver, seq, root.split(gameKey ^ 0xD1AABBL ^ round));
+  }
+
+  private GameState endOfOvertimePeriod(
+      List<PlayEvent> out,
+      GameState state,
+      GameInputs inputs,
+      int[] seq,
+      SplittableRandomSource root,
+      long gameKey) {
+    if (state.score().home() != state.score().away()) {
+      return state.withPhase(GameState.Phase.FINAL);
+    }
+    if (inputs.gameType() == GameType.REGULAR_SEASON) {
+      return state.withPhase(GameState.Phase.FINAL);
+    }
+    return startOvertimePeriod(out, state, inputs, seq, root, gameKey, state.overtimeRound() + 1);
   }
 
   private GameState emitKickoff(

--- a/src/gamesimulator/java/app/zoneblitz/gamesimulator/GameState.java
+++ b/src/gamesimulator/java/app/zoneblitz/gamesimulator/GameState.java
@@ -32,7 +32,8 @@ public record GameState(
     int homeTimeouts,
     int awayTimeouts,
     Phase phase,
-    int overtimeRound) {
+    int overtimeRound,
+    OvertimeState overtime) {
 
   public GameState {
     Objects.requireNonNull(score, "score");
@@ -44,6 +45,7 @@ public record GameState(
     Objects.requireNonNull(fatigueSnapCounts, "fatigueSnapCounts");
     Objects.requireNonNull(injuredPlayers, "injuredPlayers");
     Objects.requireNonNull(phase, "phase");
+    Objects.requireNonNull(overtime, "overtime");
     fatigueSnapCounts = Map.copyOf(fatigueSnapCounts);
     injuredPlayers = List.copyOf(injuredPlayers);
   }
@@ -62,7 +64,8 @@ public record GameState(
         3,
         3,
         Phase.REGULATION,
-        0);
+        0,
+        OvertimeState.notStarted());
   }
 
   /**
@@ -89,7 +92,8 @@ public record GameState(
         homeTimeouts,
         awayTimeouts,
         phase,
-        overtimeRound);
+        overtimeRound,
+        overtime);
   }
 
   /** Replace the current score. Used after PAT and FG events update it on their own. */
@@ -107,7 +111,8 @@ public record GameState(
         homeTimeouts,
         awayTimeouts,
         phase,
-        overtimeRound);
+        overtimeRound,
+        overtime);
   }
 
   /**
@@ -133,7 +138,8 @@ public record GameState(
         homeTimeouts,
         awayTimeouts,
         phase,
-        overtimeRound);
+        overtimeRound,
+        overtime);
   }
 
   public GameState withPhase(Phase newPhase) {
@@ -150,7 +156,8 @@ public record GameState(
         homeTimeouts,
         awayTimeouts,
         newPhase,
-        overtimeRound);
+        overtimeRound,
+        overtime);
   }
 
   public GameState withPossessionAndSpot(Side newPossession, FieldPosition newSpot) {
@@ -168,13 +175,75 @@ public record GameState(
         homeTimeouts,
         awayTimeouts,
         phase,
-        overtimeRound);
+        overtimeRound,
+        overtime);
+  }
+
+  public GameState withOvertimeRound(int newOvertimeRound) {
+    return new GameState(
+        score,
+        clock,
+        downAndDistance,
+        spot,
+        possession,
+        drive,
+        fatigueSnapCounts,
+        injuredPlayers,
+        homeTimeouts,
+        awayTimeouts,
+        phase,
+        newOvertimeRound,
+        overtime);
+  }
+
+  public GameState withOvertime(OvertimeState newOvertime) {
+    Objects.requireNonNull(newOvertime, "newOvertime");
+    return new GameState(
+        score,
+        clock,
+        downAndDistance,
+        spot,
+        possession,
+        drive,
+        fatigueSnapCounts,
+        injuredPlayers,
+        homeTimeouts,
+        awayTimeouts,
+        phase,
+        overtimeRound,
+        newOvertime);
   }
 
   /** Per-drive bookkeeping. */
   record DriveState(int driveNumber, int playsInDrive, int yardsInDrive, Side startingPossession) {
     static DriveState initial() {
       return new DriveState(1, 0, 0, Side.HOME);
+    }
+  }
+
+  /**
+   * Per-OT bookkeeping. Tracks which sides have completed a possession (drives toward modified
+   * sudden-death's both-teams-possess rule) and whether the game has entered pure sudden-death
+   * mode, in which any score ends the game immediately.
+   */
+  public record OvertimeState(boolean homePossessed, boolean awayPossessed, boolean suddenDeath) {
+    public static OvertimeState notStarted() {
+      return new OvertimeState(false, false, false);
+    }
+
+    public OvertimeState withPossessed(Side side) {
+      Objects.requireNonNull(side, "side");
+      return side == Side.HOME
+          ? new OvertimeState(true, awayPossessed, suddenDeath)
+          : new OvertimeState(homePossessed, true, suddenDeath);
+    }
+
+    public OvertimeState enterSuddenDeath() {
+      return new OvertimeState(homePossessed, awayPossessed, true);
+    }
+
+    public boolean bothPossessed() {
+      return homePossessed && awayPossessed;
     }
   }
 

--- a/src/gamesimulator/java/app/zoneblitz/gamesimulator/GameType.java
+++ b/src/gamesimulator/java/app/zoneblitz/gamesimulator/GameType.java
@@ -1,0 +1,18 @@
+package app.zoneblitz.gamesimulator;
+
+/**
+ * Competitive context for a simulated game. Governs overtime rules per the NFL rulebook:
+ *
+ * <ul>
+ *   <li>{@link #REGULAR_SEASON} — modified sudden death. A single 10-minute OT period; both teams
+ *       are guaranteed at least one possession (including after an opening-drive TD, per the 2024
+ *       rule change). If still tied when the clock expires, the game ends in a tie.
+ *   <li>{@link #PLAYOFFS} — modified sudden death for the first possession of the first period
+ *       (both teams guaranteed a possession), then full sudden death. 15-minute periods continue
+ *       until a winner is determined.
+ * </ul>
+ */
+public enum GameType {
+  REGULAR_SEASON,
+  PLAYOFFS
+}

--- a/src/main/java/app/zoneblitz/gamesimulator/GameSimEmulator.java
+++ b/src/main/java/app/zoneblitz/gamesimulator/GameSimEmulator.java
@@ -81,6 +81,7 @@ public final class GameSimEmulator {
             Coach.average(new CoachId(new UUID(1L, 1L)), "Home HC"),
             Coach.average(new CoachId(new UUID(1L, 2L)), "Away HC"),
             new GameInputs.PreGameContext(HomeFieldAdvantage.leagueAverage()),
+            GameType.REGULAR_SEASON,
             Optional.of(seed));
 
     var playerNames = new HashMap<PlayerId, String>();

--- a/src/test/java/app/zoneblitz/gamesimulator/GameSimulatorTests.java
+++ b/src/test/java/app/zoneblitz/gamesimulator/GameSimulatorTests.java
@@ -206,4 +206,149 @@ class GameSimulatorTests {
     var last = events.get(events.size() - 1);
     assertThat(last.scoreAfter().home() + last.scoreAfter().away()).isPositive();
   }
+
+  @Test
+  void concludeOvertimePossession_firstPossessionTouchdown_doesNotEndGameInOpeningOtPeriod() {
+    var state =
+        TestGameStates.of(1, 10, 25, 5, 600, 7, 0, Side.HOME)
+            .withPhase(GameState.Phase.OVERTIME)
+            .withOvertimeRound(1);
+
+    var result = GameSimulator.concludeOvertimePossession(state, Side.HOME);
+
+    assertThat(result.phase()).isEqualTo(GameState.Phase.OVERTIME);
+    assertThat(result.overtime().homePossessed()).isTrue();
+    assertThat(result.overtime().awayPossessed()).isFalse();
+    assertThat(result.overtime().suddenDeath()).isFalse();
+  }
+
+  @Test
+  void concludeOvertimePossession_bothPossessedScoresDiffer_finalizesGame() {
+    var state =
+        TestGameStates.of(1, 10, 25, 5, 300, 7, 0, Side.AWAY)
+            .withPhase(GameState.Phase.OVERTIME)
+            .withOvertimeRound(1)
+            .withOvertime(new GameState.OvertimeState(true, false, false));
+
+    var result = GameSimulator.concludeOvertimePossession(state, Side.AWAY);
+
+    assertThat(result.phase()).isEqualTo(GameState.Phase.FINAL);
+    assertThat(result.overtime().bothPossessed()).isTrue();
+    assertThat(result.overtime().suddenDeath()).isTrue();
+  }
+
+  @Test
+  void concludeOvertimePossession_bothPossessedStillTied_entersSuddenDeathWithoutFinalizing() {
+    var state =
+        TestGameStates.of(1, 10, 25, 5, 300, 3, 3, Side.AWAY)
+            .withPhase(GameState.Phase.OVERTIME)
+            .withOvertimeRound(1)
+            .withOvertime(new GameState.OvertimeState(true, false, false));
+
+    var result = GameSimulator.concludeOvertimePossession(state, Side.AWAY);
+
+    assertThat(result.phase()).isEqualTo(GameState.Phase.OVERTIME);
+    assertThat(result.overtime().suddenDeath()).isTrue();
+  }
+
+  @Test
+  void concludeOvertimePossession_suddenDeathScoreLeads_finalizesImmediately() {
+    var state =
+        TestGameStates.of(1, 10, 25, 5, 120, 10, 7, Side.HOME)
+            .withPhase(GameState.Phase.OVERTIME)
+            .withOvertimeRound(1)
+            .withOvertime(new GameState.OvertimeState(true, true, true));
+
+    var result = GameSimulator.concludeOvertimePossession(state, Side.HOME);
+
+    assertThat(result.phase()).isEqualTo(GameState.Phase.FINAL);
+  }
+
+  @Test
+  void concludeOvertimePossession_outsideOvertime_leavesStateUntouched() {
+    var state = TestGameStates.of(1, 10, 25, 2, 600, 7, 7, Side.HOME);
+
+    var result = GameSimulator.concludeOvertimePossession(state, Side.HOME);
+
+    assertThat(result).isSameAs(state);
+  }
+
+  @Test
+  void simulate_regularSeasonEndsInTie_whenNeitherSideScoresInRegulationOrOvertime() {
+    var events =
+        zeroYardSimulator(GameType.REGULAR_SEASON).simulate(inputs(Optional.of(42L))).toList();
+
+    var last = events.get(events.size() - 1);
+    assertThat(last.scoreAfter().home()).isEqualTo(last.scoreAfter().away());
+    var quarters =
+        events.stream()
+            .filter(e -> e instanceof PlayEvent.EndOfQuarter)
+            .map(e -> ((PlayEvent.EndOfQuarter) e).quarter())
+            .toList();
+    assertThat(quarters).contains(5);
+    assertThat(quarters.stream().filter(q -> q >= 5).count())
+        .as("regular-season OT plays at most one period before ending tied")
+        .isEqualTo(1L);
+  }
+
+  private SimulateGame zeroYardSimulator(GameType gameType) {
+    var personnel =
+        new FakePersonnelSelector(TestPersonnel.baselineOffense(), TestPersonnel.baselineDefense());
+    return new GameSimulator(
+        ScriptedPlayCaller.runs(1),
+        personnel,
+        zeroYardRunResolver(),
+        BandClockModel.load(new ClasspathBandRepository(), new DefaultBandSampler()),
+        new TouchbackKickoffResolver(),
+        new FlatRateExtraPointResolver(),
+        new DistanceCurveFieldGoalResolver(),
+        new DistanceCurvePuntResolver(),
+        new NoPenaltyModel(),
+        app.zoneblitz.gamesimulator.playcalling.DefensiveCallSelector.neutral());
+  }
+
+  private PlayResolver zeroYardRunResolver() {
+    return new PlayResolver() {
+      @Override
+      public PlayOutcome resolve(
+          PlayCaller.PlayCall call,
+          GameState state,
+          OffensivePersonnel offense,
+          DefensivePersonnel defense,
+          RandomSource rng) {
+        rng.nextLong();
+        return new app.zoneblitz.gamesimulator.resolver.RunOutcome.Run(
+            QB_ID,
+            app.zoneblitz.gamesimulator.event.RunConcept.INSIDE_ZONE,
+            0,
+            Optional.<PlayerId>empty(),
+            Optional.<app.zoneblitz.gamesimulator.event.FumbleOutcome>empty(),
+            false);
+      }
+    };
+  }
+
+  private GameInputs playoffInputs(Optional<Long> seed) {
+    return new GameInputs(
+        GAME_ID,
+        HOME,
+        AWAY,
+        HOME_COACH,
+        AWAY_COACH,
+        new GameInputs.PreGameContext(),
+        GameType.PLAYOFFS,
+        seed);
+  }
+
+  @Test
+  void simulate_playoffGameNeverEndsTied_evenWhenBaseOffenseNeverScores() {
+    var events =
+        zeroYardSimulator(GameType.PLAYOFFS).simulate(playoffInputs(Optional.of(7L))).toList();
+
+    var last = events.get(events.size() - 1);
+    assertThat(events.size()).isLessThanOrEqualTo(500);
+    if (last.scoreAfter().home() == last.scoreAfter().away()) {
+      assertThat(events.size()).isEqualTo(500);
+    }
+  }
 }

--- a/src/test/java/app/zoneblitz/gamesimulator/TestGameStates.java
+++ b/src/test/java/app/zoneblitz/gamesimulator/TestGameStates.java
@@ -38,7 +38,8 @@ public final class TestGameStates {
         3,
         3,
         GameState.Phase.REGULATION,
-        0);
+        0,
+        GameState.OvertimeState.notStarted());
   }
 
   public static GameState neutral(int down, int yardsToGo, int yardLine) {


### PR DESCRIPTION
Closes #582

## Summary
- Replaces the single-10-minute stub OT with modified sudden death per the 2024 NFL rulebook.
- Regular-season games play at most one 10-minute OT period and may end tied; playoff games play 15-minute periods until a winner is determined.
- Both teams are guaranteed a possession in the opening OT period (even after an opening-drive TD); pure sudden death applies thereafter.
- New `GameType` on `GameInputs` selects the rule set; `GameState` carries an `OvertimeState` so every possession-ending path (TD, FG, punt, turnover, turnover-on-downs, safety) can evaluate termination uniformly.

## Test plan
- [x] `concludeOvertimePossession` unit tests cover opening-drive TD (both-possessions rule), sudden-death after first possession, tied-after-both-possessed (enters sudden death), and walk-off scoring.
- [x] Full-sim regression: regular-season game where neither side scores ends in a single OT period with a tie; playoff game under the same scenario never terminates tied within the snap cap.
- [x] `./gradlew spotlessCheck test` passes.