### PR TITLE
feat(league): phase state machine foundation (#601)

### DIFF
--- a/src/main/java/app/zoneblitz/league/AdvancePhase.java
+++ b/src/main/java/app/zoneblitz/league/AdvancePhase.java
@@ -1,0 +1,22 @@
+package app.zoneblitz.league;
+
+/**
+ * Use case: advance a league from its current phase to the next phase.
+ *
+ * <p>Runs the outgoing phase's {@link PhaseTransitionHandler#onExit} hook, persists the new phase
+ * with {@code phase_week} reset to 1, then runs the incoming phase's {@link
+ * PhaseTransitionHandler#onEntry} hook. All within a single transaction.
+ */
+public interface AdvancePhase {
+
+  /**
+   * @param leagueId the league to advance.
+   * @param ownerSubject OAuth2 subject of the caller; a league not owned by this subject surfaces
+   *     as {@link AdvancePhaseResult.NotFound}.
+   * @return {@link AdvancePhaseResult.Advanced} on a successful transition; {@link
+   *     AdvancePhaseResult.NotFound} if the league does not exist or is not owned by {@code
+   *     ownerSubject}; {@link AdvancePhaseResult.NoNextPhase} if the league is already in the
+   *     terminal phase.
+   */
+  AdvancePhaseResult advance(long leagueId, String ownerSubject);
+}

--- a/src/main/java/app/zoneblitz/league/AdvancePhaseResult.java
+++ b/src/main/java/app/zoneblitz/league/AdvancePhaseResult.java
@@ -1,0 +1,10 @@
+package app.zoneblitz.league;
+
+public sealed interface AdvancePhaseResult {
+
+  record Advanced(long leagueId, LeaguePhase from, LeaguePhase to) implements AdvancePhaseResult {}
+
+  record NotFound(long leagueId) implements AdvancePhaseResult {}
+
+  record NoNextPhase(long leagueId, LeaguePhase phase) implements AdvancePhaseResult {}
+}

--- a/src/main/java/app/zoneblitz/league/AdvancePhaseUseCase.java
+++ b/src/main/java/app/zoneblitz/league/AdvancePhaseUseCase.java
@@ -1,0 +1,56 @@
+package app.zoneblitz.league;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Collectors;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+class AdvancePhaseUseCase implements AdvancePhase {
+
+  private static final Logger log = LoggerFactory.getLogger(AdvancePhaseUseCase.class);
+
+  private final LeagueRepository leagues;
+  private final Map<LeaguePhase, PhaseTransitionHandler> handlers;
+
+  AdvancePhaseUseCase(LeagueRepository leagues, List<PhaseTransitionHandler> handlers) {
+    this.leagues = leagues;
+    this.handlers =
+        handlers.stream()
+            .collect(Collectors.toUnmodifiableMap(PhaseTransitionHandler::phase, h -> h));
+  }
+
+  @Override
+  @Transactional
+  public AdvancePhaseResult advance(long leagueId, String ownerSubject) {
+    Objects.requireNonNull(ownerSubject, "ownerSubject");
+
+    var maybeLeague = leagues.findSummaryByIdAndOwner(leagueId, ownerSubject);
+    if (maybeLeague.isEmpty()) {
+      return new AdvancePhaseResult.NotFound(leagueId);
+    }
+    var current = maybeLeague.get().phase();
+    var maybeNext = LeaguePhases.next(current);
+    if (maybeNext.isEmpty()) {
+      return new AdvancePhaseResult.NoNextPhase(leagueId, current);
+    }
+    var next = maybeNext.get();
+
+    var exitHandler = handlers.get(current);
+    if (exitHandler != null) {
+      exitHandler.onExit(leagueId);
+    }
+    leagues.updatePhaseAndResetWeek(leagueId, next);
+    var entryHandler = handlers.get(next);
+    if (entryHandler != null) {
+      entryHandler.onEntry(leagueId);
+    }
+
+    log.info("league phase advanced id={} from={} to={}", leagueId, current, next);
+    return new AdvancePhaseResult.Advanced(leagueId, current, next);
+  }
+}

--- a/src/main/java/app/zoneblitz/league/AdvanceWeek.java
+++ b/src/main/java/app/zoneblitz/league/AdvanceWeek.java
@@ -1,0 +1,22 @@
+package app.zoneblitz.league;
+
+/**
+ * Use case: run a week tick on a league.
+ *
+ * <p>Runs CPU franchise strategies (none wired yet — the seam is in place for future phases),
+ * increments {@code phase_week}, then runs the phase-completion check. If the phase completes as a
+ * result of the tick, {@link AdvancePhase} is invoked and the response reports the new phase.
+ *
+ * <p>For the foundational scope (issue #601) no phase defines a completion rule, so advances only
+ * ever happen through {@link AdvancePhase}. {@link AdvanceWeek} exists with the correct shape so
+ * later phases can plug in without reshaping callers.
+ */
+public interface AdvanceWeek {
+
+  /**
+   * @return {@link AdvanceWeekResult.Ticked} on a successful week tick (phase may or may not have
+   *     rolled over); {@link AdvanceWeekResult.NotFound} if the league does not exist or is not
+   *     owned by {@code ownerSubject}.
+   */
+  AdvanceWeekResult advance(long leagueId, String ownerSubject);
+}

--- a/src/main/java/app/zoneblitz/league/AdvanceWeekResult.java
+++ b/src/main/java/app/zoneblitz/league/AdvanceWeekResult.java
@@ -1,0 +1,19 @@
+package app.zoneblitz.league;
+
+import java.util.Optional;
+
+public sealed interface AdvanceWeekResult {
+
+  /**
+   * @param leagueId the league that ticked.
+   * @param phase the league's phase after the tick — may differ from the entry phase if the tick
+   *     completed the previous phase.
+   * @param phaseWeek the {@code phase_week} value after the tick.
+   * @param transitionedTo present when the tick completed the previous phase and transitioned.
+   */
+  record Ticked(
+      long leagueId, LeaguePhase phase, int phaseWeek, Optional<LeaguePhase> transitionedTo)
+      implements AdvanceWeekResult {}
+
+  record NotFound(long leagueId) implements AdvanceWeekResult {}
+}

--- a/src/main/java/app/zoneblitz/league/AdvanceWeekUseCase.java
+++ b/src/main/java/app/zoneblitz/league/AdvanceWeekUseCase.java
@@ -1,0 +1,42 @@
+package app.zoneblitz.league;
+
+import java.util.Objects;
+import java.util.Optional;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+class AdvanceWeekUseCase implements AdvanceWeek {
+
+  private static final Logger log = LoggerFactory.getLogger(AdvanceWeekUseCase.class);
+
+  private final LeagueRepository leagues;
+
+  AdvanceWeekUseCase(LeagueRepository leagues) {
+    this.leagues = leagues;
+  }
+
+  @Override
+  @Transactional
+  public AdvanceWeekResult advance(long leagueId, String ownerSubject) {
+    Objects.requireNonNull(ownerSubject, "ownerSubject");
+
+    var maybeLeague = leagues.findSummaryByIdAndOwner(leagueId, ownerSubject);
+    if (maybeLeague.isEmpty()) {
+      return new AdvanceWeekResult.NotFound(leagueId);
+    }
+    var phase = maybeLeague.get().phase();
+
+    // CPU franchise strategies are a future seam (see docs/technical/league-phases.md). No
+    // phase defines a completion rule yet, so the tick is currently just "increment the counter".
+    var newWeek =
+        leagues
+            .incrementPhaseWeek(leagueId)
+            .orElseThrow(() -> new IllegalStateException("league disappeared mid-transaction"));
+
+    log.info("league week advanced id={} phase={} week={}", leagueId, phase, newWeek);
+    return new AdvanceWeekResult.Ticked(leagueId, phase, newWeek, Optional.empty());
+  }
+}

--- a/src/main/java/app/zoneblitz/league/JooqLeagueRepository.java
+++ b/src/main/java/app/zoneblitz/league/JooqLeagueRepository.java
@@ -36,6 +36,7 @@ class JooqLeagueRepository implements LeagueRepository {
                 LEAGUES.NAME,
                 LEAGUES.OWNER_SUBJECT,
                 LEAGUES.PHASE,
+                LEAGUES.PHASE_WEEK,
                 LEAGUES.TEAM_COUNT,
                 LEAGUES.SEASON_GAMES,
                 LEAGUES.CREATED_AT)
@@ -45,6 +46,7 @@ class JooqLeagueRepository implements LeagueRepository {
         record.getName(),
         record.getOwnerSubject(),
         LeaguePhase.valueOf(record.getPhase()),
+        record.getPhaseWeek(),
         new LeagueSettings(record.getTeamCount(), record.getSeasonGames()),
         record.getCreatedAt().toInstant());
   }
