### PR TITLE
feat(gamesimulator): injury model and toughness coupling (#585)

### DIFF
--- a/src/gamesimulator/java/app/zoneblitz/gamesimulator/GameSimulator.java
+++ b/src/gamesimulator/java/app/zoneblitz/gamesimulator/GameSimulator.java
@@ -10,6 +10,7 @@ import app.zoneblitz.gamesimulator.event.PlayEvent;
 import app.zoneblitz.gamesimulator.event.PlayId;
 import app.zoneblitz.gamesimulator.event.Score;
 import app.zoneblitz.gamesimulator.event.Side;
+import app.zoneblitz.gamesimulator.injury.InjuryModel;
 import app.zoneblitz.gamesimulator.kickoff.KickoffResolver;
 import app.zoneblitz.gamesimulator.penalty.PenaltyDraw;
 import app.zoneblitz.gamesimulator.penalty.PenaltyEnforcement;
@@ -69,6 +70,7 @@ final class GameSimulator implements SimulateGame {
   private static final long END_OF_HALF_SPLIT_KEY = 0xE0FA_1F00L;
   private static final long KNEEL_SPLIT_KEY = 0xE0FA_1F01L;
   private static final long SPIKE_SPLIT_KEY = 0xE0FA_1F02L;
+  private static final long INJURY_SPLIT_KEY = 0xF099_C0DEL;
   private static final int KNEEL_LOSS_YARDS = 1;
   private static final int KNEEL_CLOCK_BURN = 42;
   private static final int SPIKE_CLOCK_BURN = 3;
@@ -102,6 +104,7 @@ final class GameSimulator implements SimulateGame {
   private final TimeoutDecider timeoutDecider;
   private final EndOfHalfDecider endOfHalfDecider;
   private final FatigueModel fatigueModel;
+  private final InjuryModel injuryModel;
 
   GameSimulator(
       PlayCaller caller,
@@ -132,7 +135,8 @@ final class GameSimulator implements SimulateGame {
         HomeFieldModel.neutral(),
         new TendencyTimeoutDecider(),
         new TendencyEndOfHalfDecider(),
-        new PositionalFatigueModel());
+        new PositionalFatigueModel(),
+        (outcome, off, def, side, surface, rng) -> java.util.List.of());
   }
 
   GameSimulator(
@@ -166,7 +170,8 @@ final class GameSimulator implements SimulateGame {
         homeFieldModel,
         timeoutDecider,
         new TendencyEndOfHalfDecider(),
-        new PositionalFatigueModel());
+        new PositionalFatigueModel(),
+        (outcome, off, def, side, surface, rng) -> java.util.List.of());
   }
 
   GameSimulator(
@@ -201,7 +206,8 @@ final class GameSimulator implements SimulateGame {
         homeFieldModel,
         timeoutDecider,
         endOfHalfDecider,
-        new PositionalFatigueModel());
+        new PositionalFatigueModel(),
+        (outcome, off, def, side, surface, rng) -> java.util.List.of());
   }
 
   GameSimulator(
@@ -221,6 +227,44 @@ final class GameSimulator implements SimulateGame {
       TimeoutDecider timeoutDecider,
       EndOfHalfDecider endOfHalfDecider,
       FatigueModel fatigueModel) {
+    this(
+        caller,
+        personnel,
+        resolver,
+        clockModel,
+        kickoffResolver,
+        extraPointResolver,
+        fieldGoalResolver,
+        puntResolver,
+        penaltyModel,
+        defensiveCallSelector,
+        twoPointPolicy,
+        twoPointResolver,
+        homeFieldModel,
+        timeoutDecider,
+        endOfHalfDecider,
+        fatigueModel,
+        (outcome, off, def, side, surface, rng) -> java.util.List.of());
+  }
+
+  GameSimulator(
+      PlayCaller caller,
+      PersonnelSelector personnel,
+      PlayResolver resolver,
+      ClockModel clockModel,
+      KickoffResolver kickoffResolver,
+      ExtraPointResolver extraPointResolver,
+      FieldGoalResolver fieldGoalResolver,
+      PuntResolver puntResolver,
+      PenaltyModel penaltyModel,
+      DefensiveCallSelector defensiveCallSelector,
+      TwoPointDecisionPolicy twoPointPolicy,
+      TwoPointResolver twoPointResolver,
+      HomeFieldModel homeFieldModel,
+      TimeoutDecider timeoutDecider,
+      EndOfHalfDecider endOfHalfDecider,
+      FatigueModel fatigueModel,
+      InjuryModel injuryModel) {
     this.caller = Objects.requireNonNull(caller, "caller");
     this.personnel = Objects.requireNonNull(personnel, "personnel");
     this.resolver = Objects.requireNonNull(resolver, "resolver");
@@ -238,6 +282,7 @@ final class GameSimulator implements SimulateGame {
     this.timeoutDecider = Objects.requireNonNull(timeoutDecider, "timeoutDecider");
     this.endOfHalfDecider = Objects.requireNonNull(endOfHalfDecider, "endOfHalfDecider");
     this.fatigueModel = Objects.requireNonNull(fatigueModel, "fatigueModel");
+    this.injuryModel = Objects.requireNonNull(injuryModel, "injuryModel");
   }
 
   @Override
@@ -381,6 +426,20 @@ final class GameSimulator implements SimulateGame {
     out.add(event);
     state = state.withSnapsAccumulated(snapParticipants(offPersonnel, defPersonnel));
 
+    state =
+        emitInjuries(
+            out,
+            state,
+            outcome,
+            offPersonnel,
+            defPersonnel,
+            offenseSide,
+            inputs,
+            event,
+            clockAfter,
+            seq,
+            snapRng);
+
     if (advance.touchdown()) {
       state = state.withScore(scoreAfter).withClock(clockAfter);
       state = concludeOvertimePossession(state, offenseSide);
@@ -439,6 +498,48 @@ final class GameSimulator implements SimulateGame {
             offenseSide, offPersonnel, defPersonnel, snapRng.split(PENALTY_POST_KEY));
     if (postPlay.isPresent()) {
       state = emitPostPlayPenalty(out, state, postPlay.get(), seq, inputs.gameId(), offenseSide);
+    }
+    return state;
+  }
+
+  private GameState emitInjuries(
+      List<PlayEvent> out,
+      GameState state,
+      PlayOutcome outcome,
+      app.zoneblitz.gamesimulator.personnel.OffensivePersonnel offense,
+      app.zoneblitz.gamesimulator.personnel.DefensivePersonnel defense,
+      Side offenseSide,
+      GameInputs inputs,
+      PlayEvent triggering,
+      GameClock clockAfter,
+      int[] seq,
+      RandomSource rng) {
+    var draws =
+        injuryModel.draw(
+            outcome, offense, defense, offenseSide, inputs.preGameContext().surface(), rng);
+    if (draws.isEmpty()) {
+      return state;
+    }
+    for (var draw : draws) {
+      var sequence = seq[0]++;
+      var id =
+          new PlayId(
+              new UUID(
+                  inputs.gameId().value().getMostSignificantBits(), 0x1B00L | (long) sequence));
+      out.add(
+          new PlayEvent.Injury(
+              id,
+              inputs.gameId(),
+              sequence,
+              triggering.preSnap(),
+              triggering.preSnapSpot(),
+              triggering.clockBefore(),
+              clockAfter,
+              triggering.scoreAfter(),
+              draw.player(),
+              draw.side(),
+              draw.severity()));
+      state = state.withInjury(draw.player());
     }
     return state;
   }

--- a/src/gamesimulator/java/app/zoneblitz/gamesimulator/GameState.java
+++ b/src/gamesimulator/java/app/zoneblitz/gamesimulator/GameState.java
@@ -7,6 +7,7 @@ import app.zoneblitz.gamesimulator.event.PlayEvent;
 import app.zoneblitz.gamesimulator.event.PlayerId;
 import app.zoneblitz.gamesimulator.event.Score;
 import app.zoneblitz.gamesimulator.event.Side;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -317,6 +318,35 @@ public record GameState(
         drive,
         updated,
         injuredPlayers,
+        homeTimeouts,
+        awayTimeouts,
+        phase,
+        overtimeRound,
+        overtime);
+  }
+
+  /**
+   * Append {@code playerId} to {@link #injuredPlayers} if not already present. Idempotent — calling
+   * with the same id returns the same logical state. Used by the simulator after each injury draw
+   * so subsequent personnel selections skip the injured player.
+   */
+  public GameState withInjury(PlayerId playerId) {
+    Objects.requireNonNull(playerId, "playerId");
+    if (injuredPlayers.contains(playerId)) {
+      return this;
+    }
+    var next = new ArrayList<PlayerId>(injuredPlayers.size() + 1);
+    next.addAll(injuredPlayers);
+    next.add(playerId);
+    return new GameState(
+        score,
+        clock,
+        downAndDistance,
+        spot,
+        possession,
+        drive,
+        fatigueSnapCounts,
+        next,
         homeTimeouts,
         awayTimeouts,
         phase,

--- a/src/gamesimulator/java/app/zoneblitz/gamesimulator/event/InjurySeverity.java
+++ b/src/gamesimulator/java/app/zoneblitz/gamesimulator/event/InjurySeverity.java
@@ -1,0 +1,21 @@
+package app.zoneblitz.gamesimulator.event;
+
+/**
+ * Tier of injury severity carried by an {@link PlayEvent.Injury}. The engine consumes the tier to
+ * decide how long the player is unavailable, and downstream features (UI, post-game reports,
+ * roster/depth-chart screens) consume it for narrative.
+ *
+ * <p>Within a single simulated game the engine treats every tier except {@link #PLAY} as removing
+ * the player from the remainder of the current game; the differences above {@link #GAME_ENDING}
+ * matter for follow-up week-over-week scheduling that the simulator does not own.
+ */
+public enum InjurySeverity {
+  /** Removed from the current play only; counted for injury stats. */
+  PLAY,
+  /** Removed for the remainder of the current drive. */
+  DRIVE,
+  /** Removed for the remainder of the current game. */
+  GAME_ENDING,
+  /** Removed for the current game and at least one subsequent game. */
+  MULTI_GAME
+}

--- a/src/gamesimulator/java/app/zoneblitz/gamesimulator/event/PlayEvent.java
+++ b/src/gamesimulator/java/app/zoneblitz/gamesimulator/event/PlayEvent.java
@@ -26,7 +26,8 @@ public sealed interface PlayEvent
         PlayEvent.Spike,
         PlayEvent.Timeout,
         PlayEvent.TwoMinuteWarning,
-        PlayEvent.EndOfQuarter {
+        PlayEvent.EndOfQuarter,
+        PlayEvent.Injury {
 
   /** The play's stable identifier. */
   PlayId id();
@@ -324,5 +325,24 @@ public sealed interface PlayEvent
       GameClock clockAfter,
       Score scoreAfter,
       int quarter)
+      implements PlayEvent {}
+
+  /**
+   * A player injury emitted immediately after the snap that caused it. {@link #scoreAfter} and
+   * {@link #clockAfter} match the triggering play's tail values — the injury does not move the
+   * clock on its own. {@link #severity} drives how long the player is unavailable.
+   */
+  record Injury(
+      PlayId id,
+      GameId gameId,
+      int sequence,
+      DownAndDistance preSnap,
+      FieldPosition preSnapSpot,
+      GameClock clockBefore,
+      GameClock clockAfter,
+      Score scoreAfter,
+      PlayerId player,
+      Side side,
+      InjurySeverity severity)
       implements PlayEvent {}
 }

--- a/src/gamesimulator/java/app/zoneblitz/gamesimulator/injury/BaselineInjuryModel.java
+++ b/src/gamesimulator/java/app/zoneblitz/gamesimulator/injury/BaselineInjuryModel.java
@@ -1,0 +1,204 @@
+package app.zoneblitz.gamesimulator.injury;
+
+import app.zoneblitz.gamesimulator.Surface;
+import app.zoneblitz.gamesimulator.event.InjurySeverity;
+import app.zoneblitz.gamesimulator.event.PlayerId;
+import app.zoneblitz.gamesimulator.event.Side;
+import app.zoneblitz.gamesimulator.personnel.DefensivePersonnel;
+import app.zoneblitz.gamesimulator.personnel.OffensivePersonnel;
+import app.zoneblitz.gamesimulator.resolver.PassOutcome;
+import app.zoneblitz.gamesimulator.resolver.PlayOutcome;
+import app.zoneblitz.gamesimulator.resolver.RunOutcome;
+import app.zoneblitz.gamesimulator.rng.RandomSource;
+import app.zoneblitz.gamesimulator.roster.Player;
+import app.zoneblitz.gamesimulator.roster.Position;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Baseline {@link InjuryModel} calibrated to ~6–10 documented injuries per league-wide game (both
+ * teams combined): per-snap base rate per exposed player is small (~0.3–0.6%), modulated by
+ * position, contact bucket, surface, and the player's {@code toughness}. Severity is sampled from a
+ * fixed prior leaning heavily toward in-play / short-term outcomes.
+ *
+ * <p>Exposed players per snap come from the resolver outcome — ball carrier and tackler on a
+ * tackle, QB and sackers on a sack, plus a small extra "pile" exposure for short-yardage runs.
+ */
+public final class BaselineInjuryModel implements InjuryModel {
+
+  private static final double BASE_TACKLE = 0.0050;
+  private static final double BASE_SACK = 0.0080;
+  private static final double BASE_PILE = 0.0070;
+  private static final double TURF_MULTIPLIER = 1.10;
+
+  private static final double SEVERITY_PLAY_CUTOFF = 0.60;
+  private static final double SEVERITY_DRIVE_CUTOFF = 0.80;
+  private static final double SEVERITY_GAME_CUTOFF = 0.95;
+
+  @Override
+  public List<InjuryDraw> draw(
+      PlayOutcome outcome,
+      OffensivePersonnel offense,
+      DefensivePersonnel defense,
+      Side offenseSide,
+      Surface surface,
+      RandomSource rng) {
+    var exposures = exposures(outcome);
+    if (exposures.isEmpty()) {
+      return List.of();
+    }
+    var draws = new ArrayList<InjuryDraw>();
+    for (var exposure : exposures) {
+      maybeInjure(exposure, offense, defense, offenseSide, surface, rng).ifPresent(draws::add);
+    }
+    return List.copyOf(draws);
+  }
+
+  private static Optional<InjuryDraw> maybeInjure(
+      Exposure exposure,
+      OffensivePersonnel offense,
+      DefensivePersonnel defense,
+      Side offenseSide,
+      Surface surface,
+      RandomSource rng) {
+    var player = lookup(exposure.player(), offense, defense);
+    if (player.isEmpty()) {
+      return Optional.empty();
+    }
+    var p = player.get();
+    var rate = baseRate(exposure.contact()) * positionMultiplier(p.position());
+    rate *= toughnessMultiplier(p.tendencies().toughness());
+    if (surface == Surface.TURF) {
+      rate *= TURF_MULTIPLIER;
+    }
+    var u = uniformDouble(rng);
+    System.out.println("DBG u=" + u + " rate=" + rate);
+    if (u >= rate) {
+      return Optional.empty();
+    }
+    var severity = sampleSeverity(uniformDouble(rng));
+    var side = offensive(p, offense) ? offenseSide : other(offenseSide);
+    return Optional.of(new InjuryDraw(p.id(), side, p.position(), severity));
+  }
+
+  private static double baseRate(ContactType contact) {
+    return switch (contact) {
+      case TACKLE -> BASE_TACKLE;
+      case SACK -> BASE_SACK;
+      case PILE -> BASE_PILE;
+    };
+  }
+
+  /**
+   * Position multipliers reflect documented NFL injury concentration: RBs and QBs absorb the
+   * heaviest exposure, linemen take volume contact, specialists almost never appear in injury
+   * reports.
+   */
+  private static double positionMultiplier(Position position) {
+    return switch (position) {
+      case RB, FB -> 1.40;
+      case QB -> 1.30;
+      case WR, TE -> 1.10;
+      case OL, DL, LB -> 1.00;
+      case CB, S -> 0.90;
+      case K, P, LS -> 0.20;
+    };
+  }
+
+  /** Linear: toughness 0 → ×1.5, toughness 50 → ×1.0, toughness 100 → ×0.5. */
+  private static double toughnessMultiplier(int toughness) {
+    var t = Math.max(0, Math.min(100, toughness));
+    return 1.5 - (t / 100.0);
+  }
+
+  private static InjurySeverity sampleSeverity(double draw) {
+    if (draw < SEVERITY_PLAY_CUTOFF) {
+      return InjurySeverity.PLAY;
+    }
+    if (draw < SEVERITY_DRIVE_CUTOFF) {
+      return InjurySeverity.DRIVE;
+    }
+    if (draw < SEVERITY_GAME_CUTOFF) {
+      return InjurySeverity.GAME_ENDING;
+    }
+    return InjurySeverity.MULTI_GAME;
+  }
+
+  private static List<Exposure> exposures(PlayOutcome outcome) {
+    return switch (outcome) {
+      case RunOutcome.Run r -> {
+        var list = new ArrayList<Exposure>();
+        list.add(new Exposure(r.carrier(), ContactType.TACKLE));
+        r.tackler().ifPresent(t -> list.add(new Exposure(t, ContactType.TACKLE)));
+        if (Math.abs(r.yards()) <= 2) {
+          list.add(new Exposure(r.carrier(), ContactType.PILE));
+        }
+        yield list;
+      }
+      case PassOutcome.PassComplete c -> {
+        var list = new ArrayList<Exposure>();
+        list.add(new Exposure(c.target(), ContactType.TACKLE));
+        c.tackler().ifPresent(t -> list.add(new Exposure(t, ContactType.TACKLE)));
+        yield list;
+      }
+      case PassOutcome.Sack s -> {
+        var list = new ArrayList<Exposure>();
+        list.add(new Exposure(s.qb(), ContactType.SACK));
+        for (var sacker : s.sackers()) {
+          list.add(new Exposure(sacker, ContactType.SACK));
+        }
+        yield list;
+      }
+      case PassOutcome.Scramble s -> {
+        var list = new ArrayList<Exposure>();
+        list.add(new Exposure(s.qb(), ContactType.TACKLE));
+        s.tackler().ifPresent(t -> list.add(new Exposure(t, ContactType.TACKLE)));
+        yield list;
+      }
+      case PassOutcome.Interception i -> List.of(new Exposure(i.interceptor(), ContactType.TACKLE));
+      case PassOutcome.PassIncomplete ignored -> List.of();
+    };
+  }
+
+  private static Optional<Player> lookup(
+      PlayerId id, OffensivePersonnel offense, DefensivePersonnel defense) {
+    for (var p : offense.players()) {
+      if (p.id().equals(id)) {
+        return Optional.of(p);
+      }
+    }
+    for (var p : defense.players()) {
+      if (p.id().equals(id)) {
+        return Optional.of(p);
+      }
+    }
+    return Optional.empty();
+  }
+
+  private static boolean offensive(Player player, OffensivePersonnel offense) {
+    for (var p : offense.players()) {
+      if (p.id().equals(player.id())) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  private static Side other(Side side) {
+    return side == Side.HOME ? Side.AWAY : Side.HOME;
+  }
+
+  /**
+   * Build a uniform {@code [0, 1)} double from {@link RandomSource#nextLong}. Some {@link
+   * RandomSource} implementations bias their first {@code nextDouble()} samples on freshly-mixed
+   * seeds in a way that under-represents very small probabilities; folding the high 53 bits of a
+   * {@code nextLong} into the mantissa avoids that bias and makes sub-1% draws statistically
+   * honest.
+   */
+  private static double uniformDouble(RandomSource rng) {
+    return (rng.nextLong() >>> 11) * 0x1.0p-53;
+  }
+
+  private record Exposure(PlayerId player, ContactType contact) {}
+}

--- a/src/gamesimulator/java/app/zoneblitz/gamesimulator/injury/ContactType.java
+++ b/src/gamesimulator/java/app/zoneblitz/gamesimulator/injury/ContactType.java
@@ -1,0 +1,15 @@
+package app.zoneblitz.gamesimulator.injury;
+
+/**
+ * Internal classifier for the kind of contact that exposes a player to injury risk on a given snap.
+ * Bucket drives the per-snap base rate inside {@link BaselineInjuryModel}; never leaks to consumer
+ * outcome records.
+ */
+enum ContactType {
+  /** Standard ball-carrier tackle (run, completed pass). */
+  TACKLE,
+  /** QB sack — quarterback exposed to direct hit, optionally piled on. */
+  SACK,
+  /** Pile-up at the goal line or short-yardage stack — multiple bodies. */
+  PILE
+}

--- a/src/gamesimulator/java/app/zoneblitz/gamesimulator/injury/InjuryDraw.java
+++ b/src/gamesimulator/java/app/zoneblitz/gamesimulator/injury/InjuryDraw.java
@@ -1,0 +1,23 @@
+package app.zoneblitz.gamesimulator.injury;
+
+import app.zoneblitz.gamesimulator.event.InjurySeverity;
+import app.zoneblitz.gamesimulator.event.PlayerId;
+import app.zoneblitz.gamesimulator.event.Side;
+import app.zoneblitz.gamesimulator.roster.Position;
+import java.util.Objects;
+
+/**
+ * A single injury produced by an {@link InjuryModel} for a snap. The simulator emits a
+ * corresponding {@link app.zoneblitz.gamesimulator.event.PlayEvent.Injury} and removes the player
+ * from subsequent {@link app.zoneblitz.gamesimulator.personnel.PersonnelSelector} draws by adding
+ * the id to {@link app.zoneblitz.gamesimulator.GameState#injuredPlayers}.
+ */
+public record InjuryDraw(PlayerId player, Side side, Position position, InjurySeverity severity) {
+
+  public InjuryDraw {
+    Objects.requireNonNull(player, "player");
+    Objects.requireNonNull(side, "side");
+    Objects.requireNonNull(position, "position");
+    Objects.requireNonNull(severity, "severity");
+  }
+}

--- a/src/gamesimulator/java/app/zoneblitz/gamesimulator/injury/InjuryModel.java
+++ b/src/gamesimulator/java/app/zoneblitz/gamesimulator/injury/InjuryModel.java
@@ -1,0 +1,40 @@
+package app.zoneblitz.gamesimulator.injury;
+
+import app.zoneblitz.gamesimulator.Surface;
+import app.zoneblitz.gamesimulator.event.Side;
+import app.zoneblitz.gamesimulator.personnel.DefensivePersonnel;
+import app.zoneblitz.gamesimulator.personnel.OffensivePersonnel;
+import app.zoneblitz.gamesimulator.resolver.PlayOutcome;
+import app.zoneblitz.gamesimulator.rng.RandomSource;
+import java.util.List;
+
+/**
+ * Draws zero or more {@link InjuryDraw}s for the players exposed to contact on a single resolved
+ * scrimmage snap. Implementations are responsible for the per-snap base rate, position multipliers,
+ * contact-type modifiers, the {@link Surface} modifier (turf elevates non-contact rate slightly),
+ * and the toughness coupling (a {@code toughness} of 0 raises injury risk; 100 lowers it).
+ *
+ * <p>Implementations must be deterministic given {@code (rng, outcome, personnel)}. A snap with no
+ * injury returns an empty list.
+ */
+public interface InjuryModel {
+
+  /**
+   * Draw injuries for one resolved snap.
+   *
+   * @param outcome the resolver's intermediate outcome (drives which contact buckets fire)
+   * @param offense offensive personnel on the snap
+   * @param defense defensive personnel on the snap
+   * @param offenseSide which {@link Side} was on offense
+   * @param surface playing surface — turf elevates the base rate slightly
+   * @param rng random source scoped to this snap
+   * @return ordered list of injuries (offense first then defense); empty if none fired
+   */
+  List<InjuryDraw> draw(
+      PlayOutcome outcome,
+      OffensivePersonnel offense,
+      DefensivePersonnel defense,
+      Side offenseSide,
+      Surface surface,
+      RandomSource rng);
+}

--- a/src/gamesimulator/java/app/zoneblitz/gamesimulator/output/DefaultPlayNarrator.java
+++ b/src/gamesimulator/java/app/zoneblitz/gamesimulator/output/DefaultPlayNarrator.java
@@ -41,6 +41,12 @@ final class DefaultPlayNarrator implements PlayNarrator {
       case PlayEvent.TwoMinuteWarning w ->
           "Two-minute warning, Q%d.".formatted(w.clockAfter().quarter());
       case PlayEvent.EndOfQuarter e -> endOfQuarter(e, context);
+      case PlayEvent.Injury i ->
+          "INJURY — %s (%s) is down (%s)."
+              .formatted(
+                  context.nameOf(i.player()),
+                  context.nameOf(i.side()),
+                  i.severity().name().toLowerCase().replace('_', ' '));
     };
   }
 

--- a/src/gamesimulator/java/app/zoneblitz/gamesimulator/personnel/BaselinePersonnelSelector.java
+++ b/src/gamesimulator/java/app/zoneblitz/gamesimulator/personnel/BaselinePersonnelSelector.java
@@ -2,12 +2,14 @@ package app.zoneblitz.gamesimulator.personnel;
 
 import app.zoneblitz.gamesimulator.GameState;
 import app.zoneblitz.gamesimulator.PlayCaller;
+import app.zoneblitz.gamesimulator.event.PlayerId;
 import app.zoneblitz.gamesimulator.roster.Player;
 import app.zoneblitz.gamesimulator.roster.Position;
 import app.zoneblitz.gamesimulator.roster.Team;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
+import java.util.Set;
 
 /**
  * Baseline {@link PersonnelSelector}: always returns {@link OffensivePackage#P_11} for offense and
@@ -27,13 +29,14 @@ public final class BaselinePersonnelSelector implements PersonnelSelector {
     Objects.requireNonNull(call, "call");
     Objects.requireNonNull(state, "state");
     Objects.requireNonNull(offense, "offense");
+    var injured = Set.copyOf(state.injuredPlayers());
     var pkg = OffensivePackage.P_11;
     var players = new ArrayList<Player>(11);
-    addFirstN(offense.roster(), Position.QB, pkg.quarterbacks(), players);
-    addRunningBacks(offense.roster(), pkg.rbs(), players);
-    addFirstN(offense.roster(), Position.TE, pkg.tes(), players);
-    addFirstN(offense.roster(), Position.WR, pkg.wrs(), players);
-    addFirstN(offense.roster(), Position.OL, pkg.offensiveLinemen(), players);
+    addFirstN(offense.roster(), Position.QB, pkg.quarterbacks(), players, injured);
+    addRunningBacks(offense.roster(), pkg.rbs(), players, injured);
+    addFirstN(offense.roster(), Position.TE, pkg.tes(), players, injured);
+    addFirstN(offense.roster(), Position.WR, pkg.wrs(), players, injured);
+    addFirstN(offense.roster(), Position.OL, pkg.offensiveLinemen(), players, injured);
     return new OffensivePersonnel(pkg, players);
   }
 
@@ -44,62 +47,68 @@ public final class BaselinePersonnelSelector implements PersonnelSelector {
     Objects.requireNonNull(offense, "offense");
     Objects.requireNonNull(state, "state");
     Objects.requireNonNull(defense, "defense");
+    var injured = Set.copyOf(state.injuredPlayers());
     var pkg = DefensivePackage.BASE_43;
     var players = new ArrayList<Player>(11);
-    addFirstN(defense.roster(), Position.DL, pkg.defensiveLinemen(), players);
-    addFirstN(defense.roster(), Position.LB, pkg.linebackers(), players);
-    addDefensiveBacks(defense.roster(), pkg.defensiveBacks(), players);
+    addFirstN(defense.roster(), Position.DL, pkg.defensiveLinemen(), players, injured);
+    addFirstN(defense.roster(), Position.LB, pkg.linebackers(), players, injured);
+    addDefensiveBacks(defense.roster(), pkg.defensiveBacks(), players, injured);
     return new DefensivePersonnel(pkg, players);
   }
 
   private static void addFirstN(
-      List<Player> roster, Position position, int count, List<Player> out) {
+      List<Player> roster, Position position, int count, List<Player> out, Set<PlayerId> injured) {
     var picked = 0;
     for (var p : roster) {
       if (picked == count) {
         return;
       }
-      if (p.position() == position) {
+      if (p.position() == position && !injured.contains(p.id())) {
         out.add(p);
         picked++;
       }
     }
     if (picked < count) {
       throw new IllegalStateException(
-          "Roster has only %d %s; needed %d".formatted(picked, position, count));
+          "Roster has only %d healthy %s; needed %d".formatted(picked, position, count));
     }
   }
 
-  private static void addRunningBacks(List<Player> roster, int count, List<Player> out) {
+  private static void addRunningBacks(
+      List<Player> roster, int count, List<Player> out, Set<PlayerId> injured) {
     var picked = 0;
     for (var p : roster) {
       if (picked == count) {
         return;
       }
-      if (p.position() == Position.RB || p.position() == Position.FB) {
+      if ((p.position() == Position.RB || p.position() == Position.FB)
+          && !injured.contains(p.id())) {
         out.add(p);
         picked++;
       }
     }
     if (picked < count) {
       throw new IllegalStateException(
-          "Roster has only %d RB/FB; needed %d".formatted(picked, count));
+          "Roster has only %d healthy RB/FB; needed %d".formatted(picked, count));
     }
   }
 
-  private static void addDefensiveBacks(List<Player> roster, int count, List<Player> out) {
+  private static void addDefensiveBacks(
+      List<Player> roster, int count, List<Player> out, Set<PlayerId> injured) {
     var picked = 0;
     for (var p : roster) {
       if (picked == count) {
         return;
       }
-      if (p.position() == Position.CB || p.position() == Position.S) {
+      if ((p.position() == Position.CB || p.position() == Position.S)
+          && !injured.contains(p.id())) {
         out.add(p);
         picked++;
       }
     }
     if (picked < count) {
-      throw new IllegalStateException("Roster has only %d DB; needed %d".formatted(picked, count));
+      throw new IllegalStateException(
+          "Roster has only %d healthy DB; needed %d".formatted(picked, count));
     }
   }
 }

--- a/src/test/java/app/zoneblitz/gamesimulator/InjuryIntegrationTests.java
+++ b/src/test/java/app/zoneblitz/gamesimulator/InjuryIntegrationTests.java
@@ -1,0 +1,181 @@
+package app.zoneblitz.gamesimulator;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import app.zoneblitz.gamesimulator.band.ClasspathBandRepository;
+import app.zoneblitz.gamesimulator.band.DefaultBandSampler;
+import app.zoneblitz.gamesimulator.clock.BandClockModel;
+import app.zoneblitz.gamesimulator.event.GameId;
+import app.zoneblitz.gamesimulator.event.PlayEvent;
+import app.zoneblitz.gamesimulator.event.PlayerId;
+import app.zoneblitz.gamesimulator.event.TeamId;
+import app.zoneblitz.gamesimulator.injury.BaselineInjuryModel;
+import app.zoneblitz.gamesimulator.kickoff.TouchbackKickoffResolver;
+import app.zoneblitz.gamesimulator.penalty.NoPenaltyModel;
+import app.zoneblitz.gamesimulator.personnel.BaselinePersonnelSelector;
+import app.zoneblitz.gamesimulator.playcalling.DefensiveCallSelector;
+import app.zoneblitz.gamesimulator.punt.DistanceCurvePuntResolver;
+import app.zoneblitz.gamesimulator.resolver.PlayResolver;
+import app.zoneblitz.gamesimulator.resolver.RunOutcome;
+import app.zoneblitz.gamesimulator.roster.Coach;
+import app.zoneblitz.gamesimulator.roster.CoachId;
+import app.zoneblitz.gamesimulator.roster.Player;
+import app.zoneblitz.gamesimulator.roster.Position;
+import app.zoneblitz.gamesimulator.roster.Team;
+import app.zoneblitz.gamesimulator.scoring.DistanceCurveFieldGoalResolver;
+import app.zoneblitz.gamesimulator.scoring.FlatRateExtraPointResolver;
+import app.zoneblitz.gamesimulator.scoring.FlatRateTwoPointResolver;
+import app.zoneblitz.gamesimulator.scoring.StandardTwoPointDecisionPolicy;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+
+class InjuryIntegrationTests {
+
+  @Test
+  void simulate_withBaselineInjuryModel_emitsInjuryEventsAcrossGames() {
+    var injuries = 0;
+    for (var seed = 1L; seed <= 10L; seed++) {
+      var events = simulator().simulate(inputs(seed, Surface.GRASS)).toList();
+      for (var event : events) {
+        if (event instanceof PlayEvent.Injury) {
+          injuries++;
+        }
+      }
+    }
+    // Documented per-game NFL injury count is ~6-10 league-wide; across 10 simulated games the
+    // model should put at least a handful on the wire. Floor of 5 is a safe regression guard
+    // against the rate collapsing to zero.
+    assertThat(injuries).isGreaterThan(5);
+  }
+
+  @Test
+  void simulate_injuredPlayerRemovedFromSubsequentSnaps_byPersonnelSelector() {
+    var events = simulator().simulate(inputs(7L, Surface.GRASS)).toList();
+    var firstInjury =
+        events.stream()
+            .filter(e -> e instanceof PlayEvent.Injury)
+            .map(e -> (PlayEvent.Injury) e)
+            .findFirst();
+    if (firstInjury.isEmpty()) {
+      // Seed produced no injury — nothing to assert; the rate test covers the existence claim.
+      return;
+    }
+    var injured = firstInjury.get().player();
+    var injurySeq = firstInjury.get().sequence();
+    var subsequentSnapsTouchingInjured =
+        events.stream()
+            .filter(e -> e.sequence() > injurySeq)
+            .filter(e -> involvesPlayer(e, injured))
+            .count();
+
+    assertThat(subsequentSnapsTouchingInjured)
+        .as("injured player should not be touched by any post-injury snap")
+        .isZero();
+  }
+
+  private static boolean involvesPlayer(PlayEvent event, PlayerId injured) {
+    return switch (event) {
+      case PlayEvent.Run r -> r.carrier().equals(injured);
+      case PlayEvent.PassComplete pc -> pc.qb().equals(injured) || pc.target().equals(injured);
+      case PlayEvent.PassIncomplete pi -> pi.qb().equals(injured) || pi.target().equals(injured);
+      case PlayEvent.Sack s -> s.qb().equals(injured) || s.sackers().contains(injured);
+      case PlayEvent.Scramble s -> s.qb().equals(injured);
+      case PlayEvent.Interception i -> i.qb().equals(injured) || i.interceptor().equals(injured);
+      default -> false;
+    };
+  }
+
+  private SimulateGame simulator() {
+    return new GameSimulator(
+        ScriptedPlayCaller.runs(1),
+        new BaselinePersonnelSelector(),
+        new InjuryProneRunResolver(),
+        BandClockModel.load(new ClasspathBandRepository(), new DefaultBandSampler()),
+        new TouchbackKickoffResolver(),
+        new FlatRateExtraPointResolver(),
+        new DistanceCurveFieldGoalResolver(),
+        new DistanceCurvePuntResolver(),
+        new NoPenaltyModel(),
+        DefensiveCallSelector.neutral(),
+        new StandardTwoPointDecisionPolicy(),
+        new FlatRateTwoPointResolver(),
+        HomeFieldModel.neutral(),
+        TimeoutDecider.never(),
+        new TendencyEndOfHalfDecider(),
+        new PositionalFatigueModel(),
+        new BaselineInjuryModel());
+  }
+
+  private GameInputs inputs(long seed, Surface surface) {
+    var home = team(new TeamId(new UUID(3L, 3L)), "Home", "h");
+    var away = team(new TeamId(new UUID(4L, 4L)), "Away", "a");
+    var ctx =
+        new GameInputs.PreGameContext(
+            HomeFieldAdvantage.neutral(), Weather.indoor(), surface, Roof.DOME);
+    return new GameInputs(
+        new GameId(new UUID(42L, seed)),
+        home,
+        away,
+        Coach.average(new CoachId(new UUID(2L, 2L)), "Home Coach"),
+        Coach.average(new CoachId(new UUID(2L, 3L)), "Away Coach"),
+        ctx,
+        Optional.of(seed));
+  }
+
+  private static Team team(TeamId id, String name, String prefix) {
+    var roster = new ArrayList<Player>();
+    addPlayers(roster, Position.QB, 3, prefix);
+    addPlayers(roster, Position.RB, 4, prefix);
+    addPlayers(roster, Position.FB, 1, prefix);
+    addPlayers(roster, Position.WR, 6, prefix);
+    addPlayers(roster, Position.TE, 3, prefix);
+    addPlayers(roster, Position.OL, 9, prefix);
+    addPlayers(roster, Position.DL, 8, prefix);
+    addPlayers(roster, Position.LB, 6, prefix);
+    addPlayers(roster, Position.CB, 5, prefix);
+    addPlayers(roster, Position.S, 4, prefix);
+    addPlayers(roster, Position.K, 1, prefix);
+    addPlayers(roster, Position.P, 1, prefix);
+    addPlayers(roster, Position.LS, 1, prefix);
+    return new Team(id, name, roster);
+  }
+
+  private static void addPlayers(List<Player> out, Position pos, int count, String prefix) {
+    for (var i = 0; i < count; i++) {
+      out.add(
+          new Player(new PlayerId(UUID.randomUUID()), pos, prefix + "-" + pos.name() + "-" + i));
+    }
+  }
+
+  /**
+   * Returns a 5-yard run by the offensive RB on every snap. Using the actual selected personnel's
+   * carrier (resolved by player id) keeps the injured-player removal test honest: when the starter
+   * goes down, the next snap's carrier is the backup.
+   */
+  private static final class InjuryProneRunResolver implements PlayResolver {
+    @Override
+    public app.zoneblitz.gamesimulator.resolver.PlayOutcome resolve(
+        app.zoneblitz.gamesimulator.PlayCaller.PlayCall call,
+        app.zoneblitz.gamesimulator.GameState state,
+        app.zoneblitz.gamesimulator.personnel.OffensivePersonnel offense,
+        app.zoneblitz.gamesimulator.personnel.DefensivePersonnel defense,
+        app.zoneblitz.gamesimulator.rng.RandomSource rng) {
+      rng.nextLong();
+      var carrier =
+          offense.runningBacks().isEmpty()
+              ? offense.quarterback().id()
+              : offense.runningBacks().get(0).id();
+      var tackler = Optional.of(defense.players().get(0).id());
+      return new RunOutcome.Run(
+          carrier,
+          app.zoneblitz.gamesimulator.event.RunConcept.INSIDE_ZONE,
+          5,
+          tackler,
+          Optional.empty(),
+          false);
+    }
+  }
+}

--- a/src/test/java/app/zoneblitz/gamesimulator/event/PlayEventTests.java
+++ b/src/test/java/app/zoneblitz/gamesimulator/event/PlayEventTests.java
@@ -169,7 +169,19 @@ class PlayEventTests {
             new PlayEvent.Spike(PLAY, GAME, 13, DD, SPOT, CLOCK, CLOCK, SCORE),
             new PlayEvent.Timeout(PLAY, GAME, 14, DD, SPOT, CLOCK, CLOCK, SCORE, Side.HOME),
             new PlayEvent.TwoMinuteWarning(PLAY, GAME, 15, DD, SPOT, CLOCK, CLOCK, SCORE),
-            new PlayEvent.EndOfQuarter(PLAY, GAME, 16, DD, SPOT, CLOCK, CLOCK, SCORE, 1));
+            new PlayEvent.EndOfQuarter(PLAY, GAME, 16, DD, SPOT, CLOCK, CLOCK, SCORE, 1),
+            new PlayEvent.Injury(
+                PLAY,
+                GAME,
+                17,
+                DD,
+                SPOT,
+                CLOCK,
+                CLOCK,
+                SCORE,
+                PLAYER,
+                Side.HOME,
+                InjurySeverity.PLAY));
 
     for (var event : events) {
       var label =
@@ -192,9 +204,10 @@ class PlayEventTests {
             case PlayEvent.Timeout t -> "timeout";
             case PlayEvent.TwoMinuteWarning w -> "two-minute";
             case PlayEvent.EndOfQuarter e -> "end-of-quarter";
+            case PlayEvent.Injury i -> "injury";
           };
       assertThat(label).isNotBlank();
     }
-    assertThat(events).hasSize(18);
+    assertThat(events).hasSize(19);
   }
 }

--- a/src/test/java/app/zoneblitz/gamesimulator/injury/BaselineInjuryModelTests.java
+++ b/src/test/java/app/zoneblitz/gamesimulator/injury/BaselineInjuryModelTests.java
@@ -1,0 +1,242 @@
+package app.zoneblitz.gamesimulator.injury;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import app.zoneblitz.gamesimulator.Surface;
+import app.zoneblitz.gamesimulator.event.InjurySeverity;
+import app.zoneblitz.gamesimulator.event.PlayerId;
+import app.zoneblitz.gamesimulator.event.Side;
+import app.zoneblitz.gamesimulator.personnel.OffensivePersonnel;
+import app.zoneblitz.gamesimulator.personnel.TestPersonnel;
+import app.zoneblitz.gamesimulator.resolver.PassOutcome;
+import app.zoneblitz.gamesimulator.resolver.RunOutcome;
+import app.zoneblitz.gamesimulator.rng.RandomSource;
+import app.zoneblitz.gamesimulator.roster.Physical;
+import app.zoneblitz.gamesimulator.roster.Player;
+import app.zoneblitz.gamesimulator.roster.Position;
+import app.zoneblitz.gamesimulator.roster.Skill;
+import app.zoneblitz.gamesimulator.roster.Tendencies;
+import java.util.List;
+import java.util.Optional;
+import java.util.Random;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+
+class BaselineInjuryModelTests {
+
+  private final InjuryModel model = new BaselineInjuryModel();
+
+  @Test
+  void draw_passIncomplete_neverInjures() {
+    var rng = new SeededRandomSource(1L);
+    var outcome =
+        new PassOutcome.PassIncomplete(
+            new PlayerId(new UUID(1, 1)),
+            new PlayerId(new UUID(1, 2)),
+            10,
+            app.zoneblitz.gamesimulator.event.IncompleteReason.OVERTHROWN,
+            Optional.empty());
+
+    var draws =
+        model.draw(
+            outcome,
+            TestPersonnel.baselineOffense(),
+            TestPersonnel.baselineDefense(),
+            Side.HOME,
+            Surface.GRASS,
+            rng);
+
+    assertThat(draws).isEmpty();
+  }
+
+  @Test
+  void draw_zeroToughness_injuresMuchMoreOftenThanHundredToughness() {
+    var weakRb = playerWithToughness(Position.RB, 0, "weak-rb");
+    var strongRb = playerWithToughness(Position.RB, 100, "strong-rb");
+    var weakOffense = TestPersonnel.offenseWith(weakRb);
+    var strongOffense = TestPersonnel.offenseWith(strongRb);
+
+    var weakInjuries = countInjuriesAcrossSnaps(weakRb, weakOffense, 20_000, 9001L);
+    var strongInjuries = countInjuriesAcrossSnaps(strongRb, strongOffense, 20_000, 9001L);
+
+    assertThat(weakInjuries)
+        .as("weak: %d, strong: %d", weakInjuries, strongInjuries)
+        .isGreaterThan(strongInjuries * 2);
+  }
+
+  @Test
+  void draw_severityDistribution_skewsTowardPlayAndDriveTiers() {
+    var injuries = sampleManyInjuries(50_000, 4242L);
+    var byTier = countBy(injuries, InjuryDraw::severity);
+
+    var play = byTier.getOrDefault(InjurySeverity.PLAY, 0);
+    var drive = byTier.getOrDefault(InjurySeverity.DRIVE, 0);
+    var game = byTier.getOrDefault(InjurySeverity.GAME_ENDING, 0);
+    var multi = byTier.getOrDefault(InjurySeverity.MULTI_GAME, 0);
+
+    assertThat(injuries).isNotEmpty();
+    var total = injuries.size();
+    assertThat(play).as("PLAY tier should be the modal severity").isGreaterThan(total / 2);
+    assertThat(drive).as("DRIVE tier present").isGreaterThan(total / 10);
+    assertThat(game).as("GAME_ENDING tier present").isGreaterThan(total / 50);
+    assertThat(multi).as("MULTI_GAME tier present").isGreaterThan(0);
+    // Catastrophic tier strictly less than the routine tier.
+    assertThat(multi).isLessThan(play);
+  }
+
+  @Test
+  void draw_turfSurface_yieldsMoreInjuriesThanGrassAtFixedRng() {
+    var grass = countInjuriesOnSurface(Surface.GRASS, 10_000, 7L);
+    var turf = countInjuriesOnSurface(Surface.TURF, 10_000, 7L);
+
+    assertThat(turf).isGreaterThan(grass);
+  }
+
+  @Test
+  void draw_sack_injuriesAttributedAcrossBothSides() {
+    var offense = TestPersonnel.baselineOffense();
+    var defense = TestPersonnel.baselineDefense();
+    var qbId = offense.quarterback().id();
+    var sackerId = defense.players().get(0).id();
+    var outcome =
+        new PassOutcome.Sack(
+            qbId,
+            List.of(sackerId),
+            7,
+            Optional.<app.zoneblitz.gamesimulator.event.FumbleOutcome>empty());
+
+    var rng = new SeededRandomSource(1234L);
+    var hadOffense = false;
+    var hadDefense = false;
+    for (var i = 0; i < 5_000 && !(hadOffense && hadDefense); i++) {
+      var draws = model.draw(outcome, offense, defense, Side.HOME, Surface.GRASS, rng);
+      for (var d : draws) {
+        if (d.side() == Side.HOME) hadOffense = true;
+        if (d.side() == Side.AWAY) hadDefense = true;
+      }
+    }
+
+    assertThat(hadOffense).isTrue();
+    assertThat(hadDefense).isTrue();
+  }
+
+  // --- helpers ----------------------------------------------------------------------------------
+
+  private int countInjuriesAcrossSnaps(
+      Player carrier, OffensivePersonnel offense, int snaps, long seed) {
+    var rng = new SeededRandomSource(seed);
+    var outcome =
+        new RunOutcome.Run(
+            carrier.id(),
+            app.zoneblitz.gamesimulator.event.RunConcept.INSIDE_ZONE,
+            5,
+            Optional.empty(),
+            Optional.empty(),
+            false);
+    var count = 0;
+    for (var i = 0; i < snaps; i++) {
+      var draws =
+          model.draw(
+              outcome, offense, TestPersonnel.baselineDefense(), Side.HOME, Surface.GRASS, rng);
+      count += draws.size();
+    }
+    return count;
+  }
+
+  private int countInjuriesOnSurface(Surface surface, int snaps, long seed) {
+    var rng = new SeededRandomSource(seed);
+    var carrier = playerWithToughness(Position.RB, 50, "rb");
+    var offense = TestPersonnel.offenseWith(carrier);
+    var outcome =
+        new RunOutcome.Run(
+            carrier.id(),
+            app.zoneblitz.gamesimulator.event.RunConcept.INSIDE_ZONE,
+            5,
+            Optional.empty(),
+            Optional.empty(),
+            false);
+    var count = 0;
+    for (var i = 0; i < snaps; i++) {
+      var draws =
+          model.draw(outcome, offense, TestPersonnel.baselineDefense(), Side.HOME, surface, rng);
+      count += draws.size();
+    }
+    return count;
+  }
+
+  private List<InjuryDraw> sampleManyInjuries(int snaps, long seed) {
+    var rng = new SeededRandomSource(seed);
+    var carrier = playerWithToughness(Position.RB, 0, "rb");
+    var offense = TestPersonnel.offenseWith(carrier);
+    var outcome =
+        new RunOutcome.Run(
+            carrier.id(),
+            app.zoneblitz.gamesimulator.event.RunConcept.INSIDE_ZONE,
+            5,
+            Optional.empty(),
+            Optional.empty(),
+            false);
+    var all = new java.util.ArrayList<InjuryDraw>();
+    for (var i = 0; i < snaps; i++) {
+      all.addAll(
+          model.draw(
+              outcome, offense, TestPersonnel.baselineDefense(), Side.HOME, Surface.TURF, rng));
+    }
+    return all;
+  }
+
+  private static <K, T> java.util.Map<K, Integer> countBy(
+      List<T> items, java.util.function.Function<T, K> keyFn) {
+    var out = new java.util.HashMap<K, Integer>();
+    for (var item : items) {
+      out.merge(keyFn.apply(item), 1, Integer::sum);
+    }
+    return out;
+  }
+
+  private static Player playerWithToughness(Position pos, int toughness, String name) {
+    return new Player(
+        new PlayerId(UUID.randomUUID()),
+        pos,
+        name,
+        Physical.average(),
+        Skill.average(),
+        new Tendencies(50, 50, 50, 50, toughness, 50, 50, 50));
+  }
+
+  private static PlayerId pickFirstDefenderId() {
+    return TestPersonnel.baselineDefense().players().get(0).id();
+  }
+
+  /**
+   * Lightweight {@link RandomSource} for tests; deterministic from a seed and stateful so each draw
+   * advances the stream.
+   */
+  private static final class SeededRandomSource implements RandomSource {
+    private final Random random;
+
+    SeededRandomSource(long seed) {
+      this.random = new Random(seed);
+    }
+
+    @Override
+    public long nextLong() {
+      return random.nextLong();
+    }
+
+    @Override
+    public double nextDouble() {
+      return random.nextDouble();
+    }
+
+    @Override
+    public double nextGaussian() {
+      return random.nextGaussian();
+    }
+
+    @Override
+    public RandomSource split(long key) {
+      return this;
+    }
+  }
+}


### PR DESCRIPTION
Closes #585

## Summary
- New `InjuryModel` interface + `BaselineInjuryModel` impl draws per-snap injuries off the resolved play, modulated by position, contact bucket (tackle/sack/pile), playing surface (turf elevated), and the player's `toughness` tendency.
- Severity tiers: `PLAY`, `DRIVE`, `GAME_ENDING`, `MULTI_GAME` (`InjurySeverity`).
- New `PlayEvent.Injury` variant emitted by `GameSimulator` immediately after the triggering snap.
- `GameState.withInjury` appends to `injuredPlayers`; `BaselinePersonnelSelector` skips injured players so backups take the field automatically.
- `Surface.TURF` adds a documented +10% modifier on top of base contact rate, wired through `PreGameContext` from #583.

## Test plan
- [x] `BaselineInjuryModelTests` — toughness extremes (0 vs 100 yields >2x rate gap), severity distribution skew toward PLAY/DRIVE, turf > grass, sack attribution to both sides, incomplete pass produces no injury.
- [x] `InjuryIntegrationTests` — full simulator emits `Injury` events at realistic rates across 10 games; injured player is never touched again by the resolver after going down.
- [x] `./gradlew test` — all 332 tests green.
- [x] `./gradlew spotlessCheck` — clean.