### PR TITLE
feat(league): CPU hiring strategy (#607)

### DIFF
--- a/src/main/java/app/zoneblitz/league/AdvanceWeekUseCase.java
+++ b/src/main/java/app/zoneblitz/league/AdvanceWeekUseCase.java
@@ -1,7 +1,10 @@
 package app.zoneblitz.league;
 
+import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.stream.Collectors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
@@ -14,10 +17,20 @@ class AdvanceWeekUseCase implements AdvanceWeek {
 
   private final LeagueRepository leagues;
   private final OfferResolver offerResolver;
+  private final TeamLookup teams;
+  private final Map<LeaguePhase, CpuFranchiseStrategy> cpuStrategies;
 
-  AdvanceWeekUseCase(LeagueRepository leagues, OfferResolver offerResolver) {
+  AdvanceWeekUseCase(
+      LeagueRepository leagues,
+      OfferResolver offerResolver,
+      TeamLookup teams,
+      List<CpuFranchiseStrategy> cpuStrategies) {
     this.leagues = leagues;
     this.offerResolver = offerResolver;
+    this.teams = teams;
+    this.cpuStrategies =
+        cpuStrategies.stream()
+            .collect(Collectors.toUnmodifiableMap(CpuFranchiseStrategy::phase, s -> s));
   }
 
   @Override
@@ -31,13 +44,14 @@ class AdvanceWeekUseCase implements AdvanceWeek {
     }
     var league = maybeLeague.get();
     var phase = league.phase();
+    var phaseWeek = league.phaseWeek();
+
+    runCpuStrategies(leagueId, phase, phaseWeek);
 
     // Offer resolution runs BEFORE phase_week increments so hires are recorded on the week the
     // offers were made. See docs/technical/league-phases.md (Ticks, OfferResolver).
-    offerResolver.resolve(leagueId, phase, league.phaseWeek());
+    offerResolver.resolve(leagueId, phase, phaseWeek);
 
-    // CPU franchise strategies are a future seam (see docs/technical/league-phases.md). No
-    // phase defines a completion rule yet, so the tick is currently just "increment the counter".
     var newWeek =
         leagues
             .incrementPhaseWeek(leagueId)
@@ -45,5 +59,15 @@ class AdvanceWeekUseCase implements AdvanceWeek {
 
     log.info("league week advanced id={} phase={} week={}", leagueId, phase, newWeek);
     return new AdvanceWeekResult.Ticked(leagueId, phase, newWeek, Optional.empty());
+  }
+
+  private void runCpuStrategies(long leagueId, LeaguePhase phase, int phaseWeek) {
+    var strategy = cpuStrategies.get(phase);
+    if (strategy == null) {
+      return;
+    }
+    for (var franchiseId : teams.cpuFranchiseIdsForLeague(leagueId)) {
+      strategy.execute(leagueId, franchiseId, phaseWeek);
+    }
   }
 }

--- a/src/main/java/app/zoneblitz/league/CpuFranchiseStrategy.java
+++ b/src/main/java/app/zoneblitz/league/CpuFranchiseStrategy.java
@@ -1,0 +1,29 @@
+package app.zoneblitz.league;
+
+/**
+ * Per-phase CPU decision-maker. One implementation per {@link LeaguePhase} that requires CPU
+ * behavior; {@link AdvanceWeek} resolves the active phase's strategy and invokes {@link
+ * #execute(long, long, int)} once for each CPU-controlled franchise on every week tick.
+ *
+ * <p>See {@code docs/technical/league-phases.md} "Seams" table and "Ticks" section. Strategies must
+ * be deterministic given the inputs they receive and any league-scoped RNG they derive from {@link
+ * CandidateRandomSources}; the week tick is the only place their side effects may commit.
+ */
+interface CpuFranchiseStrategy {
+
+  /** The phase this strategy handles. */
+  LeaguePhase phase();
+
+  /**
+   * Execute one week of CPU behavior for the given franchise in the given league. Invariants:
+   *
+   * <ul>
+   *   <li>Called inside the {@link AdvanceWeek} transaction. Strategies that persist must do so
+   *       through the feature's repositories so commits are atomic with the tick.
+   *   <li>Phase state is read at call-time — {@code phaseWeek} is the week the tick is resolving
+   *       <em>before</em> increment.
+   *   <li>Called only for CPU franchises; implementations must not re-check ownership.
+   * </ul>
+   */
+  void execute(long leagueId, long franchiseId, int phaseWeek);
+}

--- a/src/main/java/app/zoneblitz/league/CpuHiringStrategy.java
+++ b/src/main/java/app/zoneblitz/league/CpuHiringStrategy.java
@@ -1,0 +1,294 @@
+package app.zoneblitz.league;
+
+import app.zoneblitz.gamesimulator.rng.RandomSource;
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.regex.Pattern;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+/**
+ * CPU decision-maker for {@link LeaguePhase#HIRING_HEAD_COACH}. Runs one week of hiring behavior
+ * per invocation:
+ *
+ * <ol>
+ *   <li>If the franchise is already {@link HiringStep#HIRED}, do nothing.
+ *   <li>If no shortlist yet, build one from the top candidates by scouted overall (unhired only),
+ *       up to {@link #SHORTLIST_SIZE}.
+ *   <li>Interview shortlisted candidates up to the weekly capacity, preferring the highest
+ *       scouted-overall candidate the franchise has interviewed the fewest times. Interview rows
+ *       follow the same noise model as user interviews ({@link InterviewNoiseModel}).
+ *   <li>If no active CPU offer is outstanding, submit a single offer on the top shortlisted
+ *       candidate that is still unhired and that the franchise does not already have an active
+ *       offer on. Terms are derived from the candidate's scouted overall via a simple willingness-
+ *       to-pay model keyed off the candidate's own compensation target — higher-rated candidates
+ *       get premium bids, lower-rated ones get sub-target bids. This is deliberately modest — the
+ *       league-phases doc calls for "no ML, no deep planning".
+ * </ol>
+ *
+ * Determinism: all random draws come from a franchise-and-candidate split of {@link
+ * CandidateRandomSources#forLeaguePhase(long, LeaguePhase)}, so the same seed reproduces identical
+ * behavior.
+ */
+@Component
+class CpuHiringStrategy implements CpuFranchiseStrategy {
+
+  private static final Logger log = LoggerFactory.getLogger(CpuHiringStrategy.class);
+
+  /** How many candidates a CPU franchise shortlists. Kept small per the ticket brief. */
+  static final int SHORTLIST_SIZE = 4;
+
+  private static final Pattern OVERALL_PATTERN =
+      Pattern.compile("\"overall\"\\s*:\\s*(-?[0-9]+(?:\\.[0-9]+)?)");
+  private static final double SCOUTED_LOWER = 20.0;
+  private static final double SCOUTED_UPPER = 99.0;
+
+  private final CandidatePoolRepository pools;
+  private final CandidateRepository candidates;
+  private final CandidatePreferencesRepository preferences;
+  private final CandidateOfferRepository offers;
+  private final FranchiseHiringStateRepository hiringStates;
+  private final FranchiseInterviewRepository interviews;
+  private final CandidateRandomSources rngs;
+
+  CpuHiringStrategy(
+      CandidatePoolRepository pools,
+      CandidateRepository candidates,
+      CandidatePreferencesRepository preferences,
+      CandidateOfferRepository offers,
+      FranchiseHiringStateRepository hiringStates,
+      FranchiseInterviewRepository interviews,
+      CandidateRandomSources rngs) {
+    this.pools = pools;
+    this.candidates = candidates;
+    this.preferences = preferences;
+    this.offers = offers;
+    this.hiringStates = hiringStates;
+    this.interviews = interviews;
+    this.rngs = rngs;
+  }
+
+  @Override
+  public LeaguePhase phase() {
+    return LeaguePhase.HIRING_HEAD_COACH;
+  }
+
+  @Override
+  public void execute(long leagueId, long franchiseId, int phaseWeek) {
+    var existing = hiringStates.find(leagueId, franchiseId, phase());
+    if (existing.isPresent() && existing.get().step() == HiringStep.HIRED) {
+      return;
+    }
+    var maybePool = pools.findByLeaguePhaseAndType(leagueId, phase(), CandidatePoolType.HEAD_COACH);
+    if (maybePool.isEmpty()) {
+      return;
+    }
+    var poolCandidates = candidates.findAllByPoolId(maybePool.get().id());
+    var unhired = poolCandidates.stream().filter(c -> c.hiredByFranchiseId().isEmpty()).toList();
+    if (unhired.isEmpty()) {
+      return;
+    }
+
+    var state = ensureState(leagueId, franchiseId, existing, unhired);
+    var shortlist = state.shortlist();
+
+    runInterviews(leagueId, franchiseId, phaseWeek, shortlist, unhired);
+    submitOfferIfNone(leagueId, franchiseId, phaseWeek, shortlist, unhired);
+  }
+
+  private FranchiseHiringState ensureState(
+      long leagueId,
+      long franchiseId,
+      java.util.Optional<FranchiseHiringState> existing,
+      List<Candidate> unhired) {
+    if (existing.isPresent() && !existing.get().shortlist().isEmpty()) {
+      return existing.get();
+    }
+    var shortlist = pickShortlist(unhired);
+    var stateId = existing.map(FranchiseHiringState::id).orElse(0L);
+    var interviewing =
+        existing.map(FranchiseHiringState::interviewingCandidateIds).orElse(List.of());
+    return hiringStates.upsert(
+        new FranchiseHiringState(
+            stateId,
+            leagueId,
+            franchiseId,
+            phase(),
+            HiringStep.SEARCHING,
+            shortlist,
+            interviewing));
+  }
+
+  private List<Long> pickShortlist(List<Candidate> unhired) {
+    return unhired.stream()
+        .sorted(
+            Comparator.comparingDouble((Candidate c) -> scoutedOverall(c.scoutedAttrs()))
+                .reversed()
+                .thenComparingLong(Candidate::id))
+        .limit(SHORTLIST_SIZE)
+        .map(Candidate::id)
+        .toList();
+  }
+
+  private void runInterviews(
+      long leagueId,
+      long franchiseId,
+      int phaseWeek,
+      List<Long> shortlist,
+      List<Candidate> unhired) {
+    var unhiredIds = unhired.stream().map(Candidate::id).toList();
+    var capacity = StartInterview.DEFAULT_WEEKLY_CAPACITY;
+    var used = interviews.countForWeek(leagueId, franchiseId, phase(), phaseWeek);
+    if (used >= capacity) {
+      return;
+    }
+    var candidatesById =
+        unhired.stream()
+            .collect(
+                java.util.stream.Collectors.toMap(
+                    Candidate::id, c -> c, (a, b) -> a, java.util.LinkedHashMap::new));
+    var eligible =
+        shortlist.stream().filter(unhiredIds::contains).map(candidatesById::get).toList();
+    var remaining = capacity - used;
+    var priorCounts = new java.util.HashMap<Long, Integer>();
+    for (var c : eligible) {
+      priorCounts.put(c.id(), interviews.countForCandidate(leagueId, franchiseId, c.id(), phase()));
+    }
+    var ordered =
+        eligible.stream()
+            .sorted(
+                Comparator.comparingInt((Candidate c) -> priorCounts.get(c.id()))
+                    .thenComparingDouble((Candidate c) -> -scoutedOverall(c.scoutedAttrs()))
+                    .thenComparingLong(Candidate::id))
+            .limit(remaining)
+            .toList();
+    for (var candidate : ordered) {
+      recordInterview(leagueId, franchiseId, phaseWeek, candidate, priorCounts.get(candidate.id()));
+    }
+  }
+
+  private void recordInterview(
+      long leagueId, long franchiseId, int phaseWeek, Candidate candidate, int priorCount) {
+    var newIndex = priorCount + 1;
+    var trueRating = extractDoubleOrDefault(OVERALL_PATTERN, candidate.hiddenAttrs(), 50.0);
+    var sigma = InterviewNoiseModel.headCoachSigma(newIndex);
+    var rng = interviewRng(leagueId, franchiseId, candidate.id(), newIndex);
+    var sample = trueRating + sigma * rng.nextGaussian();
+    var clamped = Math.max(SCOUTED_LOWER, Math.min(SCOUTED_UPPER, sample));
+    var scouted = BigDecimal.valueOf(clamped).setScale(2, RoundingMode.HALF_UP);
+    interviews.insert(
+        new NewFranchiseInterview(
+            leagueId, franchiseId, candidate.id(), phase(), phaseWeek, newIndex, scouted));
+    appendInterviewing(leagueId, franchiseId, candidate.id());
+    log.debug(
+        "cpu interview leagueId={} franchiseId={} candidateId={} index={} sigma={}",
+        leagueId,
+        franchiseId,
+        candidate.id(),
+        newIndex,
+        sigma);
+  }
+
+  private void appendInterviewing(long leagueId, long franchiseId, long candidateId) {
+    var existing = hiringStates.find(leagueId, franchiseId, phase());
+    var shortlist = existing.map(FranchiseHiringState::shortlist).orElse(List.of());
+    var interviewing =
+        existing.map(FranchiseHiringState::interviewingCandidateIds).orElse(List.of());
+    var updated = new ArrayList<Long>(interviewing.size() + 1);
+    updated.addAll(interviewing);
+    updated.add(candidateId);
+    hiringStates.upsert(
+        new FranchiseHiringState(
+            existing.map(FranchiseHiringState::id).orElse(0L),
+            leagueId,
+            franchiseId,
+            phase(),
+            HiringStep.SEARCHING,
+            shortlist,
+            List.copyOf(updated)));
+  }
+
+  private void submitOfferIfNone(
+      long leagueId,
+      long franchiseId,
+      int phaseWeek,
+      List<Long> shortlist,
+      List<Candidate> unhired) {
+    var existingOffers = offers.findActiveForFranchise(franchiseId);
+    if (!existingOffers.isEmpty()) {
+      return;
+    }
+    var unhiredById =
+        unhired.stream()
+            .collect(java.util.stream.Collectors.toMap(Candidate::id, c -> c, (a, b) -> a));
+    for (var candidateId : shortlist) {
+      var candidate = unhiredById.get(candidateId);
+      if (candidate == null) {
+        continue;
+      }
+      var prefs = preferences.findByCandidateId(candidateId);
+      if (prefs.isEmpty()) {
+        continue;
+      }
+      var terms = buildOfferTerms(candidate, prefs.get());
+      var saved =
+          offers.insertActive(candidate.id(), franchiseId, OfferTermsJson.toJson(terms), phaseWeek);
+      log.info(
+          "cpu offer submitted leagueId={} franchiseId={} candidateId={} offerId={} week={}",
+          leagueId,
+          franchiseId,
+          candidate.id(),
+          saved.id(),
+          phaseWeek);
+      return;
+    }
+  }
+
+  /**
+   * Simple willingness-to-pay: scale the candidate's compensation target by 0.85..1.20 linear in
+   * scouted overall. Contract length and guaranteed money mirror the candidate's own targets so the
+   * CPU never bids below the floor fit. Role scope / staff continuity match the candidate's
+   * preference target so categorical dimensions always score 1.0.
+   */
+  private OfferTerms buildOfferTerms(Candidate candidate, CandidatePreferences prefs) {
+    var scouted = scoutedOverall(candidate.scoutedAttrs());
+    var priority = (scouted - SCOUTED_LOWER) / (SCOUTED_UPPER - SCOUTED_LOWER);
+    var multiplier = 0.85 + Math.max(0.0, Math.min(1.0, priority)) * 0.35;
+    var compensation =
+        prefs
+            .compensationTarget()
+            .multiply(BigDecimal.valueOf(multiplier))
+            .setScale(2, RoundingMode.HALF_UP);
+    return new OfferTerms(
+        compensation,
+        prefs.contractLengthTarget(),
+        prefs.guaranteedMoneyTarget(),
+        prefs.roleScopeTarget(),
+        prefs.staffContinuityTarget());
+  }
+
+  private RandomSource interviewRng(long leagueId, long franchiseId, long candidateId, int index) {
+    var base = rngs.forLeaguePhase(leagueId, phase());
+    return base.split(franchiseId).split(candidateId).split(index);
+  }
+
+  private static double scoutedOverall(String scoutedAttrsJson) {
+    return extractDoubleOrDefault(OVERALL_PATTERN, scoutedAttrsJson, 50.0);
+  }
+
+  private static double extractDoubleOrDefault(Pattern pattern, String json, double fallback) {
+    var m = pattern.matcher(json);
+    if (m.find()) {
+      try {
+        return Double.parseDouble(m.group(1));
+      } catch (NumberFormatException ignored) {
+        return fallback;
+      }
+    }
+    return fallback;
+  }
+}

--- a/src/main/java/app/zoneblitz/league/JooqTeamLookup.java
+++ b/src/main/java/app/zoneblitz/league/JooqTeamLookup.java
@@ -23,4 +23,14 @@ class JooqTeamLookup implements TeamLookup {
         .orderBy(TEAMS.FRANCHISE_ID.asc())
         .fetch(TEAMS.FRANCHISE_ID);
   }
+
+  @Override
+  public List<Long> cpuFranchiseIdsForLeague(long leagueId) {
+    return dsl.select(TEAMS.FRANCHISE_ID)
+        .from(TEAMS)
+        .where(TEAMS.LEAGUE_ID.eq(leagueId))
+        .and(TEAMS.OWNER_SUBJECT.isNull())
+        .orderBy(TEAMS.FRANCHISE_ID.asc())
+        .fetch(TEAMS.FRANCHISE_ID);
+  }
 }

--- a/src/main/java/app/zoneblitz/league/TeamLookup.java
+++ b/src/main/java/app/zoneblitz/league/TeamLookup.java
@@ -10,4 +10,11 @@ interface TeamLookup {
 
   /** Return the franchise ids participating in the given league, ordered by franchise id. */
   List<Long> franchiseIdsForLeague(long leagueId);
+
+  /**
+   * Return the franchise ids participating in the given league whose {@code owner_subject} is null
+   * — i.e. the CPU-controlled franchises. Ordered by franchise id. Used by {@link AdvanceWeek} to
+   * dispatch {@code CpuFranchiseStrategy} per non-user franchise.
+   */
+  List<Long> cpuFranchiseIdsForLeague(long leagueId);
 }

--- a/src/test/java/app/zoneblitz/league/AdvanceWeekUseCaseTests.java
+++ b/src/test/java/app/zoneblitz/league/AdvanceWeekUseCaseTests.java
@@ -28,7 +28,8 @@ class AdvanceWeekUseCaseTests {
     var teams = new JooqTeamRepository(dsl);
     createLeague = new CreateLeagueUseCase(leagues, franchises, teams);
     OfferResolver noopResolver = (leagueId, phase, week) -> {};
-    advanceWeek = new AdvanceWeekUseCase(leagues, noopResolver);
+    advanceWeek =
+        new AdvanceWeekUseCase(leagues, noopResolver, new JooqTeamLookup(dsl), java.util.List.of());
   }
 
   @Test
@@ -67,12 +68,68 @@ class AdvanceWeekUseCaseTests {
     var league = createLeagueFor("sub-1");
     var seen = new java.util.concurrent.atomic.AtomicInteger(-1);
     OfferResolver capturingResolver = (leagueId, phase, weekAtResolve) -> seen.set(weekAtResolve);
-    var useCase = new AdvanceWeekUseCase(leagues, capturingResolver);
+    var useCase =
+        new AdvanceWeekUseCase(
+            leagues, capturingResolver, new JooqTeamLookup(dsl), java.util.List.of());
 
     useCase.advance(league.id(), "sub-1");
 
     assertThat(seen.get()).isEqualTo(1);
     assertThat(leagues.findById(league.id()).orElseThrow().phaseWeek()).isEqualTo(2);
+  }
+
+  @Test
+  void advance_invokesCpuStrategy_onceForEachCpuFranchiseOfMatchingPhase() {
+    var league = createLeagueFor("sub-1");
+    leagues.updatePhaseAndResetWeek(league.id(), LeaguePhase.HIRING_HEAD_COACH);
+    var calls = new java.util.ArrayList<Long>();
+    CpuFranchiseStrategy cpu =
+        new CpuFranchiseStrategy() {
+          @Override
+          public LeaguePhase phase() {
+            return LeaguePhase.HIRING_HEAD_COACH;
+          }
+
+          @Override
+          public void execute(long leagueId, long franchiseId, int phaseWeek) {
+            calls.add(franchiseId);
+          }
+        };
+    OfferResolver noopResolver = (leagueId, phase, week) -> {};
+    var useCase =
+        new AdvanceWeekUseCase(
+            leagues, noopResolver, new JooqTeamLookup(dsl), java.util.List.of(cpu));
+
+    useCase.advance(league.id(), "sub-1");
+
+    var expectedCpuIds = new JooqTeamLookup(dsl).cpuFranchiseIdsForLeague(league.id());
+    assertThat(calls).containsExactlyElementsOf(expectedCpuIds);
+  }
+
+  @Test
+  void advance_doesNotInvokeCpuStrategy_whenPhaseDoesNotMatch() {
+    var league = createLeagueFor("sub-1");
+    var calls = new java.util.ArrayList<Long>();
+    CpuFranchiseStrategy cpu =
+        new CpuFranchiseStrategy() {
+          @Override
+          public LeaguePhase phase() {
+            return LeaguePhase.HIRING_HEAD_COACH;
+          }
+
+          @Override
+          public void execute(long leagueId, long franchiseId, int phaseWeek) {
+            calls.add(franchiseId);
+          }
+        };
+    OfferResolver noopResolver = (leagueId, phase, week) -> {};
+    var useCase =
+        new AdvanceWeekUseCase(
+            leagues, noopResolver, new JooqTeamLookup(dsl), java.util.List.of(cpu));
+
+    useCase.advance(league.id(), "sub-1");
+
+    assertThat(calls).isEmpty();
   }
 
   @Test

--- a/src/test/java/app/zoneblitz/league/CpuHiringStrategyTests.java
+++ b/src/test/java/app/zoneblitz/league/CpuHiringStrategyTests.java
@@ -1,0 +1,278 @@
+package app.zoneblitz.league;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import app.zoneblitz.support.PostgresTestcontainer;
+import java.math.BigDecimal;
+import java.util.List;
+import org.jooq.DSLContext;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.jooq.test.autoconfigure.JooqTest;
+import org.springframework.context.annotation.Import;
+
+@JooqTest
+@Import(PostgresTestcontainer.class)
+class CpuHiringStrategyTests {
+
+  @Autowired DSLContext dsl;
+
+  private LeagueRepository leagues;
+  private JooqCandidatePoolRepository pools;
+  private JooqCandidateRepository candidates;
+  private JooqCandidatePreferencesRepository preferences;
+  private JooqCandidateOfferRepository offers;
+  private JooqFranchiseHiringStateRepository hiringStates;
+  private JooqFranchiseInterviewRepository interviews;
+  private JooqFranchiseStaffRepository staff;
+  private FranchiseProfiles profiles;
+  private TeamLookup teamLookup;
+  private CreateLeague createLeague;
+  private HiringHeadCoachTransitionHandler entryHandler;
+  private CandidateRandomSources rngs;
+  private CpuHiringStrategy strategy;
+  private PreferenceScoringOfferResolver resolver;
+
+  @BeforeEach
+  void setUp() {
+    leagues = new JooqLeagueRepository(dsl);
+    var franchiseRepo = new JooqFranchiseRepository(dsl);
+    var teamRepo = new JooqTeamRepository(dsl);
+    teamLookup = new JooqTeamLookup(dsl);
+    pools = new JooqCandidatePoolRepository(dsl);
+    candidates = new JooqCandidateRepository(dsl);
+    preferences = new JooqCandidatePreferencesRepository(dsl);
+    offers = new JooqCandidateOfferRepository(dsl);
+    hiringStates = new JooqFranchiseHiringStateRepository(dsl);
+    interviews = new JooqFranchiseInterviewRepository(dsl);
+    staff = new JooqFranchiseStaffRepository(dsl);
+    profiles = new CityFranchiseProfiles(franchiseRepo);
+    rngs = (leagueId, phase) -> new FakeRandomSource(leagueId * 31 + phase.ordinal());
+    createLeague = new CreateLeagueUseCase(leagues, franchiseRepo, teamRepo);
+    entryHandler =
+        new HiringHeadCoachTransitionHandler(
+            leagues,
+            teamLookup,
+            pools,
+            candidates,
+            preferences,
+            hiringStates,
+            new HeadCoachGenerator(),
+            rngs);
+    strategy =
+        new CpuHiringStrategy(
+            pools, candidates, preferences, offers, hiringStates, interviews, rngs);
+    resolver =
+        new PreferenceScoringOfferResolver(
+            offers, candidates, pools, preferences, profiles, hiringStates, staff, rngs);
+  }
+
+  @Test
+  void execute_week1_buildsShortlistAndRunsInterviews() {
+    var ctx = seedLeague("sub-1");
+    var cpuFranchiseId = ctx.cpuFranchises().getFirst();
+
+    strategy.execute(ctx.leagueId(), cpuFranchiseId, 1);
+
+    var state =
+        hiringStates
+            .find(ctx.leagueId(), cpuFranchiseId, LeaguePhase.HIRING_HEAD_COACH)
+            .orElseThrow();
+    assertThat(state.shortlist()).hasSize(CpuHiringStrategy.SHORTLIST_SIZE);
+    assertThat(state.step()).isEqualTo(HiringStep.SEARCHING);
+
+    var history =
+        interviews.findAllFor(ctx.leagueId(), cpuFranchiseId, LeaguePhase.HIRING_HEAD_COACH);
+    assertThat(history).hasSize(StartInterview.DEFAULT_WEEKLY_CAPACITY);
+    assertThat(history).allSatisfy(h -> assertThat(state.shortlist()).contains(h.candidateId()));
+  }
+
+  @Test
+  void execute_submitsExactlyOneActiveOfferOnShortlistedCandidate() {
+    var ctx = seedLeague("sub-1");
+    var cpuFranchiseId = ctx.cpuFranchises().getFirst();
+
+    strategy.execute(ctx.leagueId(), cpuFranchiseId, 1);
+
+    var active = offers.findActiveForFranchise(cpuFranchiseId);
+    assertThat(active).hasSize(1);
+    var state =
+        hiringStates
+            .find(ctx.leagueId(), cpuFranchiseId, LeaguePhase.HIRING_HEAD_COACH)
+            .orElseThrow();
+    assertThat(state.shortlist()).contains(active.getFirst().candidateId());
+  }
+
+  @Test
+  void execute_nextWeek_doesNotSubmitSecondOfferWhilePriorIsActive() {
+    var ctx = seedLeague("sub-1");
+    var cpuFranchiseId = ctx.cpuFranchises().getFirst();
+    strategy.execute(ctx.leagueId(), cpuFranchiseId, 1);
+    var week1Offers = offers.findActiveForFranchise(cpuFranchiseId);
+
+    strategy.execute(ctx.leagueId(), cpuFranchiseId, 2);
+
+    var week2Offers = offers.findActiveForFranchise(cpuFranchiseId);
+    assertThat(week2Offers)
+        .describedAs("still one active offer; no duplicate submitted")
+        .hasSize(1)
+        .extracting(CandidateOffer::id)
+        .containsExactlyElementsOf(week1Offers.stream().map(CandidateOffer::id).toList());
+  }
+
+  @Test
+  void execute_advancesThroughStepsEachWeek_interviewCountGrows() {
+    var ctx = seedLeague("sub-1");
+    var cpuFranchiseId = ctx.cpuFranchises().getFirst();
+
+    strategy.execute(ctx.leagueId(), cpuFranchiseId, 1);
+    var week1Count =
+        interviews.findAllFor(ctx.leagueId(), cpuFranchiseId, LeaguePhase.HIRING_HEAD_COACH).size();
+    strategy.execute(ctx.leagueId(), cpuFranchiseId, 2);
+    var week2Count =
+        interviews.findAllFor(ctx.leagueId(), cpuFranchiseId, LeaguePhase.HIRING_HEAD_COACH).size();
+
+    assertThat(week1Count).isEqualTo(StartInterview.DEFAULT_WEEKLY_CAPACITY);
+    assertThat(week2Count).isGreaterThan(week1Count);
+  }
+
+  @Test
+  void execute_whenAlreadyHired_skipsAllWork() {
+    var ctx = seedLeague("sub-1");
+    var cpuFranchiseId = ctx.cpuFranchises().getFirst();
+    hiringStates.upsert(
+        new FranchiseHiringState(
+            0L,
+            ctx.leagueId(),
+            cpuFranchiseId,
+            LeaguePhase.HIRING_HEAD_COACH,
+            HiringStep.HIRED,
+            List.of(),
+            List.of()));
+
+    strategy.execute(ctx.leagueId(), cpuFranchiseId, 1);
+
+    assertThat(offers.findActiveForFranchise(cpuFranchiseId)).isEmpty();
+    assertThat(interviews.findAllFor(ctx.leagueId(), cpuFranchiseId, LeaguePhase.HIRING_HEAD_COACH))
+        .isEmpty();
+  }
+
+  @Test
+  void execute_isDeterministicAcrossRuns_givenSameSeed() {
+    var ctxA = seedLeague("sub-A");
+    var cpuA = ctxA.cpuFranchises().getFirst();
+    strategy.execute(ctxA.leagueId(), cpuA, 1);
+    var stateA =
+        hiringStates.find(ctxA.leagueId(), cpuA, LeaguePhase.HIRING_HEAD_COACH).orElseThrow();
+    var offersA = offers.findActiveForFranchise(cpuA);
+
+    var ctxB = seedLeague("sub-B");
+    var cpuB = ctxB.cpuFranchises().getFirst();
+    strategy.execute(ctxB.leagueId(), cpuB, 1);
+    var stateB =
+        hiringStates.find(ctxB.leagueId(), cpuB, LeaguePhase.HIRING_HEAD_COACH).orElseThrow();
+    var offersB = offers.findActiveForFranchise(cpuB);
+
+    assertThat(stateB.shortlist().size()).isEqualTo(stateA.shortlist().size());
+    assertThat(offersB).hasSameSizeAs(offersA);
+  }
+
+  @Test
+  void execute_cpuOutbidsUserOnTopCandidate_winsResolution() {
+    var ctx = seedLeague("sub-1");
+    var cpuFranchiseId = ctx.cpuFranchises().getFirst();
+
+    // Precompute the candidate CPU will pick (top scouted overall) so user can pre-empt with a
+    // deliberately weak offer on the same candidate.
+    var topCandidate = topCandidateByScouted(ctx.leagueId());
+    var userFranchiseId = ctx.userFranchiseId();
+    // Initialize user's hiring state so resolver can flip loser back to SEARCHING cleanly.
+    hiringStates.upsert(
+        new FranchiseHiringState(
+            0L,
+            ctx.leagueId(),
+            userFranchiseId,
+            LeaguePhase.HIRING_HEAD_COACH,
+            HiringStep.SEARCHING,
+            List.of(),
+            List.of()));
+    offers.insertActive(topCandidate.id(), userFranchiseId, OfferTermsJson.toJson(weakOffer()), 1);
+
+    strategy.execute(ctx.leagueId(), cpuFranchiseId, 1);
+    resolver.resolve(ctx.leagueId(), LeaguePhase.HIRING_HEAD_COACH, 1);
+
+    assertThat(candidates.findById(topCandidate.id()).orElseThrow().hiredByFranchiseId())
+        .contains(cpuFranchiseId);
+    var cpuState =
+        hiringStates
+            .find(ctx.leagueId(), cpuFranchiseId, LeaguePhase.HIRING_HEAD_COACH)
+            .orElseThrow();
+    assertThat(cpuState.step()).isEqualTo(HiringStep.HIRED);
+  }
+
+  @Test
+  void execute_snipesShortlistedCandidateWhenUserHasNotOffered() {
+    var ctx = seedLeague("sub-1");
+    var cpuFranchiseId = ctx.cpuFranchises().getFirst();
+    var topCandidate = topCandidateByScouted(ctx.leagueId());
+
+    // User shortlists the candidate but submits no offer.
+    hiringStates.upsert(
+        new FranchiseHiringState(
+            0L,
+            ctx.leagueId(),
+            ctx.userFranchiseId(),
+            LeaguePhase.HIRING_HEAD_COACH,
+            HiringStep.SEARCHING,
+            List.of(topCandidate.id()),
+            List.of()));
+
+    strategy.execute(ctx.leagueId(), cpuFranchiseId, 1);
+    resolver.resolve(ctx.leagueId(), LeaguePhase.HIRING_HEAD_COACH, 1);
+
+    assertThat(candidates.findById(topCandidate.id()).orElseThrow().hiredByFranchiseId())
+        .contains(cpuFranchiseId);
+  }
+
+  private Candidate topCandidateByScouted(long leagueId) {
+    var pool =
+        pools
+            .findByLeaguePhaseAndType(
+                leagueId, LeaguePhase.HIRING_HEAD_COACH, CandidatePoolType.HEAD_COACH)
+            .orElseThrow();
+    return candidates.findAllByPoolId(pool.id()).stream()
+        .filter(c -> c.hiredByFranchiseId().isEmpty())
+        .max(java.util.Comparator.comparingDouble(c -> extractScouted(c.scoutedAttrs())))
+        .orElseThrow();
+  }
+
+  private static double extractScouted(String json) {
+    var m =
+        java.util.regex.Pattern.compile("\"overall\"\\s*:\\s*(-?[0-9]+(?:\\.[0-9]+)?)")
+            .matcher(json);
+    return m.find() ? Double.parseDouble(m.group(1)) : 0.0;
+  }
+
+  private static OfferTerms weakOffer() {
+    return new OfferTerms(
+        new BigDecimal("100000.00"),
+        1,
+        new BigDecimal("0.01"),
+        RoleScope.LOW,
+        StaffContinuity.KEEP_EXISTING);
+  }
+
+  private Ctx seedLeague(String subject) {
+    var franchises = new JooqFranchiseRepository(dsl).listAll();
+    var userFranchiseId = franchises.getFirst().id();
+    var result = createLeague.create(subject, "Dynasty-" + subject, userFranchiseId);
+    var league = ((CreateLeagueResult.Created) result).league();
+    leagues.updatePhaseAndResetWeek(league.id(), LeaguePhase.HIRING_HEAD_COACH);
+    entryHandler.onEntry(league.id());
+    var cpuFranchises = teamLookup.cpuFranchiseIdsForLeague(league.id());
+    return new Ctx(league.id(), userFranchiseId, cpuFranchises);
+  }
+
+  private record Ctx(long leagueId, long userFranchiseId, List<Long> cpuFranchises) {}
+}

--- a/src/test/java/app/zoneblitz/league/PreferenceScoringOfferResolverTests.java
+++ b/src/test/java/app/zoneblitz/league/PreferenceScoringOfferResolverTests.java
@@ -172,6 +172,12 @@ class PreferenceScoringOfferResolverTests {
   @Test
   void resolve_losingFranchise_remainsSearchingAndCanRebid() {
     var ctx = seedLeague();
+    // Force the candidate's compensation to dominate the composite score so the good-offer
+    // franchise always wins regardless of the random preferences the generator produced for this
+    // specific seed. Without this the test is seed-sensitive — at some leagueId values the
+    // candidate's random dimension weights make a low-comp offer competitive with good terms, and
+    // the outcome flips.
+    overwritePreferencesToDominateComp(ctx.candidateId);
     // Winner franchise has high offer; loser has low offer on same candidate.
     offers.insertActive(ctx.candidateId, ctx.franchiseId, OfferTermsJson.toJson(goodTerms()), 1);
     offers.insertActive(
@@ -192,6 +198,55 @@ class PreferenceScoringOfferResolverTests {
         offers.insertActive(
             otherCandidate.id(), ctx.otherFranchiseId, OfferTermsJson.toJson(goodTerms()), 2);
     assertThat(rebid.status()).isEqualTo(OfferStatus.ACTIVE);
+  }
+
+  private void overwritePreferencesToDominateComp(long candidateId) {
+    // Zero all non-comp weights, saturate the comp weight. Composite score then reduces to
+    // numericFloorFit on compensation — good terms ($20M vs any target) = 1.0, low ($500k) = 0.0.
+    dsl.update(app.zoneblitz.jooq.Tables.CANDIDATE_PREFERENCES)
+        .set(
+            app.zoneblitz.jooq.Tables.CANDIDATE_PREFERENCES.COMPENSATION_WEIGHT,
+            new BigDecimal("1.000"))
+        .set(
+            app.zoneblitz.jooq.Tables.CANDIDATE_PREFERENCES.CONTRACT_LENGTH_WEIGHT,
+            new BigDecimal("0.000"))
+        .set(
+            app.zoneblitz.jooq.Tables.CANDIDATE_PREFERENCES.GUARANTEED_MONEY_WEIGHT,
+            new BigDecimal("0.000"))
+        .set(
+            app.zoneblitz.jooq.Tables.CANDIDATE_PREFERENCES.MARKET_SIZE_WEIGHT,
+            new BigDecimal("0.000"))
+        .set(
+            app.zoneblitz.jooq.Tables.CANDIDATE_PREFERENCES.GEOGRAPHY_WEIGHT,
+            new BigDecimal("0.000"))
+        .set(
+            app.zoneblitz.jooq.Tables.CANDIDATE_PREFERENCES.CLIMATE_WEIGHT, new BigDecimal("0.000"))
+        .set(
+            app.zoneblitz.jooq.Tables.CANDIDATE_PREFERENCES.FRANCHISE_PRESTIGE_WEIGHT,
+            new BigDecimal("0.000"))
+        .set(
+            app.zoneblitz.jooq.Tables.CANDIDATE_PREFERENCES.COMPETITIVE_WINDOW_WEIGHT,
+            new BigDecimal("0.000"))
+        .set(
+            app.zoneblitz.jooq.Tables.CANDIDATE_PREFERENCES.ROLE_SCOPE_WEIGHT,
+            new BigDecimal("0.000"))
+        .set(
+            app.zoneblitz.jooq.Tables.CANDIDATE_PREFERENCES.STAFF_CONTINUITY_WEIGHT,
+            new BigDecimal("0.000"))
+        .set(
+            app.zoneblitz.jooq.Tables.CANDIDATE_PREFERENCES.SCHEME_ALIGNMENT_WEIGHT,
+            new BigDecimal("0.000"))
+        .set(
+            app.zoneblitz.jooq.Tables.CANDIDATE_PREFERENCES.OWNER_STABILITY_WEIGHT,
+            new BigDecimal("0.000"))
+        .set(
+            app.zoneblitz.jooq.Tables.CANDIDATE_PREFERENCES.FACILITY_QUALITY_WEIGHT,
+            new BigDecimal("0.000"))
+        .set(
+            app.zoneblitz.jooq.Tables.CANDIDATE_PREFERENCES.COMPENSATION_TARGET,
+            new BigDecimal("10000000.00"))
+        .where(app.zoneblitz.jooq.Tables.CANDIDATE_PREFERENCES.CANDIDATE_ID.eq(candidateId))
+        .execute();
   }
 
   private long poolIdFor(long leagueId) {


### PR DESCRIPTION
Closes #607

Stacked on #606.

## Summary
- Adds `CpuFranchiseStrategy` seam; `AdvanceWeekUseCase` dispatches the active phase's strategy once per CPU franchise before running `OfferResolver`.
- Implements `CpuHiringStrategy` for `HIRING_HEAD_COACH`: picks a 4-candidate shortlist by scouted overall, interviews up to `StartInterview.DEFAULT_WEEKLY_CAPACITY` per week (respecting franchise interview history), and submits one offer at a time via a willingness-to-pay curve keyed to the candidate's scouted rating and preference targets.
- Extends `TeamLookup` with `cpuFranchiseIdsForLeague` so dispatch has a single seam for "non-user franchises in this league".
- Hardens `PreferenceScoringOfferResolverTests#resolve_losingFranchise_remainsSearchingAndCanRebid` against generator-seed drift; the existing assertion relied on good-vs-low terms incidentally dominating, which flipped at some league-id seeds exposed by the new tests' sequence usage.

## Test plan
- [x] `./gradlew spotlessApply` / `spotlessCheck`
- [x] `./gradlew test` (502 tests, all green; `CpuHiringStrategyTests` covers shortlist, interviews, single-offer-at-a-time, week advancement, HIRED skip, determinism, CPU outbidding user, sniping shortlisted candidate; `AdvanceWeekUseCaseTests` asserts CPU dispatch per CPU franchise on matching phase and no-op otherwise)