### PR TITLE
feat(league): interviews reduce scouted noise (#605)

### DIFF
--- a/src/main/java/app/zoneblitz/league/AdvancePhase.java
+++ b/src/main/java/app/zoneblitz/league/AdvancePhase.java
@@ -1,0 +1,22 @@
+package app.zoneblitz.league;
+
+/**
+ * Use case: advance a league from its current phase to the next phase.
+ *
+ * <p>Runs the outgoing phase's {@link PhaseTransitionHandler#onExit} hook, persists the new phase
+ * with {@code phase_week} reset to 1, then runs the incoming phase's {@link
+ * PhaseTransitionHandler#onEntry} hook. All within a single transaction.
+ */
+public interface AdvancePhase {
+
+  /**
+   * @param leagueId the league to advance.
+   * @param ownerSubject OAuth2 subject of the caller; a league not owned by this subject surfaces
+   *     as {@link AdvancePhaseResult.NotFound}.
+   * @return {@link AdvancePhaseResult.Advanced} on a successful transition; {@link
+   *     AdvancePhaseResult.NotFound} if the league does not exist or is not owned by {@code
+   *     ownerSubject}; {@link AdvancePhaseResult.NoNextPhase} if the league is already in the
+   *     terminal phase.
+   */
+  AdvancePhaseResult advance(long leagueId, String ownerSubject);
+}

--- a/src/main/java/app/zoneblitz/league/AdvancePhaseResult.java
+++ b/src/main/java/app/zoneblitz/league/AdvancePhaseResult.java
@@ -1,0 +1,10 @@
+package app.zoneblitz.league;
+
+public sealed interface AdvancePhaseResult {
+
+  record Advanced(long leagueId, LeaguePhase from, LeaguePhase to) implements AdvancePhaseResult {}
+
+  record NotFound(long leagueId) implements AdvancePhaseResult {}
+
+  record NoNextPhase(long leagueId, LeaguePhase phase) implements AdvancePhaseResult {}
+}

--- a/src/main/java/app/zoneblitz/league/AdvancePhaseUseCase.java
+++ b/src/main/java/app/zoneblitz/league/AdvancePhaseUseCase.java
@@ -1,0 +1,56 @@
+package app.zoneblitz.league;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Collectors;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+class AdvancePhaseUseCase implements AdvancePhase {
+
+  private static final Logger log = LoggerFactory.getLogger(AdvancePhaseUseCase.class);
+
+  private final LeagueRepository leagues;
+  private final Map<LeaguePhase, PhaseTransitionHandler> handlers;
+
+  AdvancePhaseUseCase(LeagueRepository leagues, List<PhaseTransitionHandler> handlers) {
+    this.leagues = leagues;
+    this.handlers =
+        handlers.stream()
+            .collect(Collectors.toUnmodifiableMap(PhaseTransitionHandler::phase, h -> h));
+  }
+
+  @Override
+  @Transactional
+  public AdvancePhaseResult advance(long leagueId, String ownerSubject) {
+    Objects.requireNonNull(ownerSubject, "ownerSubject");
+
+    var maybeLeague = leagues.findSummaryByIdAndOwner(leagueId, ownerSubject);
+    if (maybeLeague.isEmpty()) {
+      return new AdvancePhaseResult.NotFound(leagueId);
+    }
+    var current = maybeLeague.get().phase();
+    var maybeNext = LeaguePhases.next(current);
+    if (maybeNext.isEmpty()) {
+      return new AdvancePhaseResult.NoNextPhase(leagueId, current);
+    }
+    var next = maybeNext.get();
+
+    var exitHandler = handlers.get(current);
+    if (exitHandler != null) {
+      exitHandler.onExit(leagueId);
+    }
+    leagues.updatePhaseAndResetWeek(leagueId, next);
+    var entryHandler = handlers.get(next);
+    if (entryHandler != null) {
+      entryHandler.onEntry(leagueId);
+    }
+
+    log.info("league phase advanced id={} from={} to={}", leagueId, current, next);
+    return new AdvancePhaseResult.Advanced(leagueId, current, next);
+  }
+}

--- a/src/main/java/app/zoneblitz/league/AdvanceWeek.java
+++ b/src/main/java/app/zoneblitz/league/AdvanceWeek.java
@@ -1,0 +1,22 @@
+package app.zoneblitz.league;
+
+/**
+ * Use case: run a week tick on a league.
+ *
+ * <p>Runs CPU franchise strategies (none wired yet — the seam is in place for future phases),
+ * increments {@code phase_week}, then runs the phase-completion check. If the phase completes as a
+ * result of the tick, {@link AdvancePhase} is invoked and the response reports the new phase.
+ *
+ * <p>For the foundational scope (issue #601) no phase defines a completion rule, so advances only
+ * ever happen through {@link AdvancePhase}. {@link AdvanceWeek} exists with the correct shape so
+ * later phases can plug in without reshaping callers.
+ */
+public interface AdvanceWeek {
+
+  /**
+   * @return {@link AdvanceWeekResult.Ticked} on a successful week tick (phase may or may not have
+   *     rolled over); {@link AdvanceWeekResult.NotFound} if the league does not exist or is not
+   *     owned by {@code ownerSubject}.
+   */
+  AdvanceWeekResult advance(long leagueId, String ownerSubject);
+}

--- a/src/main/java/app/zoneblitz/league/AdvanceWeekResult.java
+++ b/src/main/java/app/zoneblitz/league/AdvanceWeekResult.java
@@ -1,0 +1,19 @@
+package app.zoneblitz.league;
+
+import java.util.Optional;
+
+public sealed interface AdvanceWeekResult {
+
+  /**
+   * @param leagueId the league that ticked.
+   * @param phase the league's phase after the tick — may differ from the entry phase if the tick
+   *     completed the previous phase.
+   * @param phaseWeek the {@code phase_week} value after the tick.
+   * @param transitionedTo present when the tick completed the previous phase and transitioned.
+   */
+  record Ticked(
+      long leagueId, LeaguePhase phase, int phaseWeek, Optional<LeaguePhase> transitionedTo)
+      implements AdvanceWeekResult {}
+
+  record NotFound(long leagueId) implements AdvanceWeekResult {}
+}

--- a/src/main/java/app/zoneblitz/league/AdvanceWeekUseCase.java
+++ b/src/main/java/app/zoneblitz/league/AdvanceWeekUseCase.java
@@ -1,0 +1,42 @@
+package app.zoneblitz.league;
+
+import java.util.Objects;
+import java.util.Optional;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+class AdvanceWeekUseCase implements AdvanceWeek {
+
+  private static final Logger log = LoggerFactory.getLogger(AdvanceWeekUseCase.class);
+
+  private final LeagueRepository leagues;
+
+  AdvanceWeekUseCase(LeagueRepository leagues) {
+    this.leagues = leagues;
+  }
+
+  @Override
+  @Transactional
+  public AdvanceWeekResult advance(long leagueId, String ownerSubject) {
+    Objects.requireNonNull(ownerSubject, "ownerSubject");
+
+    var maybeLeague = leagues.findSummaryByIdAndOwner(leagueId, ownerSubject);
+    if (maybeLeague.isEmpty()) {
+      return new AdvanceWeekResult.NotFound(leagueId);
+    }
+    var phase = maybeLeague.get().phase();
+
+    // CPU franchise strategies are a future seam (see docs/technical/league-phases.md). No
+    // phase defines a completion rule yet, so the tick is currently just "increment the counter".
+    var newWeek =
+        leagues
+            .incrementPhaseWeek(leagueId)
+            .orElseThrow(() -> new IllegalStateException("league disappeared mid-transaction"));
+
+    log.info("league week advanced id={} phase={} week={}", leagueId, phase, newWeek);
+    return new AdvanceWeekResult.Ticked(leagueId, phase, newWeek, Optional.empty());
+  }
+}

--- a/src/main/java/app/zoneblitz/league/Candidate.java
+++ b/src/main/java/app/zoneblitz/league/Candidate.java
@@ -1,0 +1,42 @@
+package app.zoneblitz.league;
+
+import java.util.Objects;
+import java.util.Optional;
+
+/**
+ * A single candidate in a {@link CandidatePool}.
+ *
+ * <p>JSONB payloads ({@code experienceByRole}, {@code hiddenAttrs}, {@code scoutedAttrs}) are
+ * carried as raw JSON strings at this layer; the generator and consumers parse them into typed
+ * structures. {@code hiredByFranchiseId} and {@code scoutBranch} are optional because they are
+ * populated later in the candidate's lifecycle (on hire) or only for scout candidates.
+ *
+ * @param experienceByRole JSON object mapping role name to years, e.g. {@code {"OC": 10, "HC": 0}}.
+ * @param hiddenAttrs the never-revealed true-rating attribute payload. Must not be surfaced to UI.
+ * @param scoutedAttrs the noised estimate shown to franchises.
+ */
+public record Candidate(
+    long id,
+    long poolId,
+    CandidateKind kind,
+    SpecialtyPosition specialtyPosition,
+    CandidateArchetype archetype,
+    int age,
+    int totalExperienceYears,
+    String experienceByRole,
+    String hiddenAttrs,
+    String scoutedAttrs,
+    Optional<Long> hiredByFranchiseId,
+    Optional<ScoutBranch> scoutBranch) {
+
+  public Candidate {
+    Objects.requireNonNull(kind, "kind");
+    Objects.requireNonNull(specialtyPosition, "specialtyPosition");
+    Objects.requireNonNull(archetype, "archetype");
+    Objects.requireNonNull(experienceByRole, "experienceByRole");
+    Objects.requireNonNull(hiddenAttrs, "hiddenAttrs");
+    Objects.requireNonNull(scoutedAttrs, "scoutedAttrs");
+    Objects.requireNonNull(hiredByFranchiseId, "hiredByFranchiseId");
+    Objects.requireNonNull(scoutBranch, "scoutBranch");
+  }
+}

--- a/src/main/java/app/zoneblitz/league/CandidateArchetype.java
+++ b/src/main/java/app/zoneblitz/league/CandidateArchetype.java
@@ -1,0 +1,18 @@
+package app.zoneblitz.league;
+
+/**
+ * Categorical archetype tag. HC archetypes come first; other kinds' archetype sets are placeholders
+ * per the design doc and will expand as band files author them.
+ */
+public enum CandidateArchetype {
+  CEO,
+  OFFENSIVE_PLAY_CALLER,
+  DEFENSIVE_PLAY_CALLER,
+  OFFENSIVE_GURU,
+  DEFENSIVE_GURU,
+  TEACHER,
+  TACTICIAN,
+  COLLEGE_EVALUATOR,
+  PRO_EVALUATOR,
+  GENERALIST
+}

--- a/src/main/java/app/zoneblitz/league/CandidateGenerator.java
+++ b/src/main/java/app/zoneblitz/league/CandidateGenerator.java
@@ -1,0 +1,37 @@
+package app.zoneblitz.league;
+
+import app.zoneblitz.gamesimulator.rng.RandomSource;
+import java.util.List;
+
+/**
+ * Seam for generating a candidate pool for a given phase. One implementation per candidate kind
+ * (e.g. {@code HeadCoachGenerator}, {@code DirectorOfScoutingGenerator}). Generators are pure
+ * functions over ({@code poolSize}, {@link RandomSource}) — no DB access, no side effects.
+ *
+ * <p>Generators must obey the hidden-info contract in {@code docs/technical/league-phases.md}:
+ *
+ * <ol>
+ *   <li>Sample {@code true_rating} from the tier's underlying distribution.
+ *   <li>Derive price signals (compensation target, contract length, guaranteed money) from
+ *       <em>perceived value only</em> — age, experience, archetype, specialty. True rating must not
+ *       enter the price function.
+ *   <li>Derive {@code scouted_attrs} by applying tier-specific noise to the hidden attribute set.
+ * </ol>
+ *
+ * Violating step 2 collapses the market dynamic and is a bug.
+ */
+public interface CandidateGenerator {
+
+  /**
+   * Generate {@code poolSize} candidates drawn from the tier this generator represents. The
+   * returned list is immutable and ordered; ordering has no semantic meaning. Callers persist the
+   * generated candidates via the candidate and preferences repositories; the returned preferences
+   * draft is keyed once the candidate id is known.
+   *
+   * @param poolSize how many candidates to generate (must be {@code > 0}).
+   * @param rng randomness source; all stochastic draws flow through it so results are deterministic
+   *     given its seed.
+   * @return an immutable list of generated candidates (candidate + preferences draft pairs).
+   */
+  List<GeneratedCandidate> generate(int poolSize, RandomSource rng);
+}

--- a/src/main/java/app/zoneblitz/league/CandidateKind.java
+++ b/src/main/java/app/zoneblitz/league/CandidateKind.java
@@ -1,0 +1,17 @@
+package app.zoneblitz.league;
+
+/**
+ * The kind of staff seat a {@link Candidate} is generated to fill.
+ *
+ * <p>Note: this is the per-candidate kind, more granular than {@link CandidatePoolType} which
+ * identifies the pool the candidate was drawn from.
+ */
+public enum CandidateKind {
+  HEAD_COACH,
+  DIRECTOR_OF_SCOUTING,
+  OFFENSIVE_COORDINATOR,
+  DEFENSIVE_COORDINATOR,
+  SPECIAL_TEAMS_COORDINATOR,
+  POSITION_COACH,
+  SCOUT
+}

--- a/src/main/java/app/zoneblitz/league/CandidateOffer.java
+++ b/src/main/java/app/zoneblitz/league/CandidateOffer.java
@@ -1,0 +1,18 @@
+package app.zoneblitz.league;
+
+import java.util.Objects;
+
+/** A franchise's offer to a candidate. Terms JSON is generator/consumer-shaped. */
+public record CandidateOffer(
+    long id,
+    long candidateId,
+    long franchiseId,
+    String terms,
+    int submittedAtWeek,
+    OfferStatus status) {
+
+  public CandidateOffer {
+    Objects.requireNonNull(terms, "terms");
+    Objects.requireNonNull(status, "status");
+  }
+}

--- a/src/main/java/app/zoneblitz/league/CandidateOfferRepository.java
+++ b/src/main/java/app/zoneblitz/league/CandidateOfferRepository.java
@@ -1,0 +1,32 @@
+package app.zoneblitz.league;
+
+import java.util.List;
+import java.util.Optional;
+
+/** Feature-internal persistence seam for {@link CandidateOffer}. */
+interface CandidateOfferRepository {
+
+  /**
+   * Insert a new offer in {@link OfferStatus#ACTIVE} status. A franchise may only have one active
+   * offer on a given candidate at a time; violating the invariant raises the underlying DB
+   * constraint.
+   */
+  CandidateOffer insertActive(long candidateId, long franchiseId, String terms, int week);
+
+  Optional<CandidateOffer> findById(long id);
+
+  /** All offers on a candidate, ordered by submission week ascending. */
+  List<CandidateOffer> findAllForCandidate(long candidateId);
+
+  /** Active offers on a candidate. Used at offer resolution. */
+  List<CandidateOffer> findActiveForCandidate(long candidateId);
+
+  /** All active offers a franchise currently has outstanding. */
+  List<CandidateOffer> findActiveForFranchise(long franchiseId);
+
+  /**
+   * Transition the offer from {@link OfferStatus#ACTIVE} to the given terminal status. Returns true
+   * when a row was updated.
+   */
+  boolean resolve(long offerId, OfferStatus status);
+}

--- a/src/main/java/app/zoneblitz/league/CandidatePool.java
+++ b/src/main/java/app/zoneblitz/league/CandidatePool.java
@@ -1,0 +1,7 @@
+package app.zoneblitz.league;
+
+import java.time.Instant;
+
+/** League-wide pool of candidates generated on phase entry. */
+public record CandidatePool(
+    long id, long leagueId, LeaguePhase phase, CandidatePoolType type, Instant generatedAt) {}

--- a/src/main/java/app/zoneblitz/league/CandidatePoolRepository.java
+++ b/src/main/java/app/zoneblitz/league/CandidatePoolRepository.java
@@ -1,0 +1,24 @@
+package app.zoneblitz.league;
+
+import java.util.List;
+import java.util.Optional;
+
+/** Feature-internal persistence seam for {@link CandidatePool}. */
+interface CandidatePoolRepository {
+
+  /** Insert a new pool. */
+  CandidatePool insert(long leagueId, LeaguePhase phase, CandidatePoolType type);
+
+  /** Lookup by id; empty when absent. */
+  Optional<CandidatePool> findById(long id);
+
+  /**
+   * Lookup by the {@code (leagueId, phase, type)} uniqueness key. Empty when no pool has been
+   * generated for that combination.
+   */
+  Optional<CandidatePool> findByLeaguePhaseAndType(
+      long leagueId, LeaguePhase phase, CandidatePoolType type);
+
+  /** All pools for a league, newest first. */
+  List<CandidatePool> findAllForLeague(long leagueId);
+}

--- a/src/main/java/app/zoneblitz/league/CandidatePoolType.java
+++ b/src/main/java/app/zoneblitz/league/CandidatePoolType.java
@@ -1,0 +1,10 @@
+package app.zoneblitz.league;
+
+/** Candidate pool bucket. Determines which tier of the market the pool was drawn from. */
+public enum CandidatePoolType {
+  HEAD_COACH,
+  DIRECTOR_OF_SCOUTING,
+  COORDINATOR,
+  POSITION_COACH,
+  SCOUT
+}

--- a/src/main/java/app/zoneblitz/league/CandidatePreferences.java
+++ b/src/main/java/app/zoneblitz/league/CandidatePreferences.java
@@ -1,0 +1,69 @@
+package app.zoneblitz.league;
+
+import java.math.BigDecimal;
+import java.util.Objects;
+
+/**
+ * Wide preferences row for one candidate. One paired (target, weight) per dimension listed in
+ * {@code docs/technical/league-phases.md}. All 13 dimensions are mandatory so the scoring function
+ * is total.
+ *
+ * <p>Weights are 0..1; generator normalizes them across dimensions per-candidate.
+ */
+public record CandidatePreferences(
+    long candidateId,
+    BigDecimal compensationTarget,
+    BigDecimal compensationWeight,
+    int contractLengthTarget,
+    BigDecimal contractLengthWeight,
+    BigDecimal guaranteedMoneyTarget,
+    BigDecimal guaranteedMoneyWeight,
+    MarketSize marketSizeTarget,
+    BigDecimal marketSizeWeight,
+    Geography geographyTarget,
+    BigDecimal geographyWeight,
+    Climate climateTarget,
+    BigDecimal climateWeight,
+    BigDecimal franchisePrestigeTarget,
+    BigDecimal franchisePrestigeWeight,
+    CompetitiveWindow competitiveWindowTarget,
+    BigDecimal competitiveWindowWeight,
+    RoleScope roleScopeTarget,
+    BigDecimal roleScopeWeight,
+    StaffContinuity staffContinuityTarget,
+    BigDecimal staffContinuityWeight,
+    String schemeAlignmentTarget,
+    BigDecimal schemeAlignmentWeight,
+    BigDecimal ownerStabilityTarget,
+    BigDecimal ownerStabilityWeight,
+    BigDecimal facilityQualityTarget,
+    BigDecimal facilityQualityWeight) {
+
+  public CandidatePreferences {
+    Objects.requireNonNull(compensationTarget, "compensationTarget");
+    Objects.requireNonNull(compensationWeight, "compensationWeight");
+    Objects.requireNonNull(contractLengthWeight, "contractLengthWeight");
+    Objects.requireNonNull(guaranteedMoneyTarget, "guaranteedMoneyTarget");
+    Objects.requireNonNull(guaranteedMoneyWeight, "guaranteedMoneyWeight");
+    Objects.requireNonNull(marketSizeTarget, "marketSizeTarget");
+    Objects.requireNonNull(marketSizeWeight, "marketSizeWeight");
+    Objects.requireNonNull(geographyTarget, "geographyTarget");
+    Objects.requireNonNull(geographyWeight, "geographyWeight");
+    Objects.requireNonNull(climateTarget, "climateTarget");
+    Objects.requireNonNull(climateWeight, "climateWeight");
+    Objects.requireNonNull(franchisePrestigeTarget, "franchisePrestigeTarget");
+    Objects.requireNonNull(franchisePrestigeWeight, "franchisePrestigeWeight");
+    Objects.requireNonNull(competitiveWindowTarget, "competitiveWindowTarget");
+    Objects.requireNonNull(competitiveWindowWeight, "competitiveWindowWeight");
+    Objects.requireNonNull(roleScopeTarget, "roleScopeTarget");
+    Objects.requireNonNull(roleScopeWeight, "roleScopeWeight");
+    Objects.requireNonNull(staffContinuityTarget, "staffContinuityTarget");
+    Objects.requireNonNull(staffContinuityWeight, "staffContinuityWeight");
+    Objects.requireNonNull(schemeAlignmentTarget, "schemeAlignmentTarget");
+    Objects.requireNonNull(schemeAlignmentWeight, "schemeAlignmentWeight");
+    Objects.requireNonNull(ownerStabilityTarget, "ownerStabilityTarget");
+    Objects.requireNonNull(ownerStabilityWeight, "ownerStabilityWeight");
+    Objects.requireNonNull(facilityQualityTarget, "facilityQualityTarget");
+    Objects.requireNonNull(facilityQualityWeight, "facilityQualityWeight");
+  }
+}

--- a/src/main/java/app/zoneblitz/league/CandidatePreferencesDraft.java
+++ b/src/main/java/app/zoneblitz/league/CandidatePreferencesDraft.java
@@ -1,0 +1,98 @@
+package app.zoneblitz.league;
+
+import java.math.BigDecimal;
+import java.util.Objects;
+
+/**
+ * Generator-side preferences payload. Identical to {@link CandidatePreferences} minus {@code
+ * candidateId} — generators emit this shape before a candidate row exists; the caller pairs it with
+ * the assigned id post-insert via {@link #withCandidateId(long)}.
+ */
+public record CandidatePreferencesDraft(
+    BigDecimal compensationTarget,
+    BigDecimal compensationWeight,
+    int contractLengthTarget,
+    BigDecimal contractLengthWeight,
+    BigDecimal guaranteedMoneyTarget,
+    BigDecimal guaranteedMoneyWeight,
+    MarketSize marketSizeTarget,
+    BigDecimal marketSizeWeight,
+    Geography geographyTarget,
+    BigDecimal geographyWeight,
+    Climate climateTarget,
+    BigDecimal climateWeight,
+    BigDecimal franchisePrestigeTarget,
+    BigDecimal franchisePrestigeWeight,
+    CompetitiveWindow competitiveWindowTarget,
+    BigDecimal competitiveWindowWeight,
+    RoleScope roleScopeTarget,
+    BigDecimal roleScopeWeight,
+    StaffContinuity staffContinuityTarget,
+    BigDecimal staffContinuityWeight,
+    String schemeAlignmentTarget,
+    BigDecimal schemeAlignmentWeight,
+    BigDecimal ownerStabilityTarget,
+    BigDecimal ownerStabilityWeight,
+    BigDecimal facilityQualityTarget,
+    BigDecimal facilityQualityWeight) {
+
+  public CandidatePreferencesDraft {
+    Objects.requireNonNull(compensationTarget, "compensationTarget");
+    Objects.requireNonNull(compensationWeight, "compensationWeight");
+    Objects.requireNonNull(contractLengthWeight, "contractLengthWeight");
+    Objects.requireNonNull(guaranteedMoneyTarget, "guaranteedMoneyTarget");
+    Objects.requireNonNull(guaranteedMoneyWeight, "guaranteedMoneyWeight");
+    Objects.requireNonNull(marketSizeTarget, "marketSizeTarget");
+    Objects.requireNonNull(marketSizeWeight, "marketSizeWeight");
+    Objects.requireNonNull(geographyTarget, "geographyTarget");
+    Objects.requireNonNull(geographyWeight, "geographyWeight");
+    Objects.requireNonNull(climateTarget, "climateTarget");
+    Objects.requireNonNull(climateWeight, "climateWeight");
+    Objects.requireNonNull(franchisePrestigeTarget, "franchisePrestigeTarget");
+    Objects.requireNonNull(franchisePrestigeWeight, "franchisePrestigeWeight");
+    Objects.requireNonNull(competitiveWindowTarget, "competitiveWindowTarget");
+    Objects.requireNonNull(competitiveWindowWeight, "competitiveWindowWeight");
+    Objects.requireNonNull(roleScopeTarget, "roleScopeTarget");
+    Objects.requireNonNull(roleScopeWeight, "roleScopeWeight");
+    Objects.requireNonNull(staffContinuityTarget, "staffContinuityTarget");
+    Objects.requireNonNull(staffContinuityWeight, "staffContinuityWeight");
+    Objects.requireNonNull(schemeAlignmentTarget, "schemeAlignmentTarget");
+    Objects.requireNonNull(schemeAlignmentWeight, "schemeAlignmentWeight");
+    Objects.requireNonNull(ownerStabilityTarget, "ownerStabilityTarget");
+    Objects.requireNonNull(ownerStabilityWeight, "ownerStabilityWeight");
+    Objects.requireNonNull(facilityQualityTarget, "facilityQualityTarget");
+    Objects.requireNonNull(facilityQualityWeight, "facilityQualityWeight");
+  }
+
+  /** Materialize a persisted-shape {@link CandidatePreferences} by pairing with a candidate id. */
+  public CandidatePreferences withCandidateId(long candidateId) {
+    return new CandidatePreferences(
+        candidateId,
+        compensationTarget,
+        compensationWeight,
+        contractLengthTarget,
+        contractLengthWeight,
+        guaranteedMoneyTarget,
+        guaranteedMoneyWeight,
+        marketSizeTarget,
+        marketSizeWeight,
+        geographyTarget,
+        geographyWeight,
+        climateTarget,
+        climateWeight,
+        franchisePrestigeTarget,
+        franchisePrestigeWeight,
+        competitiveWindowTarget,
+        competitiveWindowWeight,
+        roleScopeTarget,
+        roleScopeWeight,
+        staffContinuityTarget,
+        staffContinuityWeight,
+        schemeAlignmentTarget,
+        schemeAlignmentWeight,
+        ownerStabilityTarget,
+        ownerStabilityWeight,
+        facilityQualityTarget,
+        facilityQualityWeight);
+  }
+}

--- a/src/main/java/app/zoneblitz/league/CandidatePreferencesRepository.java
+++ b/src/main/java/app/zoneblitz/league/CandidatePreferencesRepository.java
@@ -1,0 +1,13 @@
+package app.zoneblitz.league;
+
+import java.util.Optional;
+
+/** Feature-internal persistence seam for {@link CandidatePreferences}. */
+interface CandidatePreferencesRepository {
+
+  /** Insert the preference row for a candidate. The candidate must already exist. */
+  CandidatePreferences insert(CandidatePreferences preferences);
+
+  /** Lookup preferences by candidate id; empty if the candidate has no preferences row yet. */
+  Optional<CandidatePreferences> findByCandidateId(long candidateId);
+}

--- a/src/main/java/app/zoneblitz/league/CandidateRandomSources.java
+++ b/src/main/java/app/zoneblitz/league/CandidateRandomSources.java
@@ -1,0 +1,14 @@
+package app.zoneblitz.league;
+
+import app.zoneblitz.gamesimulator.rng.RandomSource;
+
+/**
+ * Factory seam producing a deterministic {@link RandomSource} for a {@code (leagueId, phase)} pair.
+ * Lets phase-entry handlers generate reproducible candidate pools without depending on a concrete
+ * RNG implementation.
+ */
+interface CandidateRandomSources {
+
+  /** Return a seeded {@link RandomSource} scoped to the given league and phase. */
+  RandomSource forLeaguePhase(long leagueId, LeaguePhase phase);
+}

--- a/src/main/java/app/zoneblitz/league/CandidateRepository.java
+++ b/src/main/java/app/zoneblitz/league/CandidateRepository.java
@@ -1,0 +1,26 @@
+package app.zoneblitz.league;
+
+import java.util.List;
+import java.util.Optional;
+
+/** Feature-internal persistence seam for {@link Candidate}. */
+interface CandidateRepository {
+
+  /**
+   * Insert a candidate into the given pool. {@code hiredByFranchiseId} and {@code scoutBranch}
+   * default to empty/null on insert.
+   */
+  Candidate insert(NewCandidate newCandidate);
+
+  Optional<Candidate> findById(long id);
+
+  /** All candidates in the pool, ordered by id ascending. */
+  List<Candidate> findAllByPoolId(long poolId);
+
+  /**
+   * Mark the candidate as hired by a franchise. Returns true when the update hit a row.
+   *
+   * <p>Does not enforce one-hire-per-candidate at this layer; higher-level use cases gate that.
+   */
+  boolean markHired(long candidateId, long franchiseId);
+}

--- a/src/main/java/app/zoneblitz/league/Climate.java
+++ b/src/main/java/app/zoneblitz/league/Climate.java
@@ -1,0 +1,7 @@
+package app.zoneblitz.league;
+
+public enum Climate {
+  WARM,
+  COLD,
+  NEUTRAL
+}

--- a/src/main/java/app/zoneblitz/league/CompetitiveWindow.java
+++ b/src/main/java/app/zoneblitz/league/CompetitiveWindow.java
@@ -1,0 +1,7 @@
+package app.zoneblitz.league;
+
+public enum CompetitiveWindow {
+  CONTENDER,
+  NEUTRAL,
+  REBUILD
+}

--- a/src/main/java/app/zoneblitz/league/FranchiseHiringState.java
+++ b/src/main/java/app/zoneblitz/league/FranchiseHiringState.java
@@ -1,0 +1,25 @@
+package app.zoneblitz.league;
+
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Per-franchise hiring sub-state for a hiring phase. {@code shortlist} and {@code
+ * interviewingCandidateIds} are carried as candidate-id lists.
+ */
+public record FranchiseHiringState(
+    long id,
+    long leagueId,
+    long franchiseId,
+    LeaguePhase phase,
+    HiringStep step,
+    List<Long> shortlist,
+    List<Long> interviewingCandidateIds) {
+
+  public FranchiseHiringState {
+    Objects.requireNonNull(phase, "phase");
+    Objects.requireNonNull(step, "step");
+    shortlist = List.copyOf(shortlist);
+    interviewingCandidateIds = List.copyOf(interviewingCandidateIds);
+  }
+}

--- a/src/main/java/app/zoneblitz/league/FranchiseHiringStateRepository.java
+++ b/src/main/java/app/zoneblitz/league/FranchiseHiringStateRepository.java
@@ -1,0 +1,18 @@
+package app.zoneblitz.league;
+
+import java.util.List;
+import java.util.Optional;
+
+/** Feature-internal persistence seam for {@link FranchiseHiringState}. */
+interface FranchiseHiringStateRepository {
+
+  /**
+   * Insert or replace the hiring state for a {@code (league, franchise, phase)} triple. Returns the
+   * upserted row.
+   */
+  FranchiseHiringState upsert(FranchiseHiringState state);
+
+  Optional<FranchiseHiringState> find(long leagueId, long franchiseId, LeaguePhase phase);
+
+  List<FranchiseHiringState> findAllForLeaguePhase(long leagueId, LeaguePhase phase);
+}

--- a/src/main/java/app/zoneblitz/league/FranchiseInterview.java
+++ b/src/main/java/app/zoneblitz/league/FranchiseInterview.java
@@ -1,0 +1,26 @@
+package app.zoneblitz.league;
+
+import java.math.BigDecimal;
+import java.util.Objects;
+
+/**
+ * A single completed interview a franchise conducted against a candidate. {@code interviewIndex} is
+ * the 1-based count for that (franchise, candidate) pair. {@code scoutedOverall} is the
+ * noise-reduced scouted estimate produced at the moment of the interview; stored so it is stable
+ * across subsequent views.
+ */
+public record FranchiseInterview(
+    long id,
+    long leagueId,
+    long franchiseId,
+    long candidateId,
+    LeaguePhase phase,
+    int phaseWeek,
+    int interviewIndex,
+    BigDecimal scoutedOverall) {
+
+  public FranchiseInterview {
+    Objects.requireNonNull(phase, "phase");
+    Objects.requireNonNull(scoutedOverall, "scoutedOverall");
+  }
+}

--- a/src/main/java/app/zoneblitz/league/FranchiseInterviewRepository.java
+++ b/src/main/java/app/zoneblitz/league/FranchiseInterviewRepository.java
@@ -1,0 +1,25 @@
+package app.zoneblitz.league;
+
+import java.util.List;
+
+/** Feature-internal persistence seam for {@link FranchiseInterview}. */
+interface FranchiseInterviewRepository {
+
+  /** Insert a completed interview row. Returns the persisted record with its generated id. */
+  FranchiseInterview insert(NewFranchiseInterview interview);
+
+  /**
+   * Count interviews this franchise has completed against a given candidate in the given phase.
+   * Used to drive the noise-reduction function's exponent.
+   */
+  int countForCandidate(long leagueId, long franchiseId, long candidateId, LeaguePhase phase);
+
+  /**
+   * Count interviews this franchise has completed this week of the given phase. Used to enforce the
+   * weekly capacity cap.
+   */
+  int countForWeek(long leagueId, long franchiseId, LeaguePhase phase, int phaseWeek);
+
+  /** All interviews this franchise has completed in the given phase, ordered by id ascending. */
+  List<FranchiseInterview> findAllFor(long leagueId, long franchiseId, LeaguePhase phase);
+}

--- a/src/main/java/app/zoneblitz/league/FranchiseStaffMember.java
+++ b/src/main/java/app/zoneblitz/league/FranchiseStaffMember.java
@@ -1,0 +1,28 @@
+package app.zoneblitz.league;
+
+import java.time.Instant;
+import java.util.Objects;
+import java.util.Optional;
+
+/**
+ * Terminal staff-seat hire for a franchise. {@code scoutBranch} is only populated when {@link
+ * #role()} is {@code COLLEGE_SCOUT} or {@code PRO_SCOUT}.
+ */
+public record FranchiseStaffMember(
+    long id,
+    long leagueId,
+    long franchiseId,
+    long candidateId,
+    StaffRole role,
+    Optional<ScoutBranch> scoutBranch,
+    LeaguePhase hiredAtPhase,
+    int hiredAtWeek,
+    Instant hiredAt) {
+
+  public FranchiseStaffMember {
+    Objects.requireNonNull(role, "role");
+    Objects.requireNonNull(scoutBranch, "scoutBranch");
+    Objects.requireNonNull(hiredAtPhase, "hiredAtPhase");
+    Objects.requireNonNull(hiredAt, "hiredAt");
+  }
+}

--- a/src/main/java/app/zoneblitz/league/FranchiseStaffRepository.java
+++ b/src/main/java/app/zoneblitz/league/FranchiseStaffRepository.java
@@ -1,0 +1,16 @@
+package app.zoneblitz.league;
+
+import java.util.List;
+import java.util.Optional;
+
+/** Feature-internal persistence seam for {@link FranchiseStaffMember}. */
+interface FranchiseStaffRepository {
+
+  /** Insert a new terminal staff hire. */
+  FranchiseStaffMember insert(NewFranchiseStaffMember hire);
+
+  Optional<FranchiseStaffMember> findById(long id);
+
+  /** All staff for one franchise in one league, ordered by role enum order. */
+  List<FranchiseStaffMember> findAllForFranchise(long leagueId, long franchiseId);
+}

--- a/src/main/java/app/zoneblitz/league/GeneratedCandidate.java
+++ b/src/main/java/app/zoneblitz/league/GeneratedCandidate.java
@@ -1,0 +1,16 @@
+package app.zoneblitz.league;
+
+import java.util.Objects;
+
+/**
+ * Output of a {@link CandidateGenerator}. Bundles the insert-side candidate payload with the paired
+ * preferences draft so callers can persist both in one transaction. The preferences draft carries
+ * every dimension except {@code candidateId} — that is materialized once the candidate row exists.
+ */
+public record GeneratedCandidate(NewCandidate candidate, CandidatePreferencesDraft preferences) {
+
+  public GeneratedCandidate {
+    Objects.requireNonNull(candidate, "candidate");
+    Objects.requireNonNull(preferences, "preferences");
+  }
+}

--- a/src/main/java/app/zoneblitz/league/Geography.java
+++ b/src/main/java/app/zoneblitz/league/Geography.java
@@ -1,0 +1,10 @@
+package app.zoneblitz.league;
+
+/** US region bucket used for candidate geography preference. */
+public enum Geography {
+  NE,
+  SE,
+  MW,
+  SW,
+  W
+}

--- a/src/main/java/app/zoneblitz/league/HeadCoachCandidateView.java
+++ b/src/main/java/app/zoneblitz/league/HeadCoachCandidateView.java
@@ -1,0 +1,34 @@
+package app.zoneblitz.league;
+
+import java.math.BigDecimal;
+import java.util.Objects;
+
+/**
+ * Row view-model for a single HC candidate in the hiring pool table. Derived from {@link Candidate}
+ * + {@link CandidatePreferences}; carries only the scouted projection — never the hidden
+ * true-rating payload. {@code shortlisted} reflects the requesting franchise's shortlist
+ * membership.
+ */
+public record HeadCoachCandidateView(
+    long id,
+    CandidateArchetype archetype,
+    SpecialtyPosition specialty,
+    int age,
+    int totalExperienceYears,
+    int hcYears,
+    int ocYears,
+    int positionCoachYears,
+    String scoutedOverall,
+    BigDecimal compensationTarget,
+    int contractLengthTarget,
+    BigDecimal guaranteedMoneyTarget,
+    boolean shortlisted) {
+
+  public HeadCoachCandidateView {
+    Objects.requireNonNull(archetype, "archetype");
+    Objects.requireNonNull(specialty, "specialty");
+    Objects.requireNonNull(scoutedOverall, "scoutedOverall");
+    Objects.requireNonNull(compensationTarget, "compensationTarget");
+    Objects.requireNonNull(guaranteedMoneyTarget, "guaranteedMoneyTarget");
+  }
+}

--- a/src/main/java/app/zoneblitz/league/HeadCoachCandidateView.java
+++ b/src/main/java/app/zoneblitz/league/HeadCoachCandidateView.java
@@ -22,7 +22,8 @@ public record HeadCoachCandidateView(
     BigDecimal compensationTarget,
     int contractLengthTarget,
     BigDecimal guaranteedMoneyTarget,
-    boolean shortlisted) {
+    boolean shortlisted,
+    int interviewCount) {
 
   public HeadCoachCandidateView {
     Objects.requireNonNull(archetype, "archetype");

--- a/src/main/java/app/zoneblitz/league/HeadCoachGenerator.java
+++ b/src/main/java/app/zoneblitz/league/HeadCoachGenerator.java
@@ -1,0 +1,282 @@
+package app.zoneblitz.league;
+
+import app.zoneblitz.gamesimulator.rng.RandomSource;
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.stream.IntStream;
+
+/**
+ * Generates HC candidates from {@code data/bands/coach-market.json} tier {@code HC}. Implements the
+ * hidden-info contract — true rating is sampled independently and never enters the price function.
+ * Price signals (compensation, contract length, guaranteed money) derive from perceived features
+ * only: age, total experience, archetype scarcity, and specialty.
+ */
+public final class HeadCoachGenerator implements CandidateGenerator {
+
+  private static final double GUARANTEED_MONEY_FLOOR = 0.90;
+  private static final double GUARANTEED_MONEY_CEIL = 1.00;
+  private static final double TRUE_RATING_MEAN = 65.0;
+  private static final double TRUE_RATING_STD = 12.0;
+  private static final double SCOUTED_NOISE_STD = 8.0;
+
+  private final HeadCoachMarketBands bands;
+
+  public HeadCoachGenerator() {
+    this(HeadCoachMarketBands.loadFromClasspath());
+  }
+
+  HeadCoachGenerator(HeadCoachMarketBands bands) {
+    this.bands = Objects.requireNonNull(bands, "bands");
+  }
+
+  @Override
+  public List<GeneratedCandidate> generate(int poolSize, RandomSource rng) {
+    Objects.requireNonNull(rng, "rng");
+    if (poolSize <= 0) {
+      throw new IllegalArgumentException("poolSize must be > 0, was: " + poolSize);
+    }
+    return IntStream.range(0, poolSize).mapToObj(i -> generateOne(rng)).toList();
+  }
+
+  private GeneratedCandidate generateOne(RandomSource rng) {
+    var archetype = sampleArchetype(rng);
+    var specialty = sampleSpecialty(archetype, rng);
+    var age = sampleAge(rng);
+    var totalExperience = sampleTotalExperience(age, rng);
+    var isFirstTime = rng.nextDouble() < bands.firstTimeHcRate();
+    var priorHcYears = isFirstTime ? 0 : sampleRetreadHcYears(totalExperience, rng);
+    var ocYears = sampleCoordinatorYears(totalExperience, priorHcYears, rng);
+    var positionCoachYears = Math.max(0, totalExperience - priorHcYears - ocYears);
+    var experienceByRole =
+        """
+        {"HC": %d, "OC": %d, "POSITION_COACH": %d}"""
+            .formatted(priorHcYears, ocYears, positionCoachYears);
+
+    var trueRating = clamp(TRUE_RATING_MEAN + TRUE_RATING_STD * rng.nextGaussian(), 20.0, 99.0);
+    var scoutedRating = clamp(trueRating + SCOUTED_NOISE_STD * rng.nextGaussian(), 20.0, 99.0);
+    var hiddenAttrs = attrsJson(trueRating);
+    var scoutedAttrs = attrsJson(scoutedRating);
+
+    var compensation = perceivedCompensation(age, totalExperience, priorHcYears, archetype, rng);
+    var contractLength = perceivedContractLength(priorHcYears, rng);
+    var guaranteedMoney = perceivedGuaranteedMoney(priorHcYears, rng);
+
+    var candidate =
+        new NewCandidate(
+            /* poolId= */ 0L,
+            CandidateKind.HEAD_COACH,
+            specialty,
+            archetype,
+            age,
+            totalExperience,
+            experienceByRole,
+            hiddenAttrs,
+            scoutedAttrs,
+            Optional.empty());
+    var preferences = buildPreferences(compensation, contractLength, guaranteedMoney, rng);
+    return new GeneratedCandidate(candidate, preferences);
+  }
+
+  private CandidateArchetype sampleArchetype(RandomSource rng) {
+    var u = rng.nextDouble();
+    if (u < bands.offenseShare()) {
+      return CandidateArchetype.OFFENSIVE_PLAY_CALLER;
+    }
+    if (u < bands.offenseShare() + bands.defenseShare()) {
+      return CandidateArchetype.DEFENSIVE_PLAY_CALLER;
+    }
+    return CandidateArchetype.CEO;
+  }
+
+  private SpecialtyPosition sampleSpecialty(CandidateArchetype archetype, RandomSource rng) {
+    var offensive =
+        List.of(
+            SpecialtyPosition.QB,
+            SpecialtyPosition.QB,
+            SpecialtyPosition.QB,
+            SpecialtyPosition.WR,
+            SpecialtyPosition.OL,
+            SpecialtyPosition.RB,
+            SpecialtyPosition.TE);
+    var defensive =
+        List.of(
+            SpecialtyPosition.DL,
+            SpecialtyPosition.EDGE,
+            SpecialtyPosition.LB,
+            SpecialtyPosition.LB,
+            SpecialtyPosition.CB,
+            SpecialtyPosition.CB,
+            SpecialtyPosition.S);
+    return switch (archetype) {
+      case OFFENSIVE_PLAY_CALLER -> offensive.get((int) (rng.nextDouble() * offensive.size()));
+      case DEFENSIVE_PLAY_CALLER -> defensive.get((int) (rng.nextDouble() * defensive.size()));
+      case CEO -> {
+        var u = rng.nextDouble();
+        yield u < 0.6
+            ? offensive.get((int) (rng.nextDouble() * offensive.size()))
+            : defensive.get((int) (rng.nextDouble() * defensive.size()));
+      }
+      default -> throw new IllegalStateException("Non-HC archetype generated: " + archetype);
+    };
+  }
+
+  private int sampleAge(RandomSource rng) {
+    var v = triangular(bands.ageMin(), bands.ageMode(), bands.ageMax(), rng);
+    return clampInt((int) Math.round(v), bands.ageMin(), bands.ageMax());
+  }
+
+  private int sampleTotalExperience(int age, RandomSource rng) {
+    var career = age - 22;
+    var raw =
+        triangular(
+            bands.experienceP10Years(),
+            bands.experienceMeanYears(),
+            bands.experienceP90Years() + 5,
+            rng);
+    return clampInt((int) Math.round(raw), 3, Math.max(3, career));
+  }
+
+  private int sampleRetreadHcYears(int totalExperience, RandomSource rng) {
+    var upper = Math.max(1, Math.min(10, totalExperience - 2));
+    return 1 + (int) (rng.nextDouble() * upper);
+  }
+
+  private int sampleCoordinatorYears(int totalExperience, int priorHcYears, RandomSource rng) {
+    var available = Math.max(0, totalExperience - priorHcYears);
+    if (available == 0) return 0;
+    var mean = Math.min(available, Math.max(2, available / 2));
+    var draw = (int) Math.round(mean + 2 * rng.nextGaussian());
+    return clampInt(draw, 0, available);
+  }
+
+  private BigDecimal perceivedCompensation(
+      int age,
+      int totalExperience,
+      int priorHcYears,
+      CandidateArchetype archetype,
+      RandomSource rng) {
+    var base = triangular(bands.salaryP10(), bands.salaryP50(), bands.salaryP90(), rng);
+    var ageMultiplier = ageSalaryMultiplier(age);
+    var experienceMultiplier = 0.95 + Math.min(totalExperience, 25) * 0.006;
+    var retreadMultiplier = 1.0 + Math.min(priorHcYears, 6) * 0.05;
+    var archetypeMultiplier =
+        switch (archetype) {
+          case OFFENSIVE_PLAY_CALLER -> 1.05;
+          case DEFENSIVE_PLAY_CALLER -> 0.95;
+          case CEO -> 0.90;
+          default -> 1.0;
+        };
+    var combined =
+        base * ageMultiplier * experienceMultiplier * retreadMultiplier * archetypeMultiplier;
+    var clamped =
+        Math.max(bands.salaryP10() * 0.6, Math.min(bands.salaryCeiling() * 1.1, combined));
+    return BigDecimal.valueOf(clamped).setScale(2, RoundingMode.HALF_UP);
+  }
+
+  private double ageSalaryMultiplier(int age) {
+    var peak = 52.0;
+    var deviation = Math.abs(age - peak);
+    return Math.max(0.75, 1.05 - deviation * 0.01);
+  }
+
+  private int perceivedContractLength(int priorHcYears, RandomSource rng) {
+    var u = rng.nextDouble();
+    var base =
+        u < 0.15
+            ? bands.contractP10Years()
+            : u < 0.65
+                ? bands.contractModeYears()
+                : u < 0.9 ? bands.contractP50Years() : bands.contractP90Years();
+    return priorHcYears >= 2 ? Math.min(base + 1, bands.contractP90Years() + 1) : base;
+  }
+
+  private BigDecimal perceivedGuaranteedMoney(int priorHcYears, RandomSource rng) {
+    var base =
+        GUARANTEED_MONEY_FLOOR
+            + rng.nextDouble() * (GUARANTEED_MONEY_CEIL - GUARANTEED_MONEY_FLOOR);
+    var bump = priorHcYears >= 2 ? 0.02 : 0.0;
+    var value = Math.min(1.0, base + bump);
+    return BigDecimal.valueOf(value).setScale(3, RoundingMode.HALF_UP);
+  }
+
+  private CandidatePreferencesDraft buildPreferences(
+      BigDecimal compensation, int contractLength, BigDecimal guaranteedMoney, RandomSource rng) {
+    var rawWeights = new double[13];
+    for (var i = 0; i < rawWeights.length; i++) {
+      rawWeights[i] = 0.25 + rng.nextDouble();
+    }
+    var sum = 0.0;
+    for (var w : rawWeights) sum += w;
+    var w = new BigDecimal[13];
+    for (var i = 0; i < rawWeights.length; i++) {
+      w[i] = BigDecimal.valueOf(rawWeights[i] / sum).setScale(3, RoundingMode.HALF_UP);
+    }
+
+    var marketSize = MarketSize.values()[(int) (rng.nextDouble() * MarketSize.values().length)];
+    var geography = Geography.values()[(int) (rng.nextDouble() * Geography.values().length)];
+    var climate = Climate.values()[(int) (rng.nextDouble() * Climate.values().length)];
+    var roleScope = RoleScope.values()[(int) (rng.nextDouble() * RoleScope.values().length)];
+    var staffContinuity =
+        StaffContinuity.values()[(int) (rng.nextDouble() * StaffContinuity.values().length)];
+    var competitiveWindow =
+        CompetitiveWindow.values()[(int) (rng.nextDouble() * CompetitiveWindow.values().length)];
+    var schemeAlignment = sampleSchemeAlignment(rng);
+
+    return new CandidatePreferencesDraft(
+        compensation,
+        w[0],
+        contractLength,
+        w[1],
+        guaranteedMoney,
+        w[2],
+        marketSize,
+        w[3],
+        geography,
+        w[4],
+        climate,
+        w[5],
+        BigDecimal.valueOf(50 + rng.nextDouble() * 30).setScale(2, RoundingMode.HALF_UP),
+        w[6],
+        competitiveWindow,
+        w[7],
+        roleScope,
+        w[8],
+        staffContinuity,
+        w[9],
+        schemeAlignment,
+        w[10],
+        BigDecimal.valueOf(50 + rng.nextDouble() * 30).setScale(2, RoundingMode.HALF_UP),
+        w[11],
+        BigDecimal.valueOf(50 + rng.nextDouble() * 30).setScale(2, RoundingMode.HALF_UP),
+        w[12]);
+  }
+
+  private String sampleSchemeAlignment(RandomSource rng) {
+    var schemes = List.of("SPREAD", "WEST_COAST", "AIR_RAID", "SMASHMOUTH", "COVER_2", "COVER_3");
+    return schemes.get((int) (rng.nextDouble() * schemes.size()));
+  }
+
+  private String attrsJson(double rating) {
+    return "{\"overall\": %.2f}".formatted(rating);
+  }
+
+  private static double triangular(double a, double c, double b, RandomSource rng) {
+    var u = rng.nextDouble();
+    var f = (c - a) / (b - a);
+    if (u < f) {
+      return a + Math.sqrt(u * (b - a) * (c - a));
+    }
+    return b - Math.sqrt((1 - u) * (b - a) * (b - c));
+  }
+
+  private static int clampInt(int v, int lo, int hi) {
+    return Math.max(lo, Math.min(hi, v));
+  }
+
+  private static double clamp(double v, double lo, double hi) {
+    return Math.max(lo, Math.min(hi, v));
+  }
+}

--- a/src/main/java/app/zoneblitz/league/HeadCoachHiringView.java
+++ b/src/main/java/app/zoneblitz/league/HeadCoachHiringView.java
@@ -1,0 +1,17 @@
+package app.zoneblitz.league;
+
+import java.util.List;
+import java.util.Objects;
+
+/** Composite page/fragment view-model for the HIRING_HEAD_COACH page. */
+public record HeadCoachHiringView(
+    LeagueSummary league,
+    List<HeadCoachCandidateView> pool,
+    List<HeadCoachCandidateView> shortlist) {
+
+  public HeadCoachHiringView {
+    Objects.requireNonNull(league, "league");
+    pool = List.copyOf(pool);
+    shortlist = List.copyOf(shortlist);
+  }
+}

--- a/src/main/java/app/zoneblitz/league/HeadCoachHiringView.java
+++ b/src/main/java/app/zoneblitz/league/HeadCoachHiringView.java
@@ -7,11 +7,15 @@ import java.util.Objects;
 public record HeadCoachHiringView(
     LeagueSummary league,
     List<HeadCoachCandidateView> pool,
-    List<HeadCoachCandidateView> shortlist) {
+    List<HeadCoachCandidateView> shortlist,
+    List<HeadCoachCandidateView> activeInterviews,
+    int interviewsThisWeek,
+    int interviewCapacity) {
 
   public HeadCoachHiringView {
     Objects.requireNonNull(league, "league");
     pool = List.copyOf(pool);
     shortlist = List.copyOf(shortlist);
+    activeInterviews = List.copyOf(activeInterviews);
   }
 }

--- a/src/main/java/app/zoneblitz/league/HeadCoachHiringViewModel.java
+++ b/src/main/java/app/zoneblitz/league/HeadCoachHiringViewModel.java
@@ -1,0 +1,88 @@
+package app.zoneblitz.league;
+
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.Set;
+import java.util.regex.Pattern;
+
+/**
+ * Assembles {@link HeadCoachCandidateView} rows and the composite {@link HeadCoachHiringView} from
+ * domain candidates + preferences + shortlist state. Extracted from the controller so the
+ * controller stays thin and the assembly logic is unit-testable on its own.
+ */
+final class HeadCoachHiringViewModel {
+
+  private static final Pattern OVERALL =
+      Pattern.compile("\"overall\"\\s*:\\s*(-?[0-9]+(?:\\.[0-9]+)?)");
+  private static final Pattern EXP_KEY_VALUE = Pattern.compile("\"([A-Z_]+)\"\\s*:\\s*(-?[0-9]+)");
+
+  private HeadCoachHiringViewModel() {}
+
+  static HeadCoachHiringView assemble(
+      LeagueSummary league,
+      List<Candidate> pool,
+      List<CandidatePreferences> preferences,
+      List<Long> shortlist) {
+    var prefsByCandidate =
+        preferences.stream()
+            .collect(
+                java.util.stream.Collectors.toUnmodifiableMap(
+                    CandidatePreferences::candidateId, p -> p));
+    var shortlistSet = Set.copyOf(shortlist);
+    var rows =
+        pool.stream()
+            .filter(c -> c.hiredByFranchiseId().isEmpty())
+            .map(c -> toRow(c, prefsByCandidate, shortlistSet))
+            .toList();
+    var shortlistRows = rows.stream().filter(HeadCoachCandidateView::shortlisted).toList();
+    return new HeadCoachHiringView(league, rows, shortlistRows);
+  }
+
+  private static HeadCoachCandidateView toRow(
+      Candidate candidate,
+      java.util.Map<Long, CandidatePreferences> prefsById,
+      Set<Long> shortlistSet) {
+    var prefs = prefsById.get(candidate.id());
+    return new HeadCoachCandidateView(
+        candidate.id(),
+        candidate.archetype(),
+        candidate.specialtyPosition(),
+        candidate.age(),
+        candidate.totalExperienceYears(),
+        experienceFor(candidate.experienceByRole(), "HC"),
+        experienceFor(candidate.experienceByRole(), "OC"),
+        experienceFor(candidate.experienceByRole(), "POSITION_COACH"),
+        extractOverall(candidate.scoutedAttrs()),
+        prefs == null ? BigDecimal.ZERO : prefs.compensationTarget(),
+        prefs == null ? 0 : prefs.contractLengthTarget(),
+        prefs == null ? BigDecimal.ZERO : prefs.guaranteedMoneyTarget(),
+        shortlistSet.contains(candidate.id()));
+  }
+
+  private static String extractOverall(String scoutedAttrsJson) {
+    var m = OVERALL.matcher(scoutedAttrsJson);
+    if (m.find()) {
+      try {
+        var val = Double.parseDouble(m.group(1));
+        return "%.1f".formatted(val);
+      } catch (NumberFormatException e) {
+        return "?";
+      }
+    }
+    return "?";
+  }
+
+  private static int experienceFor(String experienceByRoleJson, String role) {
+    var m = EXP_KEY_VALUE.matcher(experienceByRoleJson);
+    while (m.find()) {
+      if (m.group(1).equals(role)) {
+        try {
+          return Integer.parseInt(m.group(2));
+        } catch (NumberFormatException e) {
+          return 0;
+        }
+      }
+    }
+    return 0;
+  }
+}

--- a/src/main/java/app/zoneblitz/league/HeadCoachHiringViewModel.java
+++ b/src/main/java/app/zoneblitz/league/HeadCoachHiringViewModel.java
@@ -2,13 +2,15 @@ package app.zoneblitz.league;
 
 import java.math.BigDecimal;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.regex.Pattern;
 
 /**
  * Assembles {@link HeadCoachCandidateView} rows and the composite {@link HeadCoachHiringView} from
- * domain candidates + preferences + shortlist state. Extracted from the controller so the
- * controller stays thin and the assembly logic is unit-testable on its own.
+ * domain candidates + preferences + shortlist state + per-franchise interview history. Extracted
+ * from the controller so the controller stays thin and the assembly logic is unit-testable on its
+ * own.
  */
 final class HeadCoachHiringViewModel {
 
@@ -22,27 +24,63 @@ final class HeadCoachHiringViewModel {
       LeagueSummary league,
       List<Candidate> pool,
       List<CandidatePreferences> preferences,
-      List<Long> shortlist) {
+      List<Long> shortlist,
+      List<FranchiseInterview> interviews,
+      int interviewCapacity) {
     var prefsByCandidate =
         preferences.stream()
             .collect(
                 java.util.stream.Collectors.toUnmodifiableMap(
                     CandidatePreferences::candidateId, p -> p));
     var shortlistSet = Set.copyOf(shortlist);
+    var interviewCounts = countsByCandidate(interviews);
+    var latestScouted = latestScoutedByCandidate(interviews);
+    var interviewsThisWeek = countForWeek(interviews, league.phaseWeek());
     var rows =
         pool.stream()
             .filter(c -> c.hiredByFranchiseId().isEmpty())
-            .map(c -> toRow(c, prefsByCandidate, shortlistSet))
+            .map(c -> toRow(c, prefsByCandidate, shortlistSet, interviewCounts, latestScouted))
             .toList();
     var shortlistRows = rows.stream().filter(HeadCoachCandidateView::shortlisted).toList();
-    return new HeadCoachHiringView(league, rows, shortlistRows);
+    var activeInterviewRows = rows.stream().filter(r -> r.interviewCount() > 0).toList();
+    return new HeadCoachHiringView(
+        league, rows, shortlistRows, activeInterviewRows, interviewsThisWeek, interviewCapacity);
+  }
+
+  private static Map<Long, Integer> countsByCandidate(List<FranchiseInterview> interviews) {
+    return interviews.stream()
+        .collect(
+            java.util.stream.Collectors.groupingBy(
+                FranchiseInterview::candidateId,
+                java.util.stream.Collectors.reducing(0, ignored -> 1, Integer::sum)));
+  }
+
+  private static Map<Long, BigDecimal> latestScoutedByCandidate(
+      List<FranchiseInterview> interviews) {
+    return interviews.stream()
+        .collect(
+            java.util.stream.Collectors.toMap(
+                FranchiseInterview::candidateId,
+                FranchiseInterview::scoutedOverall,
+                (earlier, later) -> later));
+  }
+
+  private static int countForWeek(List<FranchiseInterview> interviews, int phaseWeek) {
+    return (int) interviews.stream().filter(i -> i.phaseWeek() == phaseWeek).count();
   }
 
   private static HeadCoachCandidateView toRow(
       Candidate candidate,
-      java.util.Map<Long, CandidatePreferences> prefsById,
-      Set<Long> shortlistSet) {
+      Map<Long, CandidatePreferences> prefsById,
+      Set<Long> shortlistSet,
+      Map<Long, Integer> interviewCounts,
+      Map<Long, BigDecimal> latestScouted) {
     var prefs = prefsById.get(candidate.id());
+    var count = interviewCounts.getOrDefault(candidate.id(), 0);
+    var scoutedOverall =
+        latestScouted.containsKey(candidate.id())
+            ? "%.1f".formatted(latestScouted.get(candidate.id()).doubleValue())
+            : extractOverall(candidate.scoutedAttrs());
     return new HeadCoachCandidateView(
         candidate.id(),
         candidate.archetype(),
@@ -52,11 +90,12 @@ final class HeadCoachHiringViewModel {
         experienceFor(candidate.experienceByRole(), "HC"),
         experienceFor(candidate.experienceByRole(), "OC"),
         experienceFor(candidate.experienceByRole(), "POSITION_COACH"),
-        extractOverall(candidate.scoutedAttrs()),
+        scoutedOverall,
         prefs == null ? BigDecimal.ZERO : prefs.compensationTarget(),
         prefs == null ? 0 : prefs.contractLengthTarget(),
         prefs == null ? BigDecimal.ZERO : prefs.guaranteedMoneyTarget(),
-        shortlistSet.contains(candidate.id()));
+        shortlistSet.contains(candidate.id()),
+        count);
   }
 
   private static String extractOverall(String scoutedAttrsJson) {

--- a/src/main/java/app/zoneblitz/league/HeadCoachMarketBands.java
+++ b/src/main/java/app/zoneblitz/league/HeadCoachMarketBands.java
@@ -1,0 +1,104 @@
+package app.zoneblitz.league;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.IOException;
+import java.io.InputStream;
+import java.math.BigDecimal;
+import java.util.Objects;
+
+/**
+ * Typed view over the {@code tiers.HC} section of {@code data/bands/coach-market.json}. Parsed once
+ * at construction and handed to the generator so no I/O happens mid-generation.
+ */
+record HeadCoachMarketBands(
+    int salaryP10,
+    int salaryP50,
+    int salaryP90,
+    int salaryCeiling,
+    int salaryMin,
+    int contractModeYears,
+    int contractP10Years,
+    int contractP50Years,
+    int contractP90Years,
+    int ageMode,
+    int ageP10,
+    int ageP50,
+    int ageP90,
+    int ageMin,
+    int ageMax,
+    double experienceP10Years,
+    double experienceMeanYears,
+    double experienceP90Years,
+    double firstTimeHcRate,
+    double offenseShare,
+    double defenseShare,
+    double ceoShare) {
+
+  static HeadCoachMarketBands loadFromClasspath() {
+    return loadFromClasspath("/bands/coach-market.json");
+  }
+
+  static HeadCoachMarketBands loadFromClasspath(String resource) {
+    Objects.requireNonNull(resource, "resource");
+    try (InputStream in = HeadCoachMarketBands.class.getResourceAsStream(resource)) {
+      if (in == null) {
+        throw new IllegalStateException("Band resource not found on classpath: " + resource);
+      }
+      var root = new ObjectMapper().readTree(in);
+      return fromJson(root.at("/tiers/HC"));
+    } catch (IOException e) {
+      throw new IllegalStateException("Failed to read " + resource, e);
+    }
+  }
+
+  private static HeadCoachMarketBands fromJson(JsonNode hc) {
+    if (hc == null || hc.isMissingNode()) {
+      throw new IllegalStateException("coach-market.json missing tiers.HC");
+    }
+    var salary = hc.get("salary_annual_usd");
+    var contract = hc.get("contract_length_years");
+    var age = hc.get("age_distribution");
+    var experience = hc.get("experience_distribution");
+    var split = hc.get("playcaller_specialty_split");
+    return new HeadCoachMarketBands(
+        salary.get("p10").asInt(),
+        salary.get("p50").asInt(),
+        salary.get("p90").asInt(),
+        salary.get("ceiling").asInt(),
+        (int) Math.round(salary.get("p10").asInt() * 0.5),
+        contract.get("mode").asInt(),
+        contract.get("p10").asInt(),
+        contract.get("p50").asInt(),
+        contract.get("p90").asInt(),
+        age.get("mode").asInt(),
+        age.get("p10").asInt(),
+        age.get("p50").asInt(),
+        age.get("p90").asInt(),
+        age.get("min").asInt(),
+        age.get("max").asInt(),
+        experience.get("years_experience_p10").asDouble(),
+        experience.get("years_experience_mean").asDouble(),
+        experience.get("years_experience_p90").asDouble(),
+        experience.get("first_time_hc_rate").asDouble(),
+        split.get("offense").asDouble(),
+        split.get("defense").asDouble(),
+        split.get("ceo").asDouble());
+  }
+
+  BigDecimal salaryP10Dec() {
+    return BigDecimal.valueOf(salaryP10);
+  }
+
+  BigDecimal salaryP50Dec() {
+    return BigDecimal.valueOf(salaryP50);
+  }
+
+  BigDecimal salaryP90Dec() {
+    return BigDecimal.valueOf(salaryP90);
+  }
+
+  BigDecimal salaryCeilingDec() {
+    return BigDecimal.valueOf(salaryCeiling);
+  }
+}

--- a/src/main/java/app/zoneblitz/league/HiringHeadCoachController.java
+++ b/src/main/java/app/zoneblitz/league/HiringHeadCoachController.java
@@ -25,10 +25,15 @@ class HiringHeadCoachController {
 
   private final ViewHeadCoachHiring viewHiring;
   private final ManageHeadCoachShortlist shortlist;
+  private final StartInterview startInterview;
 
-  HiringHeadCoachController(ViewHeadCoachHiring viewHiring, ManageHeadCoachShortlist shortlist) {
+  HiringHeadCoachController(
+      ViewHeadCoachHiring viewHiring,
+      ManageHeadCoachShortlist shortlist,
+      StartInterview startInterview) {
     this.viewHiring = viewHiring;
     this.shortlist = shortlist;
+    this.startInterview = startInterview;
   }
 
   @GetMapping("/leagues/{id}/hiring/head-coach")
@@ -43,6 +48,23 @@ class HiringHeadCoachController {
       @AuthenticationPrincipal OAuth2User principal, @PathVariable long id, Model model) {
     model.addAttribute("view", resolveView(principal, id));
     return "league/hiring/head-coach-fragments :: pool";
+  }
+
+  @GetMapping("/leagues/{id}/hiring/head-coach/interviews")
+  String interviewsFragment(
+      @AuthenticationPrincipal OAuth2User principal, @PathVariable long id, Model model) {
+    model.addAttribute("view", resolveView(principal, id));
+    return "league/hiring/head-coach-fragments :: interviews";
+  }
+
+  @PostMapping("/leagues/{id}/hiring/head-coach/interview/{candidateId}")
+  String startInterview(
+      @AuthenticationPrincipal OAuth2User principal,
+      @PathVariable long id,
+      @PathVariable long candidateId,
+      Model model) {
+    var result = startInterview.start(id, candidateId, principal.getAttribute("sub"));
+    return renderInterview(result, model);
   }
 
   @GetMapping("/leagues/{id}/hiring/head-coach/shortlist")
@@ -76,6 +98,27 @@ class HiringHeadCoachController {
     return viewHiring
         .view(id, principal.getAttribute("sub"))
         .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND));
+  }
+
+  private String renderInterview(InterviewResult result, Model model) {
+    return switch (result) {
+      case InterviewResult.Started started -> {
+        model.addAttribute("view", started.view());
+        log.info(
+            "interview started leagueId={} interviewsThisWeek={}",
+            started.view().league().leagueId(),
+            started.view().interviewsThisWeek());
+        yield "league/hiring/head-coach-fragments :: combined";
+      }
+      case InterviewResult.NotFound ignored ->
+          throw new ResponseStatusException(HttpStatus.NOT_FOUND);
+      case InterviewResult.UnknownCandidate ignored ->
+          throw new ResponseStatusException(HttpStatus.NOT_FOUND);
+      case InterviewResult.CapacityReached capacity ->
+          throw new ResponseStatusException(
+              HttpStatus.CONFLICT,
+              "Weekly interview capacity of %d already reached".formatted(capacity.capacity()));
+    };
   }
 
   private String renderMutation(ShortlistResult result, Model model) {

--- a/src/main/java/app/zoneblitz/league/HiringHeadCoachController.java
+++ b/src/main/java/app/zoneblitz/league/HiringHeadCoachController.java
@@ -1,0 +1,97 @@
+package app.zoneblitz.league;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.server.ResponseStatusException;
+
+/**
+ * Web controller for the HIRING_HEAD_COACH page and its HTMX fragment endpoints. Follows project
+ * convention: separate URLs for full pages vs fragments; fragments return {@code text/html}; page
+ * template composes the same fragments returned by the fragment endpoints.
+ */
+@Controller
+class HiringHeadCoachController {
+
+  private static final Logger log = LoggerFactory.getLogger(HiringHeadCoachController.class);
+
+  private final ViewHeadCoachHiring viewHiring;
+  private final ManageHeadCoachShortlist shortlist;
+
+  HiringHeadCoachController(ViewHeadCoachHiring viewHiring, ManageHeadCoachShortlist shortlist) {
+    this.viewHiring = viewHiring;
+    this.shortlist = shortlist;
+  }
+
+  @GetMapping("/leagues/{id}/hiring/head-coach")
+  String page(@AuthenticationPrincipal OAuth2User principal, @PathVariable long id, Model model) {
+    var view = resolveView(principal, id);
+    model.addAttribute("view", view);
+    return "league/hiring/head-coach";
+  }
+
+  @GetMapping("/leagues/{id}/hiring/head-coach/pool")
+  String poolFragment(
+      @AuthenticationPrincipal OAuth2User principal, @PathVariable long id, Model model) {
+    model.addAttribute("view", resolveView(principal, id));
+    return "league/hiring/head-coach-fragments :: pool";
+  }
+
+  @GetMapping("/leagues/{id}/hiring/head-coach/shortlist")
+  String shortlistFragment(
+      @AuthenticationPrincipal OAuth2User principal, @PathVariable long id, Model model) {
+    model.addAttribute("view", resolveView(principal, id));
+    return "league/hiring/head-coach-fragments :: shortlist";
+  }
+
+  @PostMapping("/leagues/{id}/hiring/head-coach/shortlist/{candidateId}")
+  String addToShortlist(
+      @AuthenticationPrincipal OAuth2User principal,
+      @PathVariable long id,
+      @PathVariable long candidateId,
+      Model model) {
+    var result = shortlist.add(id, candidateId, principal.getAttribute("sub"));
+    return renderMutation(result, model);
+  }
+
+  @DeleteMapping("/leagues/{id}/hiring/head-coach/shortlist/{candidateId}")
+  String removeFromShortlist(
+      @AuthenticationPrincipal OAuth2User principal,
+      @PathVariable long id,
+      @PathVariable long candidateId,
+      Model model) {
+    var result = shortlist.remove(id, candidateId, principal.getAttribute("sub"));
+    return renderMutation(result, model);
+  }
+
+  private HeadCoachHiringView resolveView(OAuth2User principal, long id) {
+    return viewHiring
+        .view(id, principal.getAttribute("sub"))
+        .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND));
+  }
+
+  private String renderMutation(ShortlistResult result, Model model) {
+    return switch (result) {
+      case ShortlistResult.Updated updated -> {
+        model.addAttribute("view", updated.view());
+        log.info(
+            "shortlist updated leagueId={} size={}",
+            updated.view().league().leagueId(),
+            updated.view().shortlist().size());
+        yield "league/hiring/head-coach-fragments :: combined";
+      }
+      case ShortlistResult.NotFound ignored ->
+          throw new ResponseStatusException(HttpStatus.NOT_FOUND);
+      case ShortlistResult.UnknownCandidate ignored ->
+          throw new ResponseStatusException(HttpStatus.NOT_FOUND);
+    };
+  }
+}

--- a/src/main/java/app/zoneblitz/league/HiringHeadCoachTransitionHandler.java
+++ b/src/main/java/app/zoneblitz/league/HiringHeadCoachTransitionHandler.java
@@ -1,0 +1,107 @@
+package app.zoneblitz.league;
+
+import java.util.List;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+/**
+ * Phase-entry hook for {@link LeaguePhase#HIRING_HEAD_COACH}. On entry: generate the league-wide HC
+ * candidate pool (if not already present), persist candidates + preferences, and initialize each
+ * franchise's hiring sub-state to {@link HiringStep#SEARCHING} with empty shortlist/interview
+ * lists.
+ *
+ * <p>Idempotent: re-entry of a phase that already has a pool is a no-op so autofill/recovery paths
+ * do not duplicate data.
+ */
+@Component
+class HiringHeadCoachTransitionHandler implements PhaseTransitionHandler {
+
+  private static final Logger log = LoggerFactory.getLogger(HiringHeadCoachTransitionHandler.class);
+
+  /** Per {@code docs/technical/league-phases.md}: pool size is 2–3× franchise count. */
+  private static final int POOL_SIZE_PER_FRANCHISE = 3;
+
+  private final LeagueRepository leagues;
+  private final TeamLookup teams;
+  private final CandidatePoolRepository pools;
+  private final CandidateRepository candidates;
+  private final CandidatePreferencesRepository preferences;
+  private final FranchiseHiringStateRepository hiringStates;
+  private final CandidateGenerator generator;
+  private final CandidateRandomSources rngs;
+
+  HiringHeadCoachTransitionHandler(
+      LeagueRepository leagues,
+      TeamLookup teams,
+      CandidatePoolRepository pools,
+      CandidateRepository candidates,
+      CandidatePreferencesRepository preferences,
+      FranchiseHiringStateRepository hiringStates,
+      CandidateGenerator generator,
+      CandidateRandomSources rngs) {
+    this.leagues = leagues;
+    this.teams = teams;
+    this.pools = pools;
+    this.candidates = candidates;
+    this.preferences = preferences;
+    this.hiringStates = hiringStates;
+    this.generator = generator;
+    this.rngs = rngs;
+  }
+
+  @Override
+  public LeaguePhase phase() {
+    return LeaguePhase.HIRING_HEAD_COACH;
+  }
+
+  @Override
+  public void onEntry(long leagueId) {
+    if (pools
+        .findByLeaguePhaseAndType(leagueId, phase(), CandidatePoolType.HEAD_COACH)
+        .isPresent()) {
+      log.debug("HC pool already present for league={}; entry is a no-op", leagueId);
+      return;
+    }
+    var league =
+        leagues
+            .findById(leagueId)
+            .orElseThrow(() -> new IllegalStateException("league missing: " + leagueId));
+    var franchiseIds = teams.franchiseIdsForLeague(leagueId);
+    var poolSize = Math.max(1, franchiseIds.size() * POOL_SIZE_PER_FRANCHISE);
+
+    var pool = pools.insert(leagueId, phase(), CandidatePoolType.HEAD_COACH);
+    var rng = rngs.forLeaguePhase(leagueId, phase());
+    var generated = generator.generate(poolSize, rng);
+    for (var g : generated) {
+      var withPool = attachPool(g.candidate(), pool.id());
+      var saved = candidates.insert(withPool);
+      preferences.insert(g.preferences().withCandidateId(saved.id()));
+    }
+    for (var franchiseId : franchiseIds) {
+      hiringStates.upsert(
+          new FranchiseHiringState(
+              0L, leagueId, franchiseId, phase(), HiringStep.SEARCHING, List.of(), List.of()));
+    }
+    log.info(
+        "hiring head-coach pool generated leagueId={} poolId={} size={} franchises={}",
+        league.id(),
+        pool.id(),
+        generated.size(),
+        franchiseIds.size());
+  }
+
+  private static NewCandidate attachPool(NewCandidate candidate, long poolId) {
+    return new NewCandidate(
+        poolId,
+        candidate.kind(),
+        candidate.specialtyPosition(),
+        candidate.archetype(),
+        candidate.age(),
+        candidate.totalExperienceYears(),
+        candidate.experienceByRole(),
+        candidate.hiddenAttrs(),
+        candidate.scoutedAttrs(),
+        candidate.scoutBranch());
+  }
+}

--- a/src/main/java/app/zoneblitz/league/HiringStep.java
+++ b/src/main/java/app/zoneblitz/league/HiringStep.java
@@ -1,0 +1,11 @@
+package app.zoneblitz.league;
+
+/**
+ * Per-franchise hiring sub-state within a hiring phase. {@code SEARCHING} composes several
+ * concurrent activities (browsing, interviewing, offering); {@code HIRED} is terminal for the
+ * phase.
+ */
+public enum HiringStep {
+  SEARCHING,
+  HIRED
+}

--- a/src/main/java/app/zoneblitz/league/InterviewNoiseModel.java
+++ b/src/main/java/app/zoneblitz/league/InterviewNoiseModel.java
@@ -1,0 +1,31 @@
+package app.zoneblitz.league;
+
+/**
+ * Interview noise-reduction function. Each completed interview multiplies the remaining noise above
+ * the tier floor by {@code (1 - REDUCTION)} — geometric decay with diminishing returns. The
+ * tier-dependent {@code FLOOR_STD} guarantees σ never reaches zero regardless of interview count,
+ * preserving the hidden-info pillar from {@code busts-and-gems.md}.
+ *
+ * <p>σ(n) = FLOOR_STD + (INITIAL_STD − FLOOR_STD) · (1 − REDUCTION)^n
+ */
+final class InterviewNoiseModel {
+
+  static final double HC_INITIAL_STD = 8.0;
+  static final double HC_FLOOR_STD = 2.0;
+  static final double REDUCTION_PER_INTERVIEW = 0.4;
+
+  private InterviewNoiseModel() {}
+
+  /**
+   * Scouted-signal σ after {@code interviewCount} interviews, for the HC tier. Monotonically
+   * non-increasing in {@code interviewCount}; strictly decreasing until it approaches {@link
+   * #HC_FLOOR_STD}; never reaches zero.
+   */
+  static double headCoachSigma(int interviewCount) {
+    if (interviewCount < 0) {
+      throw new IllegalArgumentException("interviewCount must be >= 0, was: " + interviewCount);
+    }
+    var residual = HC_INITIAL_STD - HC_FLOOR_STD;
+    return HC_FLOOR_STD + residual * Math.pow(1.0 - REDUCTION_PER_INTERVIEW, interviewCount);
+  }
+}

--- a/src/main/java/app/zoneblitz/league/InterviewResult.java
+++ b/src/main/java/app/zoneblitz/league/InterviewResult.java
@@ -1,0 +1,17 @@
+package app.zoneblitz.league;
+
+/** Sealed outcomes for {@link StartInterview#start}. */
+public sealed interface InterviewResult {
+
+  /** Interview recorded; the refreshed view-model is returned for fragment rendering. */
+  record Started(HeadCoachHiringView view) implements InterviewResult {}
+
+  /** League not found for the requesting user, or not in the HC hiring phase. */
+  record NotFound(long leagueId) implements InterviewResult {}
+
+  /** Candidate does not exist in this league's HC pool. */
+  record UnknownCandidate(long candidateId) implements InterviewResult {}
+
+  /** Franchise has already hit its per-week interview cap. */
+  record CapacityReached(int capacity) implements InterviewResult {}
+}

--- a/src/main/java/app/zoneblitz/league/JooqCandidateOfferRepository.java
+++ b/src/main/java/app/zoneblitz/league/JooqCandidateOfferRepository.java
@@ -1,0 +1,89 @@
+package app.zoneblitz.league;
+
+import static app.zoneblitz.jooq.Tables.CANDIDATE_OFFERS;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import org.jooq.DSLContext;
+import org.jooq.JSONB;
+import org.springframework.stereotype.Repository;
+
+@Repository
+class JooqCandidateOfferRepository implements CandidateOfferRepository {
+
+  private final DSLContext dsl;
+
+  JooqCandidateOfferRepository(DSLContext dsl) {
+    this.dsl = dsl;
+  }
+
+  @Override
+  public CandidateOffer insertActive(long candidateId, long franchiseId, String terms, int week) {
+    Objects.requireNonNull(terms, "terms");
+    var record =
+        dsl.insertInto(CANDIDATE_OFFERS)
+            .set(CANDIDATE_OFFERS.CANDIDATE_ID, candidateId)
+            .set(CANDIDATE_OFFERS.FRANCHISE_ID, franchiseId)
+            .set(CANDIDATE_OFFERS.TERMS, JSONB.valueOf(terms))
+            .set(CANDIDATE_OFFERS.SUBMITTED_AT_WEEK, week)
+            .set(CANDIDATE_OFFERS.STATUS, OfferStatus.ACTIVE.name())
+            .returning(CANDIDATE_OFFERS.fields())
+            .fetchOne();
+    return map(record);
+  }
+
+  @Override
+  public Optional<CandidateOffer> findById(long id) {
+    return dsl.selectFrom(CANDIDATE_OFFERS)
+        .where(CANDIDATE_OFFERS.ID.eq(id))
+        .fetchOptional(this::map);
+  }
+
+  @Override
+  public List<CandidateOffer> findAllForCandidate(long candidateId) {
+    return dsl.selectFrom(CANDIDATE_OFFERS)
+        .where(CANDIDATE_OFFERS.CANDIDATE_ID.eq(candidateId))
+        .orderBy(CANDIDATE_OFFERS.SUBMITTED_AT_WEEK.asc(), CANDIDATE_OFFERS.ID.asc())
+        .fetch(this::map);
+  }
+
+  @Override
+  public List<CandidateOffer> findActiveForCandidate(long candidateId) {
+    return dsl.selectFrom(CANDIDATE_OFFERS)
+        .where(CANDIDATE_OFFERS.CANDIDATE_ID.eq(candidateId))
+        .and(CANDIDATE_OFFERS.STATUS.eq(OfferStatus.ACTIVE.name()))
+        .orderBy(CANDIDATE_OFFERS.SUBMITTED_AT_WEEK.asc(), CANDIDATE_OFFERS.ID.asc())
+        .fetch(this::map);
+  }
+
+  @Override
+  public List<CandidateOffer> findActiveForFranchise(long franchiseId) {
+    return dsl.selectFrom(CANDIDATE_OFFERS)
+        .where(CANDIDATE_OFFERS.FRANCHISE_ID.eq(franchiseId))
+        .and(CANDIDATE_OFFERS.STATUS.eq(OfferStatus.ACTIVE.name()))
+        .orderBy(CANDIDATE_OFFERS.SUBMITTED_AT_WEEK.asc(), CANDIDATE_OFFERS.ID.asc())
+        .fetch(this::map);
+  }
+
+  @Override
+  public boolean resolve(long offerId, OfferStatus status) {
+    Objects.requireNonNull(status, "status");
+    return dsl.update(CANDIDATE_OFFERS)
+            .set(CANDIDATE_OFFERS.STATUS, status.name())
+            .where(CANDIDATE_OFFERS.ID.eq(offerId))
+            .and(CANDIDATE_OFFERS.STATUS.eq(OfferStatus.ACTIVE.name()))
+            .execute()
+        > 0;
+  }
+
+  private CandidateOffer map(org.jooq.Record r) {
+    return new CandidateOffer(
+        r.get(CANDIDATE_OFFERS.ID),
+        r.get(CANDIDATE_OFFERS.CANDIDATE_ID),
+        r.get(CANDIDATE_OFFERS.FRANCHISE_ID),
+        r.get(CANDIDATE_OFFERS.TERMS).data(),
+        r.get(CANDIDATE_OFFERS.SUBMITTED_AT_WEEK),
+        OfferStatus.valueOf(r.get(CANDIDATE_OFFERS.STATUS)));
+  }
+}

--- a/src/main/java/app/zoneblitz/league/JooqCandidatePoolRepository.java
+++ b/src/main/java/app/zoneblitz/league/JooqCandidatePoolRepository.java
@@ -1,0 +1,72 @@
+package app.zoneblitz.league;
+
+import static app.zoneblitz.jooq.Tables.CANDIDATE_POOLS;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import org.jooq.DSLContext;
+import org.springframework.stereotype.Repository;
+
+@Repository
+class JooqCandidatePoolRepository implements CandidatePoolRepository {
+
+  private final DSLContext dsl;
+
+  JooqCandidatePoolRepository(DSLContext dsl) {
+    this.dsl = dsl;
+  }
+
+  @Override
+  public CandidatePool insert(long leagueId, LeaguePhase phase, CandidatePoolType type) {
+    Objects.requireNonNull(phase, "phase");
+    Objects.requireNonNull(type, "type");
+    var record =
+        dsl.insertInto(CANDIDATE_POOLS)
+            .set(CANDIDATE_POOLS.LEAGUE_ID, leagueId)
+            .set(CANDIDATE_POOLS.PHASE, phase.name())
+            .set(CANDIDATE_POOLS.CANDIDATE_TYPE, type.name())
+            .returning(
+                CANDIDATE_POOLS.ID,
+                CANDIDATE_POOLS.LEAGUE_ID,
+                CANDIDATE_POOLS.PHASE,
+                CANDIDATE_POOLS.CANDIDATE_TYPE,
+                CANDIDATE_POOLS.GENERATED_AT)
+            .fetchOne();
+    return map(record);
+  }
+
+  @Override
+  public Optional<CandidatePool> findById(long id) {
+    return dsl.selectFrom(CANDIDATE_POOLS)
+        .where(CANDIDATE_POOLS.ID.eq(id))
+        .fetchOptional(this::map);
+  }
+
+  @Override
+  public Optional<CandidatePool> findByLeaguePhaseAndType(
+      long leagueId, LeaguePhase phase, CandidatePoolType type) {
+    return dsl.selectFrom(CANDIDATE_POOLS)
+        .where(CANDIDATE_POOLS.LEAGUE_ID.eq(leagueId))
+        .and(CANDIDATE_POOLS.PHASE.eq(phase.name()))
+        .and(CANDIDATE_POOLS.CANDIDATE_TYPE.eq(type.name()))
+        .fetchOptional(this::map);
+  }
+
+  @Override
+  public List<CandidatePool> findAllForLeague(long leagueId) {
+    return dsl.selectFrom(CANDIDATE_POOLS)
+        .where(CANDIDATE_POOLS.LEAGUE_ID.eq(leagueId))
+        .orderBy(CANDIDATE_POOLS.GENERATED_AT.desc())
+        .fetch(this::map);
+  }
+
+  private CandidatePool map(org.jooq.Record r) {
+    return new CandidatePool(
+        r.get(CANDIDATE_POOLS.ID),
+        r.get(CANDIDATE_POOLS.LEAGUE_ID),
+        LeaguePhase.valueOf(r.get(CANDIDATE_POOLS.PHASE)),
+        CandidatePoolType.valueOf(r.get(CANDIDATE_POOLS.CANDIDATE_TYPE)),
+        r.get(CANDIDATE_POOLS.GENERATED_AT).toInstant());
+  }
+}

--- a/src/main/java/app/zoneblitz/league/JooqCandidatePreferencesRepository.java
+++ b/src/main/java/app/zoneblitz/league/JooqCandidatePreferencesRepository.java
@@ -1,0 +1,96 @@
+package app.zoneblitz.league;
+
+import static app.zoneblitz.jooq.Tables.CANDIDATE_PREFERENCES;
+
+import java.util.Objects;
+import java.util.Optional;
+import org.jooq.DSLContext;
+import org.springframework.stereotype.Repository;
+
+@Repository
+class JooqCandidatePreferencesRepository implements CandidatePreferencesRepository {
+
+  private final DSLContext dsl;
+
+  JooqCandidatePreferencesRepository(DSLContext dsl) {
+    this.dsl = dsl;
+  }
+
+  @Override
+  public CandidatePreferences insert(CandidatePreferences prefs) {
+    Objects.requireNonNull(prefs, "prefs");
+    var record =
+        dsl.insertInto(CANDIDATE_PREFERENCES)
+            .set(CANDIDATE_PREFERENCES.CANDIDATE_ID, prefs.candidateId())
+            .set(CANDIDATE_PREFERENCES.COMPENSATION_TARGET, prefs.compensationTarget())
+            .set(CANDIDATE_PREFERENCES.COMPENSATION_WEIGHT, prefs.compensationWeight())
+            .set(CANDIDATE_PREFERENCES.CONTRACT_LENGTH_TARGET, prefs.contractLengthTarget())
+            .set(CANDIDATE_PREFERENCES.CONTRACT_LENGTH_WEIGHT, prefs.contractLengthWeight())
+            .set(CANDIDATE_PREFERENCES.GUARANTEED_MONEY_TARGET, prefs.guaranteedMoneyTarget())
+            .set(CANDIDATE_PREFERENCES.GUARANTEED_MONEY_WEIGHT, prefs.guaranteedMoneyWeight())
+            .set(CANDIDATE_PREFERENCES.MARKET_SIZE_TARGET, prefs.marketSizeTarget().name())
+            .set(CANDIDATE_PREFERENCES.MARKET_SIZE_WEIGHT, prefs.marketSizeWeight())
+            .set(CANDIDATE_PREFERENCES.GEOGRAPHY_TARGET, prefs.geographyTarget().name())
+            .set(CANDIDATE_PREFERENCES.GEOGRAPHY_WEIGHT, prefs.geographyWeight())
+            .set(CANDIDATE_PREFERENCES.CLIMATE_TARGET, prefs.climateTarget().name())
+            .set(CANDIDATE_PREFERENCES.CLIMATE_WEIGHT, prefs.climateWeight())
+            .set(CANDIDATE_PREFERENCES.FRANCHISE_PRESTIGE_TARGET, prefs.franchisePrestigeTarget())
+            .set(CANDIDATE_PREFERENCES.FRANCHISE_PRESTIGE_WEIGHT, prefs.franchisePrestigeWeight())
+            .set(
+                CANDIDATE_PREFERENCES.COMPETITIVE_WINDOW_TARGET,
+                prefs.competitiveWindowTarget().name())
+            .set(CANDIDATE_PREFERENCES.COMPETITIVE_WINDOW_WEIGHT, prefs.competitiveWindowWeight())
+            .set(CANDIDATE_PREFERENCES.ROLE_SCOPE_TARGET, prefs.roleScopeTarget().name())
+            .set(CANDIDATE_PREFERENCES.ROLE_SCOPE_WEIGHT, prefs.roleScopeWeight())
+            .set(
+                CANDIDATE_PREFERENCES.STAFF_CONTINUITY_TARGET, prefs.staffContinuityTarget().name())
+            .set(CANDIDATE_PREFERENCES.STAFF_CONTINUITY_WEIGHT, prefs.staffContinuityWeight())
+            .set(CANDIDATE_PREFERENCES.SCHEME_ALIGNMENT_TARGET, prefs.schemeAlignmentTarget())
+            .set(CANDIDATE_PREFERENCES.SCHEME_ALIGNMENT_WEIGHT, prefs.schemeAlignmentWeight())
+            .set(CANDIDATE_PREFERENCES.OWNER_STABILITY_TARGET, prefs.ownerStabilityTarget())
+            .set(CANDIDATE_PREFERENCES.OWNER_STABILITY_WEIGHT, prefs.ownerStabilityWeight())
+            .set(CANDIDATE_PREFERENCES.FACILITY_QUALITY_TARGET, prefs.facilityQualityTarget())
+            .set(CANDIDATE_PREFERENCES.FACILITY_QUALITY_WEIGHT, prefs.facilityQualityWeight())
+            .returning(CANDIDATE_PREFERENCES.fields())
+            .fetchOne();
+    return map(record);
+  }
+
+  @Override
+  public Optional<CandidatePreferences> findByCandidateId(long candidateId) {
+    return dsl.selectFrom(CANDIDATE_PREFERENCES)
+        .where(CANDIDATE_PREFERENCES.CANDIDATE_ID.eq(candidateId))
+        .fetchOptional(this::map);
+  }
+
+  private CandidatePreferences map(org.jooq.Record r) {
+    return new CandidatePreferences(
+        r.get(CANDIDATE_PREFERENCES.CANDIDATE_ID),
+        r.get(CANDIDATE_PREFERENCES.COMPENSATION_TARGET),
+        r.get(CANDIDATE_PREFERENCES.COMPENSATION_WEIGHT),
+        r.get(CANDIDATE_PREFERENCES.CONTRACT_LENGTH_TARGET),
+        r.get(CANDIDATE_PREFERENCES.CONTRACT_LENGTH_WEIGHT),
+        r.get(CANDIDATE_PREFERENCES.GUARANTEED_MONEY_TARGET),
+        r.get(CANDIDATE_PREFERENCES.GUARANTEED_MONEY_WEIGHT),
+        MarketSize.valueOf(r.get(CANDIDATE_PREFERENCES.MARKET_SIZE_TARGET)),
+        r.get(CANDIDATE_PREFERENCES.MARKET_SIZE_WEIGHT),
+        Geography.valueOf(r.get(CANDIDATE_PREFERENCES.GEOGRAPHY_TARGET)),
+        r.get(CANDIDATE_PREFERENCES.GEOGRAPHY_WEIGHT),
+        Climate.valueOf(r.get(CANDIDATE_PREFERENCES.CLIMATE_TARGET)),
+        r.get(CANDIDATE_PREFERENCES.CLIMATE_WEIGHT),
+        r.get(CANDIDATE_PREFERENCES.FRANCHISE_PRESTIGE_TARGET),
+        r.get(CANDIDATE_PREFERENCES.FRANCHISE_PRESTIGE_WEIGHT),
+        CompetitiveWindow.valueOf(r.get(CANDIDATE_PREFERENCES.COMPETITIVE_WINDOW_TARGET)),
+        r.get(CANDIDATE_PREFERENCES.COMPETITIVE_WINDOW_WEIGHT),
+        RoleScope.valueOf(r.get(CANDIDATE_PREFERENCES.ROLE_SCOPE_TARGET)),
+        r.get(CANDIDATE_PREFERENCES.ROLE_SCOPE_WEIGHT),
+        StaffContinuity.valueOf(r.get(CANDIDATE_PREFERENCES.STAFF_CONTINUITY_TARGET)),
+        r.get(CANDIDATE_PREFERENCES.STAFF_CONTINUITY_WEIGHT),
+        r.get(CANDIDATE_PREFERENCES.SCHEME_ALIGNMENT_TARGET),
+        r.get(CANDIDATE_PREFERENCES.SCHEME_ALIGNMENT_WEIGHT),
+        r.get(CANDIDATE_PREFERENCES.OWNER_STABILITY_TARGET),
+        r.get(CANDIDATE_PREFERENCES.OWNER_STABILITY_WEIGHT),
+        r.get(CANDIDATE_PREFERENCES.FACILITY_QUALITY_TARGET),
+        r.get(CANDIDATE_PREFERENCES.FACILITY_QUALITY_WEIGHT));
+  }
+}

--- a/src/main/java/app/zoneblitz/league/JooqCandidateRepository.java
+++ b/src/main/java/app/zoneblitz/league/JooqCandidateRepository.java
@@ -1,0 +1,78 @@
+package app.zoneblitz.league;
+
+import static app.zoneblitz.jooq.Tables.CANDIDATES;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import org.jooq.DSLContext;
+import org.jooq.JSONB;
+import org.springframework.stereotype.Repository;
+
+@Repository
+class JooqCandidateRepository implements CandidateRepository {
+
+  private final DSLContext dsl;
+
+  JooqCandidateRepository(DSLContext dsl) {
+    this.dsl = dsl;
+  }
+
+  @Override
+  public Candidate insert(NewCandidate newCandidate) {
+    Objects.requireNonNull(newCandidate, "newCandidate");
+    var record =
+        dsl.insertInto(CANDIDATES)
+            .set(CANDIDATES.POOL_ID, newCandidate.poolId())
+            .set(CANDIDATES.KIND, newCandidate.kind().name())
+            .set(CANDIDATES.SPECIALTY_POSITION, newCandidate.specialtyPosition().name())
+            .set(CANDIDATES.ARCHETYPE, newCandidate.archetype().name())
+            .set(CANDIDATES.AGE, newCandidate.age())
+            .set(CANDIDATES.TOTAL_EXPERIENCE_YEARS, newCandidate.totalExperienceYears())
+            .set(CANDIDATES.EXPERIENCE_BY_ROLE, JSONB.valueOf(newCandidate.experienceByRole()))
+            .set(CANDIDATES.HIDDEN_ATTRS, JSONB.valueOf(newCandidate.hiddenAttrs()))
+            .set(CANDIDATES.SCOUTED_ATTRS, JSONB.valueOf(newCandidate.scoutedAttrs()))
+            .set(CANDIDATES.SCOUT_BRANCH, newCandidate.scoutBranch().map(Enum::name).orElse(null))
+            .returning(CANDIDATES.fields())
+            .fetchOne();
+    return map(record);
+  }
+
+  @Override
+  public Optional<Candidate> findById(long id) {
+    return dsl.selectFrom(CANDIDATES).where(CANDIDATES.ID.eq(id)).fetchOptional(this::map);
+  }
+
+  @Override
+  public List<Candidate> findAllByPoolId(long poolId) {
+    return dsl.selectFrom(CANDIDATES)
+        .where(CANDIDATES.POOL_ID.eq(poolId))
+        .orderBy(CANDIDATES.ID.asc())
+        .fetch(this::map);
+  }
+
+  @Override
+  public boolean markHired(long candidateId, long franchiseId) {
+    return dsl.update(CANDIDATES)
+            .set(CANDIDATES.HIRED_BY_FRANCHISE_ID, franchiseId)
+            .where(CANDIDATES.ID.eq(candidateId))
+            .execute()
+        > 0;
+  }
+
+  private Candidate map(org.jooq.Record r) {
+    return new Candidate(
+        r.get(CANDIDATES.ID),
+        r.get(CANDIDATES.POOL_ID),
+        CandidateKind.valueOf(r.get(CANDIDATES.KIND)),
+        SpecialtyPosition.valueOf(r.get(CANDIDATES.SPECIALTY_POSITION)),
+        CandidateArchetype.valueOf(r.get(CANDIDATES.ARCHETYPE)),
+        r.get(CANDIDATES.AGE),
+        r.get(CANDIDATES.TOTAL_EXPERIENCE_YEARS),
+        r.get(CANDIDATES.EXPERIENCE_BY_ROLE).data(),
+        r.get(CANDIDATES.HIDDEN_ATTRS).data(),
+        r.get(CANDIDATES.SCOUTED_ATTRS).data(),
+        Optional.ofNullable(r.get(CANDIDATES.HIRED_BY_FRANCHISE_ID)),
+        Optional.ofNullable(r.get(CANDIDATES.SCOUT_BRANCH)).map(ScoutBranch::valueOf));
+  }
+}

--- a/src/main/java/app/zoneblitz/league/JooqFranchiseHiringStateRepository.java
+++ b/src/main/java/app/zoneblitz/league/JooqFranchiseHiringStateRepository.java
@@ -1,0 +1,75 @@
+package app.zoneblitz.league;
+
+import static app.zoneblitz.jooq.Tables.FRANCHISE_HIRING_STATES;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import org.jooq.DSLContext;
+import org.jooq.JSONB;
+import org.springframework.stereotype.Repository;
+
+@Repository
+class JooqFranchiseHiringStateRepository implements FranchiseHiringStateRepository {
+
+  private final DSLContext dsl;
+
+  JooqFranchiseHiringStateRepository(DSLContext dsl) {
+    this.dsl = dsl;
+  }
+
+  @Override
+  public FranchiseHiringState upsert(FranchiseHiringState state) {
+    Objects.requireNonNull(state, "state");
+    var shortlistJson = JSONB.valueOf(JsonLongArrays.encode(state.shortlist()));
+    var interviewingJson = JSONB.valueOf(JsonLongArrays.encode(state.interviewingCandidateIds()));
+    var record =
+        dsl.insertInto(FRANCHISE_HIRING_STATES)
+            .set(FRANCHISE_HIRING_STATES.LEAGUE_ID, state.leagueId())
+            .set(FRANCHISE_HIRING_STATES.FRANCHISE_ID, state.franchiseId())
+            .set(FRANCHISE_HIRING_STATES.PHASE, state.phase().name())
+            .set(FRANCHISE_HIRING_STATES.STEP, state.step().name())
+            .set(FRANCHISE_HIRING_STATES.SHORTLIST, shortlistJson)
+            .set(FRANCHISE_HIRING_STATES.INTERVIEWING_CANDIDATE_IDS, interviewingJson)
+            .onConflict(
+                FRANCHISE_HIRING_STATES.LEAGUE_ID,
+                FRANCHISE_HIRING_STATES.FRANCHISE_ID,
+                FRANCHISE_HIRING_STATES.PHASE)
+            .doUpdate()
+            .set(FRANCHISE_HIRING_STATES.STEP, state.step().name())
+            .set(FRANCHISE_HIRING_STATES.SHORTLIST, shortlistJson)
+            .set(FRANCHISE_HIRING_STATES.INTERVIEWING_CANDIDATE_IDS, interviewingJson)
+            .returning(FRANCHISE_HIRING_STATES.fields())
+            .fetchOne();
+    return map(record);
+  }
+
+  @Override
+  public Optional<FranchiseHiringState> find(long leagueId, long franchiseId, LeaguePhase phase) {
+    return dsl.selectFrom(FRANCHISE_HIRING_STATES)
+        .where(FRANCHISE_HIRING_STATES.LEAGUE_ID.eq(leagueId))
+        .and(FRANCHISE_HIRING_STATES.FRANCHISE_ID.eq(franchiseId))
+        .and(FRANCHISE_HIRING_STATES.PHASE.eq(phase.name()))
+        .fetchOptional(this::map);
+  }
+
+  @Override
+  public List<FranchiseHiringState> findAllForLeaguePhase(long leagueId, LeaguePhase phase) {
+    return dsl.selectFrom(FRANCHISE_HIRING_STATES)
+        .where(FRANCHISE_HIRING_STATES.LEAGUE_ID.eq(leagueId))
+        .and(FRANCHISE_HIRING_STATES.PHASE.eq(phase.name()))
+        .orderBy(FRANCHISE_HIRING_STATES.FRANCHISE_ID.asc())
+        .fetch(this::map);
+  }
+
+  private FranchiseHiringState map(org.jooq.Record r) {
+    return new FranchiseHiringState(
+        r.get(FRANCHISE_HIRING_STATES.ID),
+        r.get(FRANCHISE_HIRING_STATES.LEAGUE_ID),
+        r.get(FRANCHISE_HIRING_STATES.FRANCHISE_ID),
+        LeaguePhase.valueOf(r.get(FRANCHISE_HIRING_STATES.PHASE)),
+        HiringStep.valueOf(r.get(FRANCHISE_HIRING_STATES.STEP)),
+        JsonLongArrays.decode(r.get(FRANCHISE_HIRING_STATES.SHORTLIST).data()),
+        JsonLongArrays.decode(r.get(FRANCHISE_HIRING_STATES.INTERVIEWING_CANDIDATE_IDS).data()));
+  }
+}

--- a/src/main/java/app/zoneblitz/league/JooqFranchiseInterviewRepository.java
+++ b/src/main/java/app/zoneblitz/league/JooqFranchiseInterviewRepository.java
@@ -1,0 +1,82 @@
+package app.zoneblitz.league;
+
+import static app.zoneblitz.jooq.Tables.FRANCHISE_INTERVIEWS;
+
+import java.util.List;
+import java.util.Objects;
+import org.jooq.DSLContext;
+import org.springframework.stereotype.Repository;
+
+@Repository
+class JooqFranchiseInterviewRepository implements FranchiseInterviewRepository {
+
+  private final DSLContext dsl;
+
+  JooqFranchiseInterviewRepository(DSLContext dsl) {
+    this.dsl = dsl;
+  }
+
+  @Override
+  public FranchiseInterview insert(NewFranchiseInterview interview) {
+    Objects.requireNonNull(interview, "interview");
+    var record =
+        dsl.insertInto(FRANCHISE_INTERVIEWS)
+            .set(FRANCHISE_INTERVIEWS.LEAGUE_ID, interview.leagueId())
+            .set(FRANCHISE_INTERVIEWS.FRANCHISE_ID, interview.franchiseId())
+            .set(FRANCHISE_INTERVIEWS.CANDIDATE_ID, interview.candidateId())
+            .set(FRANCHISE_INTERVIEWS.PHASE, interview.phase().name())
+            .set(FRANCHISE_INTERVIEWS.PHASE_WEEK, interview.phaseWeek())
+            .set(FRANCHISE_INTERVIEWS.INTERVIEW_INDEX, interview.interviewIndex())
+            .set(FRANCHISE_INTERVIEWS.SCOUTED_OVERALL, interview.scoutedOverall())
+            .returning(FRANCHISE_INTERVIEWS.fields())
+            .fetchOne();
+    return map(record);
+  }
+
+  @Override
+  public int countForCandidate(
+      long leagueId, long franchiseId, long candidateId, LeaguePhase phase) {
+    return dsl.fetchCount(
+        FRANCHISE_INTERVIEWS,
+        FRANCHISE_INTERVIEWS
+            .LEAGUE_ID
+            .eq(leagueId)
+            .and(FRANCHISE_INTERVIEWS.FRANCHISE_ID.eq(franchiseId))
+            .and(FRANCHISE_INTERVIEWS.CANDIDATE_ID.eq(candidateId))
+            .and(FRANCHISE_INTERVIEWS.PHASE.eq(phase.name())));
+  }
+
+  @Override
+  public int countForWeek(long leagueId, long franchiseId, LeaguePhase phase, int phaseWeek) {
+    return dsl.fetchCount(
+        FRANCHISE_INTERVIEWS,
+        FRANCHISE_INTERVIEWS
+            .LEAGUE_ID
+            .eq(leagueId)
+            .and(FRANCHISE_INTERVIEWS.FRANCHISE_ID.eq(franchiseId))
+            .and(FRANCHISE_INTERVIEWS.PHASE.eq(phase.name()))
+            .and(FRANCHISE_INTERVIEWS.PHASE_WEEK.eq(phaseWeek)));
+  }
+
+  @Override
+  public List<FranchiseInterview> findAllFor(long leagueId, long franchiseId, LeaguePhase phase) {
+    return dsl.selectFrom(FRANCHISE_INTERVIEWS)
+        .where(FRANCHISE_INTERVIEWS.LEAGUE_ID.eq(leagueId))
+        .and(FRANCHISE_INTERVIEWS.FRANCHISE_ID.eq(franchiseId))
+        .and(FRANCHISE_INTERVIEWS.PHASE.eq(phase.name()))
+        .orderBy(FRANCHISE_INTERVIEWS.ID.asc())
+        .fetch(this::map);
+  }
+
+  private FranchiseInterview map(org.jooq.Record r) {
+    return new FranchiseInterview(
+        r.get(FRANCHISE_INTERVIEWS.ID),
+        r.get(FRANCHISE_INTERVIEWS.LEAGUE_ID),
+        r.get(FRANCHISE_INTERVIEWS.FRANCHISE_ID),
+        r.get(FRANCHISE_INTERVIEWS.CANDIDATE_ID),
+        LeaguePhase.valueOf(r.get(FRANCHISE_INTERVIEWS.PHASE)),
+        r.get(FRANCHISE_INTERVIEWS.PHASE_WEEK),
+        r.get(FRANCHISE_INTERVIEWS.INTERVIEW_INDEX),
+        r.get(FRANCHISE_INTERVIEWS.SCOUTED_OVERALL));
+  }
+}

--- a/src/main/java/app/zoneblitz/league/JooqFranchiseStaffRepository.java
+++ b/src/main/java/app/zoneblitz/league/JooqFranchiseStaffRepository.java
@@ -1,0 +1,65 @@
+package app.zoneblitz.league;
+
+import static app.zoneblitz.jooq.Tables.FRANCHISE_STAFF;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import org.jooq.DSLContext;
+import org.springframework.stereotype.Repository;
+
+@Repository
+class JooqFranchiseStaffRepository implements FranchiseStaffRepository {
+
+  private final DSLContext dsl;
+
+  JooqFranchiseStaffRepository(DSLContext dsl) {
+    this.dsl = dsl;
+  }
+
+  @Override
+  public FranchiseStaffMember insert(NewFranchiseStaffMember hire) {
+    Objects.requireNonNull(hire, "hire");
+    var record =
+        dsl.insertInto(FRANCHISE_STAFF)
+            .set(FRANCHISE_STAFF.LEAGUE_ID, hire.leagueId())
+            .set(FRANCHISE_STAFF.FRANCHISE_ID, hire.franchiseId())
+            .set(FRANCHISE_STAFF.CANDIDATE_ID, hire.candidateId())
+            .set(FRANCHISE_STAFF.ROLE, hire.role().name())
+            .set(FRANCHISE_STAFF.SCOUT_BRANCH, hire.scoutBranch().map(Enum::name).orElse(null))
+            .set(FRANCHISE_STAFF.HIRED_AT_PHASE, hire.hiredAtPhase().name())
+            .set(FRANCHISE_STAFF.HIRED_AT_WEEK, hire.hiredAtWeek())
+            .returning(FRANCHISE_STAFF.fields())
+            .fetchOne();
+    return map(record);
+  }
+
+  @Override
+  public Optional<FranchiseStaffMember> findById(long id) {
+    return dsl.selectFrom(FRANCHISE_STAFF)
+        .where(FRANCHISE_STAFF.ID.eq(id))
+        .fetchOptional(this::map);
+  }
+
+  @Override
+  public List<FranchiseStaffMember> findAllForFranchise(long leagueId, long franchiseId) {
+    return dsl.selectFrom(FRANCHISE_STAFF)
+        .where(FRANCHISE_STAFF.LEAGUE_ID.eq(leagueId))
+        .and(FRANCHISE_STAFF.FRANCHISE_ID.eq(franchiseId))
+        .orderBy(FRANCHISE_STAFF.ROLE.asc(), FRANCHISE_STAFF.ID.asc())
+        .fetch(this::map);
+  }
+
+  private FranchiseStaffMember map(org.jooq.Record r) {
+    return new FranchiseStaffMember(
+        r.get(FRANCHISE_STAFF.ID),
+        r.get(FRANCHISE_STAFF.LEAGUE_ID),
+        r.get(FRANCHISE_STAFF.FRANCHISE_ID),
+        r.get(FRANCHISE_STAFF.CANDIDATE_ID),
+        StaffRole.valueOf(r.get(FRANCHISE_STAFF.ROLE)),
+        Optional.ofNullable(r.get(FRANCHISE_STAFF.SCOUT_BRANCH)).map(ScoutBranch::valueOf),
+        LeaguePhase.valueOf(r.get(FRANCHISE_STAFF.HIRED_AT_PHASE)),
+        r.get(FRANCHISE_STAFF.HIRED_AT_WEEK),
+        r.get(FRANCHISE_STAFF.HIRED_AT).toInstant());
+  }
+}

--- a/src/main/java/app/zoneblitz/league/JooqLeagueRepository.java
+++ b/src/main/java/app/zoneblitz/league/JooqLeagueRepository.java
@@ -36,6 +36,7 @@ class JooqLeagueRepository implements LeagueRepository {
                 LEAGUES.NAME,
                 LEAGUES.OWNER_SUBJECT,
                 LEAGUES.PHASE,
+                LEAGUES.PHASE_WEEK,
                 LEAGUES.TEAM_COUNT,
                 LEAGUES.SEASON_GAMES,
                 LEAGUES.CREATED_AT)
@@ -45,6 +46,7 @@ class JooqLeagueRepository implements LeagueRepository {
         record.getName(),
         record.getOwnerSubject(),
         LeaguePhase.valueOf(record.getPhase()),
+        record.getPhaseWeek(),
         new LeagueSettings(record.getTeamCount(), record.getSeasonGames()),
         record.getCreatedAt().toInstant());
   }
@@ -64,6 +66,7 @@ class JooqLeagueRepository implements LeagueRepository {
             LEAGUES.ID,
             LEAGUES.NAME,
             LEAGUES.PHASE,
+            LEAGUES.PHASE_WEEK,
             LEAGUES.CREATED_AT,
             FRANCHISES.ID,
             FRANCHISES.NAME,
@@ -92,6 +95,7 @@ class JooqLeagueRepository implements LeagueRepository {
                     r.get(LEAGUES.ID),
                     r.get(LEAGUES.NAME),
                     LeaguePhase.valueOf(r.get(LEAGUES.PHASE)),
+                    r.get(LEAGUES.PHASE_WEEK),
                     r.get(LEAGUES.CREATED_AT).toInstant(),
                     JooqFranchiseRepository.mapFranchise(r)));
   }
@@ -102,6 +106,7 @@ class JooqLeagueRepository implements LeagueRepository {
             LEAGUES.ID,
             LEAGUES.NAME,
             LEAGUES.PHASE,
+            LEAGUES.PHASE_WEEK,
             LEAGUES.CREATED_AT,
             FRANCHISES.ID,
             FRANCHISES.NAME,
@@ -130,8 +135,54 @@ class JooqLeagueRepository implements LeagueRepository {
                     r.get(LEAGUES.ID),
                     r.get(LEAGUES.NAME),
                     LeaguePhase.valueOf(r.get(LEAGUES.PHASE)),
+                    r.get(LEAGUES.PHASE_WEEK),
                     r.get(LEAGUES.CREATED_AT).toInstant(),
                     JooqFranchiseRepository.mapFranchise(r)));
+  }
+
+  @Override
+  public Optional<League> findById(long id) {
+    return dsl.select(
+            LEAGUES.ID,
+            LEAGUES.NAME,
+            LEAGUES.OWNER_SUBJECT,
+            LEAGUES.PHASE,
+            LEAGUES.PHASE_WEEK,
+            LEAGUES.TEAM_COUNT,
+            LEAGUES.SEASON_GAMES,
+            LEAGUES.CREATED_AT)
+        .from(LEAGUES)
+        .where(LEAGUES.ID.eq(id))
+        .fetchOptional(
+            r ->
+                new League(
+                    r.get(LEAGUES.ID),
+                    r.get(LEAGUES.NAME),
+                    r.get(LEAGUES.OWNER_SUBJECT),
+                    LeaguePhase.valueOf(r.get(LEAGUES.PHASE)),
+                    r.get(LEAGUES.PHASE_WEEK),
+                    new LeagueSettings(r.get(LEAGUES.TEAM_COUNT), r.get(LEAGUES.SEASON_GAMES)),
+                    r.get(LEAGUES.CREATED_AT).toInstant()));
+  }
+
+  @Override
+  public boolean updatePhaseAndResetWeek(long id, LeaguePhase phase) {
+    return dsl.update(LEAGUES)
+            .set(LEAGUES.PHASE, phase.name())
+            .set(LEAGUES.PHASE_WEEK, 1)
+            .where(LEAGUES.ID.eq(id))
+            .execute()
+        > 0;
+  }
+
+  @Override
+  public Optional<Integer> incrementPhaseWeek(long id) {
+    return dsl.update(LEAGUES)
+        .set(LEAGUES.PHASE_WEEK, LEAGUES.PHASE_WEEK.plus(1))
+        .where(LEAGUES.ID.eq(id))
+        .returning(LEAGUES.PHASE_WEEK)
+        .fetchOptional()
+        .map(r -> r.get(LEAGUES.PHASE_WEEK));
   }
 
   @Override

--- a/src/main/java/app/zoneblitz/league/JooqTeamLookup.java
+++ b/src/main/java/app/zoneblitz/league/JooqTeamLookup.java
@@ -1,0 +1,26 @@
+package app.zoneblitz.league;
+
+import static app.zoneblitz.jooq.Tables.TEAMS;
+
+import java.util.List;
+import org.jooq.DSLContext;
+import org.springframework.stereotype.Repository;
+
+@Repository
+class JooqTeamLookup implements TeamLookup {
+
+  private final DSLContext dsl;
+
+  JooqTeamLookup(DSLContext dsl) {
+    this.dsl = dsl;
+  }
+
+  @Override
+  public List<Long> franchiseIdsForLeague(long leagueId) {
+    return dsl.select(TEAMS.FRANCHISE_ID)
+        .from(TEAMS)
+        .where(TEAMS.LEAGUE_ID.eq(leagueId))
+        .orderBy(TEAMS.FRANCHISE_ID.asc())
+        .fetch(TEAMS.FRANCHISE_ID);
+  }
+}

--- a/src/main/java/app/zoneblitz/league/JsonLongArrays.java
+++ b/src/main/java/app/zoneblitz/league/JsonLongArrays.java
@@ -1,0 +1,44 @@
+package app.zoneblitz.league;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Small utility for (de)serializing {@code List<Long>} to/from JSONB array strings without pulling
+ * a JSON binding dependency into the repository layer. The shape is deliberately strict: a JSON
+ * array of integer literals.
+ */
+final class JsonLongArrays {
+
+  private JsonLongArrays() {}
+
+  static String encode(List<Long> ids) {
+    if (ids.isEmpty()) {
+      return "[]";
+    }
+    var sb = new StringBuilder("[");
+    for (var i = 0; i < ids.size(); i++) {
+      if (i > 0) sb.append(',');
+      sb.append(ids.get(i).longValue());
+    }
+    sb.append(']');
+    return sb.toString();
+  }
+
+  static List<Long> decode(String json) {
+    if (json == null) return List.of();
+    var trimmed = json.trim();
+    if (trimmed.isEmpty() || trimmed.equals("[]")) return List.of();
+    if (!trimmed.startsWith("[") || !trimmed.endsWith("]")) {
+      throw new IllegalStateException("Expected JSON array, got: " + trimmed);
+    }
+    var body = trimmed.substring(1, trimmed.length() - 1).trim();
+    if (body.isEmpty()) return List.of();
+    var parts = body.split(",");
+    var out = new ArrayList<Long>(parts.length);
+    for (var p : parts) {
+      out.add(Long.parseLong(p.trim()));
+    }
+    return List.copyOf(out);
+  }
+}

--- a/src/main/java/app/zoneblitz/league/League.java
+++ b/src/main/java/app/zoneblitz/league/League.java
@@ -7,5 +7,6 @@ public record League(
     String name,
     String ownerSubject,
     LeaguePhase phase,
+    int phaseWeek,
     LeagueSettings settings,
     Instant createdAt) {}

--- a/src/main/java/app/zoneblitz/league/LeagueBeans.java
+++ b/src/main/java/app/zoneblitz/league/LeagueBeans.java
@@ -1,0 +1,14 @@
+package app.zoneblitz.league;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/** Wiring for league-feature beans that are not themselves {@code @Component}-annotated. */
+@Configuration
+class LeagueBeans {
+
+  @Bean
+  CandidateGenerator headCoachGenerator() {
+    return new HeadCoachGenerator();
+  }
+}

--- a/src/main/java/app/zoneblitz/league/LeagueController.java
+++ b/src/main/java/app/zoneblitz/league/LeagueController.java
@@ -26,18 +26,21 @@ class LeagueController {
   private final CreateLeague createLeague;
   private final GetLeague getLeague;
   private final DeleteLeague deleteLeague;
+  private final AdvancePhase advancePhase;
 
   LeagueController(
       ListLeaguesForUser listLeagues,
       ListFranchises listFranchises,
       CreateLeague createLeague,
       GetLeague getLeague,
-      DeleteLeague deleteLeague) {
+      DeleteLeague deleteLeague,
+      AdvancePhase advancePhase) {
     this.listLeagues = listLeagues;
     this.listFranchises = listFranchises;
     this.createLeague = createLeague;
     this.getLeague = getLeague;
     this.deleteLeague = deleteLeague;
+    this.advancePhase = advancePhase;
   }
 
   @GetMapping("/")
@@ -68,6 +71,26 @@ class LeagueController {
             .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND));
     model.addAttribute("league", league);
     return "league/settings";
+  }
+
+  @PostMapping("/leagues/{id}/phase/advance")
+  String advancePhase(@AuthenticationPrincipal OAuth2User principal, @PathVariable long id) {
+    var ownerSubject = principal.<String>getAttribute("sub");
+    var result = advancePhase.advance(id, ownerSubject);
+    return switch (result) {
+      case AdvancePhaseResult.Advanced advanced -> {
+        log.info(
+            "league phase advanced id={} from={} to={}",
+            advanced.leagueId(),
+            advanced.from(),
+            advanced.to());
+        yield "redirect:/leagues/" + id;
+      }
+      case AdvancePhaseResult.NotFound ignored ->
+          throw new ResponseStatusException(HttpStatus.NOT_FOUND);
+      case AdvancePhaseResult.NoNextPhase ignored ->
+          throw new ResponseStatusException(HttpStatus.CONFLICT);
+    };
   }
 
   @PostMapping("/leagues/{id}/delete")