@@ -64,6 +66,7 @@ class JooqLeagueRepository implements LeagueRepository {
             LEAGUES.ID,
             LEAGUES.NAME,
             LEAGUES.PHASE,
+            LEAGUES.PHASE_WEEK,
             LEAGUES.CREATED_AT,
             FRANCHISES.ID,
             FRANCHISES.NAME,
@@ -92,6 +95,7 @@ class JooqLeagueRepository implements LeagueRepository {
                     r.get(LEAGUES.ID),
                     r.get(LEAGUES.NAME),
                     LeaguePhase.valueOf(r.get(LEAGUES.PHASE)),
+                    r.get(LEAGUES.PHASE_WEEK),
                     r.get(LEAGUES.CREATED_AT).toInstant(),
                     JooqFranchiseRepository.mapFranchise(r)));
   }
@@ -102,6 +106,7 @@ class JooqLeagueRepository implements LeagueRepository {
             LEAGUES.ID,
             LEAGUES.NAME,
             LEAGUES.PHASE,
+            LEAGUES.PHASE_WEEK,
             LEAGUES.CREATED_AT,
             FRANCHISES.ID,
             FRANCHISES.NAME,
@@ -130,8 +135,54 @@ class JooqLeagueRepository implements LeagueRepository {
                     r.get(LEAGUES.ID),
                     r.get(LEAGUES.NAME),
                     LeaguePhase.valueOf(r.get(LEAGUES.PHASE)),
+                    r.get(LEAGUES.PHASE_WEEK),
                     r.get(LEAGUES.CREATED_AT).toInstant(),
                     JooqFranchiseRepository.mapFranchise(r)));
