### PR TITLE
feat(gamesimulator): fatigue tracking and motor wiring (#586)

### DIFF
--- a/src/gamesimulator/java/app/zoneblitz/gamesimulator/FatigueModel.java
+++ b/src/gamesimulator/java/app/zoneblitz/gamesimulator/FatigueModel.java
@@ -1,0 +1,57 @@
+package app.zoneblitz.gamesimulator;
+
+import app.zoneblitz.gamesimulator.event.PlayerId;
+import app.zoneblitz.gamesimulator.personnel.DefensivePersonnel;
+import app.zoneblitz.gamesimulator.personnel.OffensivePersonnel;
+import app.zoneblitz.gamesimulator.roster.DefensiveCoachTendencies;
+import app.zoneblitz.gamesimulator.roster.Player;
+import app.zoneblitz.gamesimulator.roster.Team;
+import java.util.Map;
+
+/**
+ * Fatigue accounting and rotation. Two responsibilities:
+ *
+ * <ul>
+ *   <li><b>Rotation hook</b> — given the personnel package the {@link
+ *       app.zoneblitz.gamesimulator.personnel.PersonnelSelector} picked plus accumulated snap
+ *       counts and the relevant coach tendency, swap fatigued starters for fresh backups at
+ *       fatigue-prone positions (RB, DL). Returns a {@code package} with an identical position
+ *       quota — only individual players change.
+ *   <li><b>Performance moderator</b> — answers "how fatigued is this player right now?" as a
+ *       multiplier in {@code [floor, 1.0]}. Fresh players return {@code 1.0}; degradation kicks in
+ *       past a position-specific snap threshold and is moderated by the player's {@link
+ *       app.zoneblitz.gamesimulator.roster.Tendencies#motor()} attribute. Resolvers may consult
+ *       this to scale matchup advantages, but the engine itself does not — degradation is observed
+ *       via reduced snap concentration on starters once rotation kicks in.
+ * </ul>
+ *
+ * <p>Implementations are pure given inputs.
+ */
+interface FatigueModel {
+
+  /**
+   * Rotate fatigued offensive skill players. Today only the running back position rotates: when
+   * RB1's snap count crosses a fatigue threshold and a fresher backup exists on the roster, the
+   * backup takes the snap. Position quotas are preserved.
+   */
+  OffensivePersonnel rotateOffense(
+      OffensivePersonnel base, Team offense, Map<PlayerId, Integer> snapCounts);
+
+  /**
+   * Rotate fatigued defensive front players. Defensive linemen committee in based on snap counts
+   * and the coach's {@link DefensiveCoachTendencies#substitutionAggression()} — aggressive
+   * coordinators rotate sooner, conservative coordinators ride starters longer.
+   */
+  DefensivePersonnel rotateDefense(
+      DefensivePersonnel base,
+      Team defense,
+      Map<PlayerId, Integer> snapCounts,
+      DefensiveCoachTendencies coach);
+
+  /**
+   * Performance multiplier for {@code player} given accumulated snap count. Returns {@code 1.0}
+   * before the position-specific threshold, then decays linearly toward a floor as snaps pile up.
+   * High motor pushes the threshold later; low motor brings it earlier.
+   */
+  double performanceMultiplier(Player player, int snapCount);
+}

--- a/src/gamesimulator/java/app/zoneblitz/gamesimulator/GameSimulator.java
+++ b/src/gamesimulator/java/app/zoneblitz/gamesimulator/GameSimulator.java
@@ -101,6 +101,7 @@ final class GameSimulator implements SimulateGame {
   private final TwoPointResolver twoPointResolver;
   private final TimeoutDecider timeoutDecider;
   private final EndOfHalfDecider endOfHalfDecider;
+  private final FatigueModel fatigueModel;
 
   GameSimulator(
       PlayCaller caller,
@@ -130,7 +131,8 @@ final class GameSimulator implements SimulateGame {
         twoPointResolver,
         HomeFieldModel.neutral(),
         new TendencyTimeoutDecider(),
-        new TendencyEndOfHalfDecider());
+        new TendencyEndOfHalfDecider(),
+        new PositionalFatigueModel());
   }
 
   GameSimulator(
@@ -163,7 +165,8 @@ final class GameSimulator implements SimulateGame {
         twoPointResolver,
         homeFieldModel,
         timeoutDecider,
-        new TendencyEndOfHalfDecider());
+        new TendencyEndOfHalfDecider(),
+        new PositionalFatigueModel());
   }
 
   GameSimulator(
@@ -182,6 +185,42 @@ final class GameSimulator implements SimulateGame {
       HomeFieldModel homeFieldModel,
       TimeoutDecider timeoutDecider,
       EndOfHalfDecider endOfHalfDecider) {
+    this(
+        caller,
+        personnel,
+        resolver,
+        clockModel,
+        kickoffResolver,
+        extraPointResolver,
+        fieldGoalResolver,
+        puntResolver,
+        penaltyModel,
+        defensiveCallSelector,
+        twoPointPolicy,
+        twoPointResolver,
+        homeFieldModel,
+        timeoutDecider,
+        endOfHalfDecider,
+        new PositionalFatigueModel());
+  }
+
+  GameSimulator(
+      PlayCaller caller,
+      PersonnelSelector personnel,
+      PlayResolver resolver,
+      ClockModel clockModel,
+      KickoffResolver kickoffResolver,
+      ExtraPointResolver extraPointResolver,
+      FieldGoalResolver fieldGoalResolver,
+      PuntResolver puntResolver,
+      PenaltyModel penaltyModel,
+      DefensiveCallSelector defensiveCallSelector,
+      TwoPointDecisionPolicy twoPointPolicy,
+      TwoPointResolver twoPointResolver,
+      HomeFieldModel homeFieldModel,
+      TimeoutDecider timeoutDecider,
+      EndOfHalfDecider endOfHalfDecider,
+      FatigueModel fatigueModel) {
     this.caller = Objects.requireNonNull(caller, "caller");
     this.personnel = Objects.requireNonNull(personnel, "personnel");
     this.resolver = Objects.requireNonNull(resolver, "resolver");
@@ -198,10 +237,23 @@ final class GameSimulator implements SimulateGame {
     this.homeFieldModel = Objects.requireNonNull(homeFieldModel, "homeFieldModel");
     this.timeoutDecider = Objects.requireNonNull(timeoutDecider, "timeoutDecider");
     this.endOfHalfDecider = Objects.requireNonNull(endOfHalfDecider, "endOfHalfDecider");
+    this.fatigueModel = Objects.requireNonNull(fatigueModel, "fatigueModel");
   }
 
   @Override
   public Stream<PlayEvent> simulate(GameInputs inputs) {
+    return runFullGame(inputs).events.stream();
+  }
+
+  @Override
+  public GameSummary summarize(GameInputs inputs) {
+    var run = runFullGame(inputs);
+    return new GameSummary(run.events, run.terminalState.fatigueSnapCounts());
+  }
+
+  private record GameRun(List<PlayEvent> events, GameState terminalState) {}
+
+  private GameRun runFullGame(GameInputs inputs) {
     Objects.requireNonNull(inputs, "inputs");
     var seed = inputs.seed().orElse(0L);
     var root = new SplittableRandomSource(seed);
@@ -227,7 +279,7 @@ final class GameSimulator implements SimulateGame {
       state = maybeCallTimeout(events, state, inputs, seq, root, gameKey);
       state = runSnap(events, state, inputs, seq, root, gameKey, gameFieldGoal, gamePunt);
     }
-    return events.stream();
+    return new GameRun(events, state);
   }
 
   private GameState runSnap(
@@ -272,8 +324,13 @@ final class GameSimulator implements SimulateGame {
         defensiveCallSelector.select(
             state, call.formation(), defenseCoach.defense(), snapRng.split(0xDEFE_7155L));
     Objects.requireNonNull(defensiveCall, "defensiveCall");
-    var offPersonnel = personnel.selectOffense(call, state, offense);
-    var defPersonnel = personnel.selectDefense(call, offPersonnel, state, defense);
+    var offPersonnelRaw = personnel.selectOffense(call, state, offense);
+    var offPersonnel =
+        fatigueModel.rotateOffense(offPersonnelRaw, offense, state.fatigueSnapCounts());
+    var defPersonnelRaw = personnel.selectDefense(call, offPersonnel, state, defense);
+    var defPersonnel =
+        fatigueModel.rotateDefense(
+            defPersonnelRaw, defense, state.fatigueSnapCounts(), defenseCoach.defense());
 
     var homeFieldDraw =
         homeFieldModel.drawRoadPreSnapPenalty(
@@ -322,6 +379,7 @@ final class GameSimulator implements SimulateGame {
     }
 
     out.add(event);
+    state = state.withSnapsAccumulated(snapParticipants(offPersonnel, defPersonnel));
 
     if (advance.touchdown()) {
       state = state.withScore(scoreAfter).withClock(clockAfter);
@@ -769,6 +827,21 @@ final class GameSimulator implements SimulateGame {
     return state.spot().yardLine() < FIELD_GOAL_MIN_YARD_LINE;
   }
 
+  private static java.util.List<app.zoneblitz.gamesimulator.event.PlayerId> snapParticipants(
+      app.zoneblitz.gamesimulator.personnel.OffensivePersonnel offense,
+      app.zoneblitz.gamesimulator.personnel.DefensivePersonnel defense) {
+    var ids =
+        new ArrayList<app.zoneblitz.gamesimulator.event.PlayerId>(
+            offense.players().size() + defense.players().size());
+    for (var p : offense.players()) {
+      ids.add(p.id());
+    }
+    for (var p : defense.players()) {
+      ids.add(p.id());
+    }
+    return List.copyOf(ids);
+  }
+
   private static Side otherSide(Side side) {
     return side == Side.HOME ? Side.AWAY : Side.HOME;
   }
@@ -862,7 +935,7 @@ final class GameSimulator implements SimulateGame {
     var advanced = state.withClock(nextClock);
     if (quarter == 2) {
       var secondHalfReceiver = openingReceiver == Side.HOME ? Side.AWAY : Side.HOME;
-      var afterHalf = advanced.withTimeoutsReset();
+      var afterHalf = advanced.withTimeoutsReset().withFatigueRecovered(1.0);
       return emitKickoff(
           out, afterHalf, inputs, secondHalfReceiver, seq, root.split(gameKey ^ 0xB00BL));
     }

--- a/src/gamesimulator/java/app/zoneblitz/gamesimulator/GameState.java
+++ b/src/gamesimulator/java/app/zoneblitz/gamesimulator/GameState.java
@@ -7,6 +7,7 @@ import app.zoneblitz.gamesimulator.event.PlayEvent;
 import app.zoneblitz.gamesimulator.event.PlayerId;
 import app.zoneblitz.gamesimulator.event.Score;
 import app.zoneblitz.gamesimulator.event.Side;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -211,23 +212,31 @@ public record GameState(
     return side == Side.HOME ? homeTimeouts : awayTimeouts;
   }
 
+  /**
+   * Drive-change recovery fraction. Each new possession partially restores fatigue (sideline rest
+   * during the change of possession). Tuned low so heavy starters still trend upward across the
+   * game while short three-and-outs don't accumulate as harshly as long sustained drives.
+   */
+  private static final double DRIVE_RECOVERY_FRACTION = 0.10;
+
   public GameState withPossessionAndSpot(Side newPossession, FieldPosition newSpot) {
     Objects.requireNonNull(newPossession, "newPossession");
     Objects.requireNonNull(newSpot, "newSpot");
+    var recovered = withFatigueRecovered(DRIVE_RECOVERY_FRACTION);
     return new GameState(
-        score,
-        clock,
+        recovered.score,
+        recovered.clock,
         freshFirstDown(newSpot.yardLine()),
         newSpot,
         newPossession,
-        drive,
-        fatigueSnapCounts,
-        injuredPlayers,
-        homeTimeouts,
-        awayTimeouts,
-        phase,
-        overtimeRound,
-        overtime);
+        recovered.drive,
+        recovered.fatigueSnapCounts,
+        recovered.injuredPlayers,
+        recovered.homeTimeouts,
+        recovered.awayTimeouts,
+        recovered.phase,
+        recovered.overtimeRound,
+        recovered.overtime);
   }
 
   public GameState withOvertimeRound(int newOvertimeRound) {
@@ -244,6 +253,74 @@ public record GameState(
         awayTimeouts,
         phase,
         newOvertimeRound,
+        overtime);
+  }
+
+  /**
+   * Accumulate one snap for every on-field player. Callers pass the 22 {@link PlayerId}s that
+   * participated in the snap just resolved; each entry's count is incremented by one, with missing
+   * entries treated as zero.
+   */
+  public GameState withSnapsAccumulated(List<PlayerId> onField) {
+    Objects.requireNonNull(onField, "onField");
+    if (onField.isEmpty()) {
+      return this;
+    }
+    var updated = new HashMap<>(fatigueSnapCounts);
+    for (var id : onField) {
+      Objects.requireNonNull(id, "onField entry");
+      updated.merge(id, 1, Integer::sum);
+    }
+    return new GameState(
+        score,
+        clock,
+        downAndDistance,
+        spot,
+        possession,
+        drive,
+        updated,
+        injuredPlayers,
+        homeTimeouts,
+        awayTimeouts,
+        phase,
+        overtimeRound,
+        overtime);
+  }
+
+  /**
+   * Partially recover fatigue by scaling every player's snap count by {@code (1 - fraction)}. Used
+   * between drives so that short possessions leave starters fresher. A {@code fraction} of 1.0
+   * fully zeroes snap counts (halftime reset); 0.0 is a no-op.
+   */
+  public GameState withFatigueRecovered(double fraction) {
+    if (fraction <= 0.0) {
+      return this;
+    }
+    var clamped = Math.min(1.0, fraction);
+    if (fatigueSnapCounts.isEmpty()) {
+      return this;
+    }
+    var updated = new HashMap<PlayerId, Integer>();
+    for (var entry : fatigueSnapCounts.entrySet()) {
+      var snaps = entry.getValue();
+      var recovered = (int) Math.round(snaps * (1.0 - clamped));
+      if (recovered > 0) {
+        updated.put(entry.getKey(), recovered);
+      }
+    }
+    return new GameState(
+        score,
+        clock,
+        downAndDistance,
+        spot,
+        possession,
+        drive,
+        updated,
+        injuredPlayers,
+        homeTimeouts,
+        awayTimeouts,
+        phase,
+        overtimeRound,
         overtime);
   }
 

--- a/src/gamesimulator/java/app/zoneblitz/gamesimulator/GameSummary.java
+++ b/src/gamesimulator/java/app/zoneblitz/gamesimulator/GameSummary.java
@@ -1,0 +1,23 @@
+package app.zoneblitz.gamesimulator;
+
+import app.zoneblitz.gamesimulator.event.PlayEvent;
+import app.zoneblitz.gamesimulator.event.PlayerId;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * Post-game output bundle: the full {@link PlayEvent} stream plus end-of-game accumulated stats
+ * that are derived from {@link GameState} rather than from individual events. Today only {@link
+ * #snapCounts() snap counts} are surfaced; future stats (drive summaries, time of possession,
+ * fatigue residuals) join here without changing the {@link SimulateGame#simulate} stream contract.
+ */
+public record GameSummary(List<PlayEvent> events, Map<PlayerId, Integer> snapCounts) {
+
+  public GameSummary {
+    Objects.requireNonNull(events, "events");
+    Objects.requireNonNull(snapCounts, "snapCounts");
+    events = List.copyOf(events);
+    snapCounts = Map.copyOf(snapCounts);
+  }
+}

--- a/src/gamesimulator/java/app/zoneblitz/gamesimulator/PositionalFatigueModel.java
+++ b/src/gamesimulator/java/app/zoneblitz/gamesimulator/PositionalFatigueModel.java
@@ -1,0 +1,208 @@
+package app.zoneblitz.gamesimulator;
+
+import app.zoneblitz.gamesimulator.event.PlayerId;
+import app.zoneblitz.gamesimulator.personnel.DefensivePersonnel;
+import app.zoneblitz.gamesimulator.personnel.OffensivePersonnel;
+import app.zoneblitz.gamesimulator.roster.DefensiveCoachTendencies;
+import app.zoneblitz.gamesimulator.roster.Player;
+import app.zoneblitz.gamesimulator.roster.Position;
+import app.zoneblitz.gamesimulator.roster.Team;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * Default {@link FatigueModel}. Position-specific snap thresholds drive both the rotation decision
+ * and the performance-multiplier curve. Motor moderates the threshold linearly: {@code motor=50}
+ * leaves the baseline threshold unchanged; {@code motor=100} extends it 50%; {@code motor=0}
+ * shortens it 50%.
+ *
+ * <p>Real NFL snap-share priors per Big Data Bowl tracking: starting RBs play roughly 55–70% of
+ * offensive snaps in committee backfields, with backups taking the rest. Starting interior DLs play
+ * roughly 50–65% in rotation-heavy fronts. The constants below approximate that — a 35-snap RB
+ * baseline starts committee work in the second half of a typical 60-snap game; the 40-snap DL
+ * baseline does the same and the 55-snap LB baseline keeps three-down linebackers on the field
+ * almost always.
+ */
+final class PositionalFatigueModel implements FatigueModel {
+
+  private static final int RB_BASE_THRESHOLD = 35;
+  private static final int DL_BASE_THRESHOLD = 40;
+  private static final int LB_BASE_THRESHOLD = 55;
+  private static final int FATIGUE_FLOOR = 60;
+  private static final double PERFORMANCE_FLOOR = 0.70;
+
+  @Override
+  public OffensivePersonnel rotateOffense(
+      OffensivePersonnel base, Team offense, Map<PlayerId, Integer> snapCounts) {
+    Objects.requireNonNull(base, "base");
+    Objects.requireNonNull(offense, "offense");
+    Objects.requireNonNull(snapCounts, "snapCounts");
+    var onField = base.runningBacks();
+    if (onField.isEmpty()) {
+      return base;
+    }
+    var rotated = rotateOut(onField, offense.roster(), snapCounts, Position.RB, Position.FB, 0);
+    if (rotated.equals(onField)) {
+      return base;
+    }
+    var newPlayers = replacePlayers(base.players(), onField, rotated);
+    return new OffensivePersonnel(base.pkg(), newPlayers);
+  }
+
+  @Override
+  public DefensivePersonnel rotateDefense(
+      DefensivePersonnel base,
+      Team defense,
+      Map<PlayerId, Integer> snapCounts,
+      DefensiveCoachTendencies coach) {
+    Objects.requireNonNull(base, "base");
+    Objects.requireNonNull(defense, "defense");
+    Objects.requireNonNull(snapCounts, "snapCounts");
+    Objects.requireNonNull(coach, "coach");
+    var thresholdShift = (coach.substitutionAggression() - 50) / 5;
+    var dlOn = base.defensiveLine();
+    var dlRotated =
+        rotateOut(dlOn, defense.roster(), snapCounts, Position.DL, Position.DL, thresholdShift);
+    var lbOn = base.linebackers();
+    var lbRotated =
+        rotateOut(lbOn, defense.roster(), snapCounts, Position.LB, Position.LB, thresholdShift);
+    if (dlRotated.equals(dlOn) && lbRotated.equals(lbOn)) {
+      return base;
+    }
+    var afterDl = replacePlayers(base.players(), dlOn, dlRotated);
+    var afterLb = replacePlayers(afterDl, lbOn, lbRotated);
+    return new DefensivePersonnel(base.pkg(), afterLb);
+  }
+
+  @Override
+  public double performanceMultiplier(Player player, int snapCount) {
+    Objects.requireNonNull(player, "player");
+    var threshold = motorAdjustedThreshold(player, snapCount);
+    if (snapCount <= threshold) {
+      return 1.0;
+    }
+    var span = Math.max(1, FATIGUE_FLOOR - threshold);
+    var over = Math.min(span, snapCount - threshold);
+    var fall = (1.0 - PERFORMANCE_FLOOR) * (over / (double) span);
+    return 1.0 - fall;
+  }
+
+  private static int baseThresholdFor(Position position) {
+    return switch (position) {
+      case RB, FB -> RB_BASE_THRESHOLD;
+      case DL -> DL_BASE_THRESHOLD;
+      case LB -> LB_BASE_THRESHOLD;
+      default -> Integer.MAX_VALUE;
+    };
+  }
+
+  private static int motorAdjustedThreshold(Player player, int snapCount) {
+    var base = baseThresholdFor(player.position());
+    if (base == Integer.MAX_VALUE) {
+      return base;
+    }
+    var motor = player.tendencies().motor();
+    var motorShift = (motor - 50) * base / 100;
+    return Math.max(1, base + motorShift);
+  }
+
+  /**
+   * Position-aware rotation. For each on-field player whose snap count exceeds their motor-adjusted
+   * threshold, swap in the freshest backup of the same position group not currently on the field.
+   * If no backup exists or all backups are equally fatigued (i.e. no real freshness gain), the
+   * starter stays in.
+   */
+  private List<Player> rotateOut(
+      List<Player> onField,
+      List<Player> roster,
+      Map<PlayerId, Integer> snapCounts,
+      Position primary,
+      Position alternate,
+      int thresholdShift) {
+    if (onField.isEmpty()) {
+      return onField;
+    }
+    var onFieldIds = new ArrayList<PlayerId>(onField.size());
+    for (var p : onField) {
+      onFieldIds.add(p.id());
+    }
+    var result = new ArrayList<>(onField);
+    for (var i = 0; i < result.size(); i++) {
+      var starter = result.get(i);
+      var snaps = snapCounts.getOrDefault(starter.id(), 0);
+      var threshold = motorAdjustedThreshold(starter, snaps) + thresholdShift;
+      if (snaps <= threshold) {
+        continue;
+      }
+      var backup = freshestBackup(roster, snapCounts, primary, alternate, onFieldIds);
+      if (backup.isEmpty()) {
+        continue;
+      }
+      var fresh = backup.get();
+      var freshSnaps = snapCounts.getOrDefault(fresh.id(), 0);
+      if (freshSnaps >= snaps) {
+        continue;
+      }
+      result.set(i, fresh);
+      onFieldIds.set(i, fresh.id());
+    }
+    return List.copyOf(result);
+  }
+
+  private static java.util.Optional<Player> freshestBackup(
+      List<Player> roster,
+      Map<PlayerId, Integer> snapCounts,
+      Position primary,
+      Position alternate,
+      List<PlayerId> onFieldIds) {
+    Player best = null;
+    var bestSnaps = Integer.MAX_VALUE;
+    for (var p : roster) {
+      if (p.position() != primary && p.position() != alternate) {
+        continue;
+      }
+      if (onFieldIds.contains(p.id())) {
+        continue;
+      }
+      var snaps = snapCounts.getOrDefault(p.id(), 0);
+      if (snaps < bestSnaps) {
+        bestSnaps = snaps;
+        best = p;
+      }
+    }
+    return java.util.Optional.ofNullable(best);
+  }
+
+  private static List<Player> replacePlayers(
+      List<Player> all, List<Player> oldOnes, List<Player> newOnes) {
+    if (oldOnes.equals(newOnes)) {
+      return all;
+    }
+    var result = new ArrayList<Player>(all.size());
+    var swapIndex = 0;
+    for (var p : all) {
+      var idx = indexOfId(oldOnes, p.id());
+      if (idx >= 0) {
+        result.add(newOnes.get(idx));
+        swapIndex++;
+      } else {
+        result.add(p);
+      }
+    }
+    if (swapIndex != oldOnes.size()) {
+      throw new IllegalStateException("rotation swap mismatch");
+    }
+    return List.copyOf(result);
+  }
+
+  private static int indexOfId(List<Player> players, PlayerId id) {
+    for (var i = 0; i < players.size(); i++) {
+      if (players.get(i).id().equals(id)) {
+        return i;
+      }
+    }
+    return -1;
+  }
+}

--- a/src/gamesimulator/java/app/zoneblitz/gamesimulator/SimulateGame.java
+++ b/src/gamesimulator/java/app/zoneblitz/gamesimulator/SimulateGame.java
@@ -15,4 +15,14 @@ public interface SimulateGame {
    * lazily. Events carry monotonically increasing {@code sequence} values starting at 0.
    */
   Stream<PlayEvent> simulate(GameInputs inputs);
+
+  /**
+   * Simulate the supplied game and return both the event stream (collected) and post-game
+   * accumulated stats (snap counts, etc.) derived from the terminal {@link GameState}. The default
+   * implementation collects {@link #simulate} and returns an empty stats bundle; engines that track
+   * snap participation override to surface the real numbers.
+   */
+  default GameSummary summarize(GameInputs inputs) {
+    return new GameSummary(simulate(inputs).toList(), java.util.Map.of());
+  }
 }

--- a/src/main/java/app/zoneblitz/gamesimulator/GameSimEmulator.java
+++ b/src/main/java/app/zoneblitz/gamesimulator/GameSimEmulator.java
@@ -100,9 +100,20 @@ public final class GameSimEmulator {
     var narrator = PlayNarrator.defaultNarrator();
 
     System.out.println("Zone Blitz emulator — seed=" + seed);
-    simulator
-        .simulate(inputs)
-        .forEach(event -> System.out.println(narrator.narrate(event, context)));
+    var summary = simulator.summarize(inputs);
+    summary.events().forEach(event -> System.out.println(narrator.narrate(event, context)));
+    if (!summary.snapCounts().isEmpty()) {
+      System.out.println();
+      System.out.println("Snap counts:");
+      summary.snapCounts().entrySet().stream()
+          .sorted(java.util.Map.Entry.<PlayerId, Integer>comparingByValue().reversed())
+          .forEach(
+              entry ->
+                  System.out.printf(
+                      "  %-24s %3d%n",
+                      playerNames.getOrDefault(entry.getKey(), entry.getKey().toString()),
+                      entry.getValue()));
+    }
   }
 
   private static Team buildTeam(String label, int idSeed, NameGenerator names, RandomSource rng) {

--- a/src/test/java/app/zoneblitz/gamesimulator/GameStateTests.java
+++ b/src/test/java/app/zoneblitz/gamesimulator/GameStateTests.java
@@ -96,6 +96,49 @@ class GameStateTests {
   }
 
   @Test
+  void withSnapsAccumulated_incrementsEveryParticipant() {
+    var p1 = new PlayerId(new UUID(7L, 1L));
+    var p2 = new PlayerId(new UUID(7L, 2L));
+    var state =
+        GameState.initial().withSnapsAccumulated(List.of(p1, p2)).withSnapsAccumulated(List.of(p1));
+
+    assertThat(state.fatigueSnapCounts()).containsEntry(p1, 2).containsEntry(p2, 1);
+  }
+
+  @Test
+  void withFatigueRecovered_full_zeroesAllCounts() {
+    var p1 = new PlayerId(new UUID(7L, 1L));
+    var state =
+        GameState.initial().withSnapsAccumulated(List.of(p1, p1, p1)).withFatigueRecovered(1.0);
+
+    assertThat(state.fatigueSnapCounts()).isEmpty();
+  }
+
+  @Test
+  void withFatigueRecovered_partial_scalesCountsDown() {
+    var p1 = new PlayerId(new UUID(7L, 1L));
+    var seeded = GameState.initial();
+    for (var i = 0; i < 10; i++) {
+      seeded = seeded.withSnapsAccumulated(List.of(p1));
+    }
+    var recovered = seeded.withFatigueRecovered(0.5);
+
+    assertThat(recovered.fatigueSnapCounts()).containsEntry(p1, 5);
+  }
+
+  @Test
+  void withPossessionAndSpot_appliesPartialFatigueRecovery() {
+    var p1 = new PlayerId(new UUID(7L, 1L));
+    var seeded = GameState.initial();
+    for (var i = 0; i < 100; i++) {
+      seeded = seeded.withSnapsAccumulated(List.of(p1));
+    }
+    var afterPossessionFlip = seeded.withPossessionAndSpot(Side.AWAY, new FieldPosition(25));
+
+    assertThat(afterPossessionFlip.fatigueSnapCounts().get(p1)).isLessThan(100);
+  }
+
+  @Test
   void initial_hasZeroedState() {
     var state = GameState.initial();
     assertThat(state.score()).isEqualTo(new Score(0, 0));

--- a/src/test/java/app/zoneblitz/gamesimulator/PositionalFatigueModelTests.java
+++ b/src/test/java/app/zoneblitz/gamesimulator/PositionalFatigueModelTests.java
@@ -1,0 +1,187 @@
+package app.zoneblitz.gamesimulator;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import app.zoneblitz.gamesimulator.event.PlayerId;
+import app.zoneblitz.gamesimulator.event.TeamId;
+import app.zoneblitz.gamesimulator.personnel.DefensivePackage;
+import app.zoneblitz.gamesimulator.personnel.DefensivePersonnel;
+import app.zoneblitz.gamesimulator.personnel.OffensivePackage;
+import app.zoneblitz.gamesimulator.personnel.OffensivePersonnel;
+import app.zoneblitz.gamesimulator.roster.DefensiveCoachTendencies;
+import app.zoneblitz.gamesimulator.roster.Physical;
+import app.zoneblitz.gamesimulator.roster.Player;
+import app.zoneblitz.gamesimulator.roster.Position;
+import app.zoneblitz.gamesimulator.roster.Skill;
+import app.zoneblitz.gamesimulator.roster.Team;
+import app.zoneblitz.gamesimulator.roster.Tendencies;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+
+class PositionalFatigueModelTests {
+
+  private final FatigueModel model = new PositionalFatigueModel();
+
+  @Test
+  void performanceMultiplier_freshPlayer_returnsOne() {
+    var rb = player(Position.RB, "rb-1", 50);
+    assertThat(model.performanceMultiplier(rb, 0)).isEqualTo(1.0);
+    assertThat(model.performanceMultiplier(rb, 10)).isEqualTo(1.0);
+  }
+
+  @Test
+  void performanceMultiplier_pastThreshold_decaysBelowOne() {
+    var rb = player(Position.RB, "rb-1", 50);
+    var fresh = model.performanceMultiplier(rb, 35);
+    var tired = model.performanceMultiplier(rb, 50);
+    assertThat(fresh).isEqualTo(1.0);
+    assertThat(tired).isLessThan(1.0);
+  }
+
+  @Test
+  void performanceMultiplier_highMotor_degradesLaterThanLowMotor() {
+    var lowMotor = player(Position.RB, "rb-low", 0);
+    var highMotor = player(Position.RB, "rb-high", 100);
+
+    var lowAt40 = model.performanceMultiplier(lowMotor, 40);
+    var highAt40 = model.performanceMultiplier(highMotor, 40);
+
+    assertThat(highAt40).isGreaterThan(lowAt40);
+    assertThat(highAt40).isEqualTo(1.0);
+    assertThat(lowAt40).isLessThan(1.0);
+  }
+
+  @Test
+  void performanceMultiplier_floors_atSeventyPercent() {
+    var rb = player(Position.RB, "rb-1", 50);
+    var multiplier = model.performanceMultiplier(rb, 1000);
+    assertThat(multiplier).isGreaterThanOrEqualTo(0.70);
+  }
+
+  @Test
+  void rotateOffense_freshRb_keepsStarter() {
+    var rb1 = player(Position.RB, "rb-1", 50);
+    var rb2 = player(Position.RB, "rb-2", 50);
+    var team = teamWith(rb1, rb2);
+    var personnel = offenseWith(rb1);
+
+    var rotated = model.rotateOffense(personnel, team, Map.of());
+
+    assertThat(rotated.runningBacks()).extracting(Player::id).containsExactly(rb1.id());
+  }
+
+  @Test
+  void rotateOffense_tiredRb_swapsInFresherBackup() {
+    var rb1 = player(Position.RB, "rb-1", 50);
+    var rb2 = player(Position.RB, "rb-2", 50);
+    var team = teamWith(rb1, rb2);
+    var personnel = offenseWith(rb1);
+
+    var rotated = model.rotateOffense(personnel, team, Map.of(rb1.id(), 50));
+
+    assertThat(rotated.runningBacks()).extracting(Player::id).containsExactly(rb2.id());
+  }
+
+  @Test
+  void rotateOffense_tiredRbButNoFresherBackup_keepsStarter() {
+    var rb1 = player(Position.RB, "rb-1", 50);
+    var rb2 = player(Position.RB, "rb-2", 50);
+    var team = teamWith(rb1, rb2);
+    var personnel = offenseWith(rb1);
+
+    var rotated = model.rotateOffense(personnel, team, Map.of(rb1.id(), 50, rb2.id(), 60));
+
+    assertThat(rotated.runningBacks()).extracting(Player::id).containsExactly(rb1.id());
+  }
+
+  @Test
+  void rotateDefense_tiredDl_swapsInFresherBackup() {
+    var dl1 = player(Position.DL, "dl-1", 50);
+    var dl2 = player(Position.DL, "dl-2", 50);
+    var dl3 = player(Position.DL, "dl-3", 50);
+    var dl4 = player(Position.DL, "dl-4", 50);
+    var dl5 = player(Position.DL, "dl-5", 50);
+    var defense = defenseWith(List.of(dl1, dl2, dl3, dl4));
+    var team = teamWithDefense(dl1, dl2, dl3, dl4, dl5);
+
+    var rotated =
+        model.rotateDefense(
+            defense, team, Map.of(dl1.id(), 60), DefensiveCoachTendencies.average());
+
+    assertThat(rotated.defensiveLine()).extracting(Player::id).contains(dl5.id());
+    assertThat(rotated.defensiveLine()).extracting(Player::id).doesNotContain(dl1.id());
+  }
+
+  private static Player player(Position position, String name, int motor) {
+    return new Player(
+        new PlayerId(UUID.nameUUIDFromBytes((position + "-" + name).getBytes())),
+        position,
+        name,
+        Physical.average(),
+        Skill.average(),
+        new Tendencies(50, 50, 50, 50, 50, 50, 50, motor));
+  }
+
+  private static OffensivePersonnel offenseWith(Player rb) {
+    var qb = player(Position.QB, "qb", 50);
+    var te = player(Position.TE, "te", 50);
+    var wr1 = player(Position.WR, "wr-1", 50);
+    var wr2 = player(Position.WR, "wr-2", 50);
+    var wr3 = player(Position.WR, "wr-3", 50);
+    var ol1 = player(Position.OL, "ol-1", 50);
+    var ol2 = player(Position.OL, "ol-2", 50);
+    var ol3 = player(Position.OL, "ol-3", 50);
+    var ol4 = player(Position.OL, "ol-4", 50);
+    var ol5 = player(Position.OL, "ol-5", 50);
+    return new OffensivePersonnel(
+        OffensivePackage.P_11, List.of(qb, rb, te, wr1, wr2, wr3, ol1, ol2, ol3, ol4, ol5));
+  }
+
+  private static DefensivePersonnel defenseWith(List<Player> dls) {
+    var lb1 = player(Position.LB, "lb-1", 50);
+    var lb2 = player(Position.LB, "lb-2", 50);
+    var lb3 = player(Position.LB, "lb-3", 50);
+    var cb1 = player(Position.CB, "cb-1", 50);
+    var cb2 = player(Position.CB, "cb-2", 50);
+    var s1 = player(Position.S, "s-1", 50);
+    var s2 = player(Position.S, "s-2", 50);
+    var roster = new ArrayList<Player>(11);
+    roster.addAll(dls);
+    roster.addAll(List.of(lb1, lb2, lb3, cb1, cb2, s1, s2));
+    return new DefensivePersonnel(DefensivePackage.BASE_43, roster);
+  }
+
+  private static Team teamWith(Player... rbs) {
+    var qb = player(Position.QB, "qb", 50);
+    var te = player(Position.TE, "te", 50);
+    var wr1 = player(Position.WR, "wr-1", 50);
+    var wr2 = player(Position.WR, "wr-2", 50);
+    var wr3 = player(Position.WR, "wr-3", 50);
+    var ol1 = player(Position.OL, "ol-1", 50);
+    var ol2 = player(Position.OL, "ol-2", 50);
+    var ol3 = player(Position.OL, "ol-3", 50);
+    var ol4 = player(Position.OL, "ol-4", 50);
+    var ol5 = player(Position.OL, "ol-5", 50);
+    var roster = new ArrayList<Player>();
+    roster.addAll(List.of(rbs));
+    roster.addAll(List.of(qb, te, wr1, wr2, wr3, ol1, ol2, ol3, ol4, ol5));
+    return new Team(new TeamId(new UUID(0L, 1L)), "Test", roster);
+  }
+
+  private static Team teamWithDefense(Player... dls) {
+    var lb1 = player(Position.LB, "lb-1", 50);
+    var lb2 = player(Position.LB, "lb-2", 50);
+    var lb3 = player(Position.LB, "lb-3", 50);
+    var cb1 = player(Position.CB, "cb-1", 50);
+    var cb2 = player(Position.CB, "cb-2", 50);
+    var s1 = player(Position.S, "s-1", 50);
+    var s2 = player(Position.S, "s-2", 50);
+    var roster = new ArrayList<Player>();
+    roster.addAll(List.of(dls));
+    roster.addAll(List.of(lb1, lb2, lb3, cb1, cb2, s1, s2));
+    return new Team(new TeamId(new UUID(0L, 2L)), "TestDef", roster);
+  }
+}


### PR DESCRIPTION
Closes #586

## Summary
- Per-snap fatigue accumulation in `GameState`, with partial recovery on possession change and full reset at halftime.
- New `FatigueModel` interface + `PositionalFatigueModel` impl exposing a motor-moderated performance multiplier and a rotation hook that swaps fatigued RB/DL/LB starters for the freshest available backup.
- `GameSimulator` wires the model through pre-snap personnel selection and accumulates snap counts post-snap; `DefensiveCoachTendencies.substitutionAggression` nudges the DL/LB rotation threshold.
- New `GameSummary` record + `SimulateGame.summarize` surfaces final snap counts as post-game output without disturbing the existing `Stream<PlayEvent>` contract; the emulator now prints the snap-count table.

## Test plan
- [x] `PositionalFatigueModelTests` cover the degradation curve, motor moderation, fatigue floor, and RB/DL rotation seams.
- [x] `GameStateTests` cover snap accumulation, partial/full fatigue recovery, and possession-change recovery.
- [x] Full `./gradlew test` green; `./gradlew spotlessCheck` clean.