--- a/src/main/java/app/zoneblitz/league/LeagueController.java
+++ b/src/main/java/app/zoneblitz/league/LeagueController.java
@@ -58,6 +58,9 @@ class LeagueController {
         getLeague
             .get(id, principal.getAttribute("sub"))
             .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND));
+    if (league.phase() == LeaguePhase.HIRING_HEAD_COACH) {
+      return "redirect:/leagues/" + id + "/hiring/head-coach";
+    }
     model.addAttribute("league", league);
     return "league/dashboard";
   }

--- a/src/main/java/app/zoneblitz/league/LeaguePhase.java
+++ b/src/main/java/app/zoneblitz/league/LeaguePhase.java
@@ -2,5 +2,7 @@ package app.zoneblitz.league;
 
 public enum LeaguePhase {
   INITIAL_SETUP,
-  HIRING_HEAD_COACH
+  HIRING_HEAD_COACH,
+  HIRING_DIRECTOR_OF_SCOUTING,
+  ASSEMBLING_STAFF
 }

--- a/src/main/java/app/zoneblitz/league/LeaguePhase.java
+++ b/src/main/java/app/zoneblitz/league/LeaguePhase.java
@@ -1,5 +1,6 @@
 package app.zoneblitz.league;
 
 public enum LeaguePhase {
-  INITIAL_SETUP
+  INITIAL_SETUP,
+  HIRING_HEAD_COACH
 }