+  }
+
+  @Override
+  public Optional<League> findById(long id) {
+    return dsl.select(
+            LEAGUES.ID,
+            LEAGUES.NAME,
+            LEAGUES.OWNER_SUBJECT,
+            LEAGUES.PHASE,
+            LEAGUES.PHASE_WEEK,
+            LEAGUES.TEAM_COUNT,
+            LEAGUES.SEASON_GAMES,
+            LEAGUES.CREATED_AT)
+        .from(LEAGUES)
+        .where(LEAGUES.ID.eq(id))
+        .fetchOptional(
+            r ->
+                new League(
+                    r.get(LEAGUES.ID),
+                    r.get(LEAGUES.NAME),
+                    r.get(LEAGUES.OWNER_SUBJECT),
+                    LeaguePhase.valueOf(r.get(LEAGUES.PHASE)),
+                    r.get(LEAGUES.PHASE_WEEK),
+                    new LeagueSettings(r.get(LEAGUES.TEAM_COUNT), r.get(LEAGUES.SEASON_GAMES)),
+                    r.get(LEAGUES.CREATED_AT).toInstant()));
+  }
+
+  @Override
+  public boolean updatePhaseAndResetWeek(long id, LeaguePhase phase) {
+    return dsl.update(LEAGUES)
+            .set(LEAGUES.PHASE, phase.name())
+            .set(LEAGUES.PHASE_WEEK, 1)
+            .where(LEAGUES.ID.eq(id))
+            .execute()
+        > 0;
+  }
+
+  @Override
+  public Optional<Integer> incrementPhaseWeek(long id) {
+    return dsl.update(LEAGUES)
+        .set(LEAGUES.PHASE_WEEK, LEAGUES.PHASE_WEEK.plus(1))
+        .where(LEAGUES.ID.eq(id))
+        .returning(LEAGUES.PHASE_WEEK)
+        .fetchOptional()
+        .map(r -> r.get(LEAGUES.PHASE_WEEK));
   }
 
   @Override

--- a/src/main/java/app/zoneblitz/league/League.java
+++ b/src/main/java/app/zoneblitz/league/League.java
@@ -7,5 +7,6 @@ public record League(
     String name,
     String ownerSubject,
     LeaguePhase phase,
+    int phaseWeek,
     LeagueSettings settings,
     Instant createdAt) {}

--- a/src/main/java/app/zoneblitz/league/LeagueController.java
+++ b/src/main/java/app/zoneblitz/league/LeagueController.java
@@ -26,18 +26,21 @@ class LeagueController {
   private final CreateLeague createLeague;
   private final GetLeague getLeague;
   private final DeleteLeague deleteLeague;
+  private final AdvancePhase advancePhase;
 
   LeagueController(
       ListLeaguesForUser listLeagues,
       ListFranchises listFranchises,
       CreateLeague createLeague,
       GetLeague getLeague,
-      DeleteLeague deleteLeague) {
+      DeleteLeague deleteLeague,
+      AdvancePhase advancePhase) {
     this.listLeagues = listLeagues;
     this.listFranchises = listFranchises;
     this.createLeague = createLeague;
     this.getLeague = getLeague;
     this.deleteLeague = deleteLeague;
+    this.advancePhase = advancePhase;
   }
 
   @GetMapping("/")
@@ -68,6 +71,26 @@ class LeagueController {
             .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND));
     model.addAttribute("league", league);
     return "league/settings";
+  }
+
+  @PostMapping("/leagues/{id}/phase/advance")
+  String advancePhase(@AuthenticationPrincipal OAuth2User principal, @PathVariable long id) {
+    var ownerSubject = principal.<String>getAttribute("sub");
+    var result = advancePhase.advance(id, ownerSubject);
+    return switch (result) {
+      case AdvancePhaseResult.Advanced advanced -> {
+        log.info(
+            "league phase advanced id={} from={} to={}",
+            advanced.leagueId(),
+            advanced.from(),
+            advanced.to());
+        yield "redirect:/leagues/" + id;
+      }
+      case AdvancePhaseResult.NotFound ignored ->
+          throw new ResponseStatusException(HttpStatus.NOT_FOUND);
+      case AdvancePhaseResult.NoNextPhase ignored ->
+          throw new ResponseStatusException(HttpStatus.CONFLICT);
+    };
   }
 
   @PostMapping("/leagues/{id}/delete")

