### PR TITLE
feat(league): phase completion, week cap, autofill (#608)

### DIFF
--- a/docs/technical/league-phases.md
+++ b/docs/technical/league-phases.md
@@ -256,7 +256,7 @@ No JSON endpoints from web controllers. Fragment responses are `text/html`.
 - Interview capacity per week (default 3, tune later).
 - `ASSEMBLING_STAFF` recap UX detail — which staff roles are hired by HC vs. DoS, and exact roster.
 - Week cap values (`maxWeeks`) — current defaults are guesses; tune against playtest.
-- Autofill logic — pick best remaining candidate vs. random from remaining; needs decision.
+- ~~Autofill logic — pick best remaining candidate vs. random from remaining; needs decision.~~ Resolved (#608): autofill assigns the best remaining candidate by **scouted** overall (never true rating). Deterministic tie-break uses candidate id, then a seeded RNG split per-franchise. The autofill creates an `ACCEPTED` offer with default terms matching the candidate's preference targets and runs the standard hire wiring (mark hired, upsert `HIRED` state, insert `franchise_staff` row).
 
 ---
 

--- a/src/main/java/app/zoneblitz/league/AdvanceWeekUseCase.java
+++ b/src/main/java/app/zoneblitz/league/AdvanceWeekUseCase.java
@@ -18,16 +18,25 @@ class AdvanceWeekUseCase implements AdvanceWeek {
   private final LeagueRepository leagues;
   private final OfferResolver offerResolver;
   private final TeamLookup teams;
+  private final HiringPhaseAutofill autofill;
+  private final FranchiseHiringStateRepository hiringStates;
+  private final AdvancePhase advancePhase;
   private final Map<LeaguePhase, CpuFranchiseStrategy> cpuStrategies;
 
   AdvanceWeekUseCase(
       LeagueRepository leagues,
       OfferResolver offerResolver,
       TeamLookup teams,
+      HiringPhaseAutofill autofill,
+      FranchiseHiringStateRepository hiringStates,
+      AdvancePhase advancePhase,
       List<CpuFranchiseStrategy> cpuStrategies) {
     this.leagues = leagues;
     this.offerResolver = offerResolver;
     this.teams = teams;
+    this.autofill = autofill;
+    this.hiringStates = hiringStates;
+    this.advancePhase = advancePhase;
     this.cpuStrategies =
         cpuStrategies.stream()
             .collect(Collectors.toUnmodifiableMap(CpuFranchiseStrategy::phase, s -> s));
@@ -57,8 +66,56 @@ class AdvanceWeekUseCase implements AdvanceWeek {
             .incrementPhaseWeek(leagueId)
             .orElseThrow(() -> new IllegalStateException("league disappeared mid-transaction"));
 
+    var transitionedTo = maybeCompletePhase(leagueId, phase, phaseWeek, ownerSubject);
+
     log.info("league week advanced id={} phase={} week={}", leagueId, phase, newWeek);
-    return new AdvanceWeekResult.Ticked(leagueId, phase, newWeek, Optional.empty());
+    var phaseAfter = transitionedTo.orElse(phase);
+    var weekAfter = transitionedTo.isPresent() ? 1 : newWeek;
+    return new AdvanceWeekResult.Ticked(leagueId, phaseAfter, weekAfter, transitionedTo);
+  }
+
+  private Optional<LeaguePhase> maybeCompletePhase(
+      long leagueId, LeaguePhase phase, int resolvedAtWeek, String ownerSubject) {
+    var shouldComplete = shouldComplete(leagueId, phase, resolvedAtWeek);
+    if (!shouldComplete) {
+      return Optional.empty();
+    }
+    if (overCap(phase, resolvedAtWeek)) {
+      autofill.autofill(leagueId, phase, resolvedAtWeek);
+    }
+    var advanced = advancePhase.advance(leagueId, ownerSubject);
+    return switch (advanced) {
+      case AdvancePhaseResult.Advanced a -> Optional.of(a.to());
+      case AdvancePhaseResult.NoNextPhase ignored -> Optional.empty();
+      case AdvancePhaseResult.NotFound ignored -> Optional.empty();
+    };
+  }
+
+  private boolean shouldComplete(long leagueId, LeaguePhase phase, int resolvedAtWeek) {
+    return allFranchisesHired(leagueId, phase) || overCap(phase, resolvedAtWeek);
+  }
+
+  private boolean allFranchisesHired(long leagueId, LeaguePhase phase) {
+    return switch (phase) {
+      case HIRING_HEAD_COACH, HIRING_DIRECTOR_OF_SCOUTING -> {
+        var franchiseIds = teams.franchiseIdsForLeague(leagueId);
+        if (franchiseIds.isEmpty()) {
+          yield false;
+        }
+        for (var franchiseId : franchiseIds) {
+          var state = hiringStates.find(leagueId, franchiseId, phase);
+          if (state.isEmpty() || state.get().step() != HiringStep.HIRED) {
+            yield false;
+          }
+        }
+        yield true;
+      }
+      case INITIAL_SETUP, ASSEMBLING_STAFF -> false;
+    };
+  }
+
+  private static boolean overCap(LeaguePhase phase, int resolvedAtWeek) {
+    return LeaguePhases.maxWeeks(phase).map(cap -> resolvedAtWeek >= cap).orElse(false);
   }
 
   private void runCpuStrategies(long leagueId, LeaguePhase phase, int phaseWeek) {

--- a/src/main/java/app/zoneblitz/league/BestScoutedHiringAutofill.java
+++ b/src/main/java/app/zoneblitz/league/BestScoutedHiringAutofill.java
@@ -1,0 +1,204 @@
+package app.zoneblitz.league;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Optional;
+import java.util.regex.Pattern;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+/**
+ * Default {@link HiringPhaseAutofill}: ranks remaining candidates by scouted overall (never true
+ * rating) and assigns the top one to each unresolved franchise. Ties are broken first by candidate
+ * id, then — if still tied — by a deterministic seeded RNG split per-franchise, so reruns with the
+ * same league seed produce identical hires.
+ *
+ * <p>Default terms mirror the candidate's preference targets so the synthetic offer scores a
+ * perfect fit. The hire wiring (mark candidate hired, upsert hiring state to {@link
+ * HiringStep#HIRED}, insert {@link FranchiseStaffMember}, create an {@link OfferStatus#ACCEPTED}
+ * offer row) matches the flow in {@link PreferenceScoringOfferResolver}.
+ */
+@Component
+class BestScoutedHiringAutofill implements HiringPhaseAutofill {
+
+  private static final Logger log = LoggerFactory.getLogger(BestScoutedHiringAutofill.class);
+
+  private static final Pattern OVERALL_PATTERN =
+      Pattern.compile("\"overall\"\\s*:\\s*(-?[0-9]+(?:\\.[0-9]+)?)");
+
+  private final CandidatePoolRepository pools;
+  private final CandidateRepository candidates;
+  private final CandidatePreferencesRepository preferences;
+  private final CandidateOfferRepository offers;
+  private final FranchiseHiringStateRepository hiringStates;
+  private final FranchiseStaffRepository staff;
+  private final TeamLookup teams;
+  private final CandidateRandomSources rngs;
+
+  BestScoutedHiringAutofill(
+      CandidatePoolRepository pools,
+      CandidateRepository candidates,
+      CandidatePreferencesRepository preferences,
+      CandidateOfferRepository offers,
+      FranchiseHiringStateRepository hiringStates,
+      FranchiseStaffRepository staff,
+      TeamLookup teams,
+      CandidateRandomSources rngs) {
+    this.pools = pools;
+    this.candidates = candidates;
+    this.preferences = preferences;
+    this.offers = offers;
+    this.hiringStates = hiringStates;
+    this.staff = staff;
+    this.teams = teams;
+    this.rngs = rngs;
+  }
+
+  @Override
+  public void autofill(long leagueId, LeaguePhase phase, int phaseWeek) {
+    var maybePoolType = poolTypeFor(phase);
+    if (maybePoolType.isEmpty()) {
+      return;
+    }
+    var maybePool = pools.findByLeaguePhaseAndType(leagueId, phase, maybePoolType.get());
+    if (maybePool.isEmpty()) {
+      return;
+    }
+    var role = roleFor(phase);
+
+    var remaining =
+        new ArrayList<>(
+            candidates.findAllByPoolId(maybePool.get().id()).stream()
+                .filter(c -> c.hiredByFranchiseId().isEmpty())
+                .toList());
+
+    for (var franchiseId : teams.franchiseIdsForLeague(leagueId)) {
+      if (isAlreadyHired(leagueId, franchiseId, phase)) {
+        continue;
+      }
+      if (remaining.isEmpty()) {
+        log.warn(
+            "autofill ran out of candidates leagueId={} phase={} franchiseId={}",
+            leagueId,
+            phase,
+            franchiseId);
+        return;
+      }
+      var pick = pickBest(leagueId, phase, franchiseId, remaining);
+      remaining.remove(pick);
+      assign(leagueId, phase, phaseWeek, franchiseId, pick, role);
+    }
+  }
+
+  private boolean isAlreadyHired(long leagueId, long franchiseId, LeaguePhase phase) {
+    return hiringStates
+        .find(leagueId, franchiseId, phase)
+        .map(s -> s.step() == HiringStep.HIRED)
+        .orElse(false);
+  }
+
+  private Candidate pickBest(
+      long leagueId, LeaguePhase phase, long franchiseId, List<Candidate> remaining) {
+    remaining.sort(
+        Comparator.comparingDouble((Candidate c) -> scoutedOverall(c.scoutedAttrs()))
+            .reversed()
+            .thenComparingLong(Candidate::id));
+    var topScore = scoutedOverall(remaining.getFirst().scoutedAttrs());
+    var tied =
+        remaining.stream().filter(c -> scoutedOverall(c.scoutedAttrs()) == topScore).toList();
+    if (tied.size() == 1) {
+      return tied.getFirst();
+    }
+    // Secondary tie-break: deterministic seeded RNG split per-franchise. `thenComparingLong(id)`
+    // already gave a stable order; RNG breaks cohort ties across franchises without biasing by id.
+    var rng = rngs.forLeaguePhase(leagueId, phase).split(franchiseId);
+    var pickIndex = (int) Math.floorMod(rng.nextLong(), (long) tied.size());
+    return tied.get(pickIndex);
+  }
+
+  private void assign(
+      long leagueId,
+      LeaguePhase phase,
+      int phaseWeek,
+      long franchiseId,
+      Candidate candidate,
+      StaffRole role) {
+    var maybePrefs = preferences.findByCandidateId(candidate.id());
+    if (maybePrefs.isEmpty()) {
+      log.warn(
+          "autofill skipped — missing preferences leagueId={} candidateId={}",
+          leagueId,
+          candidate.id());
+      return;
+    }
+    var terms = defaultTerms(maybePrefs.get());
+    var offer =
+        offers.insertActive(candidate.id(), franchiseId, OfferTermsJson.toJson(terms), phaseWeek);
+    offers.resolve(offer.id(), OfferStatus.ACCEPTED);
+    candidates.markHired(candidate.id(), franchiseId);
+    upsertHired(leagueId, phase, franchiseId);
+    staff.insert(
+        new NewFranchiseStaffMember(
+            leagueId, franchiseId, candidate.id(), role, Optional.empty(), phase, phaseWeek));
+    log.info(
+        "autofill hire leagueId={} phase={} franchiseId={} candidateId={} week={}",
+        leagueId,
+        phase,
+        franchiseId,
+        candidate.id(),
+        phaseWeek);
+  }
+
+  private void upsertHired(long leagueId, LeaguePhase phase, long franchiseId) {
+    var existing = hiringStates.find(leagueId, franchiseId, phase);
+    hiringStates.upsert(
+        new FranchiseHiringState(
+            existing.map(FranchiseHiringState::id).orElse(0L),
+            leagueId,
+            franchiseId,
+            phase,
+            HiringStep.HIRED,
+            existing.map(FranchiseHiringState::shortlist).orElse(List.of()),
+            existing.map(FranchiseHiringState::interviewingCandidateIds).orElse(List.of())));
+  }
+
+  private static OfferTerms defaultTerms(CandidatePreferences prefs) {
+    return new OfferTerms(
+        prefs.compensationTarget(),
+        prefs.contractLengthTarget(),
+        prefs.guaranteedMoneyTarget(),
+        prefs.roleScopeTarget(),
+        prefs.staffContinuityTarget());
+  }
+
+  private static double scoutedOverall(String scoutedAttrsJson) {
+    var m = OVERALL_PATTERN.matcher(scoutedAttrsJson);
+    if (m.find()) {
+      try {
+        return Double.parseDouble(m.group(1));
+      } catch (NumberFormatException ignored) {
+        return 0.0;
+      }
+    }
+    return 0.0;
+  }
+
+  private static Optional<CandidatePoolType> poolTypeFor(LeaguePhase phase) {
+    return switch (phase) {
+      case HIRING_HEAD_COACH -> Optional.of(CandidatePoolType.HEAD_COACH);
+      case HIRING_DIRECTOR_OF_SCOUTING -> Optional.of(CandidatePoolType.DIRECTOR_OF_SCOUTING);
+      case INITIAL_SETUP, ASSEMBLING_STAFF -> Optional.empty();
+    };
+  }
+
+  private static StaffRole roleFor(LeaguePhase phase) {
+    return switch (phase) {
+      case HIRING_HEAD_COACH -> StaffRole.HEAD_COACH;
+      case HIRING_DIRECTOR_OF_SCOUTING -> StaffRole.DIRECTOR_OF_SCOUTING;
+      case INITIAL_SETUP, ASSEMBLING_STAFF ->
+          throw new IllegalArgumentException("no hire role for phase " + phase);
+    };
+  }
+}

--- a/src/main/java/app/zoneblitz/league/HiringPhaseAutofill.java
+++ b/src/main/java/app/zoneblitz/league/HiringPhaseAutofill.java
@@ -1,0 +1,31 @@
+package app.zoneblitz.league;
+
+/**
+ * Seam invoked when a hiring phase hits its week cap before every franchise has reached {@link
+ * HiringStep#HIRED}. Auto-assigns the best remaining candidate (by scouted overall, deterministic
+ * tie-break) to each unresolved franchise, creates an {@link OfferStatus#ACCEPTED} offer with
+ * default terms, marks the candidate hired, transitions the franchise's {@link
+ * FranchiseHiringState} to {@link HiringStep#HIRED}, and inserts the corresponding {@link
+ * FranchiseStaffMember} row.
+ *
+ * <p>Never surfaces the candidate's {@code hiddenAttrs} (true rating) — the ranking is driven by
+ * {@code scoutedAttrs} only, preserving the hidden-info guarantee from {@code
+ * docs/technical/league-phases.md} (Market dynamics & hidden ratings).
+ *
+ * <p>Idempotent: running twice on a phase where every franchise is already {@link HiringStep#HIRED}
+ * is a no-op.
+ */
+interface HiringPhaseAutofill {
+
+  /**
+   * Auto-assign hires to any franchise that is not already {@link HiringStep#HIRED} in the given
+   * phase.
+   *
+   * @param leagueId the league whose hiring phase is being capped off.
+   * @param phase the hiring phase to autofill. Phases without a candidate pool (e.g. {@link
+   *     LeaguePhase#INITIAL_SETUP}, {@link LeaguePhase#ASSEMBLING_STAFF}) are a no-op.
+   * @param phaseWeek the {@code phase_week} value the autofill is running at; stored on the
+   *     resulting {@link FranchiseStaffMember#hiredAtWeek()} and the synthetic offer row.
+   */
+  void autofill(long leagueId, LeaguePhase phase, int phaseWeek);
+}

--- a/src/main/java/app/zoneblitz/league/LeaguePhases.java
+++ b/src/main/java/app/zoneblitz/league/LeaguePhases.java
@@ -4,17 +4,44 @@ import java.util.Map;
 import java.util.Optional;
 
 /**
- * Phase ordering and next-phase lookup. Centralizes the linear sequence so {@link
- * AdvancePhaseUseCase} and tests agree on "what comes next".
+ * Phase ordering, next-phase lookup, and per-phase week caps. Centralizes the linear sequence so
+ * {@link AdvancePhaseUseCase}, {@link AdvanceWeekUseCase}, and tests agree on "what comes next" and
+ * "when does the phase end by cap".
+ *
+ * <p>Per {@code docs/technical/league-phases.md} (Hiring sub-state machine):
+ *
+ * <ul>
+ *   <li>{@link LeaguePhase#HIRING_HEAD_COACH} — max 3 weeks.
+ *   <li>{@link LeaguePhase#HIRING_DIRECTOR_OF_SCOUTING} — max 3 weeks.
+ *   <li>{@link LeaguePhase#ASSEMBLING_STAFF} — max 1 week.
+ *   <li>{@link LeaguePhase#INITIAL_SETUP} — no cap; user-advanced explicitly.
+ * </ul>
  */
 final class LeaguePhases {
 
   private static final Map<LeaguePhase, LeaguePhase> NEXT =
-      Map.of(LeaguePhase.INITIAL_SETUP, LeaguePhase.HIRING_HEAD_COACH);
+      Map.of(
+          LeaguePhase.INITIAL_SETUP, LeaguePhase.HIRING_HEAD_COACH,
+          LeaguePhase.HIRING_HEAD_COACH, LeaguePhase.HIRING_DIRECTOR_OF_SCOUTING,
+          LeaguePhase.HIRING_DIRECTOR_OF_SCOUTING, LeaguePhase.ASSEMBLING_STAFF);
+
+  private static final Map<LeaguePhase, Integer> MAX_WEEKS =
+      Map.of(
+          LeaguePhase.HIRING_HEAD_COACH, 3,
+          LeaguePhase.HIRING_DIRECTOR_OF_SCOUTING, 3,
+          LeaguePhase.ASSEMBLING_STAFF, 1);
 
   private LeaguePhases() {}
 
   static Optional<LeaguePhase> next(LeaguePhase phase) {
     return Optional.ofNullable(NEXT.get(phase));
+  }
+
+  /**
+   * Returns the phase's week cap, or {@link Optional#empty()} if the phase has no cap (e.g. {@link
+   * LeaguePhase#INITIAL_SETUP}, which is user-advanced).
+   */
+  static Optional<Integer> maxWeeks(LeaguePhase phase) {
+    return Optional.ofNullable(MAX_WEEKS.get(phase));
   }
 }

--- a/src/test/java/app/zoneblitz/league/AdvancePhaseUseCaseTests.java
+++ b/src/test/java/app/zoneblitz/league/AdvancePhaseUseCaseTests.java
@@ -83,14 +83,44 @@ class AdvancePhaseUseCaseTests {
   @Test
   void advance_whenAlreadyInTerminalPhase_returnsNoNextPhase() {
     var league = createLeagueFor("sub-1");
+    leagues.updatePhaseAndResetWeek(league.id(), LeaguePhase.ASSEMBLING_STAFF);
+
+    var result = advancePhase.advance(league.id(), "sub-1");
+
+    assertThat(result)
+        .isEqualTo(new AdvancePhaseResult.NoNextPhase(league.id(), LeaguePhase.ASSEMBLING_STAFF));
+    assertThat(leagues.findById(league.id()).orElseThrow().phase())
+        .isEqualTo(LeaguePhase.ASSEMBLING_STAFF);
+  }
+
+  @Test
+  void advance_fromHiringHeadCoach_transitionsToHiringDirectorOfScouting() {
+    var league = createLeagueFor("sub-1");
     leagues.updatePhaseAndResetWeek(league.id(), LeaguePhase.HIRING_HEAD_COACH);
 
     var result = advancePhase.advance(league.id(), "sub-1");
 
     assertThat(result)
-        .isEqualTo(new AdvancePhaseResult.NoNextPhase(league.id(), LeaguePhase.HIRING_HEAD_COACH));
-    assertThat(leagues.findById(league.id()).orElseThrow().phase())
-        .isEqualTo(LeaguePhase.HIRING_HEAD_COACH);
+        .isEqualTo(
+            new AdvancePhaseResult.Advanced(
+                league.id(),
+                LeaguePhase.HIRING_HEAD_COACH,
+                LeaguePhase.HIRING_DIRECTOR_OF_SCOUTING));
+  }
+
+  @Test
+  void advance_fromHiringDirectorOfScouting_transitionsToAssemblingStaff() {
+    var league = createLeagueFor("sub-1");
+    leagues.updatePhaseAndResetWeek(league.id(), LeaguePhase.HIRING_DIRECTOR_OF_SCOUTING);
+
+    var result = advancePhase.advance(league.id(), "sub-1");
+
+    assertThat(result)
+        .isEqualTo(
+            new AdvancePhaseResult.Advanced(
+                league.id(),
+                LeaguePhase.HIRING_DIRECTOR_OF_SCOUTING,
+                LeaguePhase.ASSEMBLING_STAFF));
   }
 
   @Test

--- a/src/test/java/app/zoneblitz/league/AdvanceWeekUseCaseTests.java
+++ b/src/test/java/app/zoneblitz/league/AdvanceWeekUseCaseTests.java
@@ -3,6 +3,7 @@ package app.zoneblitz.league;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import app.zoneblitz.support.PostgresTestcontainer;
+import java.util.List;
 import java.util.Optional;
 import org.jooq.DSLContext;
 import org.junit.jupiter.api.BeforeEach;
@@ -18,18 +19,57 @@ class AdvanceWeekUseCaseTests {
   @Autowired DSLContext dsl;
 
   private LeagueRepository leagues;
+  private JooqFranchiseHiringStateRepository hiringStates;
+  private JooqCandidatePoolRepository pools;
+  private JooqCandidateRepository candidates;
+  private JooqCandidatePreferencesRepository preferences;
+  private JooqCandidateOfferRepository offers;
+  private JooqFranchiseStaffRepository staff;
+  private JooqTeamLookup teamLookup;
   private CreateLeague createLeague;
   private AdvanceWeek advanceWeek;
+  private HiringHeadCoachTransitionHandler hcEntryHandler;
+  private AdvancePhase advancePhase;
+  private HiringPhaseAutofill autofill;
+  private CandidateRandomSources rngs;
+  private OfferResolver noopResolver;
+  private RecordingAutofill recordingAutofill;
+  private RecordingAdvancePhase recordingAdvancePhase;
 
   @BeforeEach
   void setUp() {
     leagues = new JooqLeagueRepository(dsl);
+    hiringStates = new JooqFranchiseHiringStateRepository(dsl);
+    pools = new JooqCandidatePoolRepository(dsl);
+    candidates = new JooqCandidateRepository(dsl);
+    preferences = new JooqCandidatePreferencesRepository(dsl);
+    offers = new JooqCandidateOfferRepository(dsl);
+    staff = new JooqFranchiseStaffRepository(dsl);
+    teamLookup = new JooqTeamLookup(dsl);
     var franchises = new JooqFranchiseRepository(dsl);
-    var teams = new JooqTeamRepository(dsl);
-    createLeague = new CreateLeagueUseCase(leagues, franchises, teams);
-    OfferResolver noopResolver = (leagueId, phase, week) -> {};
+    var teamRepo = new JooqTeamRepository(dsl);
+    createLeague = new CreateLeagueUseCase(leagues, franchises, teamRepo);
+    rngs = (leagueId, phase) -> new FakeRandomSource(leagueId + phase.ordinal());
+    hcEntryHandler =
+        new HiringHeadCoachTransitionHandler(
+            leagues,
+            teamLookup,
+            pools,
+            candidates,
+            preferences,
+            hiringStates,
+            new HeadCoachGenerator(),
+            rngs);
+    autofill =
+        new BestScoutedHiringAutofill(
+            pools, candidates, preferences, offers, hiringStates, staff, teamLookup, rngs);
+    advancePhase = new AdvancePhaseUseCase(leagues, List.of());
+    noopResolver = (leagueId, phase, week) -> {};
+    recordingAutofill = new RecordingAutofill();
+    recordingAdvancePhase = new RecordingAdvancePhase(leagues);
     advanceWeek =
-        new AdvanceWeekUseCase(leagues, noopResolver, new JooqTeamLookup(dsl), java.util.List.of());
+        new AdvanceWeekUseCase(
+            leagues, noopResolver, teamLookup, autofill, hiringStates, advancePhase, List.of());
   }
 
   @Test
@@ -70,7 +110,13 @@ class AdvanceWeekUseCaseTests {
     OfferResolver capturingResolver = (leagueId, phase, weekAtResolve) -> seen.set(weekAtResolve);
     var useCase =
         new AdvanceWeekUseCase(
-            leagues, capturingResolver, new JooqTeamLookup(dsl), java.util.List.of());
+            leagues,
+            capturingResolver,
+            teamLookup,
+            autofill,
+            hiringStates,
+            advancePhase,
+            List.of());
 
     useCase.advance(league.id(), "sub-1");
 
@@ -95,14 +141,13 @@ class AdvanceWeekUseCaseTests {
             calls.add(franchiseId);
           }
         };
-    OfferResolver noopResolver = (leagueId, phase, week) -> {};
     var useCase =
         new AdvanceWeekUseCase(
-            leagues, noopResolver, new JooqTeamLookup(dsl), java.util.List.of(cpu));
+            leagues, noopResolver, teamLookup, autofill, hiringStates, advancePhase, List.of(cpu));
 
     useCase.advance(league.id(), "sub-1");
 
-    var expectedCpuIds = new JooqTeamLookup(dsl).cpuFranchiseIdsForLeague(league.id());
+    var expectedCpuIds = teamLookup.cpuFranchiseIdsForLeague(league.id());
     assertThat(calls).containsExactlyElementsOf(expectedCpuIds);
   }
 
@@ -122,10 +167,9 @@ class AdvanceWeekUseCaseTests {
             calls.add(franchiseId);
           }
         };
-    OfferResolver noopResolver = (leagueId, phase, week) -> {};
     var useCase =
         new AdvanceWeekUseCase(
-            leagues, noopResolver, new JooqTeamLookup(dsl), java.util.List.of(cpu));
+            leagues, noopResolver, teamLookup, autofill, hiringStates, advancePhase, List.of(cpu));
 
     useCase.advance(league.id(), "sub-1");
 
@@ -141,6 +185,129 @@ class AdvanceWeekUseCaseTests {
     assertThat(result).isEqualTo(new AdvanceWeekResult.NotFound(league.id()));
   }
 
+  @Test
+  void advance_whenAllFranchisesHired_transitionsToNextPhaseEarly() {
+    var league = createLeagueFor("sub-1");
+    leagues.updatePhaseAndResetWeek(league.id(), LeaguePhase.HIRING_HEAD_COACH);
+    markAllFranchisesHired(league.id(), LeaguePhase.HIRING_HEAD_COACH);
+    var useCase =
+        new AdvanceWeekUseCase(
+            leagues,
+            noopResolver,
+            teamLookup,
+            recordingAutofill,
+            hiringStates,
+            recordingAdvancePhase,
+            List.of());
+
+    var result = useCase.advance(league.id(), "sub-1");
+
+    assertThat(recordingAdvancePhase.calls).isEqualTo(1);
+    assertThat(recordingAutofill.calls).isEmpty();
+    var ticked = (AdvanceWeekResult.Ticked) result;
+    assertThat(ticked.transitionedTo()).contains(LeaguePhase.HIRING_DIRECTOR_OF_SCOUTING);
+    assertThat(ticked.phase()).isEqualTo(LeaguePhase.HIRING_DIRECTOR_OF_SCOUTING);
+    assertThat(ticked.phaseWeek()).isEqualTo(1);
+  }
+
+  @Test
+  void advance_whenWeekCapExceededWithPendingFranchise_runsAutofillAndTransitions() {
+    var league = createLeagueFor("sub-1");
+    leagues.updatePhaseAndResetWeek(league.id(), LeaguePhase.HIRING_HEAD_COACH);
+    hcEntryHandler.onEntry(league.id());
+    // Burn weeks 1 and 2 so the third tick is the capped one.
+    leagues.incrementPhaseWeek(league.id());
+    leagues.incrementPhaseWeek(league.id());
+    var useCase =
+        new AdvanceWeekUseCase(
+            leagues,
+            noopResolver,
+            teamLookup,
+            recordingAutofill,
+            hiringStates,
+            recordingAdvancePhase,
+            List.of());
+
+    var result = useCase.advance(league.id(), "sub-1");
+
+    assertThat(recordingAutofill.calls)
+        .containsExactly(new AutofillCall(league.id(), LeaguePhase.HIRING_HEAD_COACH, 3));
+    assertThat(recordingAdvancePhase.calls).isEqualTo(1);
+    var ticked = (AdvanceWeekResult.Ticked) result;
+    assertThat(ticked.transitionedTo()).contains(LeaguePhase.HIRING_DIRECTOR_OF_SCOUTING);
+  }
+
+  @Test
+  void advance_whenWeekCapExceededWithAllHired_transitionsAndAutofillIsNoOp() {
+    var league = createLeagueFor("sub-1");
+    leagues.updatePhaseAndResetWeek(league.id(), LeaguePhase.HIRING_HEAD_COACH);
+    markAllFranchisesHired(league.id(), LeaguePhase.HIRING_HEAD_COACH);
+    leagues.incrementPhaseWeek(league.id());
+    leagues.incrementPhaseWeek(league.id());
+    var useCase =
+        new AdvanceWeekUseCase(
+            leagues,
+            noopResolver,
+            teamLookup,
+            autofill,
+            hiringStates,
+            recordingAdvancePhase,
+            List.of());
+
+    var result = useCase.advance(league.id(), "sub-1");
+
+    // Cap triggers the autofill branch, but with every franchise already HIRED it is a no-op —
+    // no new staff rows, no new offers. Transition still happens.
+    for (var franchiseId : teamLookup.franchiseIdsForLeague(league.id())) {
+      assertThat(staff.findAllForFranchise(league.id(), franchiseId)).isEmpty();
+    }
+    assertThat(recordingAdvancePhase.calls).isEqualTo(1);
+    var ticked = (AdvanceWeekResult.Ticked) result;
+    assertThat(ticked.transitionedTo()).contains(LeaguePhase.HIRING_DIRECTOR_OF_SCOUTING);
+  }
+
+  @Test
+  void advance_whenBelowCapAndSomeFranchisesSearching_doesNotTransition() {
+    var league = createLeagueFor("sub-1");
+    leagues.updatePhaseAndResetWeek(league.id(), LeaguePhase.HIRING_HEAD_COACH);
+    // Only initialize a handful of SEARCHING states; leave others untouched.
+    hiringStates.upsert(
+        new FranchiseHiringState(
+            0L,
+            league.id(),
+            teamLookup.franchiseIdsForLeague(league.id()).getFirst(),
+            LeaguePhase.HIRING_HEAD_COACH,
+            HiringStep.SEARCHING,
+            List.of(),
+            List.of()));
+    var useCase =
+        new AdvanceWeekUseCase(
+            leagues,
+            noopResolver,
+            teamLookup,
+            recordingAutofill,
+            hiringStates,
+            recordingAdvancePhase,
+            List.of());
+
+    var result = useCase.advance(league.id(), "sub-1");
+
+    assertThat(recordingAutofill.calls).isEmpty();
+    assertThat(recordingAdvancePhase.calls).isZero();
+    var ticked = (AdvanceWeekResult.Ticked) result;
+    assertThat(ticked.transitionedTo()).isEmpty();
+    assertThat(ticked.phase()).isEqualTo(LeaguePhase.HIRING_HEAD_COACH);
+    assertThat(ticked.phaseWeek()).isEqualTo(2);
+  }
+
+  private void markAllFranchisesHired(long leagueId, LeaguePhase phase) {
+    for (var franchiseId : teamLookup.franchiseIdsForLeague(leagueId)) {
+      hiringStates.upsert(
+          new FranchiseHiringState(
+              0L, leagueId, franchiseId, phase, HiringStep.HIRED, List.of(), List.of()));
+    }
+  }
+
   private League createLeagueFor(String ownerSubject) {
     var result = createLeague.create(ownerSubject, "Dynasty", firstFranchiseId());
     return ((CreateLeagueResult.Created) result).league();
@@ -148,5 +315,43 @@ class AdvanceWeekUseCaseTests {
 
   private long firstFranchiseId() {
     return new JooqFranchiseRepository(dsl).listAll().getFirst().id();
+  }
+
+  private record AutofillCall(long leagueId, LeaguePhase phase, int phaseWeek) {}
+
+  private static final class RecordingAutofill implements HiringPhaseAutofill {
+    final List<AutofillCall> calls = new java.util.ArrayList<>();
+
+    @Override
+    public void autofill(long leagueId, LeaguePhase phase, int phaseWeek) {
+      calls.add(new AutofillCall(leagueId, phase, phaseWeek));
+    }
+  }
+
+  private static final class RecordingAdvancePhase implements AdvancePhase {
+    private final LeagueRepository leagues;
+    int calls;
+
+    RecordingAdvancePhase(LeagueRepository leagues) {
+      this.leagues = leagues;
+    }
+
+    @Override
+    public AdvancePhaseResult advance(long leagueId, String ownerSubject) {
+      calls++;
+      var league = leagues.findSummaryByIdAndOwner(leagueId, ownerSubject).orElseThrow();
+      var next = next(league.phase());
+      leagues.updatePhaseAndResetWeek(leagueId, next);
+      return new AdvancePhaseResult.Advanced(leagueId, league.phase(), next);
+    }
+
+    private static LeaguePhase next(LeaguePhase phase) {
+      return switch (phase) {
+        case INITIAL_SETUP -> LeaguePhase.HIRING_HEAD_COACH;
+        case HIRING_HEAD_COACH -> LeaguePhase.HIRING_DIRECTOR_OF_SCOUTING;
+        case HIRING_DIRECTOR_OF_SCOUTING -> LeaguePhase.ASSEMBLING_STAFF;
+        case ASSEMBLING_STAFF -> LeaguePhase.ASSEMBLING_STAFF;
+      };
+    }
   }
 }

--- a/src/test/java/app/zoneblitz/league/BestScoutedHiringAutofillTests.java
+++ b/src/test/java/app/zoneblitz/league/BestScoutedHiringAutofillTests.java
@@ -1,0 +1,225 @@
+package app.zoneblitz.league;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import app.zoneblitz.support.PostgresTestcontainer;
+import java.util.List;
+import java.util.Optional;
+import org.jooq.DSLContext;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.jooq.test.autoconfigure.JooqTest;
+import org.springframework.context.annotation.Import;
+
+@JooqTest
+@Import(PostgresTestcontainer.class)
+class BestScoutedHiringAutofillTests {
+
+  @Autowired DSLContext dsl;
+
+  private LeagueRepository leagues;
+  private JooqCandidatePoolRepository pools;
+  private JooqCandidateRepository candidates;
+  private JooqCandidatePreferencesRepository preferences;
+  private JooqCandidateOfferRepository offers;
+  private JooqFranchiseHiringStateRepository hiringStates;
+  private JooqFranchiseStaffRepository staff;
+  private JooqTeamLookup teamLookup;
+  private CreateLeague createLeague;
+  private HiringPhaseAutofill autofill;
+  private CandidateRandomSources rngs;
+
+  @BeforeEach
+  void setUp() {
+    leagues = new JooqLeagueRepository(dsl);
+    var franchises = new JooqFranchiseRepository(dsl);
+    var teamRepo = new JooqTeamRepository(dsl);
+    pools = new JooqCandidatePoolRepository(dsl);
+    candidates = new JooqCandidateRepository(dsl);
+    preferences = new JooqCandidatePreferencesRepository(dsl);
+    offers = new JooqCandidateOfferRepository(dsl);
+    hiringStates = new JooqFranchiseHiringStateRepository(dsl);
+    staff = new JooqFranchiseStaffRepository(dsl);
+    teamLookup = new JooqTeamLookup(dsl);
+    rngs = (leagueId, phase) -> new FakeRandomSource(leagueId + phase.ordinal());
+    createLeague = new CreateLeagueUseCase(leagues, franchises, teamRepo);
+    autofill =
+        new BestScoutedHiringAutofill(
+            pools, candidates, preferences, offers, hiringStates, staff, teamLookup, rngs);
+  }
+
+  @Test
+  void autofill_whenPhaseHasNoPool_isNoOp() {
+    var league = createLeagueFor("sub-1");
+
+    autofill.autofill(league.id(), LeaguePhase.HIRING_HEAD_COACH, 3);
+
+    assertThat(hiringStates.findAllForLeaguePhase(league.id(), LeaguePhase.HIRING_HEAD_COACH))
+        .isEmpty();
+  }
+
+  @Test
+  void autofill_assignsUnresolvedFranchise_withBestScoutedCandidate() {
+    var league = createLeagueFor("sub-1");
+    leagues.updatePhaseAndResetWeek(league.id(), LeaguePhase.HIRING_HEAD_COACH);
+    var pool =
+        pools.insert(league.id(), LeaguePhase.HIRING_HEAD_COACH, CandidatePoolType.HEAD_COACH);
+    // Top candidate: highest scouted overall; ranking should pick this regardless of hidden rating.
+    var topScouted = insertCandidate(pool.id(), "{\"overall\": 55.00}", "{\"overall\": 95.00}");
+    var strongHidden = insertCandidate(pool.id(), "{\"overall\": 80.00}", "{\"overall\": 60.00}");
+    // Fill out enough candidates so every franchise gets hired without running out.
+    seedFillerCandidates(pool.id(), 20, 40.00);
+
+    var franchiseIds = teamLookup.franchiseIdsForLeague(league.id());
+    var targetFranchise = franchiseIds.getFirst();
+    markSearching(league.id(), targetFranchise, LeaguePhase.HIRING_HEAD_COACH);
+
+    autofill.autofill(league.id(), LeaguePhase.HIRING_HEAD_COACH, 3);
+
+    // The first-iterated franchise gets the highest scouted pick. Ranking is by SCOUTED only.
+    assertThat(candidates.findById(topScouted.id()).orElseThrow().hiredByFranchiseId())
+        .contains(targetFranchise);
+    assertThat(candidates.findById(strongHidden.id()).orElseThrow().hiredByFranchiseId())
+        .isPresent()
+        .hasValueSatisfying(id -> assertThat(id).isNotEqualTo(targetFranchise));
+    var state =
+        hiringStates
+            .find(league.id(), targetFranchise, LeaguePhase.HIRING_HEAD_COACH)
+            .orElseThrow();
+    assertThat(state.step()).isEqualTo(HiringStep.HIRED);
+    assertThat(staff.findAllForFranchise(league.id(), targetFranchise))
+        .extracting(FranchiseStaffMember::role, FranchiseStaffMember::candidateId)
+        .containsExactly(
+            org.assertj.core.api.Assertions.tuple(StaffRole.HEAD_COACH, topScouted.id()));
+    assertThat(offers.findAllForCandidate(topScouted.id()))
+        .extracting(CandidateOffer::status)
+        .containsExactly(OfferStatus.ACCEPTED);
+  }
+
+  @Test
+  void autofill_skipsFranchisesAlreadyHired() {
+    var league = createLeagueFor("sub-1");
+    leagues.updatePhaseAndResetWeek(league.id(), LeaguePhase.HIRING_HEAD_COACH);
+    var pool =
+        pools.insert(league.id(), LeaguePhase.HIRING_HEAD_COACH, CandidatePoolType.HEAD_COACH);
+    insertCandidate(pool.id(), "{\"overall\": 70.00}", "{\"overall\": 70.00}");
+
+    // Seed additional candidates so every pending franchise in the league gets filled.
+    seedFillerCandidates(pool.id(), 20, 60.00);
+
+    var franchiseIds = teamLookup.franchiseIdsForLeague(league.id());
+    var alreadyHired = franchiseIds.get(0);
+    var pending = franchiseIds.get(1);
+    hiringStates.upsert(
+        new FranchiseHiringState(
+            0L,
+            league.id(),
+            alreadyHired,
+            LeaguePhase.HIRING_HEAD_COACH,
+            HiringStep.HIRED,
+            List.of(),
+            List.of()));
+    markSearching(league.id(), pending, LeaguePhase.HIRING_HEAD_COACH);
+
+    autofill.autofill(league.id(), LeaguePhase.HIRING_HEAD_COACH, 3);
+
+    assertThat(staff.findAllForFranchise(league.id(), alreadyHired)).isEmpty();
+    assertThat(staff.findAllForFranchise(league.id(), pending))
+        .extracting(FranchiseStaffMember::role)
+        .containsExactly(StaffRole.HEAD_COACH);
+  }
+
+  @Test
+  void autofill_neverReadsHiddenAttrs_picksByScoutedOnly() {
+    // Regression guard: two candidates with inverted hidden vs scouted ratings — autofill must
+    // pick the one with the higher scouted rating, proving hidden attrs never leak into the
+    // decision. Aligns with the hidden-info guarantee in docs/technical/league-phases.md.
+    var league = createLeagueFor("sub-1");
+    leagues.updatePhaseAndResetWeek(league.id(), LeaguePhase.HIRING_HEAD_COACH);
+    var pool =
+        pools.insert(league.id(), LeaguePhase.HIRING_HEAD_COACH, CandidatePoolType.HEAD_COACH);
+    var hiddenGem = insertCandidate(pool.id(), "{\"overall\": 95.00}", "{\"overall\": 40.00}");
+    var publicFavorite = insertCandidate(pool.id(), "{\"overall\": 55.00}", "{\"overall\": 85.00}");
+    // Fillers keep the hidden gem out of the top-1 by-scouted pick across other franchises so the
+    // first-iterated franchise is the only one that could conceivably pick it up.
+    seedFillerCandidates(pool.id(), 20, 70.00);
+
+    var franchiseIds = teamLookup.franchiseIdsForLeague(league.id());
+    var targetFranchise = franchiseIds.getFirst();
+    markSearching(league.id(), targetFranchise, LeaguePhase.HIRING_HEAD_COACH);
+
+    autofill.autofill(league.id(), LeaguePhase.HIRING_HEAD_COACH, 3);
+
+    assertThat(candidates.findById(publicFavorite.id()).orElseThrow().hiredByFranchiseId())
+        .contains(targetFranchise);
+    // Hidden gem's scouted is below the filler band, so it stays unhired for this run — the
+    // key invariant is that the target (highest scouted) franchise never received it.
+    var hiddenGemOwner = candidates.findById(hiddenGem.id()).orElseThrow().hiredByFranchiseId();
+    assertThat(hiddenGemOwner).isNotEqualTo(Optional.of(targetFranchise));
+  }
+
+  @Test
+  void autofill_multipleFranchises_getsDistinctCandidates() {
+    var league = createLeagueFor("sub-1");
+    leagues.updatePhaseAndResetWeek(league.id(), LeaguePhase.HIRING_HEAD_COACH);
+    var pool =
+        pools.insert(league.id(), LeaguePhase.HIRING_HEAD_COACH, CandidatePoolType.HEAD_COACH);
+    var topCandidate = insertCandidate(pool.id(), "{\"overall\": 80.00}", "{\"overall\": 85.00}");
+    var secondCandidate =
+        insertCandidate(pool.id(), "{\"overall\": 70.00}", "{\"overall\": 75.00}");
+    seedFillerCandidates(pool.id(), 20, 50.00);
+
+    var franchiseIds = teamLookup.franchiseIdsForLeague(league.id());
+    for (var franchiseId : franchiseIds) {
+      markSearching(league.id(), franchiseId, LeaguePhase.HIRING_HEAD_COACH);
+    }
+
+    autofill.autofill(league.id(), LeaguePhase.HIRING_HEAD_COACH, 3);
+
+    var firstHire = candidates.findById(topCandidate.id()).orElseThrow().hiredByFranchiseId();
+    var secondHire = candidates.findById(secondCandidate.id()).orElseThrow().hiredByFranchiseId();
+    assertThat(firstHire).isPresent();
+    assertThat(secondHire).isPresent();
+    assertThat(firstHire.get()).isNotEqualTo(secondHire.get());
+  }
+
+  private void seedFillerCandidates(long poolId, int count, double scoutedOverall) {
+    for (int i = 0; i < count; i++) {
+      insertCandidate(
+          poolId,
+          "{\"overall\": 50.00}",
+          "{\"overall\": " + String.format(java.util.Locale.ROOT, "%.2f", scoutedOverall) + "}");
+    }
+  }
+
+  private Candidate insertCandidate(long poolId, String hiddenAttrs, String scoutedAttrs) {
+    var saved =
+        candidates.insert(
+            new NewCandidate(
+                poolId,
+                CandidateKind.HEAD_COACH,
+                SpecialtyPosition.QB,
+                CandidateArchetype.OFFENSIVE_PLAY_CALLER,
+                43,
+                18,
+                "{\"HC\":0}",
+                hiddenAttrs,
+                scoutedAttrs,
+                Optional.empty()));
+    preferences.insert(CandidateTestData.preferencesFor(saved.id()));
+    return saved;
+  }
+
+  private void markSearching(long leagueId, long franchiseId, LeaguePhase phase) {
+    hiringStates.upsert(
+        new FranchiseHiringState(
+            0L, leagueId, franchiseId, phase, HiringStep.SEARCHING, List.of(), List.of()));
+  }
+
+  private League createLeagueFor(String ownerSubject) {
+    var franchiseId = new JooqFranchiseRepository(dsl).listAll().getFirst().id();
+    var result = createLeague.create(ownerSubject, "Dynasty-" + ownerSubject, franchiseId);
+    return ((CreateLeagueResult.Created) result).league();
+  }
+}


### PR DESCRIPTION
Closes #608

Stacked on #607.

## Summary
- `LeaguePhases` now carries `maxWeeks` (HC=3, DoS=3, ASSEMBLING_STAFF=1) and the HC→DoS→ASSEMBLING_STAFF transition chain.
- `AdvanceWeek` runs a completion check after offer resolution: early exit when every franchise is `HIRED`, otherwise auto-fill + advance once `phase_week > maxWeeks`.
- New `HiringPhaseAutofill` seam + `BestScoutedHiringAutofill` adapter: picks the best remaining candidate by **scouted** overall (never true rating), ties broken by candidate id then a seeded RNG split per-franchise. Creates an `ACCEPTED` offer with default terms matching the candidate's preference targets and runs the standard hire wiring.

## Test plan
- [x] `AdvanceWeekUseCaseTests` — early completion, cap-based autofill with and without user pending, no-op when below cap and mid-hire.
- [x] `BestScoutedHiringAutofillTests` — hidden-attrs isolation, skip-already-hired, distinct candidates per franchise, empty-pool no-op.
- [x] `AdvancePhaseUseCaseTests` — new HC→DoS and DoS→ASSEMBLING_STAFF transition assertions; terminal phase is now `ASSEMBLING_STAFF`.
- [x] `./gradlew spotlessCheck` and `./gradlew test` green.