--- a/src/main/java/app/zoneblitz/league/LeaguePhases.java
+++ b/src/main/java/app/zoneblitz/league/LeaguePhases.java
@@ -1,0 +1,20 @@
+package app.zoneblitz.league;
+
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * Phase ordering and next-phase lookup. Centralizes the linear sequence so {@link
+ * AdvancePhaseUseCase} and tests agree on "what comes next".
+ */
+final class LeaguePhases {
+
+  private static final Map<LeaguePhase, LeaguePhase> NEXT =
+      Map.of(LeaguePhase.INITIAL_SETUP, LeaguePhase.HIRING_HEAD_COACH);
+
+  private LeaguePhases() {}
+
+  static Optional<LeaguePhase> next(LeaguePhase phase) {
+    return Optional.ofNullable(NEXT.get(phase));
+  }
+}

--- a/src/main/java/app/zoneblitz/league/LeagueRepository.java
+++ b/src/main/java/app/zoneblitz/league/LeagueRepository.java
@@ -13,5 +13,22 @@ interface LeagueRepository {
 
   Optional<LeagueSummary> findSummaryByIdAndOwner(long id, String ownerSubject);
 
+  Optional<League> findById(long id);
+
+  /**
+   * Update the phase and reset {@code phase_week} to 1.
+   *
+   * @return true if a row was updated, false if the league does not exist.
+   */
+  boolean updatePhaseAndResetWeek(long id, LeaguePhase phase);
+
+  /**
+   * Increment {@code phase_week} by 1.
+   *
+   * @return the new {@code phase_week} value wrapped in {@link Optional}, or empty if the league
+   *     does not exist.
+   */
+  Optional<Integer> incrementPhaseWeek(long id);
+
   boolean deleteByIdAndOwner(long id, String ownerSubject);
 }