--- a/src/main/java/app/zoneblitz/league/LeaguePhase.java
+++ b/src/main/java/app/zoneblitz/league/LeaguePhase.java
@@ -1,5 +1,6 @@
 package app.zoneblitz.league;
 
 public enum LeaguePhase {
-  INITIAL_SETUP
+  INITIAL_SETUP,
+  HIRING_HEAD_COACH
 }

--- a/src/main/java/app/zoneblitz/league/LeaguePhases.java
+++ b/src/main/java/app/zoneblitz/league/LeaguePhases.java
@@ -1,0 +1,20 @@
+package app.zoneblitz.league;
+
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * Phase ordering and next-phase lookup. Centralizes the linear sequence so {@link
+ * AdvancePhaseUseCase} and tests agree on "what comes next".
+ */
+final class LeaguePhases {
+
+  private static final Map<LeaguePhase, LeaguePhase> NEXT =
+      Map.of(LeaguePhase.INITIAL_SETUP, LeaguePhase.HIRING_HEAD_COACH);
+
+  private LeaguePhases() {}
+
+  static Optional<LeaguePhase> next(LeaguePhase phase) {
+    return Optional.ofNullable(NEXT.get(phase));
+  }
+}

--- a/src/main/java/app/zoneblitz/league/LeagueRepository.java
+++ b/src/main/java/app/zoneblitz/league/LeagueRepository.java
@@ -13,5 +13,22 @@ interface LeagueRepository {
 
   Optional<LeagueSummary> findSummaryByIdAndOwner(long id, String ownerSubject);
 
+  Optional<League> findById(long id);
+
+  /**
+   * Update the phase and reset {@code phase_week} to 1.
+   *
+   * @return true if a row was updated, false if the league does not exist.
+   */
+  boolean updatePhaseAndResetWeek(long id, LeaguePhase phase);
+
+  /**
+   * Increment {@code phase_week} by 1.
+   *
+   * @return the new {@code phase_week} value wrapped in {@link Optional}, or empty if the league
+   *     does not exist.
+   */
+  Optional<Integer> incrementPhaseWeek(long id);
+
   boolean deleteByIdAndOwner(long id, String ownerSubject);
 }

--- a/src/main/java/app/zoneblitz/league/LeagueSummary.java
+++ b/src/main/java/app/zoneblitz/league/LeagueSummary.java
@@ -7,5 +7,6 @@ public record LeagueSummary(
     long leagueId,
     String leagueName,
     LeaguePhase phase,
+    int phaseWeek,
     Instant createdAt,
     Franchise userFranchise) {}

--- a/src/main/java/app/zoneblitz/league/PhaseTransitionHandler.java
+++ b/src/main/java/app/zoneblitz/league/PhaseTransitionHandler.java
@@ -1,0 +1,28 @@
+package app.zoneblitz.league;
+
+/**
+ * Per-phase seam invoked by {@link AdvancePhase} on exit of the outgoing phase and entry of the
+ * incoming phase. One implementation per {@link LeaguePhase}; registered by keying on the phase the
+ * handler owns.
+ *
+ * <p>Handlers own phase-specific state lifecycle — candidate-pool generation on entry, autofill
+ * resolution on exit, per-franchise sub-state reset, etc. None of that exists yet; the seam is
+ * introduced now so hiring phases can plug in without controller/use-case churn.
+ */
+interface PhaseTransitionHandler {
+
+  /** The phase this handler owns. */
+  LeaguePhase phase();
+
+  /**
+   * Called when a league is leaving this handler's {@link #phase()}. Default no-op so handlers that
+   * only care about entry don't have to override.
+   */
+  default void onExit(long leagueId) {}
+
+  /**
+   * Called when a league is entering this handler's {@link #phase()}. Default no-op so handlers
+   * that only care about exit don't have to override.
+   */
+  default void onEntry(long leagueId) {}
+}

--- a/src/main/resources/db/migration/V4__league_phase_week.sql
+++ b/src/main/resources/db/migration/V4__league_phase_week.sql
@@ -1,0 +1,3 @@
+-- Phase week counter: current week within the league's active phase (1-indexed).
+ALTER TABLE leagues
+    ADD COLUMN phase_week INTEGER NOT NULL DEFAULT 1;

--- a/src/main/resources/templates/league/dashboard.html
+++ b/src/main/resources/templates/league/dashboard.html
@@ -87,6 +87,21 @@
 
 		<main class="flex-1 p-8">
 			<h1 class="text-3xl font-bold" th:text="${league.leagueName()}">League name</h1>
