### PR TITLE
feat(league): head coach candidate generator (#603)

### DIFF
--- a/src/main/java/app/zoneblitz/league/CandidateGenerator.java
+++ b/src/main/java/app/zoneblitz/league/CandidateGenerator.java
@@ -1,0 +1,37 @@
+package app.zoneblitz.league;
+
+import app.zoneblitz.gamesimulator.rng.RandomSource;
+import java.util.List;
+
+/**
+ * Seam for generating a candidate pool for a given phase. One implementation per candidate kind
+ * (e.g. {@code HeadCoachGenerator}, {@code DirectorOfScoutingGenerator}). Generators are pure
+ * functions over ({@code poolSize}, {@link RandomSource}) — no DB access, no side effects.
+ *
+ * <p>Generators must obey the hidden-info contract in {@code docs/technical/league-phases.md}:
+ *
+ * <ol>
+ *   <li>Sample {@code true_rating} from the tier's underlying distribution.
+ *   <li>Derive price signals (compensation target, contract length, guaranteed money) from
+ *       <em>perceived value only</em> — age, experience, archetype, specialty. True rating must not
+ *       enter the price function.
+ *   <li>Derive {@code scouted_attrs} by applying tier-specific noise to the hidden attribute set.
+ * </ol>
+ *
+ * Violating step 2 collapses the market dynamic and is a bug.
+ */
+public interface CandidateGenerator {
+
+  /**
+   * Generate {@code poolSize} candidates drawn from the tier this generator represents. The
+   * returned list is immutable and ordered; ordering has no semantic meaning. Callers persist the
+   * generated candidates via the candidate and preferences repositories; the returned preferences
+   * draft is keyed once the candidate id is known.
+   *
+   * @param poolSize how many candidates to generate (must be {@code > 0}).
+   * @param rng randomness source; all stochastic draws flow through it so results are deterministic
+   *     given its seed.
+   * @return an immutable list of generated candidates (candidate + preferences draft pairs).
+   */
+  List<GeneratedCandidate> generate(int poolSize, RandomSource rng);
+}

--- a/src/main/java/app/zoneblitz/league/CandidatePreferencesDraft.java
+++ b/src/main/java/app/zoneblitz/league/CandidatePreferencesDraft.java
@@ -1,0 +1,98 @@
+package app.zoneblitz.league;
+
+import java.math.BigDecimal;
+import java.util.Objects;
+
+/**
+ * Generator-side preferences payload. Identical to {@link CandidatePreferences} minus {@code
+ * candidateId} — generators emit this shape before a candidate row exists; the caller pairs it with
+ * the assigned id post-insert via {@link #withCandidateId(long)}.
+ */
+public record CandidatePreferencesDraft(
+    BigDecimal compensationTarget,
+    BigDecimal compensationWeight,
+    int contractLengthTarget,
+    BigDecimal contractLengthWeight,
+    BigDecimal guaranteedMoneyTarget,
+    BigDecimal guaranteedMoneyWeight,
+    MarketSize marketSizeTarget,
+    BigDecimal marketSizeWeight,
+    Geography geographyTarget,
+    BigDecimal geographyWeight,
+    Climate climateTarget,
+    BigDecimal climateWeight,
+    BigDecimal franchisePrestigeTarget,
+    BigDecimal franchisePrestigeWeight,
+    CompetitiveWindow competitiveWindowTarget,
+    BigDecimal competitiveWindowWeight,
+    RoleScope roleScopeTarget,
+    BigDecimal roleScopeWeight,
+    StaffContinuity staffContinuityTarget,
+    BigDecimal staffContinuityWeight,
+    String schemeAlignmentTarget,
+    BigDecimal schemeAlignmentWeight,
+    BigDecimal ownerStabilityTarget,
+    BigDecimal ownerStabilityWeight,
+    BigDecimal facilityQualityTarget,
+    BigDecimal facilityQualityWeight) {
+
+  public CandidatePreferencesDraft {
+    Objects.requireNonNull(compensationTarget, "compensationTarget");
+    Objects.requireNonNull(compensationWeight, "compensationWeight");
+    Objects.requireNonNull(contractLengthWeight, "contractLengthWeight");
+    Objects.requireNonNull(guaranteedMoneyTarget, "guaranteedMoneyTarget");
+    Objects.requireNonNull(guaranteedMoneyWeight, "guaranteedMoneyWeight");
+    Objects.requireNonNull(marketSizeTarget, "marketSizeTarget");
+    Objects.requireNonNull(marketSizeWeight, "marketSizeWeight");
+    Objects.requireNonNull(geographyTarget, "geographyTarget");
+    Objects.requireNonNull(geographyWeight, "geographyWeight");
+    Objects.requireNonNull(climateTarget, "climateTarget");
+    Objects.requireNonNull(climateWeight, "climateWeight");
+    Objects.requireNonNull(franchisePrestigeTarget, "franchisePrestigeTarget");
+    Objects.requireNonNull(franchisePrestigeWeight, "franchisePrestigeWeight");
+    Objects.requireNonNull(competitiveWindowTarget, "competitiveWindowTarget");
+    Objects.requireNonNull(competitiveWindowWeight, "competitiveWindowWeight");
+    Objects.requireNonNull(roleScopeTarget, "roleScopeTarget");
+    Objects.requireNonNull(roleScopeWeight, "roleScopeWeight");
+    Objects.requireNonNull(staffContinuityTarget, "staffContinuityTarget");
+    Objects.requireNonNull(staffContinuityWeight, "staffContinuityWeight");
+    Objects.requireNonNull(schemeAlignmentTarget, "schemeAlignmentTarget");
+    Objects.requireNonNull(schemeAlignmentWeight, "schemeAlignmentWeight");
+    Objects.requireNonNull(ownerStabilityTarget, "ownerStabilityTarget");
+    Objects.requireNonNull(ownerStabilityWeight, "ownerStabilityWeight");
+    Objects.requireNonNull(facilityQualityTarget, "facilityQualityTarget");
+    Objects.requireNonNull(facilityQualityWeight, "facilityQualityWeight");
+  }
+
+  /** Materialize a persisted-shape {@link CandidatePreferences} by pairing with a candidate id. */
+  public CandidatePreferences withCandidateId(long candidateId) {
+    return new CandidatePreferences(
+        candidateId,
+        compensationTarget,
+        compensationWeight,
+        contractLengthTarget,
+        contractLengthWeight,
+        guaranteedMoneyTarget,
+        guaranteedMoneyWeight,
+        marketSizeTarget,
+        marketSizeWeight,
+        geographyTarget,
+        geographyWeight,
+        climateTarget,
+        climateWeight,
+        franchisePrestigeTarget,
+        franchisePrestigeWeight,
+        competitiveWindowTarget,
+        competitiveWindowWeight,
+        roleScopeTarget,
+        roleScopeWeight,
+        staffContinuityTarget,
+        staffContinuityWeight,
+        schemeAlignmentTarget,
+        schemeAlignmentWeight,
+        ownerStabilityTarget,
+        ownerStabilityWeight,
+        facilityQualityTarget,
+        facilityQualityWeight);
+  }
+}

--- a/src/main/java/app/zoneblitz/league/GeneratedCandidate.java
+++ b/src/main/java/app/zoneblitz/league/GeneratedCandidate.java
@@ -1,0 +1,16 @@
+package app.zoneblitz.league;
+
+import java.util.Objects;
+
+/**
+ * Output of a {@link CandidateGenerator}. Bundles the insert-side candidate payload with the paired
+ * preferences draft so callers can persist both in one transaction. The preferences draft carries
+ * every dimension except {@code candidateId} — that is materialized once the candidate row exists.
+ */
+public record GeneratedCandidate(NewCandidate candidate, CandidatePreferencesDraft preferences) {
+
+  public GeneratedCandidate {
+    Objects.requireNonNull(candidate, "candidate");
+    Objects.requireNonNull(preferences, "preferences");
+  }
+}

--- a/src/main/java/app/zoneblitz/league/HeadCoachGenerator.java
+++ b/src/main/java/app/zoneblitz/league/HeadCoachGenerator.java
@@ -1,0 +1,282 @@
+package app.zoneblitz.league;
+
+import app.zoneblitz.gamesimulator.rng.RandomSource;
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.stream.IntStream;
+
+/**
+ * Generates HC candidates from {@code data/bands/coach-market.json} tier {@code HC}. Implements the
+ * hidden-info contract — true rating is sampled independently and never enters the price function.
+ * Price signals (compensation, contract length, guaranteed money) derive from perceived features
+ * only: age, total experience, archetype scarcity, and specialty.
+ */
+public final class HeadCoachGenerator implements CandidateGenerator {
+
+  private static final double GUARANTEED_MONEY_FLOOR = 0.90;
+  private static final double GUARANTEED_MONEY_CEIL = 1.00;
+  private static final double TRUE_RATING_MEAN = 65.0;
+  private static final double TRUE_RATING_STD = 12.0;
+  private static final double SCOUTED_NOISE_STD = 8.0;
+
+  private final HeadCoachMarketBands bands;
+
+  public HeadCoachGenerator() {
+    this(HeadCoachMarketBands.loadFromClasspath());
+  }
+
+  HeadCoachGenerator(HeadCoachMarketBands bands) {
+    this.bands = Objects.requireNonNull(bands, "bands");
+  }
+
+  @Override
+  public List<GeneratedCandidate> generate(int poolSize, RandomSource rng) {
+    Objects.requireNonNull(rng, "rng");
+    if (poolSize <= 0) {
+      throw new IllegalArgumentException("poolSize must be > 0, was: " + poolSize);
+    }
+    return IntStream.range(0, poolSize).mapToObj(i -> generateOne(rng)).toList();
+  }
+
+  private GeneratedCandidate generateOne(RandomSource rng) {
+    var archetype = sampleArchetype(rng);
+    var specialty = sampleSpecialty(archetype, rng);
+    var age = sampleAge(rng);
+    var totalExperience = sampleTotalExperience(age, rng);
+    var isFirstTime = rng.nextDouble() < bands.firstTimeHcRate();
+    var priorHcYears = isFirstTime ? 0 : sampleRetreadHcYears(totalExperience, rng);
+    var ocYears = sampleCoordinatorYears(totalExperience, priorHcYears, rng);
+    var positionCoachYears = Math.max(0, totalExperience - priorHcYears - ocYears);
+    var experienceByRole =
+        """
+        {"HC": %d, "OC": %d, "POSITION_COACH": %d}"""
+            .formatted(priorHcYears, ocYears, positionCoachYears);
+
+    var trueRating = clamp(TRUE_RATING_MEAN + TRUE_RATING_STD * rng.nextGaussian(), 20.0, 99.0);
+    var scoutedRating = clamp(trueRating + SCOUTED_NOISE_STD * rng.nextGaussian(), 20.0, 99.0);
+    var hiddenAttrs = attrsJson(trueRating);
+    var scoutedAttrs = attrsJson(scoutedRating);
+
+    var compensation = perceivedCompensation(age, totalExperience, priorHcYears, archetype, rng);
+    var contractLength = perceivedContractLength(priorHcYears, rng);
+    var guaranteedMoney = perceivedGuaranteedMoney(priorHcYears, rng);
+
+    var candidate =
+        new NewCandidate(
+            /* poolId= */ 0L,
+            CandidateKind.HEAD_COACH,
+            specialty,
+            archetype,
+            age,
+            totalExperience,
+            experienceByRole,
+            hiddenAttrs,
+            scoutedAttrs,
+            Optional.empty());
+    var preferences = buildPreferences(compensation, contractLength, guaranteedMoney, rng);
+    return new GeneratedCandidate(candidate, preferences);
+  }
+
+  private CandidateArchetype sampleArchetype(RandomSource rng) {
+    var u = rng.nextDouble();
+    if (u < bands.offenseShare()) {
+      return CandidateArchetype.OFFENSIVE_PLAY_CALLER;
+    }
+    if (u < bands.offenseShare() + bands.defenseShare()) {
+      return CandidateArchetype.DEFENSIVE_PLAY_CALLER;
+    }
+    return CandidateArchetype.CEO;
+  }
+
+  private SpecialtyPosition sampleSpecialty(CandidateArchetype archetype, RandomSource rng) {
+    var offensive =
+        List.of(
+            SpecialtyPosition.QB,
+            SpecialtyPosition.QB,
+            SpecialtyPosition.QB,
+            SpecialtyPosition.WR,
+            SpecialtyPosition.OL,
+            SpecialtyPosition.RB,
+            SpecialtyPosition.TE);
+    var defensive =
+        List.of(
+            SpecialtyPosition.DL,
+            SpecialtyPosition.EDGE,
+            SpecialtyPosition.LB,
+            SpecialtyPosition.LB,
+            SpecialtyPosition.CB,
+            SpecialtyPosition.CB,
+            SpecialtyPosition.S);
+    return switch (archetype) {
+      case OFFENSIVE_PLAY_CALLER -> offensive.get((int) (rng.nextDouble() * offensive.size()));
+      case DEFENSIVE_PLAY_CALLER -> defensive.get((int) (rng.nextDouble() * defensive.size()));
+      case CEO -> {
+        var u = rng.nextDouble();
+        yield u < 0.6
+            ? offensive.get((int) (rng.nextDouble() * offensive.size()))
+            : defensive.get((int) (rng.nextDouble() * defensive.size()));
+      }
+      default -> throw new IllegalStateException("Non-HC archetype generated: " + archetype);
+    };
+  }
+
+  private int sampleAge(RandomSource rng) {
+    var v = triangular(bands.ageMin(), bands.ageMode(), bands.ageMax(), rng);
+    return clampInt((int) Math.round(v), bands.ageMin(), bands.ageMax());
+  }
+
+  private int sampleTotalExperience(int age, RandomSource rng) {
+    var career = age - 22;
+    var raw =
+        triangular(
+            bands.experienceP10Years(),
+            bands.experienceMeanYears(),
+            bands.experienceP90Years() + 5,
+            rng);
+    return clampInt((int) Math.round(raw), 3, Math.max(3, career));
+  }
+
+  private int sampleRetreadHcYears(int totalExperience, RandomSource rng) {
+    var upper = Math.max(1, Math.min(10, totalExperience - 2));
+    return 1 + (int) (rng.nextDouble() * upper);
+  }
+
+  private int sampleCoordinatorYears(int totalExperience, int priorHcYears, RandomSource rng) {
+    var available = Math.max(0, totalExperience - priorHcYears);
+    if (available == 0) return 0;
+    var mean = Math.min(available, Math.max(2, available / 2));
+    var draw = (int) Math.round(mean + 2 * rng.nextGaussian());
+    return clampInt(draw, 0, available);
+  }
+
+  private BigDecimal perceivedCompensation(
+      int age,
+      int totalExperience,
+      int priorHcYears,
+      CandidateArchetype archetype,
+      RandomSource rng) {
+    var base = triangular(bands.salaryP10(), bands.salaryP50(), bands.salaryP90(), rng);
+    var ageMultiplier = ageSalaryMultiplier(age);
+    var experienceMultiplier = 0.95 + Math.min(totalExperience, 25) * 0.006;
+    var retreadMultiplier = 1.0 + Math.min(priorHcYears, 6) * 0.05;
+    var archetypeMultiplier =
+        switch (archetype) {
+          case OFFENSIVE_PLAY_CALLER -> 1.05;
+          case DEFENSIVE_PLAY_CALLER -> 0.95;
+          case CEO -> 0.90;
+          default -> 1.0;
+        };
+    var combined =
+        base * ageMultiplier * experienceMultiplier * retreadMultiplier * archetypeMultiplier;
+    var clamped =
+        Math.max(bands.salaryP10() * 0.6, Math.min(bands.salaryCeiling() * 1.1, combined));
+    return BigDecimal.valueOf(clamped).setScale(2, RoundingMode.HALF_UP);
+  }
+
+  private double ageSalaryMultiplier(int age) {
+    var peak = 52.0;
+    var deviation = Math.abs(age - peak);
+    return Math.max(0.75, 1.05 - deviation * 0.01);
+  }
+
+  private int perceivedContractLength(int priorHcYears, RandomSource rng) {
+    var u = rng.nextDouble();
+    var base =
+        u < 0.15
+            ? bands.contractP10Years()
+            : u < 0.65
+                ? bands.contractModeYears()
+                : u < 0.9 ? bands.contractP50Years() : bands.contractP90Years();
+    return priorHcYears >= 2 ? Math.min(base + 1, bands.contractP90Years() + 1) : base;
+  }
+
+  private BigDecimal perceivedGuaranteedMoney(int priorHcYears, RandomSource rng) {
+    var base =
+        GUARANTEED_MONEY_FLOOR
+            + rng.nextDouble() * (GUARANTEED_MONEY_CEIL - GUARANTEED_MONEY_FLOOR);
+    var bump = priorHcYears >= 2 ? 0.02 : 0.0;
+    var value = Math.min(1.0, base + bump);
+    return BigDecimal.valueOf(value).setScale(3, RoundingMode.HALF_UP);
+  }
+
+  private CandidatePreferencesDraft buildPreferences(
+      BigDecimal compensation, int contractLength, BigDecimal guaranteedMoney, RandomSource rng) {
+    var rawWeights = new double[13];
+    for (var i = 0; i < rawWeights.length; i++) {
+      rawWeights[i] = 0.25 + rng.nextDouble();
+    }
+    var sum = 0.0;
+    for (var w : rawWeights) sum += w;
+    var w = new BigDecimal[13];
+    for (var i = 0; i < rawWeights.length; i++) {
+      w[i] = BigDecimal.valueOf(rawWeights[i] / sum).setScale(3, RoundingMode.HALF_UP);
+    }
+
+    var marketSize = MarketSize.values()[(int) (rng.nextDouble() * MarketSize.values().length)];
+    var geography = Geography.values()[(int) (rng.nextDouble() * Geography.values().length)];
+    var climate = Climate.values()[(int) (rng.nextDouble() * Climate.values().length)];
+    var roleScope = RoleScope.values()[(int) (rng.nextDouble() * RoleScope.values().length)];
+    var staffContinuity =
+        StaffContinuity.values()[(int) (rng.nextDouble() * StaffContinuity.values().length)];
+    var competitiveWindow =
+        CompetitiveWindow.values()[(int) (rng.nextDouble() * CompetitiveWindow.values().length)];
+    var schemeAlignment = sampleSchemeAlignment(rng);
+
+    return new CandidatePreferencesDraft(
+        compensation,
+        w[0],
+        contractLength,
+        w[1],
+        guaranteedMoney,
+        w[2],
+        marketSize,
+        w[3],
+        geography,
+        w[4],
+        climate,
+        w[5],
+        BigDecimal.valueOf(50 + rng.nextDouble() * 30).setScale(2, RoundingMode.HALF_UP),
+        w[6],
+        competitiveWindow,
+        w[7],
+        roleScope,
+        w[8],
+        staffContinuity,
+        w[9],
+        schemeAlignment,
+        w[10],
+        BigDecimal.valueOf(50 + rng.nextDouble() * 30).setScale(2, RoundingMode.HALF_UP),
+        w[11],
+        BigDecimal.valueOf(50 + rng.nextDouble() * 30).setScale(2, RoundingMode.HALF_UP),
+        w[12]);
+  }
+
+  private String sampleSchemeAlignment(RandomSource rng) {
+    var schemes = List.of("SPREAD", "WEST_COAST", "AIR_RAID", "SMASHMOUTH", "COVER_2", "COVER_3");
+    return schemes.get((int) (rng.nextDouble() * schemes.size()));
+  }
+
+  private String attrsJson(double rating) {
+    return "{\"overall\": %.2f}".formatted(rating);
+  }
+
+  private static double triangular(double a, double c, double b, RandomSource rng) {
+    var u = rng.nextDouble();
+    var f = (c - a) / (b - a);
+    if (u < f) {
+      return a + Math.sqrt(u * (b - a) * (c - a));
+    }
+    return b - Math.sqrt((1 - u) * (b - a) * (b - c));
+  }
+
+  private static int clampInt(int v, int lo, int hi) {
+    return Math.max(lo, Math.min(hi, v));
+  }
+
+  private static double clamp(double v, double lo, double hi) {
+    return Math.max(lo, Math.min(hi, v));
+  }
+}

--- a/src/main/java/app/zoneblitz/league/HeadCoachMarketBands.java
+++ b/src/main/java/app/zoneblitz/league/HeadCoachMarketBands.java
@@ -1,0 +1,104 @@
+package app.zoneblitz.league;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.IOException;
+import java.io.InputStream;
+import java.math.BigDecimal;
+import java.util.Objects;
+
+/**
+ * Typed view over the {@code tiers.HC} section of {@code data/bands/coach-market.json}. Parsed once
+ * at construction and handed to the generator so no I/O happens mid-generation.
+ */
+record HeadCoachMarketBands(
+    int salaryP10,
+    int salaryP50,
+    int salaryP90,
+    int salaryCeiling,
+    int salaryMin,
+    int contractModeYears,
+    int contractP10Years,
+    int contractP50Years,
+    int contractP90Years,
+    int ageMode,
+    int ageP10,
+    int ageP50,
+    int ageP90,
+    int ageMin,
+    int ageMax,
+    double experienceP10Years,
+    double experienceMeanYears,
+    double experienceP90Years,
+    double firstTimeHcRate,
+    double offenseShare,
+    double defenseShare,
+    double ceoShare) {
+
+  static HeadCoachMarketBands loadFromClasspath() {
+    return loadFromClasspath("/bands/coach-market.json");
+  }
+
+  static HeadCoachMarketBands loadFromClasspath(String resource) {
+    Objects.requireNonNull(resource, "resource");
+    try (InputStream in = HeadCoachMarketBands.class.getResourceAsStream(resource)) {
+      if (in == null) {
+        throw new IllegalStateException("Band resource not found on classpath: " + resource);
+      }
+      var root = new ObjectMapper().readTree(in);
+      return fromJson(root.at("/tiers/HC"));
+    } catch (IOException e) {
+      throw new IllegalStateException("Failed to read " + resource, e);
+    }
+  }
+
+  private static HeadCoachMarketBands fromJson(JsonNode hc) {
+    if (hc == null || hc.isMissingNode()) {
+      throw new IllegalStateException("coach-market.json missing tiers.HC");
+    }
+    var salary = hc.get("salary_annual_usd");
+    var contract = hc.get("contract_length_years");
+    var age = hc.get("age_distribution");
+    var experience = hc.get("experience_distribution");
+    var split = hc.get("playcaller_specialty_split");
+    return new HeadCoachMarketBands(
+        salary.get("p10").asInt(),
+        salary.get("p50").asInt(),
+        salary.get("p90").asInt(),
+        salary.get("ceiling").asInt(),
+        (int) Math.round(salary.get("p10").asInt() * 0.5),
+        contract.get("mode").asInt(),
+        contract.get("p10").asInt(),
+        contract.get("p50").asInt(),
+        contract.get("p90").asInt(),
+        age.get("mode").asInt(),
+        age.get("p10").asInt(),
+        age.get("p50").asInt(),
+        age.get("p90").asInt(),
+        age.get("min").asInt(),
+        age.get("max").asInt(),
+        experience.get("years_experience_p10").asDouble(),
+        experience.get("years_experience_mean").asDouble(),
+        experience.get("years_experience_p90").asDouble(),
+        experience.get("first_time_hc_rate").asDouble(),
+        split.get("offense").asDouble(),
+        split.get("defense").asDouble(),
+        split.get("ceo").asDouble());
+  }
+
+  BigDecimal salaryP10Dec() {
+    return BigDecimal.valueOf(salaryP10);
+  }
+
+  BigDecimal salaryP50Dec() {
+    return BigDecimal.valueOf(salaryP50);
+  }
+
+  BigDecimal salaryP90Dec() {
+    return BigDecimal.valueOf(salaryP90);
+  }
+
+  BigDecimal salaryCeilingDec() {
+    return BigDecimal.valueOf(salaryCeiling);
+  }
+}

--- a/src/test/java/app/zoneblitz/league/FakeRandomSource.java
+++ b/src/test/java/app/zoneblitz/league/FakeRandomSource.java
@@ -1,0 +1,40 @@
+package app.zoneblitz.league;
+
+import app.zoneblitz.gamesimulator.rng.RandomSource;
+import java.util.Random;
+
+/**
+ * Deterministic {@link RandomSource} for league tests. Backed by {@link Random} with a fixed seed
+ * so generator outputs are reproducible across runs. {@link #split(long)} returns a child with a
+ * seed derived from the parent seed and the split key.
+ */
+final class FakeRandomSource implements RandomSource {
+
+  private final Random random;
+  private final long seed;
+
+  FakeRandomSource(long seed) {
+    this.seed = seed;
+    this.random = new Random(seed);
+  }
+
+  @Override
+  public long nextLong() {
+    return random.nextLong();
+  }
+
+  @Override
+  public double nextDouble() {
+    return random.nextDouble();
+  }
+
+  @Override
+  public double nextGaussian() {
+    return random.nextGaussian();
+  }
+
+  @Override
+  public RandomSource split(long key) {
+    return new FakeRandomSource(seed ^ (key * 0x9E3779B97F4A7C15L));
+  }
+}

--- a/src/test/java/app/zoneblitz/league/HeadCoachGeneratorTests.java
+++ b/src/test/java/app/zoneblitz/league/HeadCoachGeneratorTests.java
@@ -1,0 +1,223 @@
+package app.zoneblitz.league;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.math.BigDecimal;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class HeadCoachGeneratorTests {
+
+  private CandidateGenerator generator;
+
+  @BeforeEach
+  void setUp() {
+    generator = new HeadCoachGenerator();
+  }
+
+  @Test
+  void generate_whenPoolSizeIsZeroOrNegative_throws() {
+    var rng = new FakeRandomSource(42L);
+    assertThatThrownBy(() -> generator.generate(0, rng))
+        .isInstanceOf(IllegalArgumentException.class);
+    assertThatThrownBy(() -> generator.generate(-1, rng))
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
+  void generate_producesRequestedPoolSizeWithAllRequiredFields() {
+    var rng = new FakeRandomSource(7L);
+
+    var candidates = generator.generate(20, rng);
+
+    assertThat(candidates).hasSize(20);
+    for (var generated : candidates) {
+      var candidate = generated.candidate();
+      assertThat(candidate.kind()).isEqualTo(CandidateKind.HEAD_COACH);
+      assertThat(candidate.archetype())
+          .isIn(
+              CandidateArchetype.OFFENSIVE_PLAY_CALLER,
+              CandidateArchetype.DEFENSIVE_PLAY_CALLER,
+              CandidateArchetype.CEO);
+      assertThat(candidate.age()).isBetween(32, 72);
+      assertThat(candidate.totalExperienceYears()).isGreaterThanOrEqualTo(0);
+      assertThat(candidate.experienceByRole()).contains("\"HC\"", "\"OC\"", "\"POSITION_COACH\"");
+      assertThat(candidate.hiddenAttrs()).contains("overall");
+      assertThat(candidate.scoutedAttrs()).contains("overall");
+      assertThat(candidate.scoutBranch()).isEmpty();
+
+      var prefs = generated.preferences();
+      assertThat(prefs.compensationTarget()).isGreaterThan(BigDecimal.ZERO);
+      assertThat(prefs.contractLengthTarget()).isGreaterThan(0);
+      assertThat(prefs.guaranteedMoneyTarget()).isBetween(BigDecimal.ZERO, BigDecimal.ONE);
+
+      var weightSum =
+          prefs
+              .compensationWeight()
+              .add(prefs.contractLengthWeight())
+              .add(prefs.guaranteedMoneyWeight())
+              .add(prefs.marketSizeWeight())
+              .add(prefs.geographyWeight())
+              .add(prefs.climateWeight())
+              .add(prefs.franchisePrestigeWeight())
+              .add(prefs.competitiveWindowWeight())
+              .add(prefs.roleScopeWeight())
+              .add(prefs.staffContinuityWeight())
+              .add(prefs.schemeAlignmentWeight())
+              .add(prefs.ownerStabilityWeight())
+              .add(prefs.facilityQualityWeight());
+      assertThat(weightSum.doubleValue()).isBetween(0.95, 1.05);
+    }
+  }
+
+  @Test
+  void generate_isDeterministicForSameSeed() {
+    var candidatesA = generator.generate(50, new FakeRandomSource(1234L));
+    var candidatesB = generator.generate(50, new FakeRandomSource(1234L));
+
+    assertThat(candidatesA).isEqualTo(candidatesB);
+  }
+
+  @Test
+  void generate_salaryDistributionMatchesBandPercentilesWithinTolerance() {
+    var salaries =
+        generator.generate(2_000, new FakeRandomSource(99L)).stream()
+            .map(c -> c.preferences().compensationTarget().doubleValue())
+            .sorted()
+            .toList();
+
+    var p10 = percentile(salaries, 0.10);
+    var p50 = percentile(salaries, 0.50);
+    var p90 = percentile(salaries, 0.90);
+
+    // Band file HC salary: p10 5.5M, p50 8.5M, p90 14M, ceiling 20M.
+    // Tolerance is loose because the generator overlays age/experience/archetype multipliers on the
+    // base triangular, widening the distribution. The percentile ORDERING must hold and each
+    // quantile must land within the band's reasonable window.
+    assertThat(p10).isBetween(2_500_000.0, 8_500_000.0);
+    assertThat(p50).isBetween(5_500_000.0, 12_000_000.0);
+    assertThat(p90).isBetween(9_000_000.0, 22_000_000.0);
+    assertThat(p10).isLessThan(p50);
+    assertThat(p50).isLessThan(p90);
+  }
+
+  @Test
+  void generate_firstTimeHcRateHonoredOverLargeSample() {
+    var sample = generator.generate(3_000, new FakeRandomSource(2026L));
+
+    var firstTimers =
+        sample.stream().filter(c -> extractHcYears(c.candidate().experienceByRole()) == 0).count();
+    var observedRate = firstTimers / (double) sample.size();
+
+    // Band target 0.55; generator mixes first-time pool with retread multipliers across perceived
+    // features. The rate must fall within ±5 percentage points of target.
+    assertThat(observedRate).isBetween(0.50, 0.60);
+  }
+
+  @Test
+  void generate_archetypeDistributionMatchesPlaycallerSplit() {
+    var sample = generator.generate(3_000, new FakeRandomSource(17L));
+
+    var offense =
+        sample.stream()
+                .filter(c -> c.candidate().archetype() == CandidateArchetype.OFFENSIVE_PLAY_CALLER)
+                .count()
+            / (double) sample.size();
+    var defense =
+        sample.stream()
+                .filter(c -> c.candidate().archetype() == CandidateArchetype.DEFENSIVE_PLAY_CALLER)
+                .count()
+            / (double) sample.size();
+    var ceo =
+        sample.stream().filter(c -> c.candidate().archetype() == CandidateArchetype.CEO).count()
+            / (double) sample.size();
+
+    assertThat(offense).isBetween(0.50, 0.60);
+    assertThat(defense).isBetween(0.25, 0.35);
+    assertThat(ceo).isBetween(0.10, 0.20);
+  }
+
+  @Test
+  void generate_trueRatingIsStatisticallyIndependentOfPrice() {
+    var sample = generator.generate(2_000, new FakeRandomSource(5150L));
+
+    var ratings = sample.stream().map(c -> parseOverall(c.candidate().hiddenAttrs())).toList();
+    var prices =
+        sample.stream().map(c -> c.preferences().compensationTarget().doubleValue()).toList();
+
+    var correlation = pearsonCorrelation(ratings, prices);
+
+    // If true rating leaked into the price function, |r| would be large (>~0.3). The hidden-info
+    // contract requires near-zero correlation — tolerance is ±0.12 for a 2000-sample draw.
+    assertThat(Math.abs(correlation)).isLessThan(0.12);
+  }
+
+  @Test
+  void generate_mostExperiencedHeadCoachesCommandHighestPrices() {
+    var sample = generator.generate(2_000, new FakeRandomSource(808L));
+
+    var firstTimers =
+        sample.stream()
+            .filter(c -> extractHcYears(c.candidate().experienceByRole()) == 0)
+            .mapToDouble(c -> c.preferences().compensationTarget().doubleValue())
+            .average()
+            .orElseThrow();
+    var retreads =
+        sample.stream()
+            .filter(c -> extractHcYears(c.candidate().experienceByRole()) >= 3)
+            .mapToDouble(c -> c.preferences().compensationTarget().doubleValue())
+            .average()
+            .orElseThrow();
+
+    assertThat(retreads).isGreaterThan(firstTimers);
+  }
+
+  private static int extractHcYears(String experienceByRole) {
+    var marker = "\"HC\":";
+    var idx = experienceByRole.indexOf(marker);
+    if (idx < 0) return 0;
+    var rest = experienceByRole.substring(idx + marker.length()).trim();
+    var end = 0;
+    while (end < rest.length()
+        && (Character.isDigit(rest.charAt(end)) || rest.charAt(end) == '-')) {
+      end++;
+    }
+    return Integer.parseInt(rest.substring(0, end));
+  }
+
+  private static double parseOverall(String attrsJson) {
+    var idx = attrsJson.indexOf(':');
+    var end = attrsJson.indexOf('}', idx);
+    return Double.parseDouble(attrsJson.substring(idx + 1, end).trim());
+  }
+
+  private static double percentile(List<Double> sortedValues, double p) {
+    var idx = (int) Math.floor(p * (sortedValues.size() - 1));
+    return sortedValues.get(idx);
+  }
+
+  private static double pearsonCorrelation(List<Double> xs, List<Double> ys) {
+    var n = xs.size();
+    var sumX = 0.0;
+    var sumY = 0.0;
+    for (var i = 0; i < n; i++) {
+      sumX += xs.get(i);
+      sumY += ys.get(i);
+    }
+    var meanX = sumX / n;
+    var meanY = sumY / n;
+    var covariance = 0.0;
+    var varX = 0.0;
+    var varY = 0.0;
+    for (var i = 0; i < n; i++) {
+      var dx = xs.get(i) - meanX;
+      var dy = ys.get(i) - meanY;
+      covariance += dx * dy;
+      varX += dx * dx;
+      varY += dy * dy;
+    }
+    return covariance / Math.sqrt(varX * varY);
+  }
+}


### PR DESCRIPTION
Closes #603

Stacked on #602.

## Summary
- `CandidateGenerator` seam — per-kind generator interface.
- `HeadCoachGenerator` draws age, experience, archetype (offense 0.55 / defense 0.30 / ceo 0.15), specialty, and true/scouted ratings from `data/bands/coach-market.json` tier `HC`.
- Price signals (compensation, contract length, guaranteed money) derive from perceived value only — age, total experience, prior HC years, archetype, specialty. True rating is sampled independently and never enters the price function.
- All 13 preference dimensions populated with per-candidate weights normalized to ~1.
- Pool size supplied by caller (design supports 2-3x franchise count configurability).
- Determinism via `RandomSource`; league-local `FakeRandomSource` for tests.

## Test plan
- [x] `./gradlew spotlessApply && ./gradlew spotlessCheck && ./gradlew test` all pass locally.
- [x] Salary percentile bands match `coach-market.json` priors within tolerance.
- [x] `first_time_hc_rate` honored at 0.55 (±0.05) over 3k-sample draw.
- [x] Playcaller specialty split matches band file (±0.05).
- [x] True rating vs. price Pearson |r| < 0.12 over 2k samples (hidden-info guarantee).
- [x] Retreads (>=3 prior HC years) average higher compensation than first-timers.
- [x] Generation is deterministic for a fixed seed.