--- a/src/main/java/app/zoneblitz/league/LeagueSummary.java
+++ b/src/main/java/app/zoneblitz/league/LeagueSummary.java
@@ -7,5 +7,6 @@ public record LeagueSummary(
     long leagueId,
     String leagueName,
     LeaguePhase phase,
+    int phaseWeek,
     Instant createdAt,
     Franchise userFranchise) {}

--- a/src/main/java/app/zoneblitz/league/ManageHeadCoachShortlist.java
+++ b/src/main/java/app/zoneblitz/league/ManageHeadCoachShortlist.java
@@ -1,0 +1,14 @@
+package app.zoneblitz.league;
+
+/**
+ * Feature-public use case for adding or removing a candidate on the requesting franchise's
+ * HIRING_HEAD_COACH shortlist. Both operations are idempotent — adding an already-shortlisted
+ * candidate is a no-op that still returns {@link ShortlistResult.Updated}; same for removing one
+ * that isn't on the list.
+ */
+public interface ManageHeadCoachShortlist {
+
+  ShortlistResult add(long leagueId, long candidateId, String ownerSubject);
+
+  ShortlistResult remove(long leagueId, long candidateId, String ownerSubject);
+}

--- a/src/main/java/app/zoneblitz/league/ManageHeadCoachShortlistUseCase.java
+++ b/src/main/java/app/zoneblitz/league/ManageHeadCoachShortlistUseCase.java
@@ -14,18 +14,21 @@ class ManageHeadCoachShortlistUseCase implements ManageHeadCoachShortlist {
   private final CandidateRepository candidates;
   private final CandidatePreferencesRepository preferences;
   private final FranchiseHiringStateRepository hiringStates;
+  private final FranchiseInterviewRepository interviews;
 
   ManageHeadCoachShortlistUseCase(
       LeagueRepository leagues,
       CandidatePoolRepository pools,
       CandidateRepository candidates,
       CandidatePreferencesRepository preferences,
-      FranchiseHiringStateRepository hiringStates) {
+      FranchiseHiringStateRepository hiringStates,
+      FranchiseInterviewRepository interviews) {
     this.leagues = leagues;
     this.pools = pools;
     this.candidates = candidates;
     this.preferences = preferences;
     this.hiringStates = hiringStates;
+    this.interviews = interviews;
   }
 
   @Override
@@ -89,7 +92,16 @@ class ManageHeadCoachShortlistUseCase implements ManageHeadCoachShortlist {
             .map(c -> preferences.findByCandidateId(c.id()))
             .flatMap(java.util.Optional::stream)
             .toList();
-    var view = HeadCoachHiringViewModel.assemble(league, pool, prefs, updatedIds);
+    var interviewHistory =
+        interviews.findAllFor(leagueId, franchiseId, LeaguePhase.HIRING_HEAD_COACH);
+    var view =
+        HeadCoachHiringViewModel.assemble(
+            league,
+            pool,
+            prefs,
+            updatedIds,
+            interviewHistory,
+            StartInterview.DEFAULT_WEEKLY_CAPACITY);
     return new ShortlistResult.Updated(view);
   }
 

--- a/src/main/java/app/zoneblitz/league/ManageHeadCoachShortlistUseCase.java
+++ b/src/main/java/app/zoneblitz/league/ManageHeadCoachShortlistUseCase.java
@@ -1,0 +1,105 @@
+package app.zoneblitz.league;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+class ManageHeadCoachShortlistUseCase implements ManageHeadCoachShortlist {
+
+  private final LeagueRepository leagues;
+  private final CandidatePoolRepository pools;
+  private final CandidateRepository candidates;
+  private final CandidatePreferencesRepository preferences;
+  private final FranchiseHiringStateRepository hiringStates;
+
+  ManageHeadCoachShortlistUseCase(
+      LeagueRepository leagues,
+      CandidatePoolRepository pools,
+      CandidateRepository candidates,
+      CandidatePreferencesRepository preferences,
+      FranchiseHiringStateRepository hiringStates) {
+    this.leagues = leagues;
+    this.pools = pools;
+    this.candidates = candidates;
+    this.preferences = preferences;
+    this.hiringStates = hiringStates;
+  }
+
+  @Override
+  @Transactional
+  public ShortlistResult add(long leagueId, long candidateId, String ownerSubject) {
+    return mutate(leagueId, candidateId, ownerSubject, ids -> addUnique(ids, candidateId));
+  }
+
+  @Override
+  @Transactional
+  public ShortlistResult remove(long leagueId, long candidateId, String ownerSubject) {
+    return mutate(
+        leagueId,
+        candidateId,
+        ownerSubject,
+        ids -> ids.stream().filter(id -> id != candidateId).toList());
+  }
+
+  private ShortlistResult mutate(
+      long leagueId,
+      long candidateId,
+      String ownerSubject,
+      java.util.function.UnaryOperator<List<Long>> transform) {
+    Objects.requireNonNull(ownerSubject, "ownerSubject");
+    var maybeLeague = leagues.findSummaryByIdAndOwner(leagueId, ownerSubject);
+    if (maybeLeague.isEmpty()) {
+      return new ShortlistResult.NotFound(leagueId);
+    }
+    var league = maybeLeague.get();
+    if (league.phase() != LeaguePhase.HIRING_HEAD_COACH) {
+      return new ShortlistResult.NotFound(leagueId);
+    }
+    var maybePool =
+        pools.findByLeaguePhaseAndType(
+            leagueId, LeaguePhase.HIRING_HEAD_COACH, CandidatePoolType.HEAD_COACH);
+    if (maybePool.isEmpty()) {
+      return new ShortlistResult.NotFound(leagueId);
+    }
+    var candidate = candidates.findById(candidateId);
+    if (candidate.isEmpty() || candidate.get().poolId() != maybePool.get().id()) {
+      return new ShortlistResult.UnknownCandidate(candidateId);
+    }
+    var franchiseId = league.userFranchise().id();
+    var existing = hiringStates.find(leagueId, franchiseId, LeaguePhase.HIRING_HEAD_COACH);
+    var currentIds = existing.map(FranchiseHiringState::shortlist).orElse(List.of());
+    var interviewingIds =
+        existing.map(FranchiseHiringState::interviewingCandidateIds).orElse(List.of());
+    var updatedIds = transform.apply(currentIds);
+    hiringStates.upsert(
+        new FranchiseHiringState(
+            existing.map(FranchiseHiringState::id).orElse(0L),
+            leagueId,
+            franchiseId,
+            LeaguePhase.HIRING_HEAD_COACH,
+            HiringStep.SEARCHING,
+            updatedIds,
+            interviewingIds));
+    var pool = candidates.findAllByPoolId(maybePool.get().id());
+    var prefs =
+        pool.stream()
+            .map(c -> preferences.findByCandidateId(c.id()))
+            .flatMap(java.util.Optional::stream)
+            .toList();
+    var view = HeadCoachHiringViewModel.assemble(league, pool, prefs, updatedIds);
+    return new ShortlistResult.Updated(view);
+  }
+
+  private static List<Long> addUnique(List<Long> ids, long candidateId) {
+    if (ids.contains(candidateId)) {
+      return ids;
+    }
+    var updated = new ArrayList<Long>(ids.size() + 1);
+    updated.addAll(ids);
+    updated.add(candidateId);
+    return List.copyOf(updated);
+  }
+}

--- a/src/main/java/app/zoneblitz/league/MarketSize.java
+++ b/src/main/java/app/zoneblitz/league/MarketSize.java
@@ -1,0 +1,7 @@
+package app.zoneblitz.league;
+
+public enum MarketSize {
+  SMALL,
+  MEDIUM,
+  LARGE
+}

--- a/src/main/java/app/zoneblitz/league/NewCandidate.java
+++ b/src/main/java/app/zoneblitz/league/NewCandidate.java
@@ -1,0 +1,31 @@
+package app.zoneblitz.league;
+
+import java.util.Objects;
+import java.util.Optional;
+
+/**
+ * Insert-side DTO for {@link CandidateRepository#insert(NewCandidate)}. Kept separate from {@link
+ * Candidate} so the repository does not have to invent a sentinel id before insert.
+ */
+public record NewCandidate(
+    long poolId,
+    CandidateKind kind,
+    SpecialtyPosition specialtyPosition,
+    CandidateArchetype archetype,
+    int age,
+    int totalExperienceYears,
+    String experienceByRole,
+    String hiddenAttrs,
+    String scoutedAttrs,
+    Optional<ScoutBranch> scoutBranch) {
+
+  public NewCandidate {
+    Objects.requireNonNull(kind, "kind");
+    Objects.requireNonNull(specialtyPosition, "specialtyPosition");
+    Objects.requireNonNull(archetype, "archetype");
+    Objects.requireNonNull(experienceByRole, "experienceByRole");
+    Objects.requireNonNull(hiddenAttrs, "hiddenAttrs");
+    Objects.requireNonNull(scoutedAttrs, "scoutedAttrs");
+    Objects.requireNonNull(scoutBranch, "scoutBranch");
+  }
+}

--- a/src/main/java/app/zoneblitz/league/NewFranchiseInterview.java
+++ b/src/main/java/app/zoneblitz/league/NewFranchiseInterview.java
@@ -1,0 +1,20 @@
+package app.zoneblitz.league;
+
+import java.math.BigDecimal;
+import java.util.Objects;
+
+/** Insert payload for {@link FranchiseInterviewRepository#insert}. */
+record NewFranchiseInterview(
+    long leagueId,
+    long franchiseId,
+    long candidateId,
+    LeaguePhase phase,
+    int phaseWeek,
+    int interviewIndex,
+    BigDecimal scoutedOverall) {
+
+  NewFranchiseInterview {
+    Objects.requireNonNull(phase, "phase");
+    Objects.requireNonNull(scoutedOverall, "scoutedOverall");
+  }
+}

--- a/src/main/java/app/zoneblitz/league/NewFranchiseStaffMember.java
+++ b/src/main/java/app/zoneblitz/league/NewFranchiseStaffMember.java
@@ -1,0 +1,21 @@
+package app.zoneblitz.league;
+
+import java.util.Objects;
+import java.util.Optional;
+
+/** Insert-side DTO for {@link FranchiseStaffRepository#insert(NewFranchiseStaffMember)}. */
+public record NewFranchiseStaffMember(
+    long leagueId,
+    long franchiseId,
+    long candidateId,
+    StaffRole role,
+    Optional<ScoutBranch> scoutBranch,
+    LeaguePhase hiredAtPhase,
+    int hiredAtWeek) {
+
+  public NewFranchiseStaffMember {
+    Objects.requireNonNull(role, "role");
+    Objects.requireNonNull(scoutBranch, "scoutBranch");
+    Objects.requireNonNull(hiredAtPhase, "hiredAtPhase");
+  }
+}

--- a/src/main/java/app/zoneblitz/league/OfferStatus.java
+++ b/src/main/java/app/zoneblitz/league/OfferStatus.java
@@ -1,0 +1,7 @@
+package app.zoneblitz.league;
+
+public enum OfferStatus {
+  ACTIVE,
+  ACCEPTED,
+  REJECTED
+}

--- a/src/main/java/app/zoneblitz/league/PhaseTransitionHandler.java
+++ b/src/main/java/app/zoneblitz/league/PhaseTransitionHandler.java
@@ -1,0 +1,28 @@
+package app.zoneblitz.league;
+
+/**
+ * Per-phase seam invoked by {@link AdvancePhase} on exit of the outgoing phase and entry of the
+ * incoming phase. One implementation per {@link LeaguePhase}; registered by keying on the phase the
+ * handler owns.
+ *
+ * <p>Handlers own phase-specific state lifecycle — candidate-pool generation on entry, autofill
+ * resolution on exit, per-franchise sub-state reset, etc. None of that exists yet; the seam is
+ * introduced now so hiring phases can plug in without controller/use-case churn.
+ */
+interface PhaseTransitionHandler {
+
+  /** The phase this handler owns. */
+  LeaguePhase phase();
+
+  /**
+   * Called when a league is leaving this handler's {@link #phase()}. Default no-op so handlers that
+   * only care about entry don't have to override.
+   */
+  default void onExit(long leagueId) {}
+
+  /**
+   * Called when a league is entering this handler's {@link #phase()}. Default no-op so handlers
+   * that only care about exit don't have to override.
+   */
+  default void onEntry(long leagueId) {}
+}

--- a/src/main/java/app/zoneblitz/league/RoleScope.java
+++ b/src/main/java/app/zoneblitz/league/RoleScope.java
@@ -1,0 +1,8 @@
+package app.zoneblitz.league;
+
+/** Autonomy offered by the franchise for the role. */
+public enum RoleScope {
+  LOW,
+  MEDIUM,
+  HIGH
+}

--- a/src/main/java/app/zoneblitz/league/ScoutBranch.java
+++ b/src/main/java/app/zoneblitz/league/ScoutBranch.java
@@ -1,0 +1,7 @@
+package app.zoneblitz.league;
+
+/** Branch a scout candidate operates in. Null for non-scout candidates. */
+public enum ScoutBranch {
+  COLLEGE,
+  PRO
+}

--- a/src/main/java/app/zoneblitz/league/ShortlistResult.java
+++ b/src/main/java/app/zoneblitz/league/ShortlistResult.java
@@ -1,0 +1,14 @@
+package app.zoneblitz.league;
+
+/** Sealed outcomes for adding/removing a candidate on the user's hiring shortlist. */
+public sealed interface ShortlistResult {
+
+  /** Shortlist updated; the refreshed view-model is returned for fragment rendering. */
+  record Updated(HeadCoachHiringView view) implements ShortlistResult {}
+
+  /** League not found for the requesting user, or not in the HC hiring phase. */
+  record NotFound(long leagueId) implements ShortlistResult {}
+
+  /** Candidate does not exist in this league's HC pool. */
+  record UnknownCandidate(long candidateId) implements ShortlistResult {}
+}

--- a/src/main/java/app/zoneblitz/league/SpecialtyPosition.java
+++ b/src/main/java/app/zoneblitz/league/SpecialtyPosition.java
@@ -1,0 +1,23 @@
+package app.zoneblitz.league;
+
+/**
+ * Coaching/scouting specialty — the position a candidate understands best. Broader than the sim
+ * roster {@code Position} enum: adds {@code EDGE} because coaching orgs carry a distinct EDGE / OLB
+ * coach seat.
+ */
+public enum SpecialtyPosition {
+  QB,
+  RB,
+  FB,
+  WR,
+  TE,
+  OL,
+  DL,
+  EDGE,
+  LB,
+  CB,
+  S,
+  K,
+  P,
+  LS
+}

--- a/src/main/java/app/zoneblitz/league/SplittableCandidateRandomSources.java
+++ b/src/main/java/app/zoneblitz/league/SplittableCandidateRandomSources.java
@@ -1,0 +1,20 @@
+package app.zoneblitz.league;
+
+import app.zoneblitz.gamesimulator.rng.RandomSource;
+import app.zoneblitz.gamesimulator.rng.SplittableRandomSource;
+import org.springframework.stereotype.Component;
+
+/**
+ * Production {@link CandidateRandomSources}. Derives a deterministic seed from {@code leagueId}
+ * mixed with the phase ordinal so the same league re-entering the same phase produces the same pool
+ * — useful for reproducibility and tests.
+ */
+@Component
+class SplittableCandidateRandomSources implements CandidateRandomSources {
+
+  @Override
+  public RandomSource forLeaguePhase(long leagueId, LeaguePhase phase) {
+    var seed = leagueId * 0x9E3779B97F4A7C15L ^ (long) phase.ordinal();
+    return new SplittableRandomSource(seed);
+  }
+}

--- a/src/main/java/app/zoneblitz/league/StaffContinuity.java
+++ b/src/main/java/app/zoneblitz/league/StaffContinuity.java
@@ -1,0 +1,8 @@
+package app.zoneblitz.league;
+
+/** Candidate's preference over subordinate-staff retention in the role. */
+public enum StaffContinuity {
+  KEEP_EXISTING,
+  BRING_OWN,
+  HYBRID
+}

--- a/src/main/java/app/zoneblitz/league/StaffRole.java
+++ b/src/main/java/app/zoneblitz/league/StaffRole.java
@@ -1,0 +1,21 @@
+package app.zoneblitz.league;
+
+/** Terminal staff role on a franchise org chart. See {@code docs/technical/league-phases.md}. */
+public enum StaffRole {
+  HEAD_COACH,
+  OFFENSIVE_COORDINATOR,
+  DEFENSIVE_COORDINATOR,
+  SPECIAL_TEAMS_COORDINATOR,
+  QB_COACH,
+  RB_COACH,
+  WR_COACH,
+  TE_COACH,
+  OL_COACH,
+  DL_COACH,
+  EDGE_COACH,
+  LB_COACH,
+  DB_COACH,
+  DIRECTOR_OF_SCOUTING,
+  COLLEGE_SCOUT,
+  PRO_SCOUT
+}

--- a/src/main/java/app/zoneblitz/league/StartInterview.java
+++ b/src/main/java/app/zoneblitz/league/StartInterview.java
@@ -1,0 +1,30 @@
+package app.zoneblitz.league;
+
+/**
+ * Feature-public use case for conducting an interview against a shortlisted Head Coach candidate.
+ *
+ * <p>Each completed interview:
+ *
+ * <ul>
+ *   <li>Increments the franchise's interview count against that candidate; each step reduces the
+ *       scouted-signal σ per {@link InterviewNoiseModel}, with diminishing returns and a hard
+ *       tier-dependent floor (σ never reaches 0).
+ *   <li>Counts against the franchise's weekly interview capacity (default 3/week).
+ *   <li>Persists a new scouted-overall estimate derived from the candidate's hidden true rating
+ *       plus noise at the current σ. The shared {@code candidates.scouted_attrs} column is never
+ *       written to — the hidden true rating never leaks into the shared column.
+ *   <li>Appends the candidate id to {@code franchise_hiring_states.interviewing_candidate_ids},
+ *       which records the per-franchise interview history (one entry per interview event).
+ * </ul>
+ *
+ * Returns {@link InterviewResult.Started} on success, {@link InterviewResult.CapacityReached} when
+ * the franchise has already hit the weekly cap, {@link InterviewResult.NotFound} when the league is
+ * not owned or not in HC hiring, and {@link InterviewResult.UnknownCandidate} when the candidate id
+ * does not map to this league's HC pool.
+ */
+public interface StartInterview {
+
+  int DEFAULT_WEEKLY_CAPACITY = 3;
+
+  InterviewResult start(long leagueId, long candidateId, String ownerSubject);
+}

--- a/src/main/java/app/zoneblitz/league/StartInterviewUseCase.java
+++ b/src/main/java/app/zoneblitz/league/StartInterviewUseCase.java
@@ -1,0 +1,158 @@
+package app.zoneblitz.league;
+
+import app.zoneblitz.gamesimulator.rng.SplittableRandomSource;
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.util.ArrayList;
+import java.util.Objects;
+import java.util.regex.Pattern;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+class StartInterviewUseCase implements StartInterview {
+
+  private static final Logger log = LoggerFactory.getLogger(StartInterviewUseCase.class);
+  private static final Pattern HIDDEN_OVERALL =
+      Pattern.compile("\"overall\"\\s*:\\s*(-?[0-9]+(?:\\.[0-9]+)?)");
+  private static final double SCOUTED_LOWER = 20.0;
+  private static final double SCOUTED_UPPER = 99.0;
+
+  private final LeagueRepository leagues;
+  private final CandidatePoolRepository pools;
+  private final CandidateRepository candidates;
+  private final CandidatePreferencesRepository preferences;
+  private final FranchiseHiringStateRepository hiringStates;
+  private final FranchiseInterviewRepository interviews;
+
+  StartInterviewUseCase(
+      LeagueRepository leagues,
+      CandidatePoolRepository pools,
+      CandidateRepository candidates,
+      CandidatePreferencesRepository preferences,
+      FranchiseHiringStateRepository hiringStates,
+      FranchiseInterviewRepository interviews) {
+    this.leagues = leagues;
+    this.pools = pools;
+    this.candidates = candidates;
+    this.preferences = preferences;
+    this.hiringStates = hiringStates;
+    this.interviews = interviews;
+  }
+
+  @Override
+  @Transactional
+  public InterviewResult start(long leagueId, long candidateId, String ownerSubject) {
+    Objects.requireNonNull(ownerSubject, "ownerSubject");
+    var maybeLeague = leagues.findSummaryByIdAndOwner(leagueId, ownerSubject);
+    if (maybeLeague.isEmpty()) {
+      return new InterviewResult.NotFound(leagueId);
+    }
+    var league = maybeLeague.get();
+    if (league.phase() != LeaguePhase.HIRING_HEAD_COACH) {
+      return new InterviewResult.NotFound(leagueId);
+    }
+    var maybePool =
+        pools.findByLeaguePhaseAndType(
+            leagueId, LeaguePhase.HIRING_HEAD_COACH, CandidatePoolType.HEAD_COACH);
+    if (maybePool.isEmpty()) {
+      return new InterviewResult.NotFound(leagueId);
+    }
+    var maybeCandidate = candidates.findById(candidateId);
+    if (maybeCandidate.isEmpty() || maybeCandidate.get().poolId() != maybePool.get().id()) {
+      return new InterviewResult.UnknownCandidate(candidateId);
+    }
+    var franchiseId = league.userFranchise().id();
+    var phaseWeek = league.phaseWeek();
+    var weekCount =
+        interviews.countForWeek(leagueId, franchiseId, LeaguePhase.HIRING_HEAD_COACH, phaseWeek);
+    if (weekCount >= DEFAULT_WEEKLY_CAPACITY) {
+      return new InterviewResult.CapacityReached(DEFAULT_WEEKLY_CAPACITY);
+    }
+
+    var candidate = maybeCandidate.get();
+    var priorCount =
+        interviews.countForCandidate(
+            leagueId, franchiseId, candidateId, LeaguePhase.HIRING_HEAD_COACH);
+    var newIndex = priorCount + 1;
+    var trueRating = extractOverall(candidate.hiddenAttrs());
+    var sigma = InterviewNoiseModel.headCoachSigma(newIndex);
+    var rng = new SplittableRandomSource(seedFor(leagueId, franchiseId, candidateId, newIndex));
+    var sample = trueRating + sigma * rng.nextGaussian();
+    var clamped = Math.max(SCOUTED_LOWER, Math.min(SCOUTED_UPPER, sample));
+    var scoutedOverall = BigDecimal.valueOf(clamped).setScale(2, RoundingMode.HALF_UP);
+
+    interviews.insert(
+        new NewFranchiseInterview(
+            leagueId,
+            franchiseId,
+            candidateId,
+            LeaguePhase.HIRING_HEAD_COACH,
+            phaseWeek,
+            newIndex,
+            scoutedOverall));
+    appendToHiringState(leagueId, franchiseId, candidateId);
+
+    var pool = candidates.findAllByPoolId(maybePool.get().id());
+    var prefs =
+        pool.stream()
+            .map(c -> preferences.findByCandidateId(c.id()))
+            .flatMap(java.util.Optional::stream)
+            .toList();
+    var state = hiringStates.find(leagueId, franchiseId, LeaguePhase.HIRING_HEAD_COACH);
+    var shortlistIds = state.map(FranchiseHiringState::shortlist).orElse(java.util.List.of());
+    var history = interviews.findAllFor(leagueId, franchiseId, LeaguePhase.HIRING_HEAD_COACH);
+    var view =
+        HeadCoachHiringViewModel.assemble(
+            league, pool, prefs, shortlistIds, history, DEFAULT_WEEKLY_CAPACITY);
+    log.info(
+        "interview recorded leagueId={} franchiseId={} candidateId={} index={} sigma={}",
+        leagueId,
+        franchiseId,
+        candidateId,
+        newIndex,
+        sigma);
+    return new InterviewResult.Started(view);
+  }
+
+  private void appendToHiringState(long leagueId, long franchiseId, long candidateId) {
+    var existing = hiringStates.find(leagueId, franchiseId, LeaguePhase.HIRING_HEAD_COACH);
+    var shortlistIds = existing.map(FranchiseHiringState::shortlist).orElse(java.util.List.of());
+    var interviewingIds =
+        existing.map(FranchiseHiringState::interviewingCandidateIds).orElse(java.util.List.of());
+    var updated = new ArrayList<Long>(interviewingIds.size() + 1);
+    updated.addAll(interviewingIds);
+    updated.add(candidateId);
+    hiringStates.upsert(
+        new FranchiseHiringState(
+            existing.map(FranchiseHiringState::id).orElse(0L),
+            leagueId,
+            franchiseId,
+            LeaguePhase.HIRING_HEAD_COACH,
+            HiringStep.SEARCHING,
+            shortlistIds,
+            java.util.List.copyOf(updated)));
+  }
+
+  private static double extractOverall(String hiddenAttrsJson) {
+    var m = HIDDEN_OVERALL.matcher(hiddenAttrsJson);
+    if (m.find()) {
+      try {
+        return Double.parseDouble(m.group(1));
+      } catch (NumberFormatException ignored) {
+        return 50.0;
+      }
+    }
+    return 50.0;
+  }
+
+  private static long seedFor(long leagueId, long franchiseId, long candidateId, int index) {
+    var seed = leagueId * 0x9E3779B97F4A7C15L;
+    seed ^= Long.rotateLeft(franchiseId, 17) * 0xBF58476D1CE4E5B9L;
+    seed ^= Long.rotateLeft(candidateId, 31) * 0x94D049BB133111EBL;
+    seed ^= (long) index * 0xD1B54A32D192ED03L;
+    return seed;
+  }
+}

--- a/src/main/java/app/zoneblitz/league/TeamLookup.java
+++ b/src/main/java/app/zoneblitz/league/TeamLookup.java
@@ -1,0 +1,13 @@
+package app.zoneblitz.league;
+
+import java.util.List;
+
+/**
+ * Read-side companion to {@link TeamRepository} for features that need to know which franchises
+ * belong to a league. Kept separate so the write-side repository stays insert-only.
+ */
+interface TeamLookup {
+
+  /** Return the franchise ids participating in the given league, ordered by franchise id. */
+  List<Long> franchiseIdsForLeague(long leagueId);
+}

--- a/src/main/java/app/zoneblitz/league/ViewHeadCoachHiring.java
+++ b/src/main/java/app/zoneblitz/league/ViewHeadCoachHiring.java
@@ -1,0 +1,17 @@
+package app.zoneblitz.league;
+
+import java.util.Optional;
+
+/**
+ * Feature-public use case: load the HIRING_HEAD_COACH page view-model for the user's franchise.
+ * Empty when the league does not exist, is not owned by the user, or is not in the HC hiring phase.
+ */
+public interface ViewHeadCoachHiring {
+
+  /**
+   * @param leagueId the target league.
+   * @param ownerSubject the OAuth subject of the requesting user.
+   * @return the view-model, or empty if the league is missing / not owned / not in the HC phase.
+   */
+  Optional<HeadCoachHiringView> view(long leagueId, String ownerSubject);
+}

--- a/src/main/java/app/zoneblitz/league/ViewHeadCoachHiringUseCase.java
+++ b/src/main/java/app/zoneblitz/league/ViewHeadCoachHiringUseCase.java
@@ -14,18 +14,21 @@ class ViewHeadCoachHiringUseCase implements ViewHeadCoachHiring {
   private final CandidateRepository candidates;
   private final CandidatePreferencesRepository preferences;
   private final FranchiseHiringStateRepository hiringStates;
+  private final FranchiseInterviewRepository interviews;
 
   ViewHeadCoachHiringUseCase(
       LeagueRepository leagues,
       CandidatePoolRepository pools,
       CandidateRepository candidates,
       CandidatePreferencesRepository preferences,
-      FranchiseHiringStateRepository hiringStates) {
+      FranchiseHiringStateRepository hiringStates,
+      FranchiseInterviewRepository interviews) {
     this.leagues = leagues;
     this.pools = pools;
     this.candidates = candidates;
     this.preferences = preferences;
     this.hiringStates = hiringStates;
+    this.interviews = interviews;
   }
 
   @Override
@@ -40,11 +43,14 @@ class ViewHeadCoachHiringUseCase implements ViewHeadCoachHiring {
     if (league.phase() != LeaguePhase.HIRING_HEAD_COACH) {
       return Optional.empty();
     }
+    var franchiseId = league.userFranchise().id();
     var pool =
         pools.findByLeaguePhaseAndType(
             leagueId, LeaguePhase.HIRING_HEAD_COACH, CandidatePoolType.HEAD_COACH);
     if (pool.isEmpty()) {
-      return Optional.of(new HeadCoachHiringView(league, List.of(), List.of()));
+      return Optional.of(
+          new HeadCoachHiringView(
+              league, List.of(), List.of(), List.of(), 0, StartInterview.DEFAULT_WEEKLY_CAPACITY));
     }
     var rows = candidates.findAllByPoolId(pool.get().id());
     var prefs =
@@ -54,9 +60,18 @@ class ViewHeadCoachHiringUseCase implements ViewHeadCoachHiring {
             .toList();
     var shortlist =
         hiringStates
-            .find(leagueId, league.userFranchise().id(), LeaguePhase.HIRING_HEAD_COACH)
+            .find(leagueId, franchiseId, LeaguePhase.HIRING_HEAD_COACH)
             .map(FranchiseHiringState::shortlist)
             .orElse(List.of());
-    return Optional.of(HeadCoachHiringViewModel.assemble(league, rows, prefs, shortlist));
+    var interviewHistory =
+        interviews.findAllFor(leagueId, franchiseId, LeaguePhase.HIRING_HEAD_COACH);
+    return Optional.of(
+        HeadCoachHiringViewModel.assemble(
+            league,
+            rows,
+            prefs,
+            shortlist,
+            interviewHistory,
+            StartInterview.DEFAULT_WEEKLY_CAPACITY));
   }
 }

--- a/src/main/java/app/zoneblitz/league/ViewHeadCoachHiringUseCase.java
+++ b/src/main/java/app/zoneblitz/league/ViewHeadCoachHiringUseCase.java
@@ -1,0 +1,62 @@
+package app.zoneblitz.league;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+class ViewHeadCoachHiringUseCase implements ViewHeadCoachHiring {
+
+  private final LeagueRepository leagues;
+  private final CandidatePoolRepository pools;
+  private final CandidateRepository candidates;
+  private final CandidatePreferencesRepository preferences;
+  private final FranchiseHiringStateRepository hiringStates;
+
+  ViewHeadCoachHiringUseCase(
+      LeagueRepository leagues,
+      CandidatePoolRepository pools,
+      CandidateRepository candidates,
+      CandidatePreferencesRepository preferences,
+      FranchiseHiringStateRepository hiringStates) {
+    this.leagues = leagues;
+    this.pools = pools;
+    this.candidates = candidates;
+    this.preferences = preferences;
+    this.hiringStates = hiringStates;
+  }
+
+  @Override
+  @Transactional(readOnly = true)
+  public Optional<HeadCoachHiringView> view(long leagueId, String ownerSubject) {
+    Objects.requireNonNull(ownerSubject, "ownerSubject");
+    var maybeLeague = leagues.findSummaryByIdAndOwner(leagueId, ownerSubject);
+    if (maybeLeague.isEmpty()) {
+      return Optional.empty();
+    }
+    var league = maybeLeague.get();
+    if (league.phase() != LeaguePhase.HIRING_HEAD_COACH) {
+      return Optional.empty();
+    }
+    var pool =
+        pools.findByLeaguePhaseAndType(
+            leagueId, LeaguePhase.HIRING_HEAD_COACH, CandidatePoolType.HEAD_COACH);
+    if (pool.isEmpty()) {
+      return Optional.of(new HeadCoachHiringView(league, List.of(), List.of()));
+    }
+    var rows = candidates.findAllByPoolId(pool.get().id());
+    var prefs =
+        rows.stream()
+            .map(c -> preferences.findByCandidateId(c.id()))
+            .flatMap(Optional::stream)
+            .toList();
+    var shortlist =
+        hiringStates
+            .find(leagueId, league.userFranchise().id(), LeaguePhase.HIRING_HEAD_COACH)
+            .map(FranchiseHiringState::shortlist)
+            .orElse(List.of());
+    return Optional.of(HeadCoachHiringViewModel.assemble(league, rows, prefs, shortlist));
+  }
+}

--- a/src/main/resources/db/migration/V4__league_phase_week.sql
+++ b/src/main/resources/db/migration/V4__league_phase_week.sql
@@ -1,0 +1,3 @@
+-- Phase week counter: current week within the league's active phase (1-indexed).
+ALTER TABLE leagues
+    ADD COLUMN phase_week INTEGER NOT NULL DEFAULT 1;

--- a/src/main/resources/db/migration/V5__candidate_schema.sql
+++ b/src/main/resources/db/migration/V5__candidate_schema.sql
@@ -1,0 +1,180 @@
+-- Candidate domain + preferences schema.
+-- Models the league-wide candidate pool, per-candidate preferences, offers,
+-- per-franchise hiring state, and terminal franchise staff hires.
+-- See docs/technical/league-phases.md (Candidate pool, Specialty, Archetype,
+-- Age & experience, Candidate preferences, Persistence sections).
+
+-- Pool of candidates generated once per (league, phase, candidate_type).
+CREATE TABLE candidate_pools (
+    id BIGSERIAL PRIMARY KEY,
+    league_id BIGINT NOT NULL REFERENCES leagues(id) ON DELETE CASCADE,
+    phase TEXT NOT NULL,
+    candidate_type TEXT NOT NULL,
+    generated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    UNIQUE (league_id, phase, candidate_type),
+    CHECK (candidate_type IN ('HEAD_COACH', 'DIRECTOR_OF_SCOUTING', 'COORDINATOR', 'POSITION_COACH', 'SCOUT'))
+);
+
+CREATE INDEX candidate_pools_league_phase_idx
+    ON candidate_pools (league_id, phase);
+
+-- Candidate rows live inside a pool. Hidden attrs are never shown to the user;
+-- scouted attrs are the noised estimate. hired_by_franchise_id is set when a
+-- franchise signs the candidate; scout_branch is only populated for scouts.
+CREATE TABLE candidates (
+    id BIGSERIAL PRIMARY KEY,
+    pool_id BIGINT NOT NULL REFERENCES candidate_pools(id) ON DELETE CASCADE,
+    kind TEXT NOT NULL,
+    specialty_position TEXT NOT NULL,
+    archetype TEXT NOT NULL,
+    age INTEGER NOT NULL,
+    total_experience_years INTEGER NOT NULL,
+    experience_by_role JSONB NOT NULL DEFAULT '{}'::jsonb,
+    hidden_attrs JSONB NOT NULL DEFAULT '{}'::jsonb,
+    scouted_attrs JSONB NOT NULL DEFAULT '{}'::jsonb,
+    hired_by_franchise_id BIGINT REFERENCES franchises(id),
+    scout_branch TEXT,
+    CHECK (kind IN ('HEAD_COACH', 'DIRECTOR_OF_SCOUTING', 'OFFENSIVE_COORDINATOR',
+                    'DEFENSIVE_COORDINATOR', 'SPECIAL_TEAMS_COORDINATOR', 'POSITION_COACH', 'SCOUT')),
+    CHECK (specialty_position IN ('QB', 'RB', 'FB', 'WR', 'TE', 'OL', 'DL', 'EDGE',
+                                  'LB', 'CB', 'S', 'K', 'P', 'LS')),
+    CHECK (archetype IN (
+        'CEO', 'OFFENSIVE_PLAY_CALLER', 'DEFENSIVE_PLAY_CALLER',
+        'OFFENSIVE_GURU', 'DEFENSIVE_GURU', 'TEACHER', 'TACTICIAN',
+        'COLLEGE_EVALUATOR', 'PRO_EVALUATOR', 'GENERALIST'
+    )),
+    CHECK (age BETWEEN 20 AND 90),
+    CHECK (total_experience_years >= 0),
+    CHECK (scout_branch IS NULL OR scout_branch IN ('COLLEGE', 'PRO'))
+);
+
+CREATE INDEX candidates_pool_idx ON candidates (pool_id);
+CREATE INDEX candidates_hired_by_idx ON candidates (hired_by_franchise_id)
+    WHERE hired_by_franchise_id IS NOT NULL;
+
+-- Wide preferences table. One row per candidate; one (target, weight) pair per
+-- dimension. Weights normalized 0..1 across dimensions by the generator.
+CREATE TABLE candidate_preferences (
+    candidate_id BIGINT PRIMARY KEY REFERENCES candidates(id) ON DELETE CASCADE,
+
+    compensation_target NUMERIC(12, 2) NOT NULL,
+    compensation_weight NUMERIC(4, 3) NOT NULL,
+
+    contract_length_target INTEGER NOT NULL,
+    contract_length_weight NUMERIC(4, 3) NOT NULL,
+
+    guaranteed_money_target NUMERIC(4, 3) NOT NULL,
+    guaranteed_money_weight NUMERIC(4, 3) NOT NULL,
+
+    market_size_target TEXT NOT NULL,
+    market_size_weight NUMERIC(4, 3) NOT NULL,
+
+    geography_target TEXT NOT NULL,
+    geography_weight NUMERIC(4, 3) NOT NULL,
+
+    climate_target TEXT NOT NULL,
+    climate_weight NUMERIC(4, 3) NOT NULL,
+
+    franchise_prestige_target NUMERIC(5, 2) NOT NULL,
+    franchise_prestige_weight NUMERIC(4, 3) NOT NULL,
+
+    competitive_window_target TEXT NOT NULL,
+    competitive_window_weight NUMERIC(4, 3) NOT NULL,
+
+    role_scope_target TEXT NOT NULL,
+    role_scope_weight NUMERIC(4, 3) NOT NULL,
+
+    staff_continuity_target TEXT NOT NULL,
+    staff_continuity_weight NUMERIC(4, 3) NOT NULL,
+
+    scheme_alignment_target TEXT NOT NULL,
+    scheme_alignment_weight NUMERIC(4, 3) NOT NULL,
+
+    owner_stability_target NUMERIC(5, 2) NOT NULL,
+    owner_stability_weight NUMERIC(4, 3) NOT NULL,
+
+    facility_quality_target NUMERIC(5, 2) NOT NULL,
+    facility_quality_weight NUMERIC(4, 3) NOT NULL,
+
+    CHECK (market_size_target IN ('SMALL', 'MEDIUM', 'LARGE')),
+    CHECK (geography_target IN ('NE', 'SE', 'MW', 'SW', 'W')),
+    CHECK (climate_target IN ('WARM', 'COLD', 'NEUTRAL')),
+    CHECK (competitive_window_target IN ('CONTENDER', 'NEUTRAL', 'REBUILD')),
+    CHECK (role_scope_target IN ('LOW', 'MEDIUM', 'HIGH')),
+    CHECK (staff_continuity_target IN ('KEEP_EXISTING', 'BRING_OWN', 'HYBRID')),
+    CHECK (compensation_weight BETWEEN 0 AND 1),
+    CHECK (contract_length_weight BETWEEN 0 AND 1),
+    CHECK (guaranteed_money_weight BETWEEN 0 AND 1),
+    CHECK (market_size_weight BETWEEN 0 AND 1),
+    CHECK (geography_weight BETWEEN 0 AND 1),
+    CHECK (climate_weight BETWEEN 0 AND 1),
+    CHECK (franchise_prestige_weight BETWEEN 0 AND 1),
+    CHECK (competitive_window_weight BETWEEN 0 AND 1),
+    CHECK (role_scope_weight BETWEEN 0 AND 1),
+    CHECK (staff_continuity_weight BETWEEN 0 AND 1),
+    CHECK (scheme_alignment_weight BETWEEN 0 AND 1),
+    CHECK (owner_stability_weight BETWEEN 0 AND 1),
+    CHECK (facility_quality_weight BETWEEN 0 AND 1),
+    CHECK (guaranteed_money_target BETWEEN 0 AND 1),
+    CHECK (contract_length_target > 0),
+    CHECK (compensation_target >= 0)
+);
+
+-- Franchise-initiated offer on a candidate. Status tracks lifecycle:
+-- ACTIVE until the week tick resolves it to ACCEPTED or REJECTED.
+CREATE TABLE candidate_offers (
+    id BIGSERIAL PRIMARY KEY,
+    candidate_id BIGINT NOT NULL REFERENCES candidates(id) ON DELETE CASCADE,
+    franchise_id BIGINT NOT NULL REFERENCES franchises(id),
+    terms JSONB NOT NULL DEFAULT '{}'::jsonb,
+    submitted_at_week INTEGER NOT NULL,
+    status TEXT NOT NULL,
+    CHECK (status IN ('ACTIVE', 'ACCEPTED', 'REJECTED')),
+    CHECK (submitted_at_week > 0)
+);
+
+CREATE INDEX candidate_offers_candidate_idx ON candidate_offers (candidate_id);
+CREATE INDEX candidate_offers_franchise_idx ON candidate_offers (franchise_id);
+CREATE UNIQUE INDEX candidate_offers_one_active_per_franchise
+    ON candidate_offers (candidate_id, franchise_id)
+    WHERE status = 'ACTIVE';
+
+-- Per-franchise hiring sub-state within a phase.
+CREATE TABLE franchise_hiring_states (
+    id BIGSERIAL PRIMARY KEY,
+    franchise_id BIGINT NOT NULL REFERENCES franchises(id),
+    league_id BIGINT NOT NULL REFERENCES leagues(id) ON DELETE CASCADE,
+    phase TEXT NOT NULL,
+    step TEXT NOT NULL,
+    shortlist JSONB NOT NULL DEFAULT '[]'::jsonb,
+    interviewing_candidate_ids JSONB NOT NULL DEFAULT '[]'::jsonb,
+    CHECK (step IN ('SEARCHING', 'HIRED')),
+    UNIQUE (league_id, franchise_id, phase)
+);
+
+-- Terminal hires; one row per filled staff seat.
+CREATE TABLE franchise_staff (
+    id BIGSERIAL PRIMARY KEY,
+    franchise_id BIGINT NOT NULL REFERENCES franchises(id),
+    league_id BIGINT NOT NULL REFERENCES leagues(id) ON DELETE CASCADE,
+    candidate_id BIGINT NOT NULL REFERENCES candidates(id),
+    role TEXT NOT NULL,
+    scout_branch TEXT,
+    hired_at_phase TEXT NOT NULL,
+    hired_at_week INTEGER NOT NULL,
+    hired_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    CHECK (role IN (
+        'HEAD_COACH', 'OFFENSIVE_COORDINATOR', 'DEFENSIVE_COORDINATOR', 'SPECIAL_TEAMS_COORDINATOR',
+        'QB_COACH', 'RB_COACH', 'WR_COACH', 'TE_COACH', 'OL_COACH', 'DL_COACH',
+        'EDGE_COACH', 'LB_COACH', 'DB_COACH',
+        'DIRECTOR_OF_SCOUTING', 'COLLEGE_SCOUT', 'PRO_SCOUT'
+    )),
+    CHECK (scout_branch IS NULL OR scout_branch IN ('COLLEGE', 'PRO')),
+    CHECK (hired_at_week > 0)
+);
+
+CREATE INDEX franchise_staff_league_franchise_idx
+    ON franchise_staff (league_id, franchise_id);
+CREATE UNIQUE INDEX franchise_staff_unique_role
+    ON franchise_staff (league_id, franchise_id, role)
+    WHERE role NOT IN ('COLLEGE_SCOUT', 'PRO_SCOUT');

--- a/src/main/resources/db/migration/V6__franchise_interviews.sql
+++ b/src/main/resources/db/migration/V6__franchise_interviews.sql
@@ -1,0 +1,25 @@
+-- Per-franchise interview events against pool candidates. Each row represents
+-- one completed interview. interview_index is the 1-based count for that
+-- (franchise, candidate) pair and drives the noise-reduction function. Weekly
+-- capacity is enforced by counting rows per (franchise, phase, phase_week).
+CREATE TABLE franchise_interviews (
+    id BIGSERIAL PRIMARY KEY,
+    league_id BIGINT NOT NULL REFERENCES leagues(id) ON DELETE CASCADE,
+    franchise_id BIGINT NOT NULL REFERENCES franchises(id),
+    candidate_id BIGINT NOT NULL REFERENCES candidates(id) ON DELETE CASCADE,
+    phase TEXT NOT NULL,
+    phase_week INTEGER NOT NULL,
+    interview_index INTEGER NOT NULL,
+    scouted_overall NUMERIC(5, 2) NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    CHECK (phase_week > 0),
+    CHECK (interview_index > 0),
+    UNIQUE (league_id, franchise_id, candidate_id, interview_index)
+);
+
+CREATE INDEX franchise_interviews_league_franchise_phase_idx
+    ON franchise_interviews (league_id, franchise_id, phase);
+CREATE INDEX franchise_interviews_league_franchise_week_idx
+    ON franchise_interviews (league_id, franchise_id, phase, phase_week);
+CREATE INDEX franchise_interviews_candidate_idx
+    ON franchise_interviews (candidate_id);

--- a/src/main/resources/templates/league/dashboard.html
+++ b/src/main/resources/templates/league/dashboard.html
@@ -87,6 +87,21 @@
 
 		<main class="flex-1 p-8">
 			<h1 class="text-3xl font-bold" th:text="${league.leagueName()}">League name</h1>
+			<section th:if="${league.phase().name() == 'INITIAL_SETUP'}"
+			         class="mt-6 max-w-2xl bg-white border border-slate-200 rounded p-6 shadow-sm">
+				<h2 class="text-xl font-semibold text-slate-900">Welcome to your league</h2>
+				<p class="mt-2 text-slate-700">
+					Your franchise is ready. Next up: hire a Head Coach to lead the team.
+				</p>
+				<form th:action="@{'/leagues/' + ${league.leagueId()} + '/phase/advance'}"
+				      method="post"
+				      class="mt-4">
+					<button type="submit"
+					        class="inline-flex items-center gap-2 px-4 py-2 rounded bg-slate-900 text-white font-medium hover:bg-slate-800 cursor-pointer">
+						Advance to staff hiring
+					</button>
+				</form>
+			</section>
 		</main>
 	</div>
 	<script>

--- a/src/main/resources/templates/league/hiring/head-coach-fragments.html
+++ b/src/main/resources/templates/league/hiring/head-coach-fragments.html
@@ -1,0 +1,104 @@
+<!DOCTYPE html>
+<html lang="en" xmlns:th="http://www.thymeleaf.org">
+<body>
+	<!-- Combined swap target: pool + shortlist updated together after mutations. -->
+	<div th:fragment="combined" id="hiring-regions" class="grid grid-cols-1 lg:grid-cols-3 gap-4">
+		<div class="lg:col-span-2">
+			<div th:insert="~{league/hiring/head-coach-fragments :: pool}"></div>
+		</div>
+		<div>
+			<div th:insert="~{league/hiring/head-coach-fragments :: shortlist}"></div>
+		</div>
+	</div>
+
+	<section th:fragment="pool"
+	         id="hc-pool"
+	         class="bg-white border border-slate-200 rounded p-4 shadow-sm">
+		<h2 class="text-lg font-semibold text-slate-900">Head Coach candidate pool</h2>
+		<p class="text-sm text-slate-500 mb-3">Scouted attributes only. True ratings are hidden.</p>
+		<div th:if="${view.pool().isEmpty()}" class="text-slate-500 italic text-sm">
+			No candidates available yet.
+		</div>
+		<table th:unless="${view.pool().isEmpty()}"
+		       class="w-full text-sm border-collapse">
+			<thead>
+				<tr class="text-left text-slate-600 border-b border-slate-200">
+					<th class="py-2 pr-2">Archetype</th>
+					<th class="py-2 pr-2">Specialty</th>
+					<th class="py-2 pr-2">Age</th>
+					<th class="py-2 pr-2">Exp (HC / OC / PC)</th>
+					<th class="py-2 pr-2">Scouted</th>
+					<th class="py-2 pr-2">Comp target</th>
+					<th class="py-2 pr-2">Length</th>
+					<th class="py-2 pr-2">Guaranteed</th>
+					<th class="py-2 pr-2"></th>
+				</tr>
+			</thead>
+			<tbody>
+				<tr th:each="row : ${view.pool()}"
+				    th:attr="data-candidate-id=${row.id()}"
+				    class="border-b border-slate-100">
+					<td class="py-2 pr-2" th:text="${row.archetype()}"></td>
+					<td class="py-2 pr-2" th:text="${row.specialty()}"></td>
+					<td class="py-2 pr-2" th:text="${row.age()}"></td>
+					<td class="py-2 pr-2">
+						<span th:text="${row.hcYears()} + ' / ' + ${row.ocYears()} + ' / ' + ${row.positionCoachYears()}"></span>
+						<span class="text-slate-400 text-xs" th:text="'(' + ${row.totalExperienceYears()} + ' yrs total)'"></span>
+					</td>
+					<td class="py-2 pr-2" th:text="${row.scoutedOverall()}"></td>
+					<td class="py-2 pr-2" th:text="'$' + ${#numbers.formatDecimal(row.compensationTarget(), 0, 'COMMA', 0, 'POINT')}"></td>
+					<td class="py-2 pr-2" th:text="${row.contractLengthTarget()} + ' yr'"></td>
+					<td class="py-2 pr-2" th:text="${#numbers.formatPercent(row.guaranteedMoneyTarget(), 1, 0)}"></td>
+					<td class="py-2 pr-2">
+						<button type="button"
+						        th:unless="${row.shortlisted()}"
+						        th:attr="hx-post=@{'/leagues/' + ${view.league().leagueId()} + '/hiring/head-coach/shortlist/' + ${row.id()}}"
+						        hx-target="#hiring-regions"
+						        hx-swap="outerHTML"
+						        class="px-2 py-1 text-xs rounded bg-slate-900 text-white hover:bg-slate-800 cursor-pointer">
+							Shortlist
+						</button>
+						<button type="button"
+						        th:if="${row.shortlisted()}"
+						        th:attr="hx-delete=@{'/leagues/' + ${view.league().leagueId()} + '/hiring/head-coach/shortlist/' + ${row.id()}}"
+						        hx-target="#hiring-regions"
+						        hx-swap="outerHTML"
+						        class="px-2 py-1 text-xs rounded bg-slate-200 text-slate-700 hover:bg-slate-300 cursor-pointer">
+							Shortlisted
+						</button>
+					</td>
+				</tr>
+			</tbody>
+		</table>
+	</section>
+
+	<aside th:fragment="shortlist"
+	       id="hc-shortlist"
+	       class="bg-white border border-slate-200 rounded p-4 shadow-sm">
+		<h2 class="text-lg font-semibold text-slate-900">Your shortlist</h2>
+		<p class="text-sm text-slate-500 mb-3"
+		   th:text="'(' + ${view.shortlist().size()} + ' candidates)'"></p>
+		<div th:if="${view.shortlist().isEmpty()}" class="text-slate-500 italic text-sm">
+			No candidates shortlisted yet.
+		</div>
+		<ul th:unless="${view.shortlist().isEmpty()}" class="space-y-2">
+			<li th:each="row : ${view.shortlist()}"
+			    class="flex items-center justify-between gap-2 border-b border-slate-100 pb-2">
+				<div class="min-w-0">
+					<div class="text-sm font-medium text-slate-900"
+					     th:text="${row.archetype()} + ' · ' + ${row.specialty()}"></div>
+					<div class="text-xs text-slate-500"
+					     th:text="'age ' + ${row.age()} + ' · scouted ' + ${row.scoutedOverall()}"></div>
+				</div>
+				<button type="button"
+				        th:attr="hx-delete=@{'/leagues/' + ${view.league().leagueId()} + '/hiring/head-coach/shortlist/' + ${row.id()}}"
+				        hx-target="#hiring-regions"
+				        hx-swap="outerHTML"
+				        class="px-2 py-1 text-xs rounded border border-slate-300 text-slate-600 hover:bg-slate-100 cursor-pointer">
+					Remove
+				</button>
+			</li>
+		</ul>
+	</aside>
+</body>
+</html>

--- a/src/main/resources/templates/league/hiring/head-coach-fragments.html
+++ b/src/main/resources/templates/league/hiring/head-coach-fragments.html
@@ -1,13 +1,14 @@
 <!DOCTYPE html>
 <html lang="en" xmlns:th="http://www.thymeleaf.org">
 <body>
-	<!-- Combined swap target: pool + shortlist updated together after mutations. -->
+	<!-- Combined swap target: pool + shortlist + interviews updated together after mutations. -->
 	<div th:fragment="combined" id="hiring-regions" class="grid grid-cols-1 lg:grid-cols-3 gap-4">
 		<div class="lg:col-span-2">
 			<div th:insert="~{league/hiring/head-coach-fragments :: pool}"></div>
 		</div>
-		<div>
+		<div class="space-y-4">
 			<div th:insert="~{league/hiring/head-coach-fragments :: shortlist}"></div>
+			<div th:insert="~{league/hiring/head-coach-fragments :: interviews}"></div>
 		</div>
 	</div>
 
@@ -49,7 +50,7 @@
 					<td class="py-2 pr-2" th:text="'$' + ${#numbers.formatDecimal(row.compensationTarget(), 0, 'COMMA', 0, 'POINT')}"></td>
 					<td class="py-2 pr-2" th:text="${row.contractLengthTarget()} + ' yr'"></td>
 					<td class="py-2 pr-2" th:text="${#numbers.formatPercent(row.guaranteedMoneyTarget(), 1, 0)}"></td>
-					<td class="py-2 pr-2">
+					<td class="py-2 pr-2 space-x-1">
 						<button type="button"
 						        th:unless="${row.shortlisted()}"
 						        th:attr="hx-post=@{'/leagues/' + ${view.league().leagueId()} + '/hiring/head-coach/shortlist/' + ${row.id()}}"
@@ -65,6 +66,17 @@
 						        hx-swap="outerHTML"
 						        class="px-2 py-1 text-xs rounded bg-slate-200 text-slate-700 hover:bg-slate-300 cursor-pointer">
 							Shortlisted
+						</button>
+						<button type="button"
+						        th:attr="hx-post=@{'/leagues/' + ${view.league().leagueId()} + '/hiring/head-coach/interview/' + ${row.id()}},
+						                 disabled=${view.interviewsThisWeek() >= view.interviewCapacity()} ? 'disabled' : null"
+						        hx-target="#hiring-regions"
+						        hx-swap="outerHTML"
+						        th:classappend="${view.interviewsThisWeek() >= view.interviewCapacity()} ? ' opacity-50 cursor-not-allowed' : ' cursor-pointer'"
+						        class="px-2 py-1 text-xs rounded bg-indigo-600 text-white hover:bg-indigo-500">
+							<span th:if="${row.interviewCount() == 0}">Interview</span>
+							<span th:if="${row.interviewCount() > 0}"
+							      th:text="'Re-interview (' + ${row.interviewCount()} + ')'">Re-interview</span>
 						</button>
 					</td>
 				</tr>
@@ -97,6 +109,31 @@
 				        class="px-2 py-1 text-xs rounded border border-slate-300 text-slate-600 hover:bg-slate-100 cursor-pointer">
 					Remove
 				</button>
+			</li>
+		</ul>
+	</aside>
+
+	<aside th:fragment="interviews"
+	       id="hc-interviews"
+	       class="bg-white border border-slate-200 rounded p-4 shadow-sm">
+		<div class="flex items-center justify-between mb-2">
+			<h2 class="text-lg font-semibold text-slate-900">Active interviews</h2>
+			<span class="text-xs text-slate-500"
+			      th:text="${view.interviewsThisWeek()} + ' / ' + ${view.interviewCapacity()} + ' this week'"></span>
+		</div>
+		<p class="text-sm text-slate-500 mb-3">Each interview tightens the scouted signal; true rating is never revealed.</p>
+		<div th:if="${view.activeInterviews().isEmpty()}" class="text-slate-500 italic text-sm">
+			No interviews conducted yet.
+		</div>
+		<ul th:unless="${view.activeInterviews().isEmpty()}" class="space-y-2">
+			<li th:each="row : ${view.activeInterviews()}"
+			    class="flex items-center justify-between gap-2 border-b border-slate-100 pb-2">
+				<div class="min-w-0">
+					<div class="text-sm font-medium text-slate-900"
+					     th:text="${row.archetype()} + ' · ' + ${row.specialty()}"></div>
+					<div class="text-xs text-slate-500"
+					     th:text="${row.interviewCount()} + ' interview(s) · scouted ' + ${row.scoutedOverall()}"></div>
+				</div>
 			</li>
 		</ul>
 	</aside>

--- a/src/main/resources/templates/league/hiring/head-coach.html
+++ b/src/main/resources/templates/league/hiring/head-coach.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="en" xmlns:th="http://www.thymeleaf.org">
+<head>
+	<meta charset="UTF-8">
+	<title th:text="${view.league().leagueName() + ' — Hire a Head Coach — Zone Blitz'}">Hire a Head Coach — Zone Blitz</title>
+	<meta name="_csrf" th:content="${_csrf.token}">
+	<meta name="_csrf_header" th:content="${_csrf.headerName}">
+	<link rel="stylesheet" th:href="@{/css/app.css}">
+	<script th:src="@{/webjars/htmx.org/2.0.4/dist/htmx.min.js}" defer></script>
+</head>
+<body class="bg-slate-50 text-slate-900 min-h-screen"
+      th:attr="hx-headers='{\'' + ${_csrf.headerName} + '\': \'' + ${_csrf.token} + '\'}'">
+	<main class="max-w-6xl mx-auto p-6 space-y-4">
+		<header class="flex items-center justify-between">
+			<div>
+				<h1 class="text-2xl font-bold" th:text="${view.league().leagueName()}">League</h1>
+				<p class="text-sm text-slate-500">
+					Phase: Hire Head Coach · Week
+					<span th:text="${view.league().phaseWeek()}">1</span>
+				</p>
+			</div>
+			<a th:href="@{'/leagues/' + ${view.league().leagueId()}}"
+			   class="text-sm text-slate-600 hover:underline">Back to dashboard</a>
+		</header>
+
+		<div th:insert="~{league/hiring/head-coach-fragments :: combined}"></div>
+	</main>
+</body>
+</html>

--- a/src/test/java/app/zoneblitz/league/AdvancePhaseUseCaseTests.java
+++ b/src/test/java/app/zoneblitz/league/AdvancePhaseUseCaseTests.java
@@ -1,0 +1,139 @@
+package app.zoneblitz.league;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import app.zoneblitz.support.PostgresTestcontainer;
+import java.util.ArrayList;
+import java.util.List;
+import org.jooq.DSLContext;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.jooq.test.autoconfigure.JooqTest;
+import org.springframework.context.annotation.Import;
+
+@JooqTest
+@Import(PostgresTestcontainer.class)
+class AdvancePhaseUseCaseTests {
+
+  @Autowired DSLContext dsl;
+
+  private LeagueRepository leagues;
+  private CreateLeague createLeague;
+  private AdvancePhase advancePhase;
+  private RecordingHandler initialSetupHandler;
+  private RecordingHandler hiringHandler;
+
+  @BeforeEach
+  void setUp() {
+    leagues = new JooqLeagueRepository(dsl);
+    var franchises = new JooqFranchiseRepository(dsl);
+    var teams = new JooqTeamRepository(dsl);
+    createLeague = new CreateLeagueUseCase(leagues, franchises, teams);
+    initialSetupHandler = new RecordingHandler(LeaguePhase.INITIAL_SETUP);
+    hiringHandler = new RecordingHandler(LeaguePhase.HIRING_HEAD_COACH);
+    advancePhase = new AdvancePhaseUseCase(leagues, List.of(initialSetupHandler, hiringHandler));
+  }
+
+  @Test
+  void advance_fromInitialSetup_transitionsToHiringHeadCoachAndResetsWeek() {
+    var league = createLeagueFor("sub-1");
+    leagues.incrementPhaseWeek(league.id());
+    leagues.incrementPhaseWeek(league.id());
+
+    var result = advancePhase.advance(league.id(), "sub-1");
+
+    assertThat(result)
+        .isEqualTo(
+            new AdvancePhaseResult.Advanced(
+                league.id(), LeaguePhase.INITIAL_SETUP, LeaguePhase.HIRING_HEAD_COACH));
+    var after = leagues.findById(league.id()).orElseThrow();
+    assertThat(after.phase()).isEqualTo(LeaguePhase.HIRING_HEAD_COACH);
+    assertThat(after.phaseWeek()).isEqualTo(1);
+  }
+
+  @Test
+  void advance_runsExitThenEntryHandlers() {
+    var league = createLeagueFor("sub-1");
+
+    advancePhase.advance(league.id(), "sub-1");
+
+    assertThat(initialSetupHandler.exits).containsExactly(league.id());
+    assertThat(initialSetupHandler.entries).isEmpty();
+    assertThat(hiringHandler.exits).isEmpty();
+    assertThat(hiringHandler.entries).containsExactly(league.id());
+  }
+
+  @Test
+  void advance_whenLeagueMissing_returnsNotFound() {
+    var result = advancePhase.advance(999_999L, "sub-1");
+
+    assertThat(result).isEqualTo(new AdvancePhaseResult.NotFound(999_999L));
+  }
+
+  @Test
+  void advance_whenNotOwnedByCaller_returnsNotFound() {
+    var league = createLeagueFor("owner");
+
+    var result = advancePhase.advance(league.id(), "someone-else");
+
+    assertThat(result).isEqualTo(new AdvancePhaseResult.NotFound(league.id()));
+  }
+
+  @Test
+  void advance_whenAlreadyInTerminalPhase_returnsNoNextPhase() {
+    var league = createLeagueFor("sub-1");
+    leagues.updatePhaseAndResetWeek(league.id(), LeaguePhase.HIRING_HEAD_COACH);
+
+    var result = advancePhase.advance(league.id(), "sub-1");
+
+    assertThat(result)
+        .isEqualTo(new AdvancePhaseResult.NoNextPhase(league.id(), LeaguePhase.HIRING_HEAD_COACH));
+    assertThat(leagues.findById(league.id()).orElseThrow().phase())
+        .isEqualTo(LeaguePhase.HIRING_HEAD_COACH);
+  }
+
+  @Test
+  void advance_worksWhenNoHandlersRegistered() {
+    var advanceWithoutHandlers = new AdvancePhaseUseCase(leagues, List.of());
+    var league = createLeagueFor("sub-1");
+
+    var result = advanceWithoutHandlers.advance(league.id(), "sub-1");
+
+    assertThat(result).isInstanceOf(AdvancePhaseResult.Advanced.class);
+  }
+
+  private League createLeagueFor(String ownerSubject) {
+    var result = createLeague.create(ownerSubject, "Dynasty", firstFranchiseId());
+    return ((CreateLeagueResult.Created) result).league();
+  }
+
+  private long firstFranchiseId() {
+    return new JooqFranchiseRepository(dsl).listAll().getFirst().id();
+  }
+
+  private static final class RecordingHandler implements PhaseTransitionHandler {
+    private final LeaguePhase phase;
+    final List<Long> entries = new ArrayList<>();
+    final List<Long> exits = new ArrayList<>();
+
+    RecordingHandler(LeaguePhase phase) {
+      this.phase = phase;
+    }
+
+    @Override
+    public LeaguePhase phase() {
+      return phase;
+    }
+
+    @Override
+    public void onEntry(long leagueId) {
+      entries.add(leagueId);
+    }
+
+    @Override
+    public void onExit(long leagueId) {
+      exits.add(leagueId);
+    }
+  }
+}

--- a/src/test/java/app/zoneblitz/league/AdvanceWeekUseCaseTests.java
+++ b/src/test/java/app/zoneblitz/league/AdvanceWeekUseCaseTests.java
@@ -1,0 +1,81 @@
+package app.zoneblitz.league;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import app.zoneblitz.support.PostgresTestcontainer;
+import java.util.Optional;
+import org.jooq.DSLContext;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.jooq.test.autoconfigure.JooqTest;
+import org.springframework.context.annotation.Import;
+
+@JooqTest
+@Import(PostgresTestcontainer.class)
+class AdvanceWeekUseCaseTests {
+
+  @Autowired DSLContext dsl;
+
+  private LeagueRepository leagues;
+  private CreateLeague createLeague;
+  private AdvanceWeek advanceWeek;
+
+  @BeforeEach
+  void setUp() {
+    leagues = new JooqLeagueRepository(dsl);
+    var franchises = new JooqFranchiseRepository(dsl);
+    var teams = new JooqTeamRepository(dsl);
+    createLeague = new CreateLeagueUseCase(leagues, franchises, teams);
+    advanceWeek = new AdvanceWeekUseCase(leagues);
+  }
+
+  @Test
+  void advance_incrementsPhaseWeekAndReturnsTicked() {
+    var league = createLeagueFor("sub-1");
+
+    var result = advanceWeek.advance(league.id(), "sub-1");
+
+    assertThat(result)
+        .isEqualTo(
+            new AdvanceWeekResult.Ticked(
+                league.id(), LeaguePhase.INITIAL_SETUP, 2, Optional.empty()));
+    assertThat(leagues.findById(league.id()).orElseThrow().phaseWeek()).isEqualTo(2);
+  }
+
+  @Test
+  void advance_repeatedTicks_keepIncrementing() {
+    var league = createLeagueFor("sub-1");
+
+    advanceWeek.advance(league.id(), "sub-1");
+    advanceWeek.advance(league.id(), "sub-1");
+    var result = advanceWeek.advance(league.id(), "sub-1");
+
+    assertThat(((AdvanceWeekResult.Ticked) result).phaseWeek()).isEqualTo(4);
+  }
+
+  @Test
+  void advance_whenLeagueMissing_returnsNotFound() {
+    var result = advanceWeek.advance(999_999L, "sub-1");
+
+    assertThat(result).isEqualTo(new AdvanceWeekResult.NotFound(999_999L));
+  }
+
+  @Test
+  void advance_whenNotOwnedByCaller_returnsNotFound() {
+    var league = createLeagueFor("owner");
+
+    var result = advanceWeek.advance(league.id(), "someone-else");
+
+    assertThat(result).isEqualTo(new AdvanceWeekResult.NotFound(league.id()));
+  }
+
+  private League createLeagueFor(String ownerSubject) {
+    var result = createLeague.create(ownerSubject, "Dynasty", firstFranchiseId());
+    return ((CreateLeagueResult.Created) result).league();
+  }
+
+  private long firstFranchiseId() {
+    return new JooqFranchiseRepository(dsl).listAll().getFirst().id();
+  }
+}

--- a/src/test/java/app/zoneblitz/league/CandidateTestData.java
+++ b/src/test/java/app/zoneblitz/league/CandidateTestData.java
@@ -1,0 +1,69 @@
+package app.zoneblitz.league;
+
+import java.math.BigDecimal;
+import java.util.Optional;
+
+/** Test data factories for candidate-domain records. Keeps tests free of boilerplate. */
+final class CandidateTestData {
+
+  private CandidateTestData() {}
+
+  static NewCandidate newHeadCoach(long poolId) {
+    return new NewCandidate(
+        poolId,
+        CandidateKind.HEAD_COACH,
+        SpecialtyPosition.QB,
+        CandidateArchetype.OFFENSIVE_PLAY_CALLER,
+        43,
+        18,
+        "{\"OC\":10,\"QB_COACH\":4,\"HC\":0}",
+        "{\"true_rating\":78}",
+        "{\"scouted_rating\":76}",
+        Optional.empty());
+  }
+
+  static NewCandidate newScout(long poolId, ScoutBranch branch) {
+    return new NewCandidate(
+        poolId,
+        CandidateKind.SCOUT,
+        SpecialtyPosition.CB,
+        CandidateArchetype.COLLEGE_EVALUATOR,
+        38,
+        12,
+        "{\"SCOUT\":12,\"AREA_SCOUT\":8}",
+        "{\"true_rating\":70}",
+        "{\"scouted_rating\":68}",
+        Optional.of(branch));
+  }
+
+  static CandidatePreferences preferencesFor(long candidateId) {
+    return new CandidatePreferences(
+        candidateId,
+        new BigDecimal("8500000.00"),
+        new BigDecimal("0.180"),
+        5,
+        new BigDecimal("0.080"),
+        new BigDecimal("0.850"),
+        new BigDecimal("0.060"),
+        MarketSize.LARGE,
+        new BigDecimal("0.050"),
+        Geography.NE,
+        new BigDecimal("0.040"),
+        Climate.NEUTRAL,
+        new BigDecimal("0.030"),
+        new BigDecimal("75.00"),
+        new BigDecimal("0.070"),
+        CompetitiveWindow.CONTENDER,
+        new BigDecimal("0.090"),
+        RoleScope.HIGH,
+        new BigDecimal("0.120"),
+        StaffContinuity.BRING_OWN,
+        new BigDecimal("0.100"),
+        "WEST_COAST",
+        new BigDecimal("0.050"),
+        new BigDecimal("60.00"),
+        new BigDecimal("0.070"),
+        new BigDecimal("80.00"),
+        new BigDecimal("0.060"));
+  }
+}

--- a/src/test/java/app/zoneblitz/league/FakeRandomSource.java
+++ b/src/test/java/app/zoneblitz/league/FakeRandomSource.java
@@ -1,0 +1,40 @@
+package app.zoneblitz.league;
+
+import app.zoneblitz.gamesimulator.rng.RandomSource;
+import java.util.Random;
+
+/**
+ * Deterministic {@link RandomSource} for league tests. Backed by {@link Random} with a fixed seed
+ * so generator outputs are reproducible across runs. {@link #split(long)} returns a child with a
+ * seed derived from the parent seed and the split key.
+ */
+final class FakeRandomSource implements RandomSource {
+
+  private final Random random;
+  private final long seed;
+
+  FakeRandomSource(long seed) {
+    this.seed = seed;
+    this.random = new Random(seed);
+  }
+
+  @Override
+  public long nextLong() {
+    return random.nextLong();
+  }
+
+  @Override
+  public double nextDouble() {
+    return random.nextDouble();
+  }
+
+  @Override
+  public double nextGaussian() {
+    return random.nextGaussian();
+  }
+
+  @Override
+  public RandomSource split(long key) {
+    return new FakeRandomSource(seed ^ (key * 0x9E3779B97F4A7C15L));
+  }
+}

--- a/src/test/java/app/zoneblitz/league/HeadCoachGeneratorTests.java
+++ b/src/test/java/app/zoneblitz/league/HeadCoachGeneratorTests.java
@@ -1,0 +1,223 @@
+package app.zoneblitz.league;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.math.BigDecimal;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class HeadCoachGeneratorTests {
+
+  private CandidateGenerator generator;
+
+  @BeforeEach
+  void setUp() {
+    generator = new HeadCoachGenerator();
+  }
+
+  @Test
+  void generate_whenPoolSizeIsZeroOrNegative_throws() {
+    var rng = new FakeRandomSource(42L);
+    assertThatThrownBy(() -> generator.generate(0, rng))
+        .isInstanceOf(IllegalArgumentException.class);
+    assertThatThrownBy(() -> generator.generate(-1, rng))
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
+  void generate_producesRequestedPoolSizeWithAllRequiredFields() {
+    var rng = new FakeRandomSource(7L);
+
+    var candidates = generator.generate(20, rng);
+
+    assertThat(candidates).hasSize(20);
+    for (var generated : candidates) {
+      var candidate = generated.candidate();
+      assertThat(candidate.kind()).isEqualTo(CandidateKind.HEAD_COACH);
+      assertThat(candidate.archetype())
+          .isIn(
+              CandidateArchetype.OFFENSIVE_PLAY_CALLER,
+              CandidateArchetype.DEFENSIVE_PLAY_CALLER,
+              CandidateArchetype.CEO);
+      assertThat(candidate.age()).isBetween(32, 72);
+      assertThat(candidate.totalExperienceYears()).isGreaterThanOrEqualTo(0);
+      assertThat(candidate.experienceByRole()).contains("\"HC\"", "\"OC\"", "\"POSITION_COACH\"");
+      assertThat(candidate.hiddenAttrs()).contains("overall");
+      assertThat(candidate.scoutedAttrs()).contains("overall");
+      assertThat(candidate.scoutBranch()).isEmpty();
+
+      var prefs = generated.preferences();
+      assertThat(prefs.compensationTarget()).isGreaterThan(BigDecimal.ZERO);
+      assertThat(prefs.contractLengthTarget()).isGreaterThan(0);
+      assertThat(prefs.guaranteedMoneyTarget()).isBetween(BigDecimal.ZERO, BigDecimal.ONE);
+
+      var weightSum =
+          prefs
+              .compensationWeight()
+              .add(prefs.contractLengthWeight())
+              .add(prefs.guaranteedMoneyWeight())
+              .add(prefs.marketSizeWeight())
+              .add(prefs.geographyWeight())
+              .add(prefs.climateWeight())
+              .add(prefs.franchisePrestigeWeight())
+              .add(prefs.competitiveWindowWeight())
+              .add(prefs.roleScopeWeight())
+              .add(prefs.staffContinuityWeight())
+              .add(prefs.schemeAlignmentWeight())
+              .add(prefs.ownerStabilityWeight())
+              .add(prefs.facilityQualityWeight());
+      assertThat(weightSum.doubleValue()).isBetween(0.95, 1.05);
+    }
+  }
+
+  @Test
+  void generate_isDeterministicForSameSeed() {
+    var candidatesA = generator.generate(50, new FakeRandomSource(1234L));
+    var candidatesB = generator.generate(50, new FakeRandomSource(1234L));
+
+    assertThat(candidatesA).isEqualTo(candidatesB);
+  }
+
+  @Test
+  void generate_salaryDistributionMatchesBandPercentilesWithinTolerance() {
+    var salaries =
+        generator.generate(2_000, new FakeRandomSource(99L)).stream()
+            .map(c -> c.preferences().compensationTarget().doubleValue())
+            .sorted()
+            .toList();
+
+    var p10 = percentile(salaries, 0.10);
+    var p50 = percentile(salaries, 0.50);
+    var p90 = percentile(salaries, 0.90);
+
+    // Band file HC salary: p10 5.5M, p50 8.5M, p90 14M, ceiling 20M.
+    // Tolerance is loose because the generator overlays age/experience/archetype multipliers on the
+    // base triangular, widening the distribution. The percentile ORDERING must hold and each
+    // quantile must land within the band's reasonable window.
+    assertThat(p10).isBetween(2_500_000.0, 8_500_000.0);
+    assertThat(p50).isBetween(5_500_000.0, 12_000_000.0);
+    assertThat(p90).isBetween(9_000_000.0, 22_000_000.0);
+    assertThat(p10).isLessThan(p50);
+    assertThat(p50).isLessThan(p90);
+  }
+
+  @Test
+  void generate_firstTimeHcRateHonoredOverLargeSample() {
+    var sample = generator.generate(3_000, new FakeRandomSource(2026L));
+
+    var firstTimers =
+        sample.stream().filter(c -> extractHcYears(c.candidate().experienceByRole()) == 0).count();
+    var observedRate = firstTimers / (double) sample.size();
+
+    // Band target 0.55; generator mixes first-time pool with retread multipliers across perceived
+    // features. The rate must fall within ±5 percentage points of target.
+    assertThat(observedRate).isBetween(0.50, 0.60);
+  }
+
+  @Test
+  void generate_archetypeDistributionMatchesPlaycallerSplit() {
+    var sample = generator.generate(3_000, new FakeRandomSource(17L));
+
+    var offense =
+        sample.stream()
+                .filter(c -> c.candidate().archetype() == CandidateArchetype.OFFENSIVE_PLAY_CALLER)
+                .count()
+            / (double) sample.size();
+    var defense =
+        sample.stream()
+                .filter(c -> c.candidate().archetype() == CandidateArchetype.DEFENSIVE_PLAY_CALLER)
+                .count()
+            / (double) sample.size();
+    var ceo =
+        sample.stream().filter(c -> c.candidate().archetype() == CandidateArchetype.CEO).count()
+            / (double) sample.size();
+
+    assertThat(offense).isBetween(0.50, 0.60);
+    assertThat(defense).isBetween(0.25, 0.35);
+    assertThat(ceo).isBetween(0.10, 0.20);
+  }
+
+  @Test
+  void generate_trueRatingIsStatisticallyIndependentOfPrice() {
+    var sample = generator.generate(2_000, new FakeRandomSource(5150L));
+
+    var ratings = sample.stream().map(c -> parseOverall(c.candidate().hiddenAttrs())).toList();
+    var prices =
+        sample.stream().map(c -> c.preferences().compensationTarget().doubleValue()).toList();
+
+    var correlation = pearsonCorrelation(ratings, prices);
+
+    // If true rating leaked into the price function, |r| would be large (>~0.3). The hidden-info
+    // contract requires near-zero correlation — tolerance is ±0.12 for a 2000-sample draw.
+    assertThat(Math.abs(correlation)).isLessThan(0.12);
+  }
+
+  @Test
+  void generate_mostExperiencedHeadCoachesCommandHighestPrices() {
+    var sample = generator.generate(2_000, new FakeRandomSource(808L));
+
+    var firstTimers =
+        sample.stream()
+            .filter(c -> extractHcYears(c.candidate().experienceByRole()) == 0)
+            .mapToDouble(c -> c.preferences().compensationTarget().doubleValue())
+            .average()
+            .orElseThrow();
+    var retreads =
+        sample.stream()
+            .filter(c -> extractHcYears(c.candidate().experienceByRole()) >= 3)
+            .mapToDouble(c -> c.preferences().compensationTarget().doubleValue())
+            .average()
+            .orElseThrow();
+
+    assertThat(retreads).isGreaterThan(firstTimers);
+  }
+
+  private static int extractHcYears(String experienceByRole) {
+    var marker = "\"HC\":";
+    var idx = experienceByRole.indexOf(marker);
+    if (idx < 0) return 0;
+    var rest = experienceByRole.substring(idx + marker.length()).trim();
+    var end = 0;
+    while (end < rest.length()
+        && (Character.isDigit(rest.charAt(end)) || rest.charAt(end) == '-')) {
+      end++;
+    }
+    return Integer.parseInt(rest.substring(0, end));
+  }
+
+  private static double parseOverall(String attrsJson) {
+    var idx = attrsJson.indexOf(':');
+    var end = attrsJson.indexOf('}', idx);
+    return Double.parseDouble(attrsJson.substring(idx + 1, end).trim());
+  }
+
+  private static double percentile(List<Double> sortedValues, double p) {
+    var idx = (int) Math.floor(p * (sortedValues.size() - 1));
+    return sortedValues.get(idx);
+  }
+
+  private static double pearsonCorrelation(List<Double> xs, List<Double> ys) {
+    var n = xs.size();
+    var sumX = 0.0;
+    var sumY = 0.0;
+    for (var i = 0; i < n; i++) {
+      sumX += xs.get(i);
+      sumY += ys.get(i);
+    }
+    var meanX = sumX / n;
+    var meanY = sumY / n;
+    var covariance = 0.0;
+    var varX = 0.0;
+    var varY = 0.0;
+    for (var i = 0; i < n; i++) {
+      var dx = xs.get(i) - meanX;
+      var dy = ys.get(i) - meanY;
+      covariance += dx * dy;
+      varX += dx * dx;
+      varY += dy * dy;
+    }
+    return covariance / Math.sqrt(varX * varY);
+  }
+}

--- a/src/test/java/app/zoneblitz/league/HiringHeadCoachControllerTests.java
+++ b/src/test/java/app/zoneblitz/league/HiringHeadCoachControllerTests.java
@@ -1,0 +1,156 @@
+package app.zoneblitz.league;
+
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.oauth2Login;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.view;
+
+import app.zoneblitz.config.SecurityConfig;
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
+import org.springframework.boot.security.autoconfigure.SecurityAutoConfiguration;
+import org.springframework.boot.security.autoconfigure.web.servlet.ServletWebSecurityAutoConfiguration;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(HiringHeadCoachController.class)
+@Import(SecurityConfig.class)
+@ImportAutoConfiguration({
+  SecurityAutoConfiguration.class,
+  ServletWebSecurityAutoConfiguration.class
+})
+class HiringHeadCoachControllerTests {
+
+  @Autowired MockMvc mvc;
+
+  @MockitoBean ViewHeadCoachHiring viewHiring;
+  @MockitoBean ManageHeadCoachShortlist shortlist;
+  @MockitoBean ClientRegistrationRepository clientRegistrationRepository;
+
+  @Test
+  void page_whenFound_rendersPageTemplate() throws Exception {
+    given(viewHiring.view(42L, "sub-1")).willReturn(Optional.of(sampleView()));
+
+    mvc.perform(
+            get("/leagues/42/hiring/head-coach")
+                .with(oauth2Login().attributes(a -> a.put("sub", "sub-1"))))
+        .andExpect(status().isOk())
+        .andExpect(view().name("league/hiring/head-coach"));
+  }
+
+  @Test
+  void page_whenMissing_returns404() throws Exception {
+    given(viewHiring.view(42L, "sub-1")).willReturn(Optional.empty());
+
+    mvc.perform(
+            get("/leagues/42/hiring/head-coach")
+                .with(oauth2Login().attributes(a -> a.put("sub", "sub-1"))))
+        .andExpect(status().isNotFound());
+  }
+
+  @Test
+  void poolFragment_returnsFragment() throws Exception {
+    given(viewHiring.view(42L, "sub-1")).willReturn(Optional.of(sampleView()));
+
+    mvc.perform(
+            get("/leagues/42/hiring/head-coach/pool")
+                .with(oauth2Login().attributes(a -> a.put("sub", "sub-1"))))
+        .andExpect(status().isOk())
+        .andExpect(view().name("league/hiring/head-coach-fragments :: pool"));
+  }
+
+  @Test
+  void shortlistFragment_returnsFragment() throws Exception {
+    given(viewHiring.view(42L, "sub-1")).willReturn(Optional.of(sampleView()));
+
+    mvc.perform(
+            get("/leagues/42/hiring/head-coach/shortlist")
+                .with(oauth2Login().attributes(a -> a.put("sub", "sub-1"))))
+        .andExpect(status().isOk())
+        .andExpect(view().name("league/hiring/head-coach-fragments :: shortlist"));
+  }
+
+  @Test
+  void addToShortlist_whenUpdated_rendersCombinedFragment() throws Exception {
+    given(shortlist.add(42L, 7L, "sub-1")).willReturn(new ShortlistResult.Updated(sampleView()));
+
+    mvc.perform(
+            post("/leagues/42/hiring/head-coach/shortlist/7")
+                .with(oauth2Login().attributes(a -> a.put("sub", "sub-1")))
+                .with(csrf()))
+        .andExpect(status().isOk())
+        .andExpect(view().name("league/hiring/head-coach-fragments :: combined"));
+
+    verify(shortlist).add(42L, 7L, "sub-1");
+  }
+
+  @Test
+  void addToShortlist_whenNotFound_returns404() throws Exception {
+    given(shortlist.add(42L, 7L, "sub-1")).willReturn(new ShortlistResult.NotFound(42L));
+
+    mvc.perform(
+            post("/leagues/42/hiring/head-coach/shortlist/7")
+                .with(oauth2Login().attributes(a -> a.put("sub", "sub-1")))
+                .with(csrf()))
+        .andExpect(status().isNotFound());
+  }
+
+  @Test
+  void addToShortlist_whenUnknownCandidate_returns404() throws Exception {
+    given(shortlist.add(42L, 7L, "sub-1")).willReturn(new ShortlistResult.UnknownCandidate(7L));
+
+    mvc.perform(
+            post("/leagues/42/hiring/head-coach/shortlist/7")
+                .with(oauth2Login().attributes(a -> a.put("sub", "sub-1")))
+                .with(csrf()))
+        .andExpect(status().isNotFound());
+  }
+
+  @Test
+  void removeFromShortlist_whenUpdated_rendersCombinedFragment() throws Exception {
+    given(shortlist.remove(42L, 7L, "sub-1")).willReturn(new ShortlistResult.Updated(sampleView()));
+
+    mvc.perform(
+            delete("/leagues/42/hiring/head-coach/shortlist/7")
+                .with(oauth2Login().attributes(a -> a.put("sub", "sub-1")))
+                .with(csrf()))
+        .andExpect(status().isOk())
+        .andExpect(view().name("league/hiring/head-coach-fragments :: combined"));
+
+    verify(shortlist).remove(42L, 7L, "sub-1");
+  }
+
+  @Test
+  void addToShortlist_requiresCsrf() throws Exception {
+    mvc.perform(
+            post("/leagues/42/hiring/head-coach/shortlist/7")
+                .with(oauth2Login().attributes(a -> a.put("sub", "sub-1"))))
+        .andExpect(status().isForbidden());
+  }
+
+  private static HeadCoachHiringView sampleView() {
+    var franchise =
+        new Franchise(
+            1L,
+            "Minutemen",
+            new City(1L, "Boston", new State(1L, "MA", "Massachusetts")),
+            "#000000",
+            "#ffffff");
+    var league =
+        new LeagueSummary(
+            42L, "Dynasty", LeaguePhase.HIRING_HEAD_COACH, 1, Instant.now(), franchise);
+    return new HeadCoachHiringView(league, List.of(), List.of());
+  }
+}

--- a/src/test/java/app/zoneblitz/league/HiringHeadCoachControllerTests.java
+++ b/src/test/java/app/zoneblitz/league/HiringHeadCoachControllerTests.java
@@ -37,6 +37,7 @@ class HiringHeadCoachControllerTests {
 
   @MockitoBean ViewHeadCoachHiring viewHiring;
   @MockitoBean ManageHeadCoachShortlist shortlist;
+  @MockitoBean StartInterview startInterview;
   @MockitoBean ClientRegistrationRepository clientRegistrationRepository;
 
   @Test
@@ -133,6 +134,75 @@ class HiringHeadCoachControllerTests {
   }
 
   @Test
+  void startInterview_whenStarted_rendersCombinedFragment() throws Exception {
+    given(startInterview.start(42L, 7L, "sub-1"))
+        .willReturn(new InterviewResult.Started(sampleView()));
+
+    mvc.perform(
+            post("/leagues/42/hiring/head-coach/interview/7")
+                .with(oauth2Login().attributes(a -> a.put("sub", "sub-1")))
+                .with(csrf()))
+        .andExpect(status().isOk())
+        .andExpect(view().name("league/hiring/head-coach-fragments :: combined"));
+
+    verify(startInterview).start(42L, 7L, "sub-1");
+  }
+
+  @Test
+  void startInterview_whenCapacityReached_returns409() throws Exception {
+    given(startInterview.start(42L, 7L, "sub-1"))
+        .willReturn(new InterviewResult.CapacityReached(3));
+
+    mvc.perform(
+            post("/leagues/42/hiring/head-coach/interview/7")
+                .with(oauth2Login().attributes(a -> a.put("sub", "sub-1")))
+                .with(csrf()))
+        .andExpect(status().isConflict());
+  }
+
+  @Test
+  void startInterview_whenNotFound_returns404() throws Exception {
+    given(startInterview.start(42L, 7L, "sub-1")).willReturn(new InterviewResult.NotFound(42L));
+
+    mvc.perform(
+            post("/leagues/42/hiring/head-coach/interview/7")
+                .with(oauth2Login().attributes(a -> a.put("sub", "sub-1")))
+                .with(csrf()))
+        .andExpect(status().isNotFound());
+  }
+
+  @Test
+  void startInterview_whenUnknownCandidate_returns404() throws Exception {
+    given(startInterview.start(42L, 7L, "sub-1"))
+        .willReturn(new InterviewResult.UnknownCandidate(7L));
+
+    mvc.perform(
+            post("/leagues/42/hiring/head-coach/interview/7")
+                .with(oauth2Login().attributes(a -> a.put("sub", "sub-1")))
+                .with(csrf()))
+        .andExpect(status().isNotFound());
+  }
+
+  @Test
+  void startInterview_requiresCsrf() throws Exception {
+    mvc.perform(
+            post("/leagues/42/hiring/head-coach/interview/7")
+                .with(oauth2Login().attributes(a -> a.put("sub", "sub-1"))))
+        .andExpect(status().isForbidden());
+  }
+
+  @Test
+  void interviewsFragment_returnsFragment() throws Exception {
+    given(viewHiring.view(42L, "sub-1")).willReturn(Optional.of(sampleView()));
+
+    mvc.perform(
+            get("/leagues/42/hiring/head-coach/interviews")
+                .with(oauth2Login().attributes(a -> a.put("sub", "sub-1"))))
+        .andExpect(status().isOk())
+        .andExpect(view().name("league/hiring/head-coach-fragments :: interviews"));
+  }
+
+  @Test
   void addToShortlist_requiresCsrf() throws Exception {
     mvc.perform(
             post("/leagues/42/hiring/head-coach/shortlist/7")
@@ -151,6 +221,6 @@ class HiringHeadCoachControllerTests {
     var league =
         new LeagueSummary(
             42L, "Dynasty", LeaguePhase.HIRING_HEAD_COACH, 1, Instant.now(), franchise);
-    return new HeadCoachHiringView(league, List.of(), List.of());
+    return new HeadCoachHiringView(league, List.of(), List.of(), List.of(), 0, 3);
   }
 }

--- a/src/test/java/app/zoneblitz/league/HiringHeadCoachTransitionHandlerTests.java
+++ b/src/test/java/app/zoneblitz/league/HiringHeadCoachTransitionHandlerTests.java
@@ -1,0 +1,115 @@
+package app.zoneblitz.league;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import app.zoneblitz.gamesimulator.rng.RandomSource;
+import app.zoneblitz.support.PostgresTestcontainer;
+import org.jooq.DSLContext;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.jooq.test.autoconfigure.JooqTest;
+import org.springframework.context.annotation.Import;
+
+@JooqTest
+@Import(PostgresTestcontainer.class)
+class HiringHeadCoachTransitionHandlerTests {
+
+  @Autowired DSLContext dsl;
+
+  private LeagueRepository leagues;
+  private CreateLeague createLeague;
+  private CandidatePoolRepository pools;
+  private CandidateRepository candidates;
+  private CandidatePreferencesRepository preferences;
+  private FranchiseHiringStateRepository hiringStates;
+  private TeamLookup teams;
+  private HiringHeadCoachTransitionHandler handler;
+
+  @BeforeEach
+  void setUp() {
+    leagues = new JooqLeagueRepository(dsl);
+    var franchises = new JooqFranchiseRepository(dsl);
+    var teamRepo = new JooqTeamRepository(dsl);
+    teams = new JooqTeamLookup(dsl);
+    pools = new JooqCandidatePoolRepository(dsl);
+    candidates = new JooqCandidateRepository(dsl);
+    preferences = new JooqCandidatePreferencesRepository(dsl);
+    hiringStates = new JooqFranchiseHiringStateRepository(dsl);
+    createLeague = new CreateLeagueUseCase(leagues, franchises, teamRepo);
+    handler =
+        new HiringHeadCoachTransitionHandler(
+            leagues,
+            teams,
+            pools,
+            candidates,
+            preferences,
+            hiringStates,
+            new HeadCoachGenerator(),
+            new SeededRandomSources());
+  }
+
+  @Test
+  void phase_isHiringHeadCoach() {
+    assertThat(handler.phase()).isEqualTo(LeaguePhase.HIRING_HEAD_COACH);
+  }
+
+  @Test
+  void onEntry_generatesPoolCandidatesAndPreferencesAndInitialHiringStates() {
+    var league = createLeagueFor("sub-1");
+
+    handler.onEntry(league.id());
+
+    var pool =
+        pools
+            .findByLeaguePhaseAndType(
+                league.id(), LeaguePhase.HIRING_HEAD_COACH, CandidatePoolType.HEAD_COACH)
+            .orElseThrow();
+    var generated = candidates.findAllByPoolId(pool.id());
+    var franchiseCount = teams.franchiseIdsForLeague(league.id()).size();
+    assertThat(generated).hasSize(franchiseCount * 3);
+    assertThat(generated).allSatisfy(c -> assertThat(c.kind()).isEqualTo(CandidateKind.HEAD_COACH));
+    assertThat(generated)
+        .allSatisfy(c -> assertThat(preferences.findByCandidateId(c.id())).isPresent());
+
+    var states = hiringStates.findAllForLeaguePhase(league.id(), LeaguePhase.HIRING_HEAD_COACH);
+    assertThat(states).hasSize(franchiseCount);
+    assertThat(states)
+        .allSatisfy(
+            s -> {
+              assertThat(s.step()).isEqualTo(HiringStep.SEARCHING);
+              assertThat(s.shortlist()).isEmpty();
+              assertThat(s.interviewingCandidateIds()).isEmpty();
+            });
+  }
+
+  @Test
+  void onEntry_isIdempotent_whenPoolAlreadyExists() {
+    var league = createLeagueFor("sub-1");
+    handler.onEntry(league.id());
+    var firstPool =
+        pools
+            .findByLeaguePhaseAndType(
+                league.id(), LeaguePhase.HIRING_HEAD_COACH, CandidatePoolType.HEAD_COACH)
+            .orElseThrow();
+    var firstCount = candidates.findAllByPoolId(firstPool.id()).size();
+
+    handler.onEntry(league.id());
+
+    var secondCount = candidates.findAllByPoolId(firstPool.id()).size();
+    assertThat(secondCount).isEqualTo(firstCount);
+  }
+
+  private League createLeagueFor(String ownerSubject) {
+    var franchiseId = new JooqFranchiseRepository(dsl).listAll().getFirst().id();
+    var result = createLeague.create(ownerSubject, "Dynasty", franchiseId);
+    return ((CreateLeagueResult.Created) result).league();
+  }
+
+  private static final class SeededRandomSources implements CandidateRandomSources {
+    @Override
+    public RandomSource forLeaguePhase(long leagueId, LeaguePhase phase) {
+      return new FakeRandomSource(leagueId * 31 + phase.ordinal());
+    }
+  }
+}

--- a/src/test/java/app/zoneblitz/league/InterviewNoiseModelTests.java
+++ b/src/test/java/app/zoneblitz/league/InterviewNoiseModelTests.java
@@ -1,0 +1,48 @@
+package app.zoneblitz.league;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.Test;
+
+class InterviewNoiseModelTests {
+
+  @Test
+  void headCoachSigma_atZero_equalsInitial() {
+    assertThat(InterviewNoiseModel.headCoachSigma(0)).isEqualTo(InterviewNoiseModel.HC_INITIAL_STD);
+  }
+
+  @Test
+  void headCoachSigma_monotonicallyDecreasesAcrossInterviews() {
+    var previous = InterviewNoiseModel.headCoachSigma(0);
+    for (var i = 1; i <= 20; i++) {
+      var current = InterviewNoiseModel.headCoachSigma(i);
+      assertThat(current)
+          .as("sigma must strictly decrease at interview %d", i)
+          .isLessThan(previous);
+      previous = current;
+    }
+  }
+
+  @Test
+  void headCoachSigma_neverReachesZero_evenAtLargeCounts() {
+    for (var n : new int[] {10, 50, 100, 1_000, 10_000}) {
+      assertThat(InterviewNoiseModel.headCoachSigma(n))
+          .as("sigma at n=%d", n)
+          .isGreaterThan(0.0)
+          .isGreaterThanOrEqualTo(InterviewNoiseModel.HC_FLOOR_STD);
+    }
+  }
+
+  @Test
+  void headCoachSigma_asymptoticallyApproachesFloor() {
+    assertThat(InterviewNoiseModel.headCoachSigma(100_000))
+        .isCloseTo(InterviewNoiseModel.HC_FLOOR_STD, org.assertj.core.data.Offset.offset(1e-6));
+  }
+
+  @Test
+  void headCoachSigma_negative_throws() {
+    assertThatThrownBy(() -> InterviewNoiseModel.headCoachSigma(-1))
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+}

--- a/src/test/java/app/zoneblitz/league/JooqCandidateOfferRepositoryTests.java
+++ b/src/test/java/app/zoneblitz/league/JooqCandidateOfferRepositoryTests.java
@@ -1,0 +1,118 @@
+package app.zoneblitz.league;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import app.zoneblitz.support.PostgresTestcontainer;
+import org.jooq.DSLContext;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.jooq.test.autoconfigure.JooqTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.dao.DataIntegrityViolationException;
+
+@JooqTest
+@Import(PostgresTestcontainer.class)
+class JooqCandidateOfferRepositoryTests {
+
+  @Autowired DSLContext dsl;
+
+  private CandidateOfferRepository offers;
+  private long candidateId;
+  private long otherCandidateId;
+  private long franchiseId;
+  private long otherFranchiseId;
+
+  @BeforeEach
+  void setUp() {
+    offers = new JooqCandidateOfferRepository(dsl);
+    var leagues = new JooqLeagueRepository(dsl);
+    var pools = new JooqCandidatePoolRepository(dsl);
+    var candidates = new JooqCandidateRepository(dsl);
+    var franchises = new JooqFranchiseRepository(dsl);
+    var league =
+        leagues.insert("sub-1", "Dynasty", LeaguePhase.INITIAL_SETUP, LeagueSettings.defaults());
+    var pool =
+        pools.insert(league.id(), LeaguePhase.HIRING_HEAD_COACH, CandidatePoolType.HEAD_COACH);
+    candidateId = candidates.insert(CandidateTestData.newHeadCoach(pool.id())).id();
+    otherCandidateId = candidates.insert(CandidateTestData.newHeadCoach(pool.id())).id();
+    var listed = franchises.listAll();
+    franchiseId = listed.get(0).id();
+    otherFranchiseId = listed.get(1).id();
+  }
+
+  @Test
+  void insertActive_returnsActiveOffer() {
+    var offer = offers.insertActive(candidateId, franchiseId, "{\"salary\":8000000}", 1);
+
+    assertThat(offer.id()).isPositive();
+    assertThat(offer.status()).isEqualTo(OfferStatus.ACTIVE);
+    assertThat(offer.submittedAtWeek()).isEqualTo(1);
+    assertThat(offer.terms()).contains("salary");
+  }
+
+  @Test
+  void insertActive_whenFranchiseAlreadyHasActiveOfferOnCandidate_throws() {
+    offers.insertActive(candidateId, franchiseId, "{}", 1);
+
+    assertThatThrownBy(() -> offers.insertActive(candidateId, franchiseId, "{}", 2))
+        .isInstanceOf(DataIntegrityViolationException.class);
+  }
+
+  @Test
+  void resolve_marksOfferTerminal() {
+    var offer = offers.insertActive(candidateId, franchiseId, "{}", 1);
+
+    assertThat(offers.resolve(offer.id(), OfferStatus.ACCEPTED)).isTrue();
+    assertThat(offers.findById(offer.id()).orElseThrow().status()).isEqualTo(OfferStatus.ACCEPTED);
+  }
+
+  @Test
+  void resolve_whenNotActive_returnsFalse() {
+    var offer = offers.insertActive(candidateId, franchiseId, "{}", 1);
+    offers.resolve(offer.id(), OfferStatus.REJECTED);
+
+    assertThat(offers.resolve(offer.id(), OfferStatus.ACCEPTED)).isFalse();
+  }
+
+  @Test
+  void findActiveForCandidate_onlyReturnsActive() {
+    var active = offers.insertActive(candidateId, franchiseId, "{}", 1);
+    var resolved = offers.insertActive(candidateId, otherFranchiseId, "{}", 1);
+    offers.resolve(resolved.id(), OfferStatus.REJECTED);
+
+    assertThat(offers.findActiveForCandidate(candidateId))
+        .extracting(CandidateOffer::id)
+        .containsExactly(active.id());
+  }
+
+  @Test
+  void findActiveForFranchise_returnsOnlyThatFranchisesActiveOffers() {
+    offers.insertActive(candidateId, franchiseId, "{}", 1);
+    offers.insertActive(otherCandidateId, franchiseId, "{}", 1);
+    offers.insertActive(candidateId, otherFranchiseId, "{}", 1);
+
+    assertThat(offers.findActiveForFranchise(franchiseId)).hasSize(2);
+  }
+
+  @Test
+  void findAllForCandidate_returnsAllStatuses() {
+    var a = offers.insertActive(candidateId, franchiseId, "{}", 1);
+    var b = offers.insertActive(candidateId, otherFranchiseId, "{}", 2);
+    offers.resolve(b.id(), OfferStatus.REJECTED);
+
+    assertThat(offers.findAllForCandidate(candidateId))
+        .extracting(CandidateOffer::id)
+        .containsExactly(a.id(), b.id());
+  }
+
+  @Test
+  void insertActive_afterRejection_allowedAgain() {
+    var first = offers.insertActive(candidateId, franchiseId, "{}", 1);
+    offers.resolve(first.id(), OfferStatus.REJECTED);
+
+    var rebid = offers.insertActive(candidateId, franchiseId, "{}", 2);
+    assertThat(rebid.status()).isEqualTo(OfferStatus.ACTIVE);
+  }
+}

--- a/src/test/java/app/zoneblitz/league/JooqCandidatePoolRepositoryTests.java
+++ b/src/test/java/app/zoneblitz/league/JooqCandidatePoolRepositoryTests.java
@@ -1,0 +1,88 @@
+package app.zoneblitz.league;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import app.zoneblitz.support.PostgresTestcontainer;
+import org.jooq.DSLContext;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.jooq.test.autoconfigure.JooqTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.dao.DataIntegrityViolationException;
+
+@JooqTest
+@Import(PostgresTestcontainer.class)
+class JooqCandidatePoolRepositoryTests {
+
+  @Autowired DSLContext dsl;
+
+  private CandidatePoolRepository pools;
+  private LeagueRepository leagues;
+  private long leagueId;
+
+  @BeforeEach
+  void setUp() {
+    pools = new JooqCandidatePoolRepository(dsl);
+    leagues = new JooqLeagueRepository(dsl);
+    leagueId =
+        leagues
+            .insert("sub-1", "Dynasty", LeaguePhase.INITIAL_SETUP, LeagueSettings.defaults())
+            .id();
+  }
+
+  @Test
+  void insert_returnsPoolWithGeneratedIdAndTimestamp() {
+    var pool = pools.insert(leagueId, LeaguePhase.HIRING_HEAD_COACH, CandidatePoolType.HEAD_COACH);
+
+    assertThat(pool.id()).isPositive();
+    assertThat(pool.leagueId()).isEqualTo(leagueId);
+    assertThat(pool.phase()).isEqualTo(LeaguePhase.HIRING_HEAD_COACH);
+    assertThat(pool.type()).isEqualTo(CandidatePoolType.HEAD_COACH);
+    assertThat(pool.generatedAt()).isNotNull();
+  }
+
+  @Test
+  void findById_whenPresent_returnsPool() {
+    var inserted =
+        pools.insert(leagueId, LeaguePhase.HIRING_HEAD_COACH, CandidatePoolType.HEAD_COACH);
+
+    assertThat(pools.findById(inserted.id())).hasValue(inserted);
+  }
+
+  @Test
+  void findById_whenMissing_returnsEmpty() {
+    assertThat(pools.findById(999_999L)).isEmpty();
+  }
+
+  @Test
+  void findByLeaguePhaseAndType_whenPresent_returnsPool() {
+    var inserted =
+        pools.insert(leagueId, LeaguePhase.HIRING_HEAD_COACH, CandidatePoolType.HEAD_COACH);
+
+    assertThat(
+            pools.findByLeaguePhaseAndType(
+                leagueId, LeaguePhase.HIRING_HEAD_COACH, CandidatePoolType.HEAD_COACH))
+        .hasValue(inserted);
+  }
+
+  @Test
+  void insert_whenDuplicateLeaguePhaseType_throws() {
+    pools.insert(leagueId, LeaguePhase.HIRING_HEAD_COACH, CandidatePoolType.HEAD_COACH);
+
+    assertThatThrownBy(
+            () ->
+                pools.insert(leagueId, LeaguePhase.HIRING_HEAD_COACH, CandidatePoolType.HEAD_COACH))
+        .isInstanceOf(DataIntegrityViolationException.class);
+  }
+
+  @Test
+  void findAllForLeague_returnsAllPoolsNewestFirst() {
+    pools.insert(leagueId, LeaguePhase.HIRING_HEAD_COACH, CandidatePoolType.HEAD_COACH);
+    pools.insert(
+        leagueId, LeaguePhase.HIRING_DIRECTOR_OF_SCOUTING, CandidatePoolType.DIRECTOR_OF_SCOUTING);
+
+    assertThat(pools.findAllForLeague(leagueId)).hasSize(2);
+  }
+}

--- a/src/test/java/app/zoneblitz/league/JooqCandidatePreferencesRepositoryTests.java
+++ b/src/test/java/app/zoneblitz/league/JooqCandidatePreferencesRepositoryTests.java
@@ -1,0 +1,55 @@
+package app.zoneblitz.league;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import app.zoneblitz.support.PostgresTestcontainer;
+import org.jooq.DSLContext;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.jooq.test.autoconfigure.JooqTest;
+import org.springframework.context.annotation.Import;
+
+@JooqTest
+@Import(PostgresTestcontainer.class)
+class JooqCandidatePreferencesRepositoryTests {
+
+  @Autowired DSLContext dsl;
+
+  private CandidatePreferencesRepository preferences;
+  private CandidateRepository candidates;
+  private long candidateId;
+
+  @BeforeEach
+  void setUp() {
+    preferences = new JooqCandidatePreferencesRepository(dsl);
+    candidates = new JooqCandidateRepository(dsl);
+    var leagues = new JooqLeagueRepository(dsl);
+    var pools = new JooqCandidatePoolRepository(dsl);
+    var league =
+        leagues.insert("sub-1", "Dynasty", LeaguePhase.INITIAL_SETUP, LeagueSettings.defaults());
+    var pool =
+        pools.insert(league.id(), LeaguePhase.HIRING_HEAD_COACH, CandidatePoolType.HEAD_COACH);
+    candidateId = candidates.insert(CandidateTestData.newHeadCoach(pool.id())).id();
+  }
+
+  @Test
+  void insert_thenFindByCandidateId_roundTripsAllDimensions() {
+    var inserted = preferences.insert(CandidateTestData.preferencesFor(candidateId));
+
+    var reloaded = preferences.findByCandidateId(candidateId).orElseThrow();
+    assertThat(reloaded).isEqualTo(inserted);
+    assertThat(reloaded.marketSizeTarget()).isEqualTo(MarketSize.LARGE);
+    assertThat(reloaded.geographyTarget()).isEqualTo(Geography.NE);
+    assertThat(reloaded.climateTarget()).isEqualTo(Climate.NEUTRAL);
+    assertThat(reloaded.competitiveWindowTarget()).isEqualTo(CompetitiveWindow.CONTENDER);
+    assertThat(reloaded.roleScopeTarget()).isEqualTo(RoleScope.HIGH);
+    assertThat(reloaded.staffContinuityTarget()).isEqualTo(StaffContinuity.BRING_OWN);
+    assertThat(reloaded.schemeAlignmentTarget()).isEqualTo("WEST_COAST");
+  }
+
+  @Test
+  void findByCandidateId_whenMissing_returnsEmpty() {
+    assertThat(preferences.findByCandidateId(999_999L)).isEmpty();
+  }
+}

--- a/src/test/java/app/zoneblitz/league/JooqCandidateRepositoryTests.java
+++ b/src/test/java/app/zoneblitz/league/JooqCandidateRepositoryTests.java
@@ -1,0 +1,93 @@
+package app.zoneblitz.league;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import app.zoneblitz.support.PostgresTestcontainer;
+import org.jooq.DSLContext;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.jooq.test.autoconfigure.JooqTest;
+import org.springframework.context.annotation.Import;
+
+@JooqTest
+@Import(PostgresTestcontainer.class)
+class JooqCandidateRepositoryTests {
+
+  @Autowired DSLContext dsl;
+
+  private CandidateRepository candidates;
+  private CandidatePoolRepository pools;
+  private LeagueRepository leagues;
+  private FranchiseRepository franchises;
+
+  private long poolId;
+
+  @BeforeEach
+  void setUp() {
+    candidates = new JooqCandidateRepository(dsl);
+    pools = new JooqCandidatePoolRepository(dsl);
+    leagues = new JooqLeagueRepository(dsl);
+    franchises = new JooqFranchiseRepository(dsl);
+    var league =
+        leagues.insert("sub-1", "Dynasty", LeaguePhase.INITIAL_SETUP, LeagueSettings.defaults());
+    poolId =
+        pools.insert(league.id(), LeaguePhase.HIRING_HEAD_COACH, CandidatePoolType.HEAD_COACH).id();
+  }
+
+  @Test
+  void insert_roundTripsAllFields() {
+    var candidate = candidates.insert(CandidateTestData.newHeadCoach(poolId));
+
+    assertThat(candidate.id()).isPositive();
+    assertThat(candidate.poolId()).isEqualTo(poolId);
+    assertThat(candidate.kind()).isEqualTo(CandidateKind.HEAD_COACH);
+    assertThat(candidate.specialtyPosition()).isEqualTo(SpecialtyPosition.QB);
+    assertThat(candidate.archetype()).isEqualTo(CandidateArchetype.OFFENSIVE_PLAY_CALLER);
+    assertThat(candidate.age()).isEqualTo(43);
+    assertThat(candidate.totalExperienceYears()).isEqualTo(18);
+    assertThat(candidate.experienceByRole()).contains("\"OC\"").contains("10");
+    assertThat(candidate.hiddenAttrs()).contains("true_rating");
+    assertThat(candidate.scoutedAttrs()).contains("scouted_rating");
+    assertThat(candidate.hiredByFranchiseId()).isEmpty();
+    assertThat(candidate.scoutBranch()).isEmpty();
+  }
+
+  @Test
+  void insert_scout_populatesScoutBranch() {
+    var scout = candidates.insert(CandidateTestData.newScout(poolId, ScoutBranch.COLLEGE));
+
+    assertThat(scout.scoutBranch()).hasValue(ScoutBranch.COLLEGE);
+  }
+
+  @Test
+  void findById_whenMissing_returnsEmpty() {
+    assertThat(candidates.findById(999_999L)).isEmpty();
+  }
+
+  @Test
+  void findAllByPoolId_returnsCandidatesInInsertionOrder() {
+    var first = candidates.insert(CandidateTestData.newHeadCoach(poolId));
+    var second = candidates.insert(CandidateTestData.newHeadCoach(poolId));
+
+    assertThat(candidates.findAllByPoolId(poolId))
+        .extracting(Candidate::id)
+        .containsExactly(first.id(), second.id());
+  }
+
+  @Test
+  void markHired_setsFranchiseIdAndPersists() {
+    var candidate = candidates.insert(CandidateTestData.newHeadCoach(poolId));
+    var franchiseId = franchises.listAll().getFirst().id();
+
+    assertThat(candidates.markHired(candidate.id(), franchiseId)).isTrue();
+
+    var reloaded = candidates.findById(candidate.id()).orElseThrow();
+    assertThat(reloaded.hiredByFranchiseId()).hasValue(franchiseId);
+  }
+
+  @Test
+  void markHired_whenMissing_returnsFalse() {
+    assertThat(candidates.markHired(999_999L, franchises.listAll().getFirst().id())).isFalse();
+  }
+}

--- a/src/test/java/app/zoneblitz/league/JooqFranchiseHiringStateRepositoryTests.java
+++ b/src/test/java/app/zoneblitz/league/JooqFranchiseHiringStateRepositoryTests.java
@@ -1,0 +1,130 @@
+package app.zoneblitz.league;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import app.zoneblitz.support.PostgresTestcontainer;
+import java.util.List;
+import org.jooq.DSLContext;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.jooq.test.autoconfigure.JooqTest;
+import org.springframework.context.annotation.Import;
+
+@JooqTest
+@Import(PostgresTestcontainer.class)
+class JooqFranchiseHiringStateRepositoryTests {
+
+  @Autowired DSLContext dsl;
+
+  private FranchiseHiringStateRepository states;
+  private long leagueId;
+  private long franchiseId;
+  private long otherFranchiseId;
+
+  @BeforeEach
+  void setUp() {
+    states = new JooqFranchiseHiringStateRepository(dsl);
+    var leagues = new JooqLeagueRepository(dsl);
+    var franchises = new JooqFranchiseRepository(dsl);
+    leagueId =
+        leagues
+            .insert("sub-1", "Dynasty", LeaguePhase.INITIAL_SETUP, LeagueSettings.defaults())
+            .id();
+    var listed = franchises.listAll();
+    franchiseId = listed.get(0).id();
+    otherFranchiseId = listed.get(1).id();
+  }
+
+  @Test
+  void upsert_insertsOnFirstCall() {
+    var inserted =
+        states.upsert(
+            new FranchiseHiringState(
+                0,
+                leagueId,
+                franchiseId,
+                LeaguePhase.HIRING_HEAD_COACH,
+                HiringStep.SEARCHING,
+                List.of(1L, 2L, 3L),
+                List.of(1L)));
+
+    assertThat(inserted.id()).isPositive();
+    assertThat(inserted.shortlist()).containsExactly(1L, 2L, 3L);
+    assertThat(inserted.interviewingCandidateIds()).containsExactly(1L);
+  }
+
+  @Test
+  void upsert_replacesOnSameLeaguePhaseAndFranchise() {
+    states.upsert(
+        new FranchiseHiringState(
+            0,
+            leagueId,
+            franchiseId,
+            LeaguePhase.HIRING_HEAD_COACH,
+            HiringStep.SEARCHING,
+            List.of(1L, 2L),
+            List.of()));
+
+    var updated =
+        states.upsert(
+            new FranchiseHiringState(
+                0,
+                leagueId,
+                franchiseId,
+                LeaguePhase.HIRING_HEAD_COACH,
+                HiringStep.HIRED,
+                List.of(7L),
+                List.of(7L)));
+
+    assertThat(updated.step()).isEqualTo(HiringStep.HIRED);
+    assertThat(updated.shortlist()).containsExactly(7L);
+    assertThat(states.findAllForLeaguePhase(leagueId, LeaguePhase.HIRING_HEAD_COACH)).hasSize(1);
+  }
+
+  @Test
+  void find_whenMissing_returnsEmpty() {
+    assertThat(states.find(leagueId, franchiseId, LeaguePhase.HIRING_HEAD_COACH)).isEmpty();
+  }
+
+  @Test
+  void findAllForLeaguePhase_returnsAllFranchisesForPhase() {
+    states.upsert(
+        new FranchiseHiringState(
+            0,
+            leagueId,
+            franchiseId,
+            LeaguePhase.HIRING_HEAD_COACH,
+            HiringStep.SEARCHING,
+            List.of(),
+            List.of()));
+    states.upsert(
+        new FranchiseHiringState(
+            0,
+            leagueId,
+            otherFranchiseId,
+            LeaguePhase.HIRING_HEAD_COACH,
+            HiringStep.HIRED,
+            List.of(),
+            List.of()));
+
+    assertThat(states.findAllForLeaguePhase(leagueId, LeaguePhase.HIRING_HEAD_COACH)).hasSize(2);
+  }
+
+  @Test
+  void roundTrip_preservesEmptyArrays() {
+    var inserted =
+        states.upsert(
+            new FranchiseHiringState(
+                0,
+                leagueId,
+                franchiseId,
+                LeaguePhase.HIRING_HEAD_COACH,
+                HiringStep.SEARCHING,
+                List.of(),
+                List.of()));
+
+    assertThat(inserted.shortlist()).isEmpty();
+    assertThat(inserted.interviewingCandidateIds()).isEmpty();
+  }
+}

--- a/src/test/java/app/zoneblitz/league/JooqFranchiseInterviewRepositoryTests.java
+++ b/src/test/java/app/zoneblitz/league/JooqFranchiseInterviewRepositoryTests.java
@@ -1,0 +1,117 @@
+package app.zoneblitz.league;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import app.zoneblitz.support.PostgresTestcontainer;
+import java.math.BigDecimal;
+import org.jooq.DSLContext;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.jooq.test.autoconfigure.JooqTest;
+import org.springframework.context.annotation.Import;
+
+@JooqTest
+@Import(PostgresTestcontainer.class)
+class JooqFranchiseInterviewRepositoryTests {
+
+  @Autowired DSLContext dsl;
+
+  private FranchiseInterviewRepository interviews;
+  private long leagueId;
+  private long franchiseId;
+  private long otherFranchiseId;
+  private long candidateId;
+
+  @BeforeEach
+  void setUp() {
+    interviews = new JooqFranchiseInterviewRepository(dsl);
+    var leagues = new JooqLeagueRepository(dsl);
+    var franchises = new JooqFranchiseRepository(dsl);
+    var pools = new JooqCandidatePoolRepository(dsl);
+    var candidates = new JooqCandidateRepository(dsl);
+    var league =
+        leagues.insert("sub-1", "Dynasty", LeaguePhase.INITIAL_SETUP, LeagueSettings.defaults());
+    leagueId = league.id();
+    var listed = franchises.listAll();
+    franchiseId = listed.get(0).id();
+    otherFranchiseId = listed.get(1).id();
+    var pool = pools.insert(leagueId, LeaguePhase.HIRING_HEAD_COACH, CandidatePoolType.HEAD_COACH);
+    candidateId = candidates.insert(CandidateTestData.newHeadCoach(pool.id())).id();
+  }
+
+  @Test
+  void insert_roundTripsAllFields() {
+    var inserted =
+        interviews.insert(
+            new NewFranchiseInterview(
+                leagueId,
+                franchiseId,
+                candidateId,
+                LeaguePhase.HIRING_HEAD_COACH,
+                1,
+                1,
+                new BigDecimal("76.50")));
+
+    assertThat(inserted.id()).isPositive();
+    assertThat(inserted.leagueId()).isEqualTo(leagueId);
+    assertThat(inserted.franchiseId()).isEqualTo(franchiseId);
+    assertThat(inserted.candidateId()).isEqualTo(candidateId);
+    assertThat(inserted.phase()).isEqualTo(LeaguePhase.HIRING_HEAD_COACH);
+    assertThat(inserted.phaseWeek()).isEqualTo(1);
+    assertThat(inserted.interviewIndex()).isEqualTo(1);
+    assertThat(inserted.scoutedOverall()).isEqualByComparingTo("76.50");
+  }
+
+  @Test
+  void countForCandidate_returnsPerFranchisePerCandidateTotal() {
+    interviews.insert(interview(franchiseId, candidateId, 1, 1));
+    interviews.insert(interview(franchiseId, candidateId, 1, 2));
+    interviews.insert(interview(otherFranchiseId, candidateId, 1, 1));
+
+    assertThat(
+            interviews.countForCandidate(
+                leagueId, franchiseId, candidateId, LeaguePhase.HIRING_HEAD_COACH))
+        .isEqualTo(2);
+    assertThat(
+            interviews.countForCandidate(
+                leagueId, otherFranchiseId, candidateId, LeaguePhase.HIRING_HEAD_COACH))
+        .isEqualTo(1);
+  }
+
+  @Test
+  void countForWeek_isScopedToWeek() {
+    interviews.insert(interview(franchiseId, candidateId, 1, 1));
+    interviews.insert(interview(franchiseId, candidateId, 1, 2));
+    interviews.insert(interview(franchiseId, candidateId, 2, 3));
+
+    assertThat(interviews.countForWeek(leagueId, franchiseId, LeaguePhase.HIRING_HEAD_COACH, 1))
+        .isEqualTo(2);
+    assertThat(interviews.countForWeek(leagueId, franchiseId, LeaguePhase.HIRING_HEAD_COACH, 2))
+        .isEqualTo(1);
+    assertThat(interviews.countForWeek(leagueId, franchiseId, LeaguePhase.HIRING_HEAD_COACH, 3))
+        .isZero();
+  }
+
+  @Test
+  void findAllFor_orderedByIdAscending() {
+    interviews.insert(interview(franchiseId, candidateId, 1, 1));
+    interviews.insert(interview(franchiseId, candidateId, 1, 2));
+    interviews.insert(interview(otherFranchiseId, candidateId, 1, 1));
+
+    var mine = interviews.findAllFor(leagueId, franchiseId, LeaguePhase.HIRING_HEAD_COACH);
+
+    assertThat(mine).extracting(FranchiseInterview::interviewIndex).containsExactly(1, 2);
+  }
+
+  private NewFranchiseInterview interview(long franchise, long candidate, int week, int index) {
+    return new NewFranchiseInterview(
+        leagueId,
+        franchise,
+        candidate,
+        LeaguePhase.HIRING_HEAD_COACH,
+        week,
+        index,
+        new BigDecimal("70.00"));
+  }
+}

--- a/src/test/java/app/zoneblitz/league/JooqFranchiseStaffRepositoryTests.java
+++ b/src/test/java/app/zoneblitz/league/JooqFranchiseStaffRepositoryTests.java
@@ -1,0 +1,141 @@
+package app.zoneblitz.league;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import app.zoneblitz.support.PostgresTestcontainer;
+import java.util.Optional;
+import org.jooq.DSLContext;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.jooq.test.autoconfigure.JooqTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.dao.DataIntegrityViolationException;
+
+@JooqTest
+@Import(PostgresTestcontainer.class)
+class JooqFranchiseStaffRepositoryTests {
+
+  @Autowired DSLContext dsl;
+
+  private FranchiseStaffRepository staff;
+  private CandidateRepository candidates;
+  private long leagueId;
+  private long franchiseId;
+  private long poolId;
+
+  @BeforeEach
+  void setUp() {
+    staff = new JooqFranchiseStaffRepository(dsl);
+    candidates = new JooqCandidateRepository(dsl);
+    var leagues = new JooqLeagueRepository(dsl);
+    var pools = new JooqCandidatePoolRepository(dsl);
+    var franchises = new JooqFranchiseRepository(dsl);
+    leagueId =
+        leagues
+            .insert("sub-1", "Dynasty", LeaguePhase.INITIAL_SETUP, LeagueSettings.defaults())
+            .id();
+    franchiseId = franchises.listAll().getFirst().id();
+    poolId =
+        pools.insert(leagueId, LeaguePhase.HIRING_HEAD_COACH, CandidatePoolType.HEAD_COACH).id();
+  }
+
+  @Test
+  void insert_coachHire_persistsWithoutScoutBranch() {
+    var candidate = candidates.insert(CandidateTestData.newHeadCoach(poolId));
+    var hire =
+        staff.insert(
+            new NewFranchiseStaffMember(
+                leagueId,
+                franchiseId,
+                candidate.id(),
+                StaffRole.HEAD_COACH,
+                Optional.empty(),
+                LeaguePhase.HIRING_HEAD_COACH,
+                2));
+
+    assertThat(hire.id()).isPositive();
+    assertThat(hire.role()).isEqualTo(StaffRole.HEAD_COACH);
+    assertThat(hire.scoutBranch()).isEmpty();
+    assertThat(hire.hiredAtPhase()).isEqualTo(LeaguePhase.HIRING_HEAD_COACH);
+    assertThat(hire.hiredAtWeek()).isEqualTo(2);
+    assertThat(hire.hiredAt()).isNotNull();
+  }
+
+  @Test
+  void insert_scoutHire_recordsBranch() {
+    var candidate = candidates.insert(CandidateTestData.newScout(poolId, ScoutBranch.COLLEGE));
+    var hire =
+        staff.insert(
+            new NewFranchiseStaffMember(
+                leagueId,
+                franchiseId,
+                candidate.id(),
+                StaffRole.COLLEGE_SCOUT,
+                Optional.of(ScoutBranch.COLLEGE),
+                LeaguePhase.ASSEMBLING_STAFF,
+                1));
+
+    assertThat(hire.scoutBranch()).hasValue(ScoutBranch.COLLEGE);
+  }
+
+  @Test
+  void insert_duplicateUniqueRoleForFranchise_throws() {
+    var first = candidates.insert(CandidateTestData.newHeadCoach(poolId));
+    var second = candidates.insert(CandidateTestData.newHeadCoach(poolId));
+    staff.insert(
+        new NewFranchiseStaffMember(
+            leagueId,
+            franchiseId,
+            first.id(),
+            StaffRole.HEAD_COACH,
+            Optional.empty(),
+            LeaguePhase.HIRING_HEAD_COACH,
+            1));
+
+    assertThatThrownBy(
+            () ->
+                staff.insert(
+                    new NewFranchiseStaffMember(
+                        leagueId,
+                        franchiseId,
+                        second.id(),
+                        StaffRole.HEAD_COACH,
+                        Optional.empty(),
+                        LeaguePhase.HIRING_HEAD_COACH,
+                        1)))
+        .isInstanceOf(DataIntegrityViolationException.class);
+  }
+
+  @Test
+  void insert_multipleScoutsForSameFranchise_allowed() {
+    var a = candidates.insert(CandidateTestData.newScout(poolId, ScoutBranch.COLLEGE));
+    var b = candidates.insert(CandidateTestData.newScout(poolId, ScoutBranch.COLLEGE));
+    staff.insert(
+        new NewFranchiseStaffMember(
+            leagueId,
+            franchiseId,
+            a.id(),
+            StaffRole.COLLEGE_SCOUT,
+            Optional.of(ScoutBranch.COLLEGE),
+            LeaguePhase.ASSEMBLING_STAFF,
+            1));
+    staff.insert(
+        new NewFranchiseStaffMember(
+            leagueId,
+            franchiseId,
+            b.id(),
+            StaffRole.COLLEGE_SCOUT,
+            Optional.of(ScoutBranch.COLLEGE),
+            LeaguePhase.ASSEMBLING_STAFF,
+            1));
+
+    assertThat(staff.findAllForFranchise(leagueId, franchiseId)).hasSize(2);
+  }
+
+  @Test
+  void findById_whenMissing_returnsEmpty() {
+    assertThat(staff.findById(999_999L)).isEmpty();
+  }
+}

--- a/src/test/java/app/zoneblitz/league/JooqLeagueRepositoryTests.java
+++ b/src/test/java/app/zoneblitz/league/JooqLeagueRepositoryTests.java
@@ -142,6 +142,68 @@ class JooqLeagueRepositoryTests {
     assertThat(leagues.deleteByIdAndOwner(999_999L, "sub-1")).isFalse();
   }
 
+  @Test
+  void insert_setsPhaseWeekToOneByDefault() {
+    var league =
+        leagues.insert("sub-1", "Dynasty", LeaguePhase.INITIAL_SETUP, LeagueSettings.defaults());
+
+    assertThat(league.phaseWeek()).isEqualTo(1);
+  }
+
+  @Test
+  void findById_whenPresent_returnsLeagueWithPhaseWeek() {
+    var inserted =
+        leagues.insert("sub-1", "Dynasty", LeaguePhase.INITIAL_SETUP, LeagueSettings.defaults());
+
+    assertThat(leagues.findById(inserted.id()))
+        .hasValueSatisfying(
+            l -> {
+              assertThat(l.id()).isEqualTo(inserted.id());
+              assertThat(l.phase()).isEqualTo(LeaguePhase.INITIAL_SETUP);
+              assertThat(l.phaseWeek()).isEqualTo(1);
+            });
+  }
+
+  @Test
+  void findById_whenMissing_returnsEmpty() {
+    assertThat(leagues.findById(999_999L)).isEmpty();
+  }
+
+  @Test
+  void incrementPhaseWeek_whenPresent_bumpsCounterAndReturnsNewValue() {
+    var league =
+        leagues.insert("sub-1", "Dynasty", LeaguePhase.INITIAL_SETUP, LeagueSettings.defaults());
+
+    assertThat(leagues.incrementPhaseWeek(league.id())).hasValue(2);
+    assertThat(leagues.incrementPhaseWeek(league.id())).hasValue(3);
+    assertThat(leagues.findById(league.id()).orElseThrow().phaseWeek()).isEqualTo(3);
+  }
+
+  @Test
+  void incrementPhaseWeek_whenMissing_returnsEmpty() {
+    assertThat(leagues.incrementPhaseWeek(999_999L)).isEmpty();
+  }
+
+  @Test
+  void updatePhaseAndResetWeek_changesPhaseAndResetsWeekToOne() {
+    var league =
+        leagues.insert("sub-1", "Dynasty", LeaguePhase.INITIAL_SETUP, LeagueSettings.defaults());
+    leagues.incrementPhaseWeek(league.id());
+    leagues.incrementPhaseWeek(league.id());
+
+    assertThat(leagues.updatePhaseAndResetWeek(league.id(), LeaguePhase.HIRING_HEAD_COACH))
+        .isTrue();
+
+    var after = leagues.findById(league.id()).orElseThrow();
+    assertThat(after.phase()).isEqualTo(LeaguePhase.HIRING_HEAD_COACH);
+    assertThat(after.phaseWeek()).isEqualTo(1);
+  }
+
+  @Test
+  void updatePhaseAndResetWeek_whenMissing_returnsFalse() {
+    assertThat(leagues.updatePhaseAndResetWeek(999_999L, LeaguePhase.HIRING_HEAD_COACH)).isFalse();
+  }
+
   private long pickOther(long excludeId) {
     return franchises.listAll().stream()
         .filter(f -> f.id() != excludeId)

--- a/src/test/java/app/zoneblitz/league/LeagueControllerTests.java
+++ b/src/test/java/app/zoneblitz/league/LeagueControllerTests.java
@@ -44,6 +44,7 @@ class LeagueControllerTests {
   @MockitoBean CreateLeague createLeague;
   @MockitoBean GetLeague getLeague;
   @MockitoBean DeleteLeague deleteLeague;
+  @MockitoBean AdvancePhase advancePhase;
   @MockitoBean ClientRegistrationRepository clientRegistrationRepository;
 
   @Test
@@ -88,6 +89,7 @@ class LeagueControllerTests {
             "Dynasty",
             "sub-1",
             LeaguePhase.INITIAL_SETUP,
+            1,
             LeagueSettings.defaults(),
             Instant.now());
     given(createLeague.create(eq("sub-1"), eq("Dynasty"), anyLong()))
@@ -112,6 +114,7 @@ class LeagueControllerTests {
             42L,
             "Dynasty",
             LeaguePhase.INITIAL_SETUP,
+            1,
             Instant.now(),
             new Franchise(
                 1L,
@@ -157,6 +160,7 @@ class LeagueControllerTests {
             42L,
             "Dynasty",
             LeaguePhase.INITIAL_SETUP,
+            1,
             Instant.now(),
             new Franchise(
                 1L,
@@ -210,6 +214,52 @@ class LeagueControllerTests {
   @Test
   void delete_requiresCsrf() throws Exception {
     mvc.perform(post("/leagues/42/delete").with(oauth2Login())).andExpect(status().isForbidden());
+  }
+
+  @Test
+  void advancePhase_whenAdvanced_redirectsToDashboard() throws Exception {
+    given(advancePhase.advance(42L, "sub-1"))
+        .willReturn(
+            new AdvancePhaseResult.Advanced(
+                42L, LeaguePhase.INITIAL_SETUP, LeaguePhase.HIRING_HEAD_COACH));
+
+    mvc.perform(
+            post("/leagues/42/phase/advance")
+                .with(oauth2Login().attributes(a -> a.put("sub", "sub-1")))
+                .with(csrf()))
+        .andExpect(status().is3xxRedirection())
+        .andExpect(redirectedUrl("/leagues/42"));
+
+    verify(advancePhase).advance(42L, "sub-1");
+  }
+
+  @Test
+  void advancePhase_whenNotFound_returns404() throws Exception {
+    given(advancePhase.advance(42L, "sub-1")).willReturn(new AdvancePhaseResult.NotFound(42L));
+
+    mvc.perform(
+            post("/leagues/42/phase/advance")
+                .with(oauth2Login().attributes(a -> a.put("sub", "sub-1")))
+                .with(csrf()))
+        .andExpect(status().isNotFound());
+  }
+
+  @Test
+  void advancePhase_whenNoNextPhase_returns409() throws Exception {
+    given(advancePhase.advance(42L, "sub-1"))
+        .willReturn(new AdvancePhaseResult.NoNextPhase(42L, LeaguePhase.HIRING_HEAD_COACH));
+
+    mvc.perform(
+            post("/leagues/42/phase/advance")
+                .with(oauth2Login().attributes(a -> a.put("sub", "sub-1")))
+                .with(csrf()))
+        .andExpect(status().isConflict());
+  }
+
+  @Test
+  void advancePhase_requiresCsrf() throws Exception {
+    mvc.perform(post("/leagues/42/phase/advance").with(oauth2Login()))
+        .andExpect(status().isForbidden());
   }
 
   @Test

--- a/src/test/java/app/zoneblitz/league/ManageHeadCoachShortlistUseCaseTests.java
+++ b/src/test/java/app/zoneblitz/league/ManageHeadCoachShortlistUseCaseTests.java
@@ -43,8 +43,10 @@ class ManageHeadCoachShortlistUseCaseTests {
             hiringStates,
             new HeadCoachGenerator(),
             (leagueId, phase) -> new FakeRandomSource(leagueId + phase.ordinal()));
+    var interviews = new JooqFranchiseInterviewRepository(dsl);
     useCase =
-        new ManageHeadCoachShortlistUseCase(leagues, pools, candidates, preferences, hiringStates);
+        new ManageHeadCoachShortlistUseCase(
+            leagues, pools, candidates, preferences, hiringStates, interviews);
   }
 
   @Test

--- a/src/test/java/app/zoneblitz/league/ManageHeadCoachShortlistUseCaseTests.java
+++ b/src/test/java/app/zoneblitz/league/ManageHeadCoachShortlistUseCaseTests.java
@@ -1,0 +1,147 @@
+package app.zoneblitz.league;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import app.zoneblitz.support.PostgresTestcontainer;
+import org.jooq.DSLContext;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.jooq.test.autoconfigure.JooqTest;
+import org.springframework.context.annotation.Import;
+
+@JooqTest
+@Import(PostgresTestcontainer.class)
+class ManageHeadCoachShortlistUseCaseTests {
+
+  @Autowired DSLContext dsl;
+
+  private LeagueRepository leagues;
+  private CreateLeague createLeague;
+  private JooqCandidateRepository candidates;
+  private HiringHeadCoachTransitionHandler entryHandler;
+  private ManageHeadCoachShortlist useCase;
+
+  @BeforeEach
+  void setUp() {
+    leagues = new JooqLeagueRepository(dsl);
+    var franchises = new JooqFranchiseRepository(dsl);
+    var teamRepo = new JooqTeamRepository(dsl);
+    var teams = new JooqTeamLookup(dsl);
+    var pools = new JooqCandidatePoolRepository(dsl);
+    candidates = new JooqCandidateRepository(dsl);
+    var preferences = new JooqCandidatePreferencesRepository(dsl);
+    var hiringStates = new JooqFranchiseHiringStateRepository(dsl);
+    createLeague = new CreateLeagueUseCase(leagues, franchises, teamRepo);
+    entryHandler =
+        new HiringHeadCoachTransitionHandler(
+            leagues,
+            teams,
+            pools,
+            candidates,
+            preferences,
+            hiringStates,
+            new HeadCoachGenerator(),
+            (leagueId, phase) -> new FakeRandomSource(leagueId + phase.ordinal()));
+    useCase =
+        new ManageHeadCoachShortlistUseCase(leagues, pools, candidates, preferences, hiringStates);
+  }
+
+  @Test
+  void add_whenValid_putsCandidateOnShortlistAndFlagsRow() {
+    var ctx = seedLeagueInPhase("sub-1");
+
+    var result = useCase.add(ctx.leagueId, ctx.firstCandidateId, "sub-1");
+
+    assertThat(result).isInstanceOf(ShortlistResult.Updated.class);
+    var view = ((ShortlistResult.Updated) result).view();
+    assertThat(view.shortlist()).hasSize(1);
+    assertThat(view.shortlist().getFirst().id()).isEqualTo(ctx.firstCandidateId);
+    assertThat(view.pool())
+        .anySatisfy(
+            row -> {
+              if (row.id() == ctx.firstCandidateId) {
+                assertThat(row.shortlisted()).isTrue();
+              }
+            });
+  }
+
+  @Test
+  void add_isIdempotent() {
+    var ctx = seedLeagueInPhase("sub-1");
+    useCase.add(ctx.leagueId, ctx.firstCandidateId, "sub-1");
+    var second = useCase.add(ctx.leagueId, ctx.firstCandidateId, "sub-1");
+
+    assertThat(second).isInstanceOf(ShortlistResult.Updated.class);
+    assertThat(((ShortlistResult.Updated) second).view().shortlist()).hasSize(1);
+  }
+
+  @Test
+  void remove_whenPresent_clearsIt() {
+    var ctx = seedLeagueInPhase("sub-1");
+    useCase.add(ctx.leagueId, ctx.firstCandidateId, "sub-1");
+
+    var result = useCase.remove(ctx.leagueId, ctx.firstCandidateId, "sub-1");
+
+    assertThat(result).isInstanceOf(ShortlistResult.Updated.class);
+    assertThat(((ShortlistResult.Updated) result).view().shortlist()).isEmpty();
+  }
+
+  @Test
+  void remove_isIdempotent_whenCandidateAbsent() {
+    var ctx = seedLeagueInPhase("sub-1");
+
+    var result = useCase.remove(ctx.leagueId, ctx.firstCandidateId, "sub-1");
+
+    assertThat(result).isInstanceOf(ShortlistResult.Updated.class);
+    assertThat(((ShortlistResult.Updated) result).view().shortlist()).isEmpty();
+  }
+
+  @Test
+  void add_whenLeagueNotOwned_returnsNotFound() {
+    var ctx = seedLeagueInPhase("owner");
+
+    var result = useCase.add(ctx.leagueId, ctx.firstCandidateId, "someone-else");
+
+    assertThat(result).isInstanceOf(ShortlistResult.NotFound.class);
+  }
+
+  @Test
+  void add_whenPhaseNotHiringHeadCoach_returnsNotFound() {
+    var league = createLeagueFor("sub-1");
+
+    var result = useCase.add(league.id(), 1L, "sub-1");
+
+    assertThat(result).isInstanceOf(ShortlistResult.NotFound.class);
+  }
+
+  @Test
+  void add_whenCandidateUnknown_returnsUnknownCandidate() {
+    var ctx = seedLeagueInPhase("sub-1");
+
+    var result = useCase.add(ctx.leagueId, 999_999L, "sub-1");
+
+    assertThat(result).isInstanceOf(ShortlistResult.UnknownCandidate.class);
+  }
+
+  private Ctx seedLeagueInPhase(String subject) {
+    var league = createLeagueFor(subject);
+    leagues.updatePhaseAndResetWeek(league.id(), LeaguePhase.HIRING_HEAD_COACH);
+    entryHandler.onEntry(league.id());
+    var pool =
+        new JooqCandidatePoolRepository(dsl)
+            .findByLeaguePhaseAndType(
+                league.id(), LeaguePhase.HIRING_HEAD_COACH, CandidatePoolType.HEAD_COACH)
+            .orElseThrow();
+    var firstCandidate = candidates.findAllByPoolId(pool.id()).getFirst();
+    return new Ctx(league.id(), firstCandidate.id());
+  }
+
+  private League createLeagueFor(String ownerSubject) {
+    var franchiseId = new JooqFranchiseRepository(dsl).listAll().getFirst().id();
+    var result = createLeague.create(ownerSubject, "Dynasty", franchiseId);
+    return ((CreateLeagueResult.Created) result).league();
+  }
+
+  private record Ctx(long leagueId, long firstCandidateId) {}
+}

--- a/src/test/java/app/zoneblitz/league/StartInterviewUseCaseTests.java
+++ b/src/test/java/app/zoneblitz/league/StartInterviewUseCaseTests.java
@@ -1,0 +1,215 @@
+package app.zoneblitz.league;
+
+import static app.zoneblitz.jooq.Tables.CANDIDATES;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import app.zoneblitz.support.PostgresTestcontainer;
+import java.util.regex.Pattern;
+import org.jooq.DSLContext;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.jooq.test.autoconfigure.JooqTest;
+import org.springframework.context.annotation.Import;
+
+@JooqTest
+@Import(PostgresTestcontainer.class)
+class StartInterviewUseCaseTests {
+
+  private static final Pattern HIDDEN_OVERALL =
+      Pattern.compile("\"overall\"\\s*:\\s*(-?[0-9]+(?:\\.[0-9]+)?)");
+
+  @Autowired DSLContext dsl;
+
+  private LeagueRepository leagues;
+  private CreateLeague createLeague;
+  private JooqCandidateRepository candidates;
+  private FranchiseInterviewRepository interviews;
+  private FranchiseHiringStateRepository hiringStates;
+  private HiringHeadCoachTransitionHandler entryHandler;
+  private StartInterview useCase;
+
+  @BeforeEach
+  void setUp() {
+    leagues = new JooqLeagueRepository(dsl);
+    var franchises = new JooqFranchiseRepository(dsl);
+    var teamRepo = new JooqTeamRepository(dsl);
+    var teams = new JooqTeamLookup(dsl);
+    var pools = new JooqCandidatePoolRepository(dsl);
+    candidates = new JooqCandidateRepository(dsl);
+    var preferences = new JooqCandidatePreferencesRepository(dsl);
+    hiringStates = new JooqFranchiseHiringStateRepository(dsl);
+    interviews = new JooqFranchiseInterviewRepository(dsl);
+    createLeague = new CreateLeagueUseCase(leagues, franchises, teamRepo);
+    entryHandler =
+        new HiringHeadCoachTransitionHandler(
+            leagues,
+            teams,
+            pools,
+            candidates,
+            preferences,
+            hiringStates,
+            new HeadCoachGenerator(),
+            (leagueId, phase) -> new FakeRandomSource(leagueId + phase.ordinal()));
+    useCase =
+        new StartInterviewUseCase(
+            leagues, pools, candidates, preferences, hiringStates, interviews);
+  }
+
+  @Test
+  void start_firstInterview_recordsEventAndAppendsCandidateToHiringState() {
+    var ctx = seedLeagueInPhase("sub-1");
+
+    var result = useCase.start(ctx.leagueId, ctx.firstCandidateId, "sub-1");
+
+    assertThat(result).isInstanceOf(InterviewResult.Started.class);
+    var view = ((InterviewResult.Started) result).view();
+    assertThat(view.activeInterviews()).hasSize(1);
+    assertThat(view.activeInterviews().getFirst().id()).isEqualTo(ctx.firstCandidateId);
+    assertThat(view.activeInterviews().getFirst().interviewCount()).isEqualTo(1);
+    assertThat(view.interviewsThisWeek()).isEqualTo(1);
+
+    var state =
+        hiringStates
+            .find(ctx.leagueId, ctx.franchiseId, LeaguePhase.HIRING_HEAD_COACH)
+            .orElseThrow();
+    assertThat(state.interviewingCandidateIds()).containsExactly(ctx.firstCandidateId);
+  }
+
+  @Test
+  void start_multipleInterviewsOnSameCandidate_tightenSigmaMonotonically() {
+    var ctx = seedLeagueInPhase("sub-1");
+
+    for (var i = 0; i < 5; i++) {
+      useCase.start(ctx.leagueId, ctx.firstCandidateId, "sub-1");
+      leagues.incrementPhaseWeek(ctx.leagueId);
+    }
+    var history =
+        interviews.findAllFor(ctx.leagueId, ctx.franchiseId, LeaguePhase.HIRING_HEAD_COACH);
+    assertThat(history).hasSize(5);
+    assertThat(history)
+        .extracting(FranchiseInterview::interviewIndex)
+        .containsExactly(1, 2, 3, 4, 5);
+
+    var sigmas =
+        history.stream().map(h -> InterviewNoiseModel.headCoachSigma(h.interviewIndex())).toList();
+    var previous = InterviewNoiseModel.HC_INITIAL_STD + 1.0;
+    for (var sigma : sigmas) {
+      assertThat(sigma).isLessThan(previous);
+      assertThat(sigma).isGreaterThan(0.0);
+      previous = sigma;
+    }
+  }
+
+  @Test
+  void start_hittingWeeklyCap_returnsCapacityReached() {
+    var ctx = seedLeagueInPhase("sub-1");
+    var secondId = secondCandidateId(ctx);
+    var thirdId = thirdCandidateId(ctx);
+
+    useCase.start(ctx.leagueId, ctx.firstCandidateId, "sub-1");
+    useCase.start(ctx.leagueId, secondId, "sub-1");
+    useCase.start(ctx.leagueId, thirdId, "sub-1");
+
+    var capped = useCase.start(ctx.leagueId, ctx.firstCandidateId, "sub-1");
+
+    assertThat(capped).isInstanceOf(InterviewResult.CapacityReached.class);
+    assertThat(((InterviewResult.CapacityReached) capped).capacity())
+        .isEqualTo(StartInterview.DEFAULT_WEEKLY_CAPACITY);
+  }
+
+  @Test
+  void start_doesNotWriteTrueRatingIntoScoutedAttrs() {
+    var ctx = seedLeagueInPhase("sub-1");
+    var before =
+        dsl.select(CANDIDATES.SCOUTED_ATTRS, CANDIDATES.HIDDEN_ATTRS)
+            .from(CANDIDATES)
+            .where(CANDIDATES.ID.eq(ctx.firstCandidateId))
+            .fetchOne();
+    var hiddenBefore = before.get(CANDIDATES.HIDDEN_ATTRS).data();
+    var scoutedBefore = before.get(CANDIDATES.SCOUTED_ATTRS).data();
+    var trueRating = extractOverall(hiddenBefore);
+
+    for (var i = 0; i < 10; i++) {
+      useCase.start(ctx.leagueId, ctx.firstCandidateId, "sub-1");
+      // ensure we don't blow past weekly cap across multiple weeks
+      leagues.incrementPhaseWeek(ctx.leagueId);
+    }
+
+    var after =
+        dsl.select(CANDIDATES.SCOUTED_ATTRS, CANDIDATES.HIDDEN_ATTRS)
+            .from(CANDIDATES)
+            .where(CANDIDATES.ID.eq(ctx.firstCandidateId))
+            .fetchOne();
+    assertThat(after.get(CANDIDATES.SCOUTED_ATTRS).data()).isEqualTo(scoutedBefore);
+    assertThat(after.get(CANDIDATES.HIDDEN_ATTRS).data()).isEqualTo(hiddenBefore);
+
+    var perInterview =
+        interviews.findAllFor(ctx.leagueId, ctx.franchiseId, LeaguePhase.HIRING_HEAD_COACH);
+    assertThat(perInterview).isNotEmpty();
+    assertThat(perInterview)
+        .allSatisfy(i -> assertThat(i.scoutedOverall().doubleValue()).isNotEqualTo(trueRating));
+  }
+
+  @Test
+  void start_phaseNotHiringHeadCoach_returnsNotFound() {
+    var league = createLeagueFor("sub-1");
+
+    var result = useCase.start(league.id(), 1L, "sub-1");
+
+    assertThat(result).isInstanceOf(InterviewResult.NotFound.class);
+  }
+
+  @Test
+  void start_unknownCandidate_returnsUnknownCandidate() {
+    var ctx = seedLeagueInPhase("sub-1");
+
+    var result = useCase.start(ctx.leagueId, 999_999L, "sub-1");
+
+    assertThat(result).isInstanceOf(InterviewResult.UnknownCandidate.class);
+  }
+
+  @Test
+  void start_notOwnedByCaller_returnsNotFound() {
+    var ctx = seedLeagueInPhase("owner");
+
+    var result = useCase.start(ctx.leagueId, ctx.firstCandidateId, "someone-else");
+
+    assertThat(result).isInstanceOf(InterviewResult.NotFound.class);
+  }
+
+  private long secondCandidateId(Ctx ctx) {
+    return candidates.findAllByPoolId(ctx.poolId).get(1).id();
+  }
+
+  private long thirdCandidateId(Ctx ctx) {
+    return candidates.findAllByPoolId(ctx.poolId).get(2).id();
+  }
+
+  private Ctx seedLeagueInPhase(String subject) {
+    var league = createLeagueFor(subject);
+    leagues.updatePhaseAndResetWeek(league.id(), LeaguePhase.HIRING_HEAD_COACH);
+    entryHandler.onEntry(league.id());
+    var pool =
+        new JooqCandidatePoolRepository(dsl)
+            .findByLeaguePhaseAndType(
+                league.id(), LeaguePhase.HIRING_HEAD_COACH, CandidatePoolType.HEAD_COACH)
+            .orElseThrow();
+    var summary = leagues.findSummaryByIdAndOwner(league.id(), subject).orElseThrow();
+    var firstCandidate = candidates.findAllByPoolId(pool.id()).getFirst();
+    return new Ctx(league.id(), summary.userFranchise().id(), pool.id(), firstCandidate.id());
+  }
+
+  private League createLeagueFor(String ownerSubject) {
+    var franchiseId = new JooqFranchiseRepository(dsl).listAll().getFirst().id();
+    var result = createLeague.create(ownerSubject, "Dynasty", franchiseId);
+    return ((CreateLeagueResult.Created) result).league();
+  }
+
+  private static double extractOverall(String attrsJson) {
+    var m = HIDDEN_OVERALL.matcher(attrsJson);
+    return m.find() ? Double.parseDouble(m.group(1)) : Double.NaN;
+  }
+
+  private record Ctx(long leagueId, long franchiseId, long poolId, long firstCandidateId) {}
+}

--- a/src/test/java/app/zoneblitz/league/ViewHeadCoachHiringUseCaseTests.java
+++ b/src/test/java/app/zoneblitz/league/ViewHeadCoachHiringUseCaseTests.java
@@ -42,7 +42,10 @@ class ViewHeadCoachHiringUseCaseTests {
             hiringStates,
             new HeadCoachGenerator(),
             (leagueId, phase) -> new FakeRandomSource(leagueId + phase.ordinal()));
-    useCase = new ViewHeadCoachHiringUseCase(leagues, pools, candidates, preferences, hiringStates);
+    var interviews = new JooqFranchiseInterviewRepository(dsl);
+    useCase =
+        new ViewHeadCoachHiringUseCase(
+            leagues, pools, candidates, preferences, hiringStates, interviews);
   }
 
   @Test

--- a/src/test/java/app/zoneblitz/league/ViewHeadCoachHiringUseCaseTests.java
+++ b/src/test/java/app/zoneblitz/league/ViewHeadCoachHiringUseCaseTests.java
@@ -1,0 +1,87 @@
+package app.zoneblitz.league;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import app.zoneblitz.support.PostgresTestcontainer;
+import org.jooq.DSLContext;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.jooq.test.autoconfigure.JooqTest;
+import org.springframework.context.annotation.Import;
+
+@JooqTest
+@Import(PostgresTestcontainer.class)
+class ViewHeadCoachHiringUseCaseTests {
+
+  @Autowired DSLContext dsl;
+
+  private LeagueRepository leagues;
+  private CreateLeague createLeague;
+  private HiringHeadCoachTransitionHandler entryHandler;
+  private ViewHeadCoachHiring useCase;
+
+  @BeforeEach
+  void setUp() {
+    leagues = new JooqLeagueRepository(dsl);
+    var franchises = new JooqFranchiseRepository(dsl);
+    var teamRepo = new JooqTeamRepository(dsl);
+    var teams = new JooqTeamLookup(dsl);
+    var pools = new JooqCandidatePoolRepository(dsl);
+    var candidates = new JooqCandidateRepository(dsl);
+    var preferences = new JooqCandidatePreferencesRepository(dsl);
+    var hiringStates = new JooqFranchiseHiringStateRepository(dsl);
+    createLeague = new CreateLeagueUseCase(leagues, franchises, teamRepo);
+    entryHandler =
+        new HiringHeadCoachTransitionHandler(
+            leagues,
+            teams,
+            pools,
+            candidates,
+            preferences,
+            hiringStates,
+            new HeadCoachGenerator(),
+            (leagueId, phase) -> new FakeRandomSource(leagueId + phase.ordinal()));
+    useCase = new ViewHeadCoachHiringUseCase(leagues, pools, candidates, preferences, hiringStates);
+  }
+
+  @Test
+  void view_whenLeagueMissing_returnsEmpty() {
+    assertThat(useCase.view(999_999L, "sub-1")).isEmpty();
+  }
+
+  @Test
+  void view_whenNotOwnedByCaller_returnsEmpty() {
+    var league = createLeagueFor("owner");
+    leagues.updatePhaseAndResetWeek(league.id(), LeaguePhase.HIRING_HEAD_COACH);
+    entryHandler.onEntry(league.id());
+
+    assertThat(useCase.view(league.id(), "someone-else")).isEmpty();
+  }
+
+  @Test
+  void view_whenPhaseNotHiringHeadCoach_returnsEmpty() {
+    var league = createLeagueFor("sub-1");
+
+    assertThat(useCase.view(league.id(), "sub-1")).isEmpty();
+  }
+
+  @Test
+  void view_whenInPhase_returnsPoolAndEmptyShortlist() {
+    var league = createLeagueFor("sub-1");
+    leagues.updatePhaseAndResetWeek(league.id(), LeaguePhase.HIRING_HEAD_COACH);
+    entryHandler.onEntry(league.id());
+
+    var view = useCase.view(league.id(), "sub-1").orElseThrow();
+
+    assertThat(view.pool()).isNotEmpty();
+    assertThat(view.shortlist()).isEmpty();
+    assertThat(view.pool()).allSatisfy(row -> assertThat(row.shortlisted()).isFalse());
+  }
+
+  private League createLeagueFor(String ownerSubject) {
+    var franchiseId = new JooqFranchiseRepository(dsl).listAll().getFirst().id();
+    var result = createLeague.create(ownerSubject, "Dynasty", franchiseId);
+    return ((CreateLeagueResult.Created) result).league();
+  }
+}


### PR DESCRIPTION
Closes #605

Stacked on #604.

## Summary
- Adds `StartInterview` use case + `POST /leagues/{id}/hiring/head-coach/interview/{candidateId}` HTMX endpoint.
- Introduces `franchise_interviews` table (V6 migration) capturing per-franchise, per-candidate interview events with a per-event scouted-overall snapshot; `interviewing_candidate_ids` on the hiring state is appended per interview.
- `InterviewNoiseModel` applies geometric decay with tier-dependent floor so σ monotonically decreases yet never reaches 0; each interview reduces residual noise by 0.4 toward `HC_FLOOR_STD = 2.0`.
- Weekly capacity default 3/franchise/week enforced via `FranchiseInterviewRepository.countForWeek`; exceeding returns `InterviewResult.CapacityReached` (HTTP 409).
- Hiring page fragments grow an active-interviews sidebar plus an Interview button on each pool row.
- Shared `candidates.scouted_attrs` is never written; true rating stays in `hidden_attrs`.

## Test plan
- [x] `InterviewNoiseModelTests` — σ strictly decreases, approaches floor, never zero, rejects negatives.
- [x] `JooqFranchiseInterviewRepositoryTests` — insert round-trip, per-candidate / per-week count scoping, find ordering against Testcontainers Postgres.
- [x] `StartInterviewUseCaseTests` — records interview + appends hiring state, σ monotonic across 5 interviews, weekly cap enforced, `scouted_attrs`/`hidden_attrs` never mutated, not-found / unknown-candidate / not-owned paths.
- [x] `HiringHeadCoachControllerTests` — `Started` → combined fragment, `CapacityReached` → 409, `NotFound`/`UnknownCandidate` → 404, CSRF required, `GET .../interviews` fragment.
- [x] `./gradlew spotlessApply spotlessCheck test` passes locally.