+			<section th:if="${league.phase().name() == 'INITIAL_SETUP'}"
+			         class="mt-6 max-w-2xl bg-white border border-slate-200 rounded p-6 shadow-sm">
+				<h2 class="text-xl font-semibold text-slate-900">Welcome to your league</h2>
+				<p class="mt-2 text-slate-700">
+					Your franchise is ready. Next up: hire a Head Coach to lead the team.
+				</p>
+				<form th:action="@{'/leagues/' + ${league.leagueId()} + '/phase/advance'}"
+				      method="post"
+				      class="mt-4">
+					<button type="submit"
+					        class="inline-flex items-center gap-2 px-4 py-2 rounded bg-slate-900 text-white font-medium hover:bg-slate-800 cursor-pointer">
+						Advance to staff hiring
+					</button>
+				</form>
+			</section>
 		</main>
 	</div>
 	<script>

--- a/src/test/java/app/zoneblitz/league/AdvancePhaseUseCaseTests.java
+++ b/src/test/java/app/zoneblitz/league/AdvancePhaseUseCaseTests.java
@@ -1,0 +1,139 @@
+package app.zoneblitz.league;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import app.zoneblitz.support.PostgresTestcontainer;
+import java.util.ArrayList;
+import java.util.List;
+import org.jooq.DSLContext;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.jooq.test.autoconfigure.JooqTest;
+import org.springframework.context.annotation.Import;
+
+@JooqTest
+@Import(PostgresTestcontainer.class)
+class AdvancePhaseUseCaseTests {
+
+  @Autowired DSLContext dsl;
+
+  private LeagueRepository leagues;
+  private CreateLeague createLeague;
+  private AdvancePhase advancePhase;
+  private RecordingHandler initialSetupHandler;
+  private RecordingHandler hiringHandler;
+
+  @BeforeEach
+  void setUp() {
+    leagues = new JooqLeagueRepository(dsl);
+    var franchises = new JooqFranchiseRepository(dsl);
+    var teams = new JooqTeamRepository(dsl);
+    createLeague = new CreateLeagueUseCase(leagues, franchises, teams);
+    initialSetupHandler = new RecordingHandler(LeaguePhase.INITIAL_SETUP);
+    hiringHandler = new RecordingHandler(LeaguePhase.HIRING_HEAD_COACH);
+    advancePhase = new AdvancePhaseUseCase(leagues, List.of(initialSetupHandler, hiringHandler));
+  }
+
+  @Test
+  void advance_fromInitialSetup_transitionsToHiringHeadCoachAndResetsWeek() {
+    var league = createLeagueFor("sub-1");
+    leagues.incrementPhaseWeek(league.id());
+    leagues.incrementPhaseWeek(league.id());
+
+    var result = advancePhase.advance(league.id(), "sub-1");
+
+    assertThat(result)
+        .isEqualTo(
+            new AdvancePhaseResult.Advanced(
+                league.id(), LeaguePhase.INITIAL_SETUP, LeaguePhase.HIRING_HEAD_COACH));
+    var after = leagues.findById(league.id()).orElseThrow();
+    assertThat(after.phase()).isEqualTo(LeaguePhase.HIRING_HEAD_COACH);
+    assertThat(after.phaseWeek()).isEqualTo(1);
+  }
+
+  @Test
+  void advance_runsExitThenEntryHandlers() {
+    var league = createLeagueFor("sub-1");
+
+    advancePhase.advance(league.id(), "sub-1");
+
+    assertThat(initialSetupHandler.exits).containsExactly(league.id());
+    assertThat(initialSetupHandler.entries).isEmpty();
+    assertThat(hiringHandler.exits).isEmpty();
+    assertThat(hiringHandler.entries).containsExactly(league.id());
+  }
+
+  @Test
+  void advance_whenLeagueMissing_returnsNotFound() {
+    var result = advancePhase.advance(999_999L, "sub-1");
+
+    assertThat(result).isEqualTo(new AdvancePhaseResult.NotFound(999_999L));
+  }
+
+  @Test
+  void advance_whenNotOwnedByCaller_returnsNotFound() {
+    var league = createLeagueFor("owner");
+
+    var result = advancePhase.advance(league.id(), "someone-else");
+
+    assertThat(result).isEqualTo(new AdvancePhaseResult.NotFound(league.id()));
+  }
+
+  @Test
+  void advance_whenAlreadyInTerminalPhase_returnsNoNextPhase() {
+    var league = createLeagueFor("sub-1");
+    leagues.updatePhaseAndResetWeek(league.id(), LeaguePhase.HIRING_HEAD_COACH);
+
+    var result = advancePhase.advance(league.id(), "sub-1");
+
+    assertThat(result)
+        .isEqualTo(new AdvancePhaseResult.NoNextPhase(league.id(), LeaguePhase.HIRING_HEAD_COACH));
+    assertThat(leagues.findById(league.id()).orElseThrow().phase())
+        .isEqualTo(LeaguePhase.HIRING_HEAD_COACH);
+  }
+
+  @Test
+  void advance_worksWhenNoHandlersRegistered() {
+    var advanceWithoutHandlers = new AdvancePhaseUseCase(leagues, List.of());
+    var league = createLeagueFor("sub-1");
+
+    var result = advanceWithoutHandlers.advance(league.id(), "sub-1");
+
+    assertThat(result).isInstanceOf(AdvancePhaseResult.Advanced.class);
+  }
+
+  private League createLeagueFor(String ownerSubject) {
+    var result = createLeague.create(ownerSubject, "Dynasty", firstFranchiseId());
+    return ((CreateLeagueResult.Created) result).league();
+  }
+
+  private long firstFranchiseId() {
+    return new JooqFranchiseRepository(dsl).listAll().getFirst().id();
+  }
+
+  private static final class RecordingHandler implements PhaseTransitionHandler {
+    private final LeaguePhase phase;
+    final List<Long> entries = new ArrayList<>();
+    final List<Long> exits = new ArrayList<>();
+
+    RecordingHandler(LeaguePhase phase) {
+      this.phase = phase;
+    }
+
+    @Override
+    public LeaguePhase phase() {
+      return phase;
+    }
+
+    @Override
+    public void onEntry(long leagueId) {
+      entries.add(leagueId);
+    }
+
+    @Override
+    public void onExit(long leagueId) {
+      exits.add(leagueId);
+    }
+  }
+}

