### PR TITLE
test(gamesimulator): unit-test DefaultBandSampler.saturate bounds

### DIFF
--- a/src/gamesimulator/java/app/zoneblitz/gamesimulator/band/DefaultBandSampler.java
+++ b/src/gamesimulator/java/app/zoneblitz/gamesimulator/band/DefaultBandSampler.java
@@ -51,7 +51,7 @@ public final class DefaultBandSampler implements BandSampler {
     return clamped;
   }
 
-  private static double saturate(double shift) {
+  static double saturate(double shift) {
     return SHIFT_SATURATION * Math.tanh(shift / SHIFT_SATURATION);
   }
 

--- a/src/test/java/app/zoneblitz/gamesimulator/band/DefaultBandSamplerSaturateTests.java
+++ b/src/test/java/app/zoneblitz/gamesimulator/band/DefaultBandSamplerSaturateTests.java
@@ -1,0 +1,68 @@
+package app.zoneblitz.gamesimulator.band;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.offset;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+class DefaultBandSamplerSaturateTests {
+
+  private static final double ASYMPTOTE = 0.6;
+
+  @Test
+  void saturate_atZero_returnsZero() {
+    assertThat(DefaultBandSampler.saturate(0.0)).isEqualTo(0.0);
+  }
+
+  @Test
+  void saturate_nearZero_hasSlopeOne() {
+    assertThat(DefaultBandSampler.saturate(0.1)).isCloseTo(0.1, offset(1e-3));
+    assertThat(DefaultBandSampler.saturate(-0.1)).isCloseTo(-0.1, offset(1e-3));
+  }
+
+  @ParameterizedTest
+  @ValueSource(
+      doubles = {-1e9, -100.0, -10.0, -1.0, -0.5, -0.1, 0.0, 0.1, 0.5, 1.0, 10.0, 100.0, 1e9})
+  void saturate_anyFiniteShift_staysWithinAsymptote(double shift) {
+    var result = DefaultBandSampler.saturate(shift);
+
+    assertThat(Math.abs(result)).isLessThanOrEqualTo(ASYMPTOTE);
+  }
+
+  @ParameterizedTest
+  @ValueSource(doubles = {0.1, 0.5, 1.0, 2.0, 5.0, 100.0})
+  void saturate_isOddSymmetric(double shift) {
+    assertThat(DefaultBandSampler.saturate(-shift)).isEqualTo(-DefaultBandSampler.saturate(shift));
+  }
+
+  @Test
+  void saturate_largePositiveShift_approachesAsymptote() {
+    assertThat(DefaultBandSampler.saturate(100.0)).isCloseTo(ASYMPTOTE, offset(1e-6));
+  }
+
+  @Test
+  void saturate_largeNegativeShift_approachesNegativeAsymptote() {
+    assertThat(DefaultBandSampler.saturate(-100.0)).isCloseTo(-ASYMPTOTE, offset(1e-6));
+  }
+
+  @Test
+  void saturate_positiveInfinity_returnsAsymptote() {
+    assertThat(DefaultBandSampler.saturate(Double.POSITIVE_INFINITY)).isEqualTo(ASYMPTOTE);
+  }
+
+  @Test
+  void saturate_negativeInfinity_returnsNegativeAsymptote() {
+    assertThat(DefaultBandSampler.saturate(Double.NEGATIVE_INFINITY)).isEqualTo(-ASYMPTOTE);
+  }
+
+  @Test
+  void saturate_isMonotonicallyIncreasing() {
+    var samples = new double[] {-10.0, -1.0, -0.5, -0.1, 0.0, 0.1, 0.5, 1.0, 10.0};
+    for (var i = 1; i < samples.length; i++) {
+      assertThat(DefaultBandSampler.saturate(samples[i]))
+          .isGreaterThan(DefaultBandSampler.saturate(samples[i - 1]));
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Adds a focused unit-test suite for `DefaultBandSampler.saturate()` (previously only exercised indirectly via the 10k-game calibration harness).
- Relaxes `saturate` from `private` to package-private so it can be tested directly without routing through the full sampler pipeline.

## Cases covered
- Identity at zero (`saturate(0) == 0`)
- Slope approximately 1 near zero (`saturate(±0.1) ≈ ±0.1`)
- `|saturate(x)| <= 0.6` for a parameterized range spanning `[-1e9, 1e9]` (double-precision `tanh` saturates to exactly ±1, so the realized bound is `<=`, not strict `<`)
- Odd symmetry: `saturate(-x) == -saturate(x)`
- Large magnitudes approach ±0.6 asymptote
- `±Infinity` returns exactly `±0.6`
- Monotonically increasing across a representative sample

Closes #623

## Test plan
- [x] `./gradlew test --tests 'app.zoneblitz.gamesimulator.band.DefaultBandSamplerSaturateTests'`
- [x] `./gradlew spotlessCheck`

Generated with [Claude Code](https://claude.com/claude-code)