--- a/src/test/java/app/zoneblitz/league/AdvanceWeekUseCaseTests.java
+++ b/src/test/java/app/zoneblitz/league/AdvanceWeekUseCaseTests.java
@@ -1,0 +1,81 @@
+package app.zoneblitz.league;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import app.zoneblitz.support.PostgresTestcontainer;
+import java.util.Optional;
+import org.jooq.DSLContext;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.jooq.test.autoconfigure.JooqTest;
+import org.springframework.context.annotation.Import;
+
+@JooqTest
+@Import(PostgresTestcontainer.class)
+class AdvanceWeekUseCaseTests {
+
+  @Autowired DSLContext dsl;
+
+  private LeagueRepository leagues;
+  private CreateLeague createLeague;
+  private AdvanceWeek advanceWeek;
+
+  @BeforeEach
+  void setUp() {
+    leagues = new JooqLeagueRepository(dsl);
+    var franchises = new JooqFranchiseRepository(dsl);
+    var teams = new JooqTeamRepository(dsl);
+    createLeague = new CreateLeagueUseCase(leagues, franchises, teams);
+    advanceWeek = new AdvanceWeekUseCase(leagues);
+  }
+
+  @Test
+  void advance_incrementsPhaseWeekAndReturnsTicked() {
+    var league = createLeagueFor("sub-1");
+
+    var result = advanceWeek.advance(league.id(), "sub-1");
+
+    assertThat(result)
+        .isEqualTo(
+            new AdvanceWeekResult.Ticked(
+                league.id(), LeaguePhase.INITIAL_SETUP, 2, Optional.empty()));
+    assertThat(leagues.findById(league.id()).orElseThrow().phaseWeek()).isEqualTo(2);
+  }
+
+  @Test
+  void advance_repeatedTicks_keepIncrementing() {
+    var league = createLeagueFor("sub-1");
+
+    advanceWeek.advance(league.id(), "sub-1");
+    advanceWeek.advance(league.id(), "sub-1");
+    var result = advanceWeek.advance(league.id(), "sub-1");
+
+    assertThat(((AdvanceWeekResult.Ticked) result).phaseWeek()).isEqualTo(4);
+  }
+
+  @Test
+  void advance_whenLeagueMissing_returnsNotFound() {
+    var result = advanceWeek.advance(999_999L, "sub-1");
+
+    assertThat(result).isEqualTo(new AdvanceWeekResult.NotFound(999_999L));
+  }
+
+  @Test
+  void advance_whenNotOwnedByCaller_returnsNotFound() {
+    var league = createLeagueFor("owner");
+
+    var result = advanceWeek.advance(league.id(), "someone-else");
+
+    assertThat(result).isEqualTo(new AdvanceWeekResult.NotFound(league.id()));
+  }
+
+  private League createLeagueFor(String ownerSubject) {
+    var result = createLeague.create(ownerSubject, "Dynasty", firstFranchiseId());
+    return ((CreateLeagueResult.Created) result).league();
+  }
+
+  private long firstFranchiseId() {
+    return new JooqFranchiseRepository(dsl).listAll().getFirst().id();
+  }
+}

--- a/src/test/java/app/zoneblitz/league/JooqLeagueRepositoryTests.java
+++ b/src/test/java/app/zoneblitz/league/JooqLeagueRepositoryTests.java
@@ -142,6 +142,68 @@ class JooqLeagueRepositoryTests {
     assertThat(leagues.deleteByIdAndOwner(999_999L, "sub-1")).isFalse();
   }
 
+  @Test
+  void insert_setsPhaseWeekToOneByDefault() {
+    var league =
+        leagues.insert("sub-1", "Dynasty", LeaguePhase.INITIAL_SETUP, LeagueSettings.defaults());
+
+    assertThat(league.phaseWeek()).isEqualTo(1);
+  }
+
+  @Test
+  void findById_whenPresent_returnsLeagueWithPhaseWeek() {
+    var inserted =
+        leagues.insert("sub-1", "Dynasty", LeaguePhase.INITIAL_SETUP, LeagueSettings.defaults());
+
+    assertThat(leagues.findById(inserted.id()))
+        .hasValueSatisfying(
+            l -> {
+              assertThat(l.id()).isEqualTo(inserted.id());
+              assertThat(l.phase()).isEqualTo(LeaguePhase.INITIAL_SETUP);
+              assertThat(l.phaseWeek()).isEqualTo(1);
+            });
+  }
+
+  @Test
+  void findById_whenMissing_returnsEmpty() {
+    assertThat(leagues.findById(999_999L)).isEmpty();
+  }
+
+  @Test
+  void incrementPhaseWeek_whenPresent_bumpsCounterAndReturnsNewValue() {
+    var league =
+        leagues.insert("sub-1", "Dynasty", LeaguePhase.INITIAL_SETUP, LeagueSettings.defaults());
+
+    assertThat(leagues.incrementPhaseWeek(league.id())).hasValue(2);
+    assertThat(leagues.incrementPhaseWeek(league.id())).hasValue(3);
+    assertThat(leagues.findById(league.id()).orElseThrow().phaseWeek()).isEqualTo(3);
+  }
+
+  @Test
+  void incrementPhaseWeek_whenMissing_returnsEmpty() {
+    assertThat(leagues.incrementPhaseWeek(999_999L)).isEmpty();
+  }
+
+  @Test
+  void updatePhaseAndResetWeek_changesPhaseAndResetsWeekToOne() {
+    var league =
+        leagues.insert("sub-1", "Dynasty", LeaguePhase.INITIAL_SETUP, LeagueSettings.defaults());
+    leagues.incrementPhaseWeek(league.id());
+    leagues.incrementPhaseWeek(league.id());
+
+    assertThat(leagues.updatePhaseAndResetWeek(league.id(), LeaguePhase.HIRING_HEAD_COACH))
+        .isTrue();
+
+    var after = leagues.findById(league.id()).orElseThrow();
+    assertThat(after.phase()).isEqualTo(LeaguePhase.HIRING_HEAD_COACH);
+    assertThat(after.phaseWeek()).isEqualTo(1);
+  }
+
+  @Test
+  void updatePhaseAndResetWeek_whenMissing_returnsFalse() {
+    assertThat(leagues.updatePhaseAndResetWeek(999_999L, LeaguePhase.HIRING_HEAD_COACH)).isFalse();
+  }
+
   private long pickOther(long excludeId) {
     return franchises.listAll().stream()
         .filter(f -> f.id() != excludeId)

--- a/src/test/java/app/zoneblitz/league/LeagueControllerTests.java
+++ b/src/test/java/app/zoneblitz/league/LeagueControllerTests.java
@@ -44,6 +44,7 @@ class LeagueControllerTests {
   @MockitoBean CreateLeague createLeague;
   @MockitoBean GetLeague getLeague;
   @MockitoBean DeleteLeague deleteLeague;
+  @MockitoBean AdvancePhase advancePhase;
   @MockitoBean ClientRegistrationRepository clientRegistrationRepository;
 
   @Test
@@ -88,6 +89,7 @@ class LeagueControllerTests {
             "Dynasty",
             "sub-1",
             LeaguePhase.INITIAL_SETUP,
+            1,
             LeagueSettings.defaults(),
             Instant.now());
     given(createLeague.create(eq("sub-1"), eq("Dynasty"), anyLong()))
@@ -112,6 +114,7 @@ class LeagueControllerTests {
             42L,
             "Dynasty",
             LeaguePhase.INITIAL_SETUP,
+            1,
             Instant.now(),
             new Franchise(
                 1L,
@@ -157,6 +160,7 @@ class LeagueControllerTests {
             42L,
             "Dynasty",
             LeaguePhase.INITIAL_SETUP,
+            1,
             Instant.now(),
             new Franchise(
                 1L,
@@ -210,6 +214,52 @@ class LeagueControllerTests {
   @Test
   void delete_requiresCsrf() throws Exception {
     mvc.perform(post("/leagues/42/delete").with(oauth2Login())).andExpect(status().isForbidden());
+  }
+
+  @Test
+  void advancePhase_whenAdvanced_redirectsToDashboard() throws Exception {
+    given(advancePhase.advance(42L, "sub-1"))
+        .willReturn(
+            new AdvancePhaseResult.Advanced(
+                42L, LeaguePhase.INITIAL_SETUP, LeaguePhase.HIRING_HEAD_COACH));
+
+    mvc.perform(
+            post("/leagues/42/phase/advance")
+                .with(oauth2Login().attributes(a -> a.put("sub", "sub-1")))
+                .with(csrf()))
+        .andExpect(status().is3xxRedirection())
+        .andExpect(redirectedUrl("/leagues/42"));
+
+    verify(advancePhase).advance(42L, "sub-1");
+  }
+
+  @Test
+  void advancePhase_whenNotFound_returns404() throws Exception {
+    given(advancePhase.advance(42L, "sub-1")).willReturn(new AdvancePhaseResult.NotFound(42L));
+
+    mvc.perform(
+            post("/leagues/42/phase/advance")
+                .with(oauth2Login().attributes(a -> a.put("sub", "sub-1")))
+                .with(csrf()))
+        .andExpect(status().isNotFound());
+  }
+
+  @Test
+  void advancePhase_whenNoNextPhase_returns409() throws Exception {
+    given(advancePhase.advance(42L, "sub-1"))
+        .willReturn(new AdvancePhaseResult.NoNextPhase(42L, LeaguePhase.HIRING_HEAD_COACH));
+
+    mvc.perform(
+            post("/leagues/42/phase/advance")
+                .with(oauth2Login().attributes(a -> a.put("sub", "sub-1")))
+                .with(csrf()))
+        .andExpect(status().isConflict());
+  }
+
+  @Test
+  void advancePhase_requiresCsrf() throws Exception {
+    mvc.perform(post("/leagues/42/phase/advance").with(oauth2Login()))
+        .andExpect(status().isForbidden());
   }
 
   @Test


### PR DESCRIPTION
Closes #601.

## Summary

Foundational infrastructure for the league phase state machine. No hiring mechanics — just the tick/transition engine and the `INITIAL_SETUP` dashboard advance.

## Changes

- **Schema**: `V4__league_phase_week.sql` adds `leagues.phase_week INT NOT NULL DEFAULT 1`.
- **Domain**: `LeaguePhase` enum gains `HIRING_HEAD_COACH` (acceptance criteria allowed a placeholder next phase). `League` and `LeagueSummary` records carry `phaseWeek`. `LeaguePhases` helper owns the linear phase sequence.
- **Seams**:
  - `PhaseTransitionHandler` (package-private) — one per phase, `onExit` / `onEntry` hooks. No concrete handlers wired yet; registration is collection-injection friendly so future hiring phases plug in without controller or use-case churn.
  - `LeagueRepository` gains `findById`, `incrementPhaseWeek`, `updatePhaseAndResetWeek`.
- **Use cases** (public interfaces, package-private `@Service` implementations, `@Transactional`):
  - `AdvancePhase` → `AdvancePhaseResult.{Advanced, NotFound, NoNextPhase}`. Runs `onExit` on the current phase's handler, resets `phase_week` to 1, runs `onEntry` on the incoming phase's handler.
  - `AdvanceWeek` → `AdvanceWeekResult.{Ticked, NotFound}`. CPU-strategy seam is a no-op comment placeholder per scope; increments `phase_week` and returns the new week. No phase defines a completion rule yet, so no transition fires from a tick today — the shape is in place for later phases.
- **Web**: `POST /leagues/{id}/phase/advance` on `LeagueController` — 302 redirect back to the dashboard on success, 404 on not-found, 409 on `NoNextPhase`. Dashboard (`templates/league/dashboard.html`) renders an "Advance to staff hiring" button for the `INITIAL_SETUP` phase (simple `POST` form; CSRF via Thymeleaf's default). The issue mentioned HTMX; since the whole dashboard swap is required on phase change, a plain form POST + redirect is more appropriate than a fragment — documented here for review.
- **Tests** (all `@JooqTest` + Testcontainers for DB-touching, `@WebMvcTest` for controller):
  - `JooqLeagueRepositoryTests` — new cases for default `phase_week`, `findById`, `incrementPhaseWeek`, `updatePhaseAndResetWeek`.
  - `AdvancePhaseUseCaseTests` — happy path, exit/entry handler ordering, not-found, cross-owner not-found, terminal-phase guard, no-handlers case.
  - `AdvanceWeekUseCaseTests` — increment semantics, repeated ticks, not-found, cross-owner.
  - `LeagueControllerTests` — new `advancePhase` cases for each result variant plus CSRF guard.

## Deviations from acceptance criteria

- **HTMX vs. form POST** on the advance button. The advance is a whole-dashboard state change (phase view swap), so a classic `POST` + redirect is used instead of an HTMX fragment swap. Fragment-based HTMX for the hiring phase views can land with those phase UIs.
- **Next phase is `HIRING_HEAD_COACH`**, not a placeholder constant, because the state machine already needs a real next enum value for the transition code and tests to be meaningful. The hiring phase has no behavior wired — just the enum and the advance target.

## Test plan

- [x] `./gradlew spotlessApply` + `./gradlew spotlessCheck`
- [x] `./gradlew test` (384 tests; one pre-existing flaky game-sim test `HomeFieldAdvantageIntegrationTests` passes on re-run, unrelated)
- [ ] Manual smoke: create a league, click "Advance to staff hiring" on the dashboard, verify phase moves to `HIRING_HEAD_COACH` and `phase_week` resets to 1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)