### PR TITLE
feat(league): hiring & staff-assembly phases (#604–#611)

### DIFF
--- a/docs/technical/league-phases.md
+++ b/docs/technical/league-phases.md
@@ -256,7 +256,7 @@ No JSON endpoints from web controllers. Fragment responses are `text/html`.
 - Interview capacity per week (default 3, tune later).
 - `ASSEMBLING_STAFF` recap UX detail — which staff roles are hired by HC vs. DoS, and exact roster.
 - Week cap values (`maxWeeks`) — current defaults are guesses; tune against playtest.
-- Autofill logic — pick best remaining candidate vs. random from remaining; needs decision.
+- ~~Autofill logic — pick best remaining candidate vs. random from remaining; needs decision.~~ Resolved (#608): autofill assigns the best remaining candidate by **scouted** overall (never true rating). Deterministic tie-break uses candidate id, then a seeded RNG split per-franchise. The autofill creates an `ACCEPTED` offer with default terms matching the candidate's preference targets and runs the standard hire wiring (mark hired, upsert `HIRED` state, insert `franchise_staff` row).
 
 ---
 

--- a/src/main/java/app/zoneblitz/league/AdvanceWeekUseCase.java
+++ b/src/main/java/app/zoneblitz/league/AdvanceWeekUseCase.java
@@ -1,7 +1,10 @@
 package app.zoneblitz.league;
 
+import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.stream.Collectors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
@@ -13,9 +16,30 @@ class AdvanceWeekUseCase implements AdvanceWeek {
   private static final Logger log = LoggerFactory.getLogger(AdvanceWeekUseCase.class);
 
   private final LeagueRepository leagues;
+  private final OfferResolver offerResolver;
+  private final TeamLookup teams;
+  private final HiringPhaseAutofill autofill;
+  private final FranchiseHiringStateRepository hiringStates;
+  private final AdvancePhase advancePhase;
+  private final Map<LeaguePhase, CpuFranchiseStrategy> cpuStrategies;
 
-  AdvanceWeekUseCase(LeagueRepository leagues) {
+  AdvanceWeekUseCase(
+      LeagueRepository leagues,
+      OfferResolver offerResolver,
+      TeamLookup teams,
+      HiringPhaseAutofill autofill,
+      FranchiseHiringStateRepository hiringStates,
+      AdvancePhase advancePhase,
+      List<CpuFranchiseStrategy> cpuStrategies) {
     this.leagues = leagues;
+    this.offerResolver = offerResolver;
+    this.teams = teams;
+    this.autofill = autofill;
+    this.hiringStates = hiringStates;
+    this.advancePhase = advancePhase;
+    this.cpuStrategies =
+        cpuStrategies.stream()
+            .collect(Collectors.toUnmodifiableMap(CpuFranchiseStrategy::phase, s -> s));
   }
 
   @Override
@@ -27,16 +51,80 @@ class AdvanceWeekUseCase implements AdvanceWeek {
     if (maybeLeague.isEmpty()) {
       return new AdvanceWeekResult.NotFound(leagueId);
     }
-    var phase = maybeLeague.get().phase();
+    var league = maybeLeague.get();
+    var phase = league.phase();
+    var phaseWeek = league.phaseWeek();
 
-    // CPU franchise strategies are a future seam (see docs/technical/league-phases.md). No
-    // phase defines a completion rule yet, so the tick is currently just "increment the counter".
+    runCpuStrategies(leagueId, phase, phaseWeek);
+
+    // Offer resolution runs BEFORE phase_week increments so hires are recorded on the week the
+    // offers were made. See docs/technical/league-phases.md (Ticks, OfferResolver).
+    offerResolver.resolve(leagueId, phase, phaseWeek);
+
     var newWeek =
         leagues
             .incrementPhaseWeek(leagueId)
             .orElseThrow(() -> new IllegalStateException("league disappeared mid-transaction"));
 
+    var transitionedTo = maybeCompletePhase(leagueId, phase, phaseWeek, ownerSubject);
+
     log.info("league week advanced id={} phase={} week={}", leagueId, phase, newWeek);
-    return new AdvanceWeekResult.Ticked(leagueId, phase, newWeek, Optional.empty());
+    var phaseAfter = transitionedTo.orElse(phase);
+    var weekAfter = transitionedTo.isPresent() ? 1 : newWeek;
+    return new AdvanceWeekResult.Ticked(leagueId, phaseAfter, weekAfter, transitionedTo);
+  }
+
+  private Optional<LeaguePhase> maybeCompletePhase(
+      long leagueId, LeaguePhase phase, int resolvedAtWeek, String ownerSubject) {
+    var shouldComplete = shouldComplete(leagueId, phase, resolvedAtWeek);
+    if (!shouldComplete) {
+      return Optional.empty();
+    }
+    if (overCap(phase, resolvedAtWeek)) {
+      autofill.autofill(leagueId, phase, resolvedAtWeek);
+    }
+    var advanced = advancePhase.advance(leagueId, ownerSubject);
+    return switch (advanced) {
+      case AdvancePhaseResult.Advanced a -> Optional.of(a.to());
+      case AdvancePhaseResult.NoNextPhase ignored -> Optional.empty();
+      case AdvancePhaseResult.NotFound ignored -> Optional.empty();
+    };
+  }
+
+  private boolean shouldComplete(long leagueId, LeaguePhase phase, int resolvedAtWeek) {
+    return allFranchisesHired(leagueId, phase) || overCap(phase, resolvedAtWeek);
+  }
+
+  private boolean allFranchisesHired(long leagueId, LeaguePhase phase) {
+    return switch (phase) {
+      case HIRING_HEAD_COACH, HIRING_DIRECTOR_OF_SCOUTING -> {
+        var franchiseIds = teams.franchiseIdsForLeague(leagueId);
+        if (franchiseIds.isEmpty()) {
+          yield false;
+        }
+        for (var franchiseId : franchiseIds) {
+          var state = hiringStates.find(leagueId, franchiseId, phase);
+          if (state.isEmpty() || state.get().step() != HiringStep.HIRED) {
+            yield false;
+          }
+        }
+        yield true;
+      }
+      case INITIAL_SETUP, ASSEMBLING_STAFF, COMPLETE -> false;
+    };
+  }
+
+  private static boolean overCap(LeaguePhase phase, int resolvedAtWeek) {
+    return LeaguePhases.maxWeeks(phase).map(cap -> resolvedAtWeek >= cap).orElse(false);
+  }
+
+  private void runCpuStrategies(long leagueId, LeaguePhase phase, int phaseWeek) {
+    var strategy = cpuStrategies.get(phase);
+    if (strategy == null) {
+      return;
+    }
+    for (var franchiseId : teams.cpuFranchiseIdsForLeague(leagueId)) {
+      strategy.execute(leagueId, franchiseId, phaseWeek);
+    }
   }
 }

--- a/src/main/java/app/zoneblitz/league/BestScoutedHiringAutofill.java
+++ b/src/main/java/app/zoneblitz/league/BestScoutedHiringAutofill.java
@@ -1,0 +1,204 @@
+package app.zoneblitz.league;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Optional;
+import java.util.regex.Pattern;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+/**
+ * Default {@link HiringPhaseAutofill}: ranks remaining candidates by scouted overall (never true
+ * rating) and assigns the top one to each unresolved franchise. Ties are broken first by candidate
+ * id, then — if still tied — by a deterministic seeded RNG split per-franchise, so reruns with the
+ * same league seed produce identical hires.
+ *
+ * <p>Default terms mirror the candidate's preference targets so the synthetic offer scores a
+ * perfect fit. The hire wiring (mark candidate hired, upsert hiring state to {@link
+ * HiringStep#HIRED}, insert {@link FranchiseStaffMember}, create an {@link OfferStatus#ACCEPTED}
+ * offer row) matches the flow in {@link PreferenceScoringOfferResolver}.
+ */
+@Component
+class BestScoutedHiringAutofill implements HiringPhaseAutofill {
+
+  private static final Logger log = LoggerFactory.getLogger(BestScoutedHiringAutofill.class);
+
+  private static final Pattern OVERALL_PATTERN =
+      Pattern.compile("\"overall\"\\s*:\\s*(-?[0-9]+(?:\\.[0-9]+)?)");
+
+  private final CandidatePoolRepository pools;
+  private final CandidateRepository candidates;
+  private final CandidatePreferencesRepository preferences;
+  private final CandidateOfferRepository offers;
+  private final FranchiseHiringStateRepository hiringStates;
+  private final FranchiseStaffRepository staff;
+  private final TeamLookup teams;
+  private final CandidateRandomSources rngs;
+
+  BestScoutedHiringAutofill(
+      CandidatePoolRepository pools,
+      CandidateRepository candidates,
+      CandidatePreferencesRepository preferences,
+      CandidateOfferRepository offers,
+      FranchiseHiringStateRepository hiringStates,
+      FranchiseStaffRepository staff,
+      TeamLookup teams,
+      CandidateRandomSources rngs) {
+    this.pools = pools;
+    this.candidates = candidates;
+    this.preferences = preferences;
+    this.offers = offers;
+    this.hiringStates = hiringStates;
+    this.staff = staff;
+    this.teams = teams;
+    this.rngs = rngs;
+  }
+
+  @Override
+  public void autofill(long leagueId, LeaguePhase phase, int phaseWeek) {
+    var maybePoolType = poolTypeFor(phase);
+    if (maybePoolType.isEmpty()) {
+      return;
+    }
+    var maybePool = pools.findByLeaguePhaseAndType(leagueId, phase, maybePoolType.get());
+    if (maybePool.isEmpty()) {
+      return;
+    }
+    var role = roleFor(phase);
+
+    var remaining =
+        new ArrayList<>(
+            candidates.findAllByPoolId(maybePool.get().id()).stream()
+                .filter(c -> c.hiredByFranchiseId().isEmpty())
+                .toList());
+
+    for (var franchiseId : teams.franchiseIdsForLeague(leagueId)) {
+      if (isAlreadyHired(leagueId, franchiseId, phase)) {
+        continue;
+      }
+      if (remaining.isEmpty()) {
+        log.warn(
+            "autofill ran out of candidates leagueId={} phase={} franchiseId={}",
+            leagueId,
+            phase,
+            franchiseId);
+        return;
+      }
+      var pick = pickBest(leagueId, phase, franchiseId, remaining);
+      remaining.remove(pick);
+      assign(leagueId, phase, phaseWeek, franchiseId, pick, role);
+    }
+  }
+
+  private boolean isAlreadyHired(long leagueId, long franchiseId, LeaguePhase phase) {
+    return hiringStates
+        .find(leagueId, franchiseId, phase)
+        .map(s -> s.step() == HiringStep.HIRED)
+        .orElse(false);
+  }
+
+  private Candidate pickBest(
+      long leagueId, LeaguePhase phase, long franchiseId, List<Candidate> remaining) {
+    remaining.sort(
+        Comparator.comparingDouble((Candidate c) -> scoutedOverall(c.scoutedAttrs()))
+            .reversed()
+            .thenComparingLong(Candidate::id));
+    var topScore = scoutedOverall(remaining.getFirst().scoutedAttrs());
+    var tied =
+        remaining.stream().filter(c -> scoutedOverall(c.scoutedAttrs()) == topScore).toList();
+    if (tied.size() == 1) {
+      return tied.getFirst();
+    }
+    // Secondary tie-break: deterministic seeded RNG split per-franchise. `thenComparingLong(id)`
+    // already gave a stable order; RNG breaks cohort ties across franchises without biasing by id.
+    var rng = rngs.forLeaguePhase(leagueId, phase).split(franchiseId);
+    var pickIndex = (int) Math.floorMod(rng.nextLong(), (long) tied.size());
+    return tied.get(pickIndex);
+  }
+
+  private void assign(
+      long leagueId,
+      LeaguePhase phase,
+      int phaseWeek,
+      long franchiseId,
+      Candidate candidate,
+      StaffRole role) {
+    var maybePrefs = preferences.findByCandidateId(candidate.id());
+    if (maybePrefs.isEmpty()) {
+      log.warn(
+          "autofill skipped — missing preferences leagueId={} candidateId={}",
+          leagueId,
+          candidate.id());
+      return;
+    }
+    var terms = defaultTerms(maybePrefs.get());
+    var offer =
+        offers.insertActive(candidate.id(), franchiseId, OfferTermsJson.toJson(terms), phaseWeek);
+    offers.resolve(offer.id(), OfferStatus.ACCEPTED);
+    candidates.markHired(candidate.id(), franchiseId);
+    upsertHired(leagueId, phase, franchiseId);
+    staff.insert(
+        new NewFranchiseStaffMember(
+            leagueId, franchiseId, candidate.id(), role, Optional.empty(), phase, phaseWeek));
+    log.info(
+        "autofill hire leagueId={} phase={} franchiseId={} candidateId={} week={}",
+        leagueId,
+        phase,
+        franchiseId,
+        candidate.id(),
+        phaseWeek);
+  }
+
+  private void upsertHired(long leagueId, LeaguePhase phase, long franchiseId) {
+    var existing = hiringStates.find(leagueId, franchiseId, phase);
+    hiringStates.upsert(
+        new FranchiseHiringState(
+            existing.map(FranchiseHiringState::id).orElse(0L),
+            leagueId,
+            franchiseId,
+            phase,
+            HiringStep.HIRED,
+            existing.map(FranchiseHiringState::shortlist).orElse(List.of()),
+            existing.map(FranchiseHiringState::interviewingCandidateIds).orElse(List.of())));
+  }
+
+  private static OfferTerms defaultTerms(CandidatePreferences prefs) {
+    return new OfferTerms(
+        prefs.compensationTarget(),
+        prefs.contractLengthTarget(),
+        prefs.guaranteedMoneyTarget(),
+        prefs.roleScopeTarget(),
+        prefs.staffContinuityTarget());
+  }
+
+  private static double scoutedOverall(String scoutedAttrsJson) {
+    var m = OVERALL_PATTERN.matcher(scoutedAttrsJson);
+    if (m.find()) {
+      try {
+        return Double.parseDouble(m.group(1));
+      } catch (NumberFormatException ignored) {
+        return 0.0;
+      }
+    }
+    return 0.0;
+  }
+
+  private static Optional<CandidatePoolType> poolTypeFor(LeaguePhase phase) {
+    return switch (phase) {
+      case HIRING_HEAD_COACH -> Optional.of(CandidatePoolType.HEAD_COACH);
+      case HIRING_DIRECTOR_OF_SCOUTING -> Optional.of(CandidatePoolType.DIRECTOR_OF_SCOUTING);
+      case INITIAL_SETUP, ASSEMBLING_STAFF, COMPLETE -> Optional.empty();
+    };
+  }
+
+  private static StaffRole roleFor(LeaguePhase phase) {
+    return switch (phase) {
+      case HIRING_HEAD_COACH -> StaffRole.HEAD_COACH;
+      case HIRING_DIRECTOR_OF_SCOUTING -> StaffRole.DIRECTOR_OF_SCOUTING;
+      case INITIAL_SETUP, ASSEMBLING_STAFF, COMPLETE ->
+          throw new IllegalArgumentException("no hire role for phase " + phase);
+    };
+  }
+}

--- a/src/main/java/app/zoneblitz/league/CandidateRandomSources.java
+++ b/src/main/java/app/zoneblitz/league/CandidateRandomSources.java
@@ -1,0 +1,14 @@
+package app.zoneblitz.league;
+
+import app.zoneblitz.gamesimulator.rng.RandomSource;
+
+/**
+ * Factory seam producing a deterministic {@link RandomSource} for a {@code (leagueId, phase)} pair.
+ * Lets phase-entry handlers generate reproducible candidate pools without depending on a concrete
+ * RNG implementation.
+ */
+interface CandidateRandomSources {
+
+  /** Return a seeded {@link RandomSource} scoped to the given league and phase. */
+  RandomSource forLeaguePhase(long leagueId, LeaguePhase phase);
+}

--- a/src/main/java/app/zoneblitz/league/CityFranchiseProfiles.java
+++ b/src/main/java/app/zoneblitz/league/CityFranchiseProfiles.java
@@ -1,0 +1,66 @@
+package app.zoneblitz.league;
+
+import java.math.BigDecimal;
+import java.util.Map;
+import java.util.Optional;
+import org.springframework.stereotype.Component;
+
+/**
+ * v1 {@link FranchiseProfiles}: maps each seeded franchise city to static market-size, geography,
+ * and climate constants. Dynamic preference dimensions resolve to equal-footing constants so they
+ * do not discriminate between franchises until a franchise-ratings layer lands (see {@code
+ * docs/technical/league-phases.md} "v1 equal-footing note").
+ */
+@Component
+class CityFranchiseProfiles implements FranchiseProfiles {
+
+  private static final BigDecimal EQUAL_FOOTING_PRESTIGE = new BigDecimal("50.00");
+  private static final BigDecimal EQUAL_FOOTING_OWNER_STABILITY = new BigDecimal("50.00");
+  private static final BigDecimal EQUAL_FOOTING_FACILITY_QUALITY = new BigDecimal("50.00");
+  private static final CompetitiveWindow EQUAL_FOOTING_WINDOW = CompetitiveWindow.NEUTRAL;
+  private static final String EQUAL_FOOTING_SCHEME = "BALANCED";
+
+  // Static per-city attributes for the v1 seeded franchises. Keyed by city name; state code is
+  // ignored because names are unique across the seed set.
+  private static final Map<String, CityAttrs> CITY_ATTRS =
+      Map.of(
+          "Boston", new CityAttrs(MarketSize.LARGE, Geography.NE, Climate.COLD),
+          "New York", new CityAttrs(MarketSize.LARGE, Geography.NE, Climate.COLD),
+          "Atlanta", new CityAttrs(MarketSize.LARGE, Geography.SE, Climate.WARM),
+          "Miami", new CityAttrs(MarketSize.LARGE, Geography.SE, Climate.WARM),
+          "Chicago", new CityAttrs(MarketSize.LARGE, Geography.MW, Climate.COLD),
+          "Dallas", new CityAttrs(MarketSize.LARGE, Geography.SW, Climate.WARM),
+          "Denver", new CityAttrs(MarketSize.MEDIUM, Geography.W, Climate.COLD),
+          "Los Angeles", new CityAttrs(MarketSize.LARGE, Geography.W, Climate.WARM));
+
+  private static final CityAttrs FALLBACK =
+      new CityAttrs(MarketSize.MEDIUM, Geography.MW, Climate.NEUTRAL);
+
+  private final FranchiseRepository franchises;
+
+  CityFranchiseProfiles(FranchiseRepository franchises) {
+    this.franchises = franchises;
+  }
+
+  @Override
+  public Optional<FranchiseProfile> forFranchise(long franchiseId) {
+    return franchises
+        .findById(franchiseId)
+        .map(
+            f -> {
+              var attrs = CITY_ATTRS.getOrDefault(f.city().name(), FALLBACK);
+              return new FranchiseProfile(
+                  f.id(),
+                  attrs.marketSize(),
+                  attrs.geography(),
+                  attrs.climate(),
+                  EQUAL_FOOTING_PRESTIGE,
+                  EQUAL_FOOTING_WINDOW,
+                  EQUAL_FOOTING_OWNER_STABILITY,
+                  EQUAL_FOOTING_FACILITY_QUALITY,
+                  EQUAL_FOOTING_SCHEME);
+            });
+  }
+
+  private record CityAttrs(MarketSize marketSize, Geography geography, Climate climate) {}
+}

--- a/src/main/java/app/zoneblitz/league/CoordinatorGenerator.java
+++ b/src/main/java/app/zoneblitz/league/CoordinatorGenerator.java
@@ -1,0 +1,164 @@
+package app.zoneblitz.league;
+
+import app.zoneblitz.gamesimulator.rng.RandomSource;
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.stream.IntStream;
+
+/**
+ * Lightweight placeholder generator for coordinator candidates (OC, DC, ST). Reuses the HC band
+ * file as a pricing anchor — coordinators earn a fraction of HC salaries — so no new band resource
+ * is required for v1 of {@link LeaguePhase#ASSEMBLING_STAFF}. Specialty sampling is biased by the
+ * coordinator kind (OC favors offensive positions, DC defensive, ST special teams).
+ *
+ * <p>Follows the hidden-info contract: true rating sampled independently; price signals derived
+ * from perceived features only.
+ */
+public final class CoordinatorGenerator {
+
+  private static final double COORDINATOR_SALARY_FRACTION = 0.30;
+  private static final double TRUE_RATING_MEAN = 60.0;
+  private static final double TRUE_RATING_STD = 10.0;
+  private static final double SCOUTED_NOISE_STD = 8.0;
+  private static final double GUARANTEED_MONEY_FLOOR = 0.60;
+  private static final double GUARANTEED_MONEY_CEIL = 0.90;
+
+  private final HeadCoachMarketBands bands;
+
+  public CoordinatorGenerator() {
+    this(HeadCoachMarketBands.loadFromClasspath());
+  }
+
+  CoordinatorGenerator(HeadCoachMarketBands bands) {
+    this.bands = Objects.requireNonNull(bands, "bands");
+  }
+
+  /**
+   * Generate {@code poolSize} coordinator candidates of the given {@code kind}. {@code kind} must
+   * be one of {@link CandidateKind#OFFENSIVE_COORDINATOR}, {@link
+   * CandidateKind#DEFENSIVE_COORDINATOR}, or {@link CandidateKind#SPECIAL_TEAMS_COORDINATOR}.
+   */
+  public List<GeneratedCandidate> generate(int poolSize, CandidateKind kind, RandomSource rng) {
+    Objects.requireNonNull(kind, "kind");
+    Objects.requireNonNull(rng, "rng");
+    if (poolSize <= 0) {
+      throw new IllegalArgumentException("poolSize must be > 0, was: " + poolSize);
+    }
+    if (!isCoordinator(kind)) {
+      throw new IllegalArgumentException("not a coordinator kind: " + kind);
+    }
+    return IntStream.range(0, poolSize).mapToObj(i -> generateOne(kind, rng)).toList();
+  }
+
+  private GeneratedCandidate generateOne(CandidateKind kind, RandomSource rng) {
+    var archetype = archetypeFor(kind, rng);
+    var specialty = sampleSpecialty(kind, rng);
+    var age = sampleAge(rng);
+    var totalExperience = sampleTotalExperience(age, rng);
+    var experienceByRole =
+        """
+        {"%s": %d}"""
+            .formatted(kind.name(), Math.min(totalExperience, 10));
+
+    var trueRating = clamp(TRUE_RATING_MEAN + TRUE_RATING_STD * rng.nextGaussian(), 20.0, 99.0);
+    var scoutedRating = clamp(trueRating + SCOUTED_NOISE_STD * rng.nextGaussian(), 20.0, 99.0);
+
+    var compensation = perceivedCompensation(age, totalExperience, rng);
+    var contractLength = 2 + (int) Math.round(rng.nextDouble() * 2);
+    var guaranteedMoney =
+        BigDecimal.valueOf(
+                GUARANTEED_MONEY_FLOOR
+                    + rng.nextDouble() * (GUARANTEED_MONEY_CEIL - GUARANTEED_MONEY_FLOOR))
+            .setScale(3, RoundingMode.HALF_UP);
+
+    var candidate =
+        new NewCandidate(
+            /* poolId= */ 0L,
+            kind,
+            specialty,
+            archetype,
+            age,
+            totalExperience,
+            experienceByRole,
+            "{\"overall\": %.2f}".formatted(trueRating),
+            "{\"overall\": %.2f}".formatted(scoutedRating),
+            Optional.empty());
+    var preferences =
+        StaffPreferencesFactory.uniform(compensation, contractLength, guaranteedMoney, rng);
+    return new GeneratedCandidate(candidate, preferences);
+  }
+
+  private CandidateArchetype archetypeFor(CandidateKind kind, RandomSource rng) {
+    return switch (kind) {
+      case OFFENSIVE_COORDINATOR ->
+          rng.nextDouble() < 0.7
+              ? CandidateArchetype.OFFENSIVE_PLAY_CALLER
+              : CandidateArchetype.OFFENSIVE_GURU;
+      case DEFENSIVE_COORDINATOR ->
+          rng.nextDouble() < 0.7
+              ? CandidateArchetype.DEFENSIVE_PLAY_CALLER
+              : CandidateArchetype.DEFENSIVE_GURU;
+      case SPECIAL_TEAMS_COORDINATOR -> CandidateArchetype.TACTICIAN;
+      case HEAD_COACH, DIRECTOR_OF_SCOUTING, POSITION_COACH, SCOUT ->
+          throw new IllegalStateException("not a coordinator: " + kind);
+    };
+  }
+
+  private SpecialtyPosition sampleSpecialty(CandidateKind kind, RandomSource rng) {
+    var offensive =
+        List.of(
+            SpecialtyPosition.QB,
+            SpecialtyPosition.WR,
+            SpecialtyPosition.OL,
+            SpecialtyPosition.RB,
+            SpecialtyPosition.TE);
+    var defensive =
+        List.of(
+            SpecialtyPosition.DL,
+            SpecialtyPosition.EDGE,
+            SpecialtyPosition.LB,
+            SpecialtyPosition.CB,
+            SpecialtyPosition.S);
+    var specialTeams = List.of(SpecialtyPosition.K, SpecialtyPosition.P, SpecialtyPosition.LS);
+    var choices =
+        switch (kind) {
+          case OFFENSIVE_COORDINATOR -> offensive;
+          case DEFENSIVE_COORDINATOR -> defensive;
+          case SPECIAL_TEAMS_COORDINATOR -> specialTeams;
+          case HEAD_COACH, DIRECTOR_OF_SCOUTING, POSITION_COACH, SCOUT ->
+              throw new IllegalStateException("not a coordinator: " + kind);
+        };
+    return choices.get((int) (rng.nextDouble() * choices.size()));
+  }
+
+  private int sampleAge(RandomSource rng) {
+    return 34 + (int) Math.round(rng.nextDouble() * 20);
+  }
+
+  private int sampleTotalExperience(int age, RandomSource rng) {
+    var career = Math.max(5, age - 24);
+    var draw = 5 + (int) Math.round(rng.nextDouble() * 15);
+    return Math.min(draw, career);
+  }
+
+  private BigDecimal perceivedCompensation(int age, int totalExperience, RandomSource rng) {
+    var hcBase = bands.salaryP10() + rng.nextDouble() * (bands.salaryP50() - bands.salaryP10());
+    var ageMultiplier = 0.85 + Math.min(Math.abs(age - 48), 15) * -0.005;
+    var experienceMultiplier = 0.9 + Math.min(totalExperience, 20) * 0.01;
+    var value = hcBase * COORDINATOR_SALARY_FRACTION * ageMultiplier * experienceMultiplier;
+    return BigDecimal.valueOf(Math.max(400_000, value)).setScale(2, RoundingMode.HALF_UP);
+  }
+
+  private static boolean isCoordinator(CandidateKind kind) {
+    return kind == CandidateKind.OFFENSIVE_COORDINATOR
+        || kind == CandidateKind.DEFENSIVE_COORDINATOR
+        || kind == CandidateKind.SPECIAL_TEAMS_COORDINATOR;
+  }
+
+  private static double clamp(double v, double lo, double hi) {
+    return Math.max(lo, Math.min(hi, v));
+  }
+}

--- a/src/main/java/app/zoneblitz/league/CpuFranchiseStrategy.java
+++ b/src/main/java/app/zoneblitz/league/CpuFranchiseStrategy.java
@@ -1,0 +1,29 @@
+package app.zoneblitz.league;
+
+/**
+ * Per-phase CPU decision-maker. One implementation per {@link LeaguePhase} that requires CPU
+ * behavior; {@link AdvanceWeek} resolves the active phase's strategy and invokes {@link
+ * #execute(long, long, int)} once for each CPU-controlled franchise on every week tick.
+ *
+ * <p>See {@code docs/technical/league-phases.md} "Seams" table and "Ticks" section. Strategies must
+ * be deterministic given the inputs they receive and any league-scoped RNG they derive from {@link
+ * CandidateRandomSources}; the week tick is the only place their side effects may commit.
+ */
+interface CpuFranchiseStrategy {
+
+  /** The phase this strategy handles. */
+  LeaguePhase phase();
+
+  /**
+   * Execute one week of CPU behavior for the given franchise in the given league. Invariants:
+   *
+   * <ul>
+   *   <li>Called inside the {@link AdvanceWeek} transaction. Strategies that persist must do so
+   *       through the feature's repositories so commits are atomic with the tick.
+   *   <li>Phase state is read at call-time — {@code phaseWeek} is the week the tick is resolving
+   *       <em>before</em> increment.
+   *   <li>Called only for CPU franchises; implementations must not re-check ownership.
+   * </ul>
+   */
+  void execute(long leagueId, long franchiseId, int phaseWeek);
+}

--- a/src/main/java/app/zoneblitz/league/CpuHiringStrategy.java
+++ b/src/main/java/app/zoneblitz/league/CpuHiringStrategy.java
@@ -1,0 +1,302 @@
+package app.zoneblitz.league;
+
+import app.zoneblitz.gamesimulator.rng.RandomSource;
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.regex.Pattern;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * CPU decision-maker for the two hiring phases ({@link LeaguePhase#HIRING_HEAD_COACH} and {@link
+ * LeaguePhase#HIRING_DIRECTOR_OF_SCOUTING}). One bean is registered per phase; the behavior is
+ * identical — only the phase/pool-type pair differs — because the hiring sub-state machine is
+ * phase-agnostic per {@code docs/technical/league-phases.md} (Hiring sub-state machine).
+ *
+ * <p>Runs one week of hiring behavior per invocation:
+ *
+ * <ol>
+ *   <li>If the franchise is already {@link HiringStep#HIRED}, do nothing.
+ *   <li>If no shortlist yet, build one from the top candidates by scouted overall (unhired only),
+ *       up to {@link #SHORTLIST_SIZE}.
+ *   <li>Interview shortlisted candidates up to the weekly capacity, preferring the highest
+ *       scouted-overall candidate the franchise has interviewed the fewest times. Interview rows
+ *       follow the same noise model as user interviews ({@link InterviewNoiseModel}).
+ *   <li>If no active CPU offer is outstanding, submit a single offer on the top shortlisted
+ *       candidate that is still unhired and that the franchise does not already have an active
+ *       offer on. Terms are derived from the candidate's scouted overall via a simple willingness-
+ *       to-pay model keyed off the candidate's own compensation target — higher-rated candidates
+ *       get premium bids, lower-rated ones get sub-target bids. This is deliberately modest — the
+ *       league-phases doc calls for "no ML, no deep planning".
+ * </ol>
+ *
+ * Determinism: all random draws come from a franchise-and-candidate split of {@link
+ * CandidateRandomSources#forLeaguePhase(long, LeaguePhase)}, so the same seed reproduces identical
+ * behavior.
+ */
+class CpuHiringStrategy implements CpuFranchiseStrategy {
+
+  private static final Logger log = LoggerFactory.getLogger(CpuHiringStrategy.class);
+
+  /** How many candidates a CPU franchise shortlists. Kept small per the ticket brief. */
+  static final int SHORTLIST_SIZE = 4;
+
+  private static final Pattern OVERALL_PATTERN =
+      Pattern.compile("\"overall\"\\s*:\\s*(-?[0-9]+(?:\\.[0-9]+)?)");
+  private static final double SCOUTED_LOWER = 20.0;
+  private static final double SCOUTED_UPPER = 99.0;
+
+  private final LeaguePhase phase;
+  private final CandidatePoolType poolType;
+  private final CandidatePoolRepository pools;
+  private final CandidateRepository candidates;
+  private final CandidatePreferencesRepository preferences;
+  private final CandidateOfferRepository offers;
+  private final FranchiseHiringStateRepository hiringStates;
+  private final FranchiseInterviewRepository interviews;
+  private final CandidateRandomSources rngs;
+
+  CpuHiringStrategy(
+      LeaguePhase phase,
+      CandidatePoolType poolType,
+      CandidatePoolRepository pools,
+      CandidateRepository candidates,
+      CandidatePreferencesRepository preferences,
+      CandidateOfferRepository offers,
+      FranchiseHiringStateRepository hiringStates,
+      FranchiseInterviewRepository interviews,
+      CandidateRandomSources rngs) {
+    this.phase = phase;
+    this.poolType = poolType;
+    this.pools = pools;
+    this.candidates = candidates;
+    this.preferences = preferences;
+    this.offers = offers;
+    this.hiringStates = hiringStates;
+    this.interviews = interviews;
+    this.rngs = rngs;
+  }
+
+  @Override
+  public LeaguePhase phase() {
+    return phase;
+  }
+
+  @Override
+  public void execute(long leagueId, long franchiseId, int phaseWeek) {
+    var existing = hiringStates.find(leagueId, franchiseId, phase());
+    if (existing.isPresent() && existing.get().step() == HiringStep.HIRED) {
+      return;
+    }
+    var maybePool = pools.findByLeaguePhaseAndType(leagueId, phase(), poolType);
+    if (maybePool.isEmpty()) {
+      return;
+    }
+    var poolCandidates = candidates.findAllByPoolId(maybePool.get().id());
+    var unhired = poolCandidates.stream().filter(c -> c.hiredByFranchiseId().isEmpty()).toList();
+    if (unhired.isEmpty()) {
+      return;
+    }
+
+    var state = ensureState(leagueId, franchiseId, existing, unhired);
+    var shortlist = state.shortlist();
+
+    runInterviews(leagueId, franchiseId, phaseWeek, shortlist, unhired);
+    submitOfferIfNone(leagueId, franchiseId, phaseWeek, shortlist, unhired);
+  }
+
+  private FranchiseHiringState ensureState(
+      long leagueId,
+      long franchiseId,
+      java.util.Optional<FranchiseHiringState> existing,
+      List<Candidate> unhired) {
+    if (existing.isPresent() && !existing.get().shortlist().isEmpty()) {
+      return existing.get();
+    }
+    var shortlist = pickShortlist(unhired);
+    var stateId = existing.map(FranchiseHiringState::id).orElse(0L);
+    var interviewing =
+        existing.map(FranchiseHiringState::interviewingCandidateIds).orElse(List.of());
+    return hiringStates.upsert(
+        new FranchiseHiringState(
+            stateId,
+            leagueId,
+            franchiseId,
+            phase(),
+            HiringStep.SEARCHING,
+            shortlist,
+            interviewing));
+  }
+
+  private List<Long> pickShortlist(List<Candidate> unhired) {
+    return unhired.stream()
+        .sorted(
+            Comparator.comparingDouble((Candidate c) -> scoutedOverall(c.scoutedAttrs()))
+                .reversed()
+                .thenComparingLong(Candidate::id))
+        .limit(SHORTLIST_SIZE)
+        .map(Candidate::id)
+        .toList();
+  }
+
+  private void runInterviews(
+      long leagueId,
+      long franchiseId,
+      int phaseWeek,
+      List<Long> shortlist,
+      List<Candidate> unhired) {
+    var unhiredIds = unhired.stream().map(Candidate::id).toList();
+    var capacity = StartInterview.DEFAULT_WEEKLY_CAPACITY;
+    var used = interviews.countForWeek(leagueId, franchiseId, phase(), phaseWeek);
+    if (used >= capacity) {
+      return;
+    }
+    var candidatesById =
+        unhired.stream()
+            .collect(
+                java.util.stream.Collectors.toMap(
+                    Candidate::id, c -> c, (a, b) -> a, java.util.LinkedHashMap::new));
+    var eligible =
+        shortlist.stream().filter(unhiredIds::contains).map(candidatesById::get).toList();
+    var remaining = capacity - used;
+    var priorCounts = new java.util.HashMap<Long, Integer>();
+    for (var c : eligible) {
+      priorCounts.put(c.id(), interviews.countForCandidate(leagueId, franchiseId, c.id(), phase()));
+    }
+    var ordered =
+        eligible.stream()
+            .sorted(
+                Comparator.comparingInt((Candidate c) -> priorCounts.get(c.id()))
+                    .thenComparingDouble((Candidate c) -> -scoutedOverall(c.scoutedAttrs()))
+                    .thenComparingLong(Candidate::id))
+            .limit(remaining)
+            .toList();
+    for (var candidate : ordered) {
+      recordInterview(leagueId, franchiseId, phaseWeek, candidate, priorCounts.get(candidate.id()));
+    }
+  }
+
+  private void recordInterview(
+      long leagueId, long franchiseId, int phaseWeek, Candidate candidate, int priorCount) {
+    var newIndex = priorCount + 1;
+    var trueRating = extractDoubleOrDefault(OVERALL_PATTERN, candidate.hiddenAttrs(), 50.0);
+    var sigma = InterviewNoiseModel.headCoachSigma(newIndex);
+    var rng = interviewRng(leagueId, franchiseId, candidate.id(), newIndex);
+    var sample = trueRating + sigma * rng.nextGaussian();
+    var clamped = Math.max(SCOUTED_LOWER, Math.min(SCOUTED_UPPER, sample));
+    var scouted = BigDecimal.valueOf(clamped).setScale(2, RoundingMode.HALF_UP);
+    interviews.insert(
+        new NewFranchiseInterview(
+            leagueId, franchiseId, candidate.id(), phase(), phaseWeek, newIndex, scouted));
+    appendInterviewing(leagueId, franchiseId, candidate.id());
+    log.debug(
+        "cpu interview leagueId={} franchiseId={} candidateId={} index={} sigma={}",
+        leagueId,
+        franchiseId,
+        candidate.id(),
+        newIndex,
+        sigma);
+  }
+
+  private void appendInterviewing(long leagueId, long franchiseId, long candidateId) {
+    var existing = hiringStates.find(leagueId, franchiseId, phase());
+    var shortlist = existing.map(FranchiseHiringState::shortlist).orElse(List.of());
+    var interviewing =
+        existing.map(FranchiseHiringState::interviewingCandidateIds).orElse(List.of());
+    var updated = new ArrayList<Long>(interviewing.size() + 1);
+    updated.addAll(interviewing);
+    updated.add(candidateId);
+    hiringStates.upsert(
+        new FranchiseHiringState(
+            existing.map(FranchiseHiringState::id).orElse(0L),
+            leagueId,
+            franchiseId,
+            phase(),
+            HiringStep.SEARCHING,
+            shortlist,
+            List.copyOf(updated)));
+  }
+
+  private void submitOfferIfNone(
+      long leagueId,
+      long franchiseId,
+      int phaseWeek,
+      List<Long> shortlist,
+      List<Candidate> unhired) {
+    var existingOffers = offers.findActiveForFranchise(franchiseId);
+    if (!existingOffers.isEmpty()) {
+      return;
+    }
+    var unhiredById =
+        unhired.stream()
+            .collect(java.util.stream.Collectors.toMap(Candidate::id, c -> c, (a, b) -> a));
+    for (var candidateId : shortlist) {
+      var candidate = unhiredById.get(candidateId);
+      if (candidate == null) {
+        continue;
+      }
+      var prefs = preferences.findByCandidateId(candidateId);
+      if (prefs.isEmpty()) {
+        continue;
+      }
+      var terms = buildOfferTerms(candidate, prefs.get());
+      var saved =
+          offers.insertActive(candidate.id(), franchiseId, OfferTermsJson.toJson(terms), phaseWeek);
+      log.info(
+          "cpu offer submitted leagueId={} franchiseId={} candidateId={} offerId={} week={}",
+          leagueId,
+          franchiseId,
+          candidate.id(),
+          saved.id(),
+          phaseWeek);
+      return;
+    }
+  }
+
+  /**
+   * Simple willingness-to-pay: scale the candidate's compensation target by 0.85..1.20 linear in
+   * scouted overall. Contract length and guaranteed money mirror the candidate's own targets so the
+   * CPU never bids below the floor fit. Role scope / staff continuity match the candidate's
+   * preference target so categorical dimensions always score 1.0.
+   */
+  private OfferTerms buildOfferTerms(Candidate candidate, CandidatePreferences prefs) {
+    var scouted = scoutedOverall(candidate.scoutedAttrs());
+    var priority = (scouted - SCOUTED_LOWER) / (SCOUTED_UPPER - SCOUTED_LOWER);
+    var multiplier = 0.85 + Math.max(0.0, Math.min(1.0, priority)) * 0.35;
+    var compensation =
+        prefs
+            .compensationTarget()
+            .multiply(BigDecimal.valueOf(multiplier))
+            .setScale(2, RoundingMode.HALF_UP);
+    return new OfferTerms(
+        compensation,
+        prefs.contractLengthTarget(),
+        prefs.guaranteedMoneyTarget(),
+        prefs.roleScopeTarget(),
+        prefs.staffContinuityTarget());
+  }
+
+  private RandomSource interviewRng(long leagueId, long franchiseId, long candidateId, int index) {
+    var base = rngs.forLeaguePhase(leagueId, phase());
+    return base.split(franchiseId).split(candidateId).split(index);
+  }
+
+  private static double scoutedOverall(String scoutedAttrsJson) {
+    return extractDoubleOrDefault(OVERALL_PATTERN, scoutedAttrsJson, 50.0);
+  }
+
+  private static double extractDoubleOrDefault(Pattern pattern, String json, double fallback) {
+    var m = pattern.matcher(json);
+    if (m.find()) {
+      try {
+        return Double.parseDouble(m.group(1));
+      } catch (NumberFormatException ignored) {
+        return fallback;
+      }
+    }
+    return fallback;
+  }
+}

--- a/src/main/java/app/zoneblitz/league/DirectorOfScoutingCandidateView.java
+++ b/src/main/java/app/zoneblitz/league/DirectorOfScoutingCandidateView.java
@@ -1,0 +1,34 @@
+package app.zoneblitz.league;
+
+import java.math.BigDecimal;
+import java.util.Objects;
+
+/**
+ * Row view-model for a single Director-of-Scouting candidate in the hiring pool table. Carries only
+ * the scouted projection — never the hidden true-rating payload. {@code shortlisted} reflects the
+ * requesting franchise's shortlist membership for the DoS phase.
+ */
+public record DirectorOfScoutingCandidateView(
+    long id,
+    CandidateArchetype archetype,
+    SpecialtyPosition specialty,
+    int age,
+    int totalExperienceYears,
+    int dosYears,
+    int scoutYears,
+    int areaScoutYears,
+    String scoutedOverall,
+    BigDecimal compensationTarget,
+    int contractLengthTarget,
+    BigDecimal guaranteedMoneyTarget,
+    boolean shortlisted,
+    int interviewCount) {
+
+  public DirectorOfScoutingCandidateView {
+    Objects.requireNonNull(archetype, "archetype");
+    Objects.requireNonNull(specialty, "specialty");
+    Objects.requireNonNull(scoutedOverall, "scoutedOverall");
+    Objects.requireNonNull(compensationTarget, "compensationTarget");
+    Objects.requireNonNull(guaranteedMoneyTarget, "guaranteedMoneyTarget");
+  }
+}

--- a/src/main/java/app/zoneblitz/league/DirectorOfScoutingGenerator.java
+++ b/src/main/java/app/zoneblitz/league/DirectorOfScoutingGenerator.java
@@ -1,0 +1,265 @@
+package app.zoneblitz.league;
+
+import app.zoneblitz.gamesimulator.rng.RandomSource;
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.stream.IntStream;
+
+/**
+ * Generates Director-of-Scouting candidates from {@code data/bands/scout-market.json} tier {@code
+ * DIRECTOR}. Mirrors {@link HeadCoachGenerator}: true rating is sampled independently; price
+ * signals (compensation, contract length, guaranteed money) derive from perceived features only
+ * (age, experience, archetype).
+ *
+ * <p>Scout-specific archetypes are TBD per {@code docs/technical/league-phases.md}; this generator
+ * uses {@link CandidateArchetype#COLLEGE_EVALUATOR}, {@link CandidateArchetype#PRO_EVALUATOR}, and
+ * {@link CandidateArchetype#GENERALIST} as placeholders keyed off the band's {@code
+ * position_focus_split.generalist} share.
+ */
+public final class DirectorOfScoutingGenerator implements CandidateGenerator {
+
+  private static final double TRUE_RATING_MEAN = 62.0;
+  private static final double TRUE_RATING_STD = 11.0;
+  private static final double SCOUTED_NOISE_STD = 9.0;
+  private static final double GUARANTEED_MONEY_FLOOR = 0.55;
+  private static final double GUARANTEED_MONEY_CEIL = 0.85;
+
+  private final ScoutMarketBands bands;
+
+  public DirectorOfScoutingGenerator() {
+    this(ScoutMarketBands.loadFromClasspath());
+  }
+
+  DirectorOfScoutingGenerator(ScoutMarketBands bands) {
+    this.bands = Objects.requireNonNull(bands, "bands");
+  }
+
+  @Override
+  public List<GeneratedCandidate> generate(int poolSize, RandomSource rng) {
+    Objects.requireNonNull(rng, "rng");
+    if (poolSize <= 0) {
+      throw new IllegalArgumentException("poolSize must be > 0, was: " + poolSize);
+    }
+    return IntStream.range(0, poolSize).mapToObj(i -> generateOne(rng)).toList();
+  }
+
+  private GeneratedCandidate generateOne(RandomSource rng) {
+    var archetype = sampleArchetype(rng);
+    var specialty = sampleSpecialty(archetype, rng);
+    var age = sampleAge(rng);
+    var totalExperience = sampleTotalExperience(age, rng);
+    var priorDosYears = samplePriorDosYears(totalExperience, rng);
+    var scoutYears = sampleScoutYears(totalExperience, priorDosYears, rng);
+    var areaScoutYears = Math.max(0, totalExperience - priorDosYears - scoutYears);
+    var experienceByRole =
+        """
+        {"DOS": %d, "SCOUT": %d, "AREA_SCOUT": %d}"""
+            .formatted(priorDosYears, scoutYears, areaScoutYears);
+
+    var trueRating = clamp(TRUE_RATING_MEAN + TRUE_RATING_STD * rng.nextGaussian(), 20.0, 99.0);
+    var scoutedRating = clamp(trueRating + SCOUTED_NOISE_STD * rng.nextGaussian(), 20.0, 99.0);
+    var hiddenAttrs = attrsJson(trueRating);
+    var scoutedAttrs = attrsJson(scoutedRating);
+
+    var compensation = perceivedCompensation(age, totalExperience, priorDosYears, archetype, rng);
+    var contractLength = perceivedContractLength(priorDosYears, rng);
+    var guaranteedMoney = perceivedGuaranteedMoney(priorDosYears, rng);
+
+    var candidate =
+        new NewCandidate(
+            /* poolId= */ 0L,
+            CandidateKind.DIRECTOR_OF_SCOUTING,
+            specialty,
+            archetype,
+            age,
+            totalExperience,
+            experienceByRole,
+            hiddenAttrs,
+            scoutedAttrs,
+            Optional.empty());
+    var preferences = buildPreferences(compensation, contractLength, guaranteedMoney, rng);
+    return new GeneratedCandidate(candidate, preferences);
+  }
+
+  private CandidateArchetype sampleArchetype(RandomSource rng) {
+    var u = rng.nextDouble();
+    if (u < bands.generalistShare()) {
+      return CandidateArchetype.GENERALIST;
+    }
+    var remainder = 1.0 - bands.generalistShare();
+    var collegeShare = remainder * 0.6;
+    return u < bands.generalistShare() + collegeShare
+        ? CandidateArchetype.COLLEGE_EVALUATOR
+        : CandidateArchetype.PRO_EVALUATOR;
+  }
+
+  private SpecialtyPosition sampleSpecialty(CandidateArchetype archetype, RandomSource rng) {
+    var positions = SpecialtyPosition.values();
+    return positions[(int) (rng.nextDouble() * positions.length)];
+  }
+
+  private int sampleAge(RandomSource rng) {
+    var v = triangular(bands.ageMin(), bands.ageMode(), bands.ageMax(), rng);
+    return clampInt((int) Math.round(v), bands.ageMin(), bands.ageMax());
+  }
+
+  private int sampleTotalExperience(int age, RandomSource rng) {
+    var career = Math.max(5, age - 22);
+    var raw =
+        triangular(
+            bands.experienceP10Years(),
+            bands.experienceMeanYears(),
+            bands.experienceP90Years() + 4,
+            rng);
+    return clampInt((int) Math.round(raw), 5, career);
+  }
+
+  private int samplePriorDosYears(int totalExperience, RandomSource rng) {
+    // First-time DoS is common — directors are usually newly-promoted cross-checkers.
+    var isFirstTime = rng.nextDouble() < 0.65;
+    if (isFirstTime) {
+      return 0;
+    }
+    var upper = Math.max(1, Math.min(8, totalExperience - 5));
+    return 1 + (int) (rng.nextDouble() * upper);
+  }
+
+  private int sampleScoutYears(int totalExperience, int priorDosYears, RandomSource rng) {
+    var available = Math.max(0, totalExperience - priorDosYears);
+    if (available == 0) return 0;
+    var mean = Math.min(available, Math.max(2, available / 2));
+    var draw = (int) Math.round(mean + 2 * rng.nextGaussian());
+    return clampInt(draw, 0, available);
+  }
+
+  private BigDecimal perceivedCompensation(
+      int age,
+      int totalExperience,
+      int priorDosYears,
+      CandidateArchetype archetype,
+      RandomSource rng) {
+    var base = triangular(bands.salaryP10(), bands.salaryP50(), bands.salaryP90(), rng);
+    var ageMultiplier = ageSalaryMultiplier(age);
+    var experienceMultiplier = 0.90 + Math.min(totalExperience, 25) * 0.008;
+    var retreadMultiplier = 1.0 + Math.min(priorDosYears, 6) * 0.04;
+    var archetypeMultiplier =
+        switch (archetype) {
+          case COLLEGE_EVALUATOR -> 1.02;
+          case PRO_EVALUATOR -> 0.98;
+          case GENERALIST -> 1.05;
+          default -> 1.0;
+        };
+    var combined =
+        base * ageMultiplier * experienceMultiplier * retreadMultiplier * archetypeMultiplier;
+    var clamped =
+        Math.max(bands.salaryP10() * 0.5, Math.min(bands.salaryCeiling() * 1.1, combined));
+    return BigDecimal.valueOf(clamped).setScale(2, RoundingMode.HALF_UP);
+  }
+
+  private double ageSalaryMultiplier(int age) {
+    var peak = 50.0;
+    var deviation = Math.abs(age - peak);
+    return Math.max(0.8, 1.05 - deviation * 0.01);
+  }
+
+  private int perceivedContractLength(int priorDosYears, RandomSource rng) {
+    var u = rng.nextDouble();
+    var base =
+        u < 0.15
+            ? bands.contractP10Years()
+            : u < 0.65
+                ? bands.contractModeYears()
+                : u < 0.9 ? bands.contractP50Years() : bands.contractP90Years();
+    return priorDosYears >= 2 ? Math.min(base + 1, bands.contractP90Years() + 1) : base;
+  }
+
+  private BigDecimal perceivedGuaranteedMoney(int priorDosYears, RandomSource rng) {
+    var base =
+        GUARANTEED_MONEY_FLOOR
+            + rng.nextDouble() * (GUARANTEED_MONEY_CEIL - GUARANTEED_MONEY_FLOOR);
+    var bump = priorDosYears >= 2 ? 0.05 : 0.0;
+    var value = Math.min(1.0, base + bump);
+    return BigDecimal.valueOf(value).setScale(3, RoundingMode.HALF_UP);
+  }
+
+  private CandidatePreferencesDraft buildPreferences(
+      BigDecimal compensation, int contractLength, BigDecimal guaranteedMoney, RandomSource rng) {
+    var rawWeights = new double[13];
+    for (var i = 0; i < rawWeights.length; i++) {
+      rawWeights[i] = 0.25 + rng.nextDouble();
+    }
+    var sum = 0.0;
+    for (var weight : rawWeights) sum += weight;
+    var w = new BigDecimal[13];
+    for (var i = 0; i < rawWeights.length; i++) {
+      w[i] = BigDecimal.valueOf(rawWeights[i] / sum).setScale(3, RoundingMode.HALF_UP);
+    }
+
+    var marketSize = MarketSize.values()[(int) (rng.nextDouble() * MarketSize.values().length)];
+    var geography = Geography.values()[(int) (rng.nextDouble() * Geography.values().length)];
+    var climate = Climate.values()[(int) (rng.nextDouble() * Climate.values().length)];
+    var roleScope = RoleScope.values()[(int) (rng.nextDouble() * RoleScope.values().length)];
+    var staffContinuity =
+        StaffContinuity.values()[(int) (rng.nextDouble() * StaffContinuity.values().length)];
+    var competitiveWindow =
+        CompetitiveWindow.values()[(int) (rng.nextDouble() * CompetitiveWindow.values().length)];
+    var schemeAlignment = sampleSchemeAlignment(rng);
+
+    return new CandidatePreferencesDraft(
+        compensation,
+        w[0],
+        contractLength,
+        w[1],
+        guaranteedMoney,
+        w[2],
+        marketSize,
+        w[3],
+        geography,
+        w[4],
+        climate,
+        w[5],
+        BigDecimal.valueOf(50 + rng.nextDouble() * 30).setScale(2, RoundingMode.HALF_UP),
+        w[6],
+        competitiveWindow,
+        w[7],
+        roleScope,
+        w[8],
+        staffContinuity,
+        w[9],
+        schemeAlignment,
+        w[10],
+        BigDecimal.valueOf(50 + rng.nextDouble() * 30).setScale(2, RoundingMode.HALF_UP),
+        w[11],
+        BigDecimal.valueOf(50 + rng.nextDouble() * 30).setScale(2, RoundingMode.HALF_UP),
+        w[12]);
+  }
+
+  private String sampleSchemeAlignment(RandomSource rng) {
+    var schemes = List.of("SPREAD", "WEST_COAST", "AIR_RAID", "SMASHMOUTH", "COVER_2", "COVER_3");
+    return schemes.get((int) (rng.nextDouble() * schemes.size()));
+  }
+
+  private String attrsJson(double rating) {
+    return "{\"overall\": %.2f}".formatted(rating);
+  }
+
+  private static double triangular(double a, double c, double b, RandomSource rng) {
+    var u = rng.nextDouble();
+    var f = (c - a) / (b - a);
+    if (u < f) {
+      return a + Math.sqrt(u * (b - a) * (c - a));
+    }
+    return b - Math.sqrt((1 - u) * (b - a) * (b - c));
+  }
+
+  private static int clampInt(int v, int lo, int hi) {
+    return Math.max(lo, Math.min(hi, v));
+  }
+
+  private static double clamp(double v, double lo, double hi) {
+    return Math.max(lo, Math.min(hi, v));
+  }
+}

--- a/src/main/java/app/zoneblitz/league/DirectorOfScoutingHiringView.java
+++ b/src/main/java/app/zoneblitz/league/DirectorOfScoutingHiringView.java
@@ -1,0 +1,21 @@
+package app.zoneblitz.league;
+
+import java.util.List;
+import java.util.Objects;
+
+/** Composite page/fragment view-model for the HIRING_DIRECTOR_OF_SCOUTING page. */
+public record DirectorOfScoutingHiringView(
+    LeagueSummary league,
+    List<DirectorOfScoutingCandidateView> pool,
+    List<DirectorOfScoutingCandidateView> shortlist,
+    List<DirectorOfScoutingCandidateView> activeInterviews,
+    int interviewsThisWeek,
+    int interviewCapacity) {
+
+  public DirectorOfScoutingHiringView {
+    Objects.requireNonNull(league, "league");
+    pool = List.copyOf(pool);
+    shortlist = List.copyOf(shortlist);
+    activeInterviews = List.copyOf(activeInterviews);
+  }
+}

--- a/src/main/java/app/zoneblitz/league/DirectorOfScoutingHiringViewModel.java
+++ b/src/main/java/app/zoneblitz/league/DirectorOfScoutingHiringViewModel.java
@@ -1,0 +1,126 @@
+package app.zoneblitz.league;
+
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.regex.Pattern;
+
+/**
+ * Assembles {@link DirectorOfScoutingCandidateView} rows and the composite {@link
+ * DirectorOfScoutingHiringView}. Mirrors {@link HeadCoachHiringViewModel} for the DoS phase — only
+ * the experience-by-role keys (DOS / SCOUT / AREA_SCOUT) differ.
+ */
+final class DirectorOfScoutingHiringViewModel {
+
+  private static final Pattern OVERALL =
+      Pattern.compile("\"overall\"\\s*:\\s*(-?[0-9]+(?:\\.[0-9]+)?)");
+  private static final Pattern EXP_KEY_VALUE = Pattern.compile("\"([A-Z_]+)\"\\s*:\\s*(-?[0-9]+)");
+
+  private DirectorOfScoutingHiringViewModel() {}
+
+  static DirectorOfScoutingHiringView assemble(
+      LeagueSummary league,
+      List<Candidate> pool,
+      List<CandidatePreferences> preferences,
+      List<Long> shortlist,
+      List<FranchiseInterview> interviews,
+      int interviewCapacity) {
+    var prefsByCandidate =
+        preferences.stream()
+            .collect(
+                java.util.stream.Collectors.toUnmodifiableMap(
+                    CandidatePreferences::candidateId, p -> p));
+    var shortlistSet = Set.copyOf(shortlist);
+    var interviewCounts = countsByCandidate(interviews);
+    var latestScouted = latestScoutedByCandidate(interviews);
+    var interviewsThisWeek = countForWeek(interviews, league.phaseWeek());
+    var rows =
+        pool.stream()
+            .filter(c -> c.hiredByFranchiseId().isEmpty())
+            .map(c -> toRow(c, prefsByCandidate, shortlistSet, interviewCounts, latestScouted))
+            .toList();
+    var shortlistRows = rows.stream().filter(DirectorOfScoutingCandidateView::shortlisted).toList();
+    var activeInterviewRows = rows.stream().filter(r -> r.interviewCount() > 0).toList();
+    return new DirectorOfScoutingHiringView(
+        league, rows, shortlistRows, activeInterviewRows, interviewsThisWeek, interviewCapacity);
+  }
+
+  private static Map<Long, Integer> countsByCandidate(List<FranchiseInterview> interviews) {
+    return interviews.stream()
+        .collect(
+            java.util.stream.Collectors.groupingBy(
+                FranchiseInterview::candidateId,
+                java.util.stream.Collectors.reducing(0, ignored -> 1, Integer::sum)));
+  }
+
+  private static Map<Long, BigDecimal> latestScoutedByCandidate(
+      List<FranchiseInterview> interviews) {
+    return interviews.stream()
+        .collect(
+            java.util.stream.Collectors.toMap(
+                FranchiseInterview::candidateId,
+                FranchiseInterview::scoutedOverall,
+                (earlier, later) -> later));
+  }
+
+  private static int countForWeek(List<FranchiseInterview> interviews, int phaseWeek) {
+    return (int) interviews.stream().filter(i -> i.phaseWeek() == phaseWeek).count();
+  }
+
+  private static DirectorOfScoutingCandidateView toRow(
+      Candidate candidate,
+      Map<Long, CandidatePreferences> prefsById,
+      Set<Long> shortlistSet,
+      Map<Long, Integer> interviewCounts,
+      Map<Long, BigDecimal> latestScouted) {
+    var prefs = prefsById.get(candidate.id());
+    var count = interviewCounts.getOrDefault(candidate.id(), 0);
+    var scoutedOverall =
+        latestScouted.containsKey(candidate.id())
+            ? "%.1f".formatted(latestScouted.get(candidate.id()).doubleValue())
+            : extractOverall(candidate.scoutedAttrs());
+    return new DirectorOfScoutingCandidateView(
+        candidate.id(),
+        candidate.archetype(),
+        candidate.specialtyPosition(),
+        candidate.age(),
+        candidate.totalExperienceYears(),
+        experienceFor(candidate.experienceByRole(), "DOS"),
+        experienceFor(candidate.experienceByRole(), "SCOUT"),
+        experienceFor(candidate.experienceByRole(), "AREA_SCOUT"),
+        scoutedOverall,
+        prefs == null ? BigDecimal.ZERO : prefs.compensationTarget(),
+        prefs == null ? 0 : prefs.contractLengthTarget(),
+        prefs == null ? BigDecimal.ZERO : prefs.guaranteedMoneyTarget(),
+        shortlistSet.contains(candidate.id()),
+        count);
+  }
+
+  private static String extractOverall(String scoutedAttrsJson) {
+    var m = OVERALL.matcher(scoutedAttrsJson);
+    if (m.find()) {
+      try {
+        var val = Double.parseDouble(m.group(1));
+        return "%.1f".formatted(val);
+      } catch (NumberFormatException e) {
+        return "?";
+      }
+    }
+    return "?";
+  }
+
+  private static int experienceFor(String experienceByRoleJson, String role) {
+    var m = EXP_KEY_VALUE.matcher(experienceByRoleJson);
+    while (m.find()) {
+      if (m.group(1).equals(role)) {
+        try {
+          return Integer.parseInt(m.group(2));
+        } catch (NumberFormatException e) {
+          return 0;
+        }
+      }
+    }
+    return 0;
+  }
+}

--- a/src/main/java/app/zoneblitz/league/FranchiseInterview.java
+++ b/src/main/java/app/zoneblitz/league/FranchiseInterview.java
@@ -1,0 +1,26 @@
+package app.zoneblitz.league;
+
+import java.math.BigDecimal;
+import java.util.Objects;
+
+/**
+ * A single completed interview a franchise conducted against a candidate. {@code interviewIndex} is
+ * the 1-based count for that (franchise, candidate) pair. {@code scoutedOverall} is the
+ * noise-reduced scouted estimate produced at the moment of the interview; stored so it is stable
+ * across subsequent views.
+ */
+public record FranchiseInterview(
+    long id,
+    long leagueId,
+    long franchiseId,
+    long candidateId,
+    LeaguePhase phase,
+    int phaseWeek,
+    int interviewIndex,
+    BigDecimal scoutedOverall) {
+
+  public FranchiseInterview {
+    Objects.requireNonNull(phase, "phase");
+    Objects.requireNonNull(scoutedOverall, "scoutedOverall");
+  }
+}

--- a/src/main/java/app/zoneblitz/league/FranchiseInterviewRepository.java
+++ b/src/main/java/app/zoneblitz/league/FranchiseInterviewRepository.java
@@ -1,0 +1,25 @@
+package app.zoneblitz.league;
+
+import java.util.List;
+
+/** Feature-internal persistence seam for {@link FranchiseInterview}. */
+interface FranchiseInterviewRepository {
+
+  /** Insert a completed interview row. Returns the persisted record with its generated id. */
+  FranchiseInterview insert(NewFranchiseInterview interview);
+
+  /**
+   * Count interviews this franchise has completed against a given candidate in the given phase.
+   * Used to drive the noise-reduction function's exponent.
+   */
+  int countForCandidate(long leagueId, long franchiseId, long candidateId, LeaguePhase phase);
+
+  /**
+   * Count interviews this franchise has completed this week of the given phase. Used to enforce the
+   * weekly capacity cap.
+   */
+  int countForWeek(long leagueId, long franchiseId, LeaguePhase phase, int phaseWeek);
+
+  /** All interviews this franchise has completed in the given phase, ordered by id ascending. */
+  List<FranchiseInterview> findAllFor(long leagueId, long franchiseId, LeaguePhase phase);
+}

--- a/src/main/java/app/zoneblitz/league/FranchiseProfile.java
+++ b/src/main/java/app/zoneblitz/league/FranchiseProfile.java
@@ -1,0 +1,36 @@
+package app.zoneblitz.league;
+
+import java.math.BigDecimal;
+import java.util.Objects;
+
+/**
+ * Snapshot of a franchise's preference-relevant attributes used by {@link OfferResolver} scoring.
+ * Static fields ({@code marketSize}, {@code geography}, {@code climate}) are sourced from the
+ * franchise's city; dynamic fields ({@code prestige}, {@code window}, {@code ownerStability},
+ * {@code facilityQuality}, {@code schemeAlignment}) are equal-footing constants for v1 per {@code
+ * docs/technical/league-phases.md} "v1 equal-footing note" — they do not differentiate offers
+ * across franchises yet but do round-trip so candidates carrying weights on them score
+ * consistently.
+ */
+public record FranchiseProfile(
+    long franchiseId,
+    MarketSize marketSize,
+    Geography geography,
+    Climate climate,
+    BigDecimal prestige,
+    CompetitiveWindow window,
+    BigDecimal ownerStability,
+    BigDecimal facilityQuality,
+    String schemeAlignment) {
+
+  public FranchiseProfile {
+    Objects.requireNonNull(marketSize, "marketSize");
+    Objects.requireNonNull(geography, "geography");
+    Objects.requireNonNull(climate, "climate");
+    Objects.requireNonNull(prestige, "prestige");
+    Objects.requireNonNull(window, "window");
+    Objects.requireNonNull(ownerStability, "ownerStability");
+    Objects.requireNonNull(facilityQuality, "facilityQuality");
+    Objects.requireNonNull(schemeAlignment, "schemeAlignment");
+  }
+}

--- a/src/main/java/app/zoneblitz/league/FranchiseProfiles.java
+++ b/src/main/java/app/zoneblitz/league/FranchiseProfiles.java
@@ -1,0 +1,13 @@
+package app.zoneblitz.league;
+
+import java.util.Optional;
+
+/**
+ * Seam returning a {@link FranchiseProfile} for preference scoring. One implementation per wiring
+ * of city data; v1 derives static fields from the franchise's seeded city and returns equal-footing
+ * constants for dynamic fields.
+ */
+interface FranchiseProfiles {
+
+  Optional<FranchiseProfile> forFranchise(long franchiseId);
+}

--- a/src/main/java/app/zoneblitz/league/HeadCoachCandidateView.java
+++ b/src/main/java/app/zoneblitz/league/HeadCoachCandidateView.java
@@ -1,0 +1,35 @@
+package app.zoneblitz.league;
+
+import java.math.BigDecimal;
+import java.util.Objects;
+
+/**
+ * Row view-model for a single HC candidate in the hiring pool table. Derived from {@link Candidate}
+ * + {@link CandidatePreferences}; carries only the scouted projection — never the hidden
+ * true-rating payload. {@code shortlisted} reflects the requesting franchise's shortlist
+ * membership.
+ */
+public record HeadCoachCandidateView(
+    long id,
+    CandidateArchetype archetype,
+    SpecialtyPosition specialty,
+    int age,
+    int totalExperienceYears,
+    int hcYears,
+    int ocYears,
+    int positionCoachYears,
+    String scoutedOverall,
+    BigDecimal compensationTarget,
+    int contractLengthTarget,
+    BigDecimal guaranteedMoneyTarget,
+    boolean shortlisted,
+    int interviewCount) {
+
+  public HeadCoachCandidateView {
+    Objects.requireNonNull(archetype, "archetype");
+    Objects.requireNonNull(specialty, "specialty");
+    Objects.requireNonNull(scoutedOverall, "scoutedOverall");
+    Objects.requireNonNull(compensationTarget, "compensationTarget");
+    Objects.requireNonNull(guaranteedMoneyTarget, "guaranteedMoneyTarget");
+  }
+}

--- a/src/main/java/app/zoneblitz/league/HeadCoachHiringView.java
+++ b/src/main/java/app/zoneblitz/league/HeadCoachHiringView.java
@@ -1,0 +1,21 @@
+package app.zoneblitz.league;
+
+import java.util.List;
+import java.util.Objects;
+
+/** Composite page/fragment view-model for the HIRING_HEAD_COACH page. */
+public record HeadCoachHiringView(
+    LeagueSummary league,
+    List<HeadCoachCandidateView> pool,
+    List<HeadCoachCandidateView> shortlist,
+    List<HeadCoachCandidateView> activeInterviews,
+    int interviewsThisWeek,
+    int interviewCapacity) {
+
+  public HeadCoachHiringView {
+    Objects.requireNonNull(league, "league");
+    pool = List.copyOf(pool);
+    shortlist = List.copyOf(shortlist);
+    activeInterviews = List.copyOf(activeInterviews);
+  }
+}

--- a/src/main/java/app/zoneblitz/league/HeadCoachHiringViewModel.java
+++ b/src/main/java/app/zoneblitz/league/HeadCoachHiringViewModel.java
@@ -1,0 +1,127 @@
+package app.zoneblitz.league;
+
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.regex.Pattern;
+
+/**
+ * Assembles {@link HeadCoachCandidateView} rows and the composite {@link HeadCoachHiringView} from
+ * domain candidates + preferences + shortlist state + per-franchise interview history. Extracted
+ * from the controller so the controller stays thin and the assembly logic is unit-testable on its
+ * own.
+ */
+final class HeadCoachHiringViewModel {
+
+  private static final Pattern OVERALL =
+      Pattern.compile("\"overall\"\\s*:\\s*(-?[0-9]+(?:\\.[0-9]+)?)");
+  private static final Pattern EXP_KEY_VALUE = Pattern.compile("\"([A-Z_]+)\"\\s*:\\s*(-?[0-9]+)");
+
+  private HeadCoachHiringViewModel() {}
+
+  static HeadCoachHiringView assemble(
+      LeagueSummary league,
+      List<Candidate> pool,
+      List<CandidatePreferences> preferences,
+      List<Long> shortlist,
+      List<FranchiseInterview> interviews,
+      int interviewCapacity) {
+    var prefsByCandidate =
+        preferences.stream()
+            .collect(
+                java.util.stream.Collectors.toUnmodifiableMap(
+                    CandidatePreferences::candidateId, p -> p));
+    var shortlistSet = Set.copyOf(shortlist);
+    var interviewCounts = countsByCandidate(interviews);
+    var latestScouted = latestScoutedByCandidate(interviews);
+    var interviewsThisWeek = countForWeek(interviews, league.phaseWeek());
+    var rows =
+        pool.stream()
+            .filter(c -> c.hiredByFranchiseId().isEmpty())
+            .map(c -> toRow(c, prefsByCandidate, shortlistSet, interviewCounts, latestScouted))
+            .toList();
+    var shortlistRows = rows.stream().filter(HeadCoachCandidateView::shortlisted).toList();
+    var activeInterviewRows = rows.stream().filter(r -> r.interviewCount() > 0).toList();
+    return new HeadCoachHiringView(
+        league, rows, shortlistRows, activeInterviewRows, interviewsThisWeek, interviewCapacity);
+  }
+
+  private static Map<Long, Integer> countsByCandidate(List<FranchiseInterview> interviews) {
+    return interviews.stream()
+        .collect(
+            java.util.stream.Collectors.groupingBy(
+                FranchiseInterview::candidateId,
+                java.util.stream.Collectors.reducing(0, ignored -> 1, Integer::sum)));
+  }
+
+  private static Map<Long, BigDecimal> latestScoutedByCandidate(
+      List<FranchiseInterview> interviews) {
+    return interviews.stream()
+        .collect(
+            java.util.stream.Collectors.toMap(
+                FranchiseInterview::candidateId,
+                FranchiseInterview::scoutedOverall,
+                (earlier, later) -> later));
+  }
+
+  private static int countForWeek(List<FranchiseInterview> interviews, int phaseWeek) {
+    return (int) interviews.stream().filter(i -> i.phaseWeek() == phaseWeek).count();
+  }
+
+  private static HeadCoachCandidateView toRow(
+      Candidate candidate,
+      Map<Long, CandidatePreferences> prefsById,
+      Set<Long> shortlistSet,
+      Map<Long, Integer> interviewCounts,
+      Map<Long, BigDecimal> latestScouted) {
+    var prefs = prefsById.get(candidate.id());
+    var count = interviewCounts.getOrDefault(candidate.id(), 0);
+    var scoutedOverall =
+        latestScouted.containsKey(candidate.id())
+            ? "%.1f".formatted(latestScouted.get(candidate.id()).doubleValue())
+            : extractOverall(candidate.scoutedAttrs());
+    return new HeadCoachCandidateView(
+        candidate.id(),
+        candidate.archetype(),
+        candidate.specialtyPosition(),
+        candidate.age(),
+        candidate.totalExperienceYears(),
+        experienceFor(candidate.experienceByRole(), "HC"),
+        experienceFor(candidate.experienceByRole(), "OC"),
+        experienceFor(candidate.experienceByRole(), "POSITION_COACH"),
+        scoutedOverall,
+        prefs == null ? BigDecimal.ZERO : prefs.compensationTarget(),
+        prefs == null ? 0 : prefs.contractLengthTarget(),
+        prefs == null ? BigDecimal.ZERO : prefs.guaranteedMoneyTarget(),
+        shortlistSet.contains(candidate.id()),
+        count);
+  }
+
+  private static String extractOverall(String scoutedAttrsJson) {
+    var m = OVERALL.matcher(scoutedAttrsJson);
+    if (m.find()) {
+      try {
+        var val = Double.parseDouble(m.group(1));
+        return "%.1f".formatted(val);
+      } catch (NumberFormatException e) {
+        return "?";
+      }
+    }
+    return "?";
+  }
+
+  private static int experienceFor(String experienceByRoleJson, String role) {
+    var m = EXP_KEY_VALUE.matcher(experienceByRoleJson);
+    while (m.find()) {
+      if (m.group(1).equals(role)) {
+        try {
+          return Integer.parseInt(m.group(2));
+        } catch (NumberFormatException e) {
+          return 0;
+        }
+      }
+    }
+    return 0;
+  }
+}

--- a/src/main/java/app/zoneblitz/league/HiringAssemblingStaffTransitionHandler.java
+++ b/src/main/java/app/zoneblitz/league/HiringAssemblingStaffTransitionHandler.java
@@ -1,0 +1,356 @@
+package app.zoneblitz.league;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+/**
+ * Phase-entry hook for {@link LeaguePhase#ASSEMBLING_STAFF}. Programmatically assembles every
+ * franchise's subordinate staff tree at phase entry:
+ *
+ * <ul>
+ *   <li>The Head Coach hires 1 OC, 1 DC, 1 ST coordinator and 9 position coaches (QB, RB, WR, TE,
+ *       OL, DL, EDGE, LB, DB) — 12 total.
+ *   <li>The Director of Scouting hires 5 college scouts and 3 pro scouts — 8 total.
+ * </ul>
+ *
+ * <p>Selection is biased by the HC's archetype/specialty (coordinator archetypes weighted toward HC
+ * archetype, position coaches biased when HC specialty matches) and by the DoS archetype (college
+ * vs pro emphasis on the scout branches). The bias is implemented at generation time — candidates
+ * are generated per franchise with kind- and branch-appropriate archetypes, then ranked by scouted
+ * overall with a small bias bonus so the top k are selected deterministically from the seeded RNG.
+ *
+ * <p>Idempotent: re-entry of a phase that already has at least one assembled staff row for a
+ * franchise is a no-op for that franchise.
+ */
+@Component
+class HiringAssemblingStaffTransitionHandler implements PhaseTransitionHandler {
+
+  private static final Logger log =
+      LoggerFactory.getLogger(HiringAssemblingStaffTransitionHandler.class);
+
+  private static final List<SpecialtyPosition> POSITION_COACH_SPECIALTIES =
+      List.of(
+          SpecialtyPosition.QB,
+          SpecialtyPosition.RB,
+          SpecialtyPosition.WR,
+          SpecialtyPosition.TE,
+          SpecialtyPosition.OL,
+          SpecialtyPosition.DL,
+          SpecialtyPosition.EDGE,
+          SpecialtyPosition.LB,
+          SpecialtyPosition.CB);
+
+  private static final int COLLEGE_SCOUTS = 5;
+  private static final int PRO_SCOUTS = 3;
+  private static final int GENERATION_OVERSAMPLE = 3;
+
+  private final TeamLookup teams;
+  private final CandidatePoolRepository pools;
+  private final CandidateRepository candidates;
+  private final CandidatePreferencesRepository preferences;
+  private final FranchiseStaffRepository staff;
+  private final CoordinatorGenerator coordinatorGenerator;
+  private final PositionCoachGenerator positionCoachGenerator;
+  private final ScoutCandidateGenerator scoutGenerator;
+  private final CandidateRandomSources rngs;
+
+  HiringAssemblingStaffTransitionHandler(
+      TeamLookup teams,
+      CandidatePoolRepository pools,
+      CandidateRepository candidates,
+      CandidatePreferencesRepository preferences,
+      FranchiseStaffRepository staff,
+      CoordinatorGenerator coordinatorGenerator,
+      PositionCoachGenerator positionCoachGenerator,
+      ScoutCandidateGenerator scoutGenerator,
+      CandidateRandomSources rngs) {
+    this.teams = Objects.requireNonNull(teams, "teams");
+    this.pools = Objects.requireNonNull(pools, "pools");
+    this.candidates = Objects.requireNonNull(candidates, "candidates");
+    this.preferences = Objects.requireNonNull(preferences, "preferences");
+    this.staff = Objects.requireNonNull(staff, "staff");
+    this.coordinatorGenerator =
+        Objects.requireNonNull(coordinatorGenerator, "coordinatorGenerator");
+    this.positionCoachGenerator =
+        Objects.requireNonNull(positionCoachGenerator, "positionCoachGenerator");
+    this.scoutGenerator = Objects.requireNonNull(scoutGenerator, "scoutGenerator");
+    this.rngs = Objects.requireNonNull(rngs, "rngs");
+  }
+
+  @Override
+  public LeaguePhase phase() {
+    return LeaguePhase.ASSEMBLING_STAFF;
+  }
+
+  @Override
+  public void onEntry(long leagueId) {
+    var franchiseIds = teams.franchiseIdsForLeague(leagueId);
+    if (franchiseIds.isEmpty()) {
+      log.debug("no franchises for league={}, assembling-staff is a no-op", leagueId);
+      return;
+    }
+    var coordinatorPool = findOrCreatePool(leagueId, CandidatePoolType.COORDINATOR);
+    var positionCoachPool = findOrCreatePool(leagueId, CandidatePoolType.POSITION_COACH);
+    var scoutPool = findOrCreatePool(leagueId, CandidatePoolType.SCOUT);
+
+    var rng = rngs.forLeaguePhase(leagueId, phase());
+    var assembledCount = 0;
+    for (var franchiseId : franchiseIds) {
+      if (alreadyAssembled(leagueId, franchiseId)) {
+        log.debug(
+            "franchise already has subordinate staff leagueId={} franchiseId={}; skipping",
+            leagueId,
+            franchiseId);
+        continue;
+      }
+      assembleFor(
+          leagueId, franchiseId, coordinatorPool.id(), positionCoachPool.id(), scoutPool.id(), rng);
+      assembledCount++;
+    }
+    log.info(
+        "assembling-staff completed leagueId={} franchisesAssembled={}/{}",
+        leagueId,
+        assembledCount,
+        franchiseIds.size());
+  }
+
+  private CandidatePool findOrCreatePool(long leagueId, CandidatePoolType type) {
+    return pools
+        .findByLeaguePhaseAndType(leagueId, phase(), type)
+        .orElseGet(() -> pools.insert(leagueId, phase(), type));
+  }
+
+  private boolean alreadyAssembled(long leagueId, long franchiseId) {
+    return staff.findAllForFranchise(leagueId, franchiseId).stream()
+        .anyMatch(
+            s -> s.role() != StaffRole.HEAD_COACH && s.role() != StaffRole.DIRECTOR_OF_SCOUTING);
+  }
+
+  private void assembleFor(
+      long leagueId,
+      long franchiseId,
+      long coordinatorPoolId,
+      long positionCoachPoolId,
+      long scoutPoolId,
+      app.zoneblitz.gamesimulator.rng.RandomSource rng) {
+    var hc = findHired(leagueId, franchiseId, StaffRole.HEAD_COACH);
+    var dos = findHired(leagueId, franchiseId, StaffRole.DIRECTOR_OF_SCOUTING);
+
+    hireCoordinator(
+        leagueId,
+        franchiseId,
+        coordinatorPoolId,
+        StaffRole.OFFENSIVE_COORDINATOR,
+        CandidateKind.OFFENSIVE_COORDINATOR,
+        hc,
+        rng);
+    hireCoordinator(
+        leagueId,
+        franchiseId,
+        coordinatorPoolId,
+        StaffRole.DEFENSIVE_COORDINATOR,
+        CandidateKind.DEFENSIVE_COORDINATOR,
+        hc,
+        rng);
+    hireCoordinator(
+        leagueId,
+        franchiseId,
+        coordinatorPoolId,
+        StaffRole.SPECIAL_TEAMS_COORDINATOR,
+        CandidateKind.SPECIAL_TEAMS_COORDINATOR,
+        hc,
+        rng);
+
+    for (var specialty : POSITION_COACH_SPECIALTIES) {
+      hirePositionCoach(leagueId, franchiseId, positionCoachPoolId, specialty, hc, rng);
+    }
+
+    for (var i = 0; i < COLLEGE_SCOUTS; i++) {
+      hireScout(leagueId, franchiseId, scoutPoolId, ScoutBranch.COLLEGE, dos, rng);
+    }
+    for (var i = 0; i < PRO_SCOUTS; i++) {
+      hireScout(leagueId, franchiseId, scoutPoolId, ScoutBranch.PRO, dos, rng);
+    }
+  }
+
+  private Optional<Candidate> findHired(long leagueId, long franchiseId, StaffRole role) {
+    return staff.findAllForFranchise(leagueId, franchiseId).stream()
+        .filter(s -> s.role() == role)
+        .findFirst()
+        .flatMap(s -> candidates.findById(s.candidateId()));
+  }
+
+  private void hireCoordinator(
+      long leagueId,
+      long franchiseId,
+      long poolId,
+      StaffRole role,
+      CandidateKind kind,
+      Optional<Candidate> hc,
+      app.zoneblitz.gamesimulator.rng.RandomSource rng) {
+    var generated = coordinatorGenerator.generate(GENERATION_OVERSAMPLE, kind, rng);
+    var pick = pickBiased(generated, c -> coordinatorBias(c, kind, hc));
+    persistAndHire(leagueId, franchiseId, poolId, pick, role, Optional.empty());
+  }
+
+  private void hirePositionCoach(
+      long leagueId,
+      long franchiseId,
+      long poolId,
+      SpecialtyPosition specialty,
+      Optional<Candidate> hc,
+      app.zoneblitz.gamesimulator.rng.RandomSource rng) {
+    var generated = positionCoachGenerator.generate(GENERATION_OVERSAMPLE, specialty, rng);
+    var pick = pickBiased(generated, c -> positionCoachBias(c, specialty, hc));
+    persistAndHire(
+        leagueId, franchiseId, poolId, pick, positionCoachRoleFor(specialty), Optional.empty());
+  }
+
+  private void hireScout(
+      long leagueId,
+      long franchiseId,
+      long poolId,
+      ScoutBranch branch,
+      Optional<Candidate> dos,
+      app.zoneblitz.gamesimulator.rng.RandomSource rng) {
+    var generated = scoutGenerator.generate(GENERATION_OVERSAMPLE, branch, rng);
+    var pick = pickBiased(generated, c -> scoutBias(c, branch, dos));
+    var role = branch == ScoutBranch.COLLEGE ? StaffRole.COLLEGE_SCOUT : StaffRole.PRO_SCOUT;
+    persistAndHire(leagueId, franchiseId, poolId, pick, role, Optional.of(branch));
+  }
+
+  private static StaffRole positionCoachRoleFor(SpecialtyPosition specialty) {
+    return switch (specialty) {
+      case QB -> StaffRole.QB_COACH;
+      case RB, FB -> StaffRole.RB_COACH;
+      case WR -> StaffRole.WR_COACH;
+      case TE -> StaffRole.TE_COACH;
+      case OL -> StaffRole.OL_COACH;
+      case DL -> StaffRole.DL_COACH;
+      case EDGE -> StaffRole.EDGE_COACH;
+      case LB -> StaffRole.LB_COACH;
+      case CB, S -> StaffRole.DB_COACH;
+      case K, P, LS ->
+          throw new IllegalStateException(
+              "special teams specialty used as position-coach role: " + specialty);
+    };
+  }
+
+  private GeneratedCandidate pickBiased(
+      List<GeneratedCandidate> generated,
+      java.util.function.ToDoubleFunction<GeneratedCandidate> bias) {
+    var ranked = new ArrayList<>(generated);
+    ranked.sort(
+        Comparator.<GeneratedCandidate>comparingDouble(
+                c -> scoutedOverall(c.candidate().scoutedAttrs()) + bias.applyAsDouble(c))
+            .reversed());
+    return ranked.getFirst();
+  }
+
+  private double coordinatorBias(GeneratedCandidate g, CandidateKind kind, Optional<Candidate> hc) {
+    if (hc.isEmpty()) {
+      return 0.0;
+    }
+    var hcArchetype = hc.get().archetype();
+    var coordArchetype = g.candidate().archetype();
+    // Boost when coordinator archetype matches HC's offensive/defensive lean.
+    if (kind == CandidateKind.OFFENSIVE_COORDINATOR
+        && (hcArchetype == CandidateArchetype.OFFENSIVE_PLAY_CALLER
+            || hcArchetype == CandidateArchetype.OFFENSIVE_GURU)
+        && (coordArchetype == CandidateArchetype.OFFENSIVE_PLAY_CALLER
+            || coordArchetype == CandidateArchetype.OFFENSIVE_GURU)) {
+      return 5.0;
+    }
+    if (kind == CandidateKind.DEFENSIVE_COORDINATOR
+        && (hcArchetype == CandidateArchetype.DEFENSIVE_PLAY_CALLER
+            || hcArchetype == CandidateArchetype.DEFENSIVE_GURU)
+        && (coordArchetype == CandidateArchetype.DEFENSIVE_PLAY_CALLER
+            || coordArchetype == CandidateArchetype.DEFENSIVE_GURU)) {
+      return 5.0;
+    }
+    return 0.0;
+  }
+
+  private double positionCoachBias(
+      GeneratedCandidate g, SpecialtyPosition specialty, Optional<Candidate> hc) {
+    if (hc.isEmpty()) {
+      return 0.0;
+    }
+    return hc.get().specialtyPosition() == specialty ? 4.0 : 0.0;
+  }
+
+  private double scoutBias(GeneratedCandidate g, ScoutBranch branch, Optional<Candidate> dos) {
+    if (dos.isEmpty()) {
+      return 0.0;
+    }
+    var dosArchetype = dos.get().archetype();
+    if (branch == ScoutBranch.COLLEGE && dosArchetype == CandidateArchetype.COLLEGE_EVALUATOR) {
+      return 4.0;
+    }
+    if (branch == ScoutBranch.PRO && dosArchetype == CandidateArchetype.PRO_EVALUATOR) {
+      return 4.0;
+    }
+    if (dosArchetype == CandidateArchetype.GENERALIST) {
+      return 2.0;
+    }
+    return 0.0;
+  }
+
+  private void persistAndHire(
+      long leagueId,
+      long franchiseId,
+      long poolId,
+      GeneratedCandidate pick,
+      StaffRole role,
+      Optional<ScoutBranch> scoutBranch) {
+    var insert =
+        new NewCandidate(
+            poolId,
+            pick.candidate().kind(),
+            pick.candidate().specialtyPosition(),
+            pick.candidate().archetype(),
+            pick.candidate().age(),
+            pick.candidate().totalExperienceYears(),
+            pick.candidate().experienceByRole(),
+            pick.candidate().hiddenAttrs(),
+            pick.candidate().scoutedAttrs(),
+            pick.candidate().scoutBranch());
+    var saved = candidates.insert(insert);
+    preferences.insert(pick.preferences().withCandidateId(saved.id()));
+    candidates.markHired(saved.id(), franchiseId);
+    staff.insert(
+        new NewFranchiseStaffMember(
+            leagueId, franchiseId, saved.id(), role, scoutBranch, phase(), 1));
+  }
+
+  private static double scoutedOverall(String scoutedAttrsJson) {
+    var idx = scoutedAttrsJson.indexOf("\"overall\"");
+    if (idx < 0) {
+      return 0.0;
+    }
+    var colon = scoutedAttrsJson.indexOf(':', idx);
+    if (colon < 0) {
+      return 0.0;
+    }
+    var end = scoutedAttrsJson.length();
+    var stop = scoutedAttrsJson.indexOf(',', colon);
+    var close = scoutedAttrsJson.indexOf('}', colon);
+    if (stop >= 0) {
+      end = Math.min(end, stop);
+    }
+    if (close >= 0) {
+      end = Math.min(end, close);
+    }
+    try {
+      return Double.parseDouble(scoutedAttrsJson.substring(colon + 1, end).trim());
+    } catch (NumberFormatException ex) {
+      return 0.0;
+    }
+  }
+}

--- a/src/main/java/app/zoneblitz/league/HiringDirectorOfScoutingController.java
+++ b/src/main/java/app/zoneblitz/league/HiringDirectorOfScoutingController.java
@@ -1,0 +1,166 @@
+package app.zoneblitz.league;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.server.ResponseStatusException;
+
+/**
+ * Web controller for the HIRING_DIRECTOR_OF_SCOUTING page and its HTMX fragment endpoints. Mirrors
+ * {@link HiringHeadCoachController}. The underlying shortlist / interview / offer use cases are
+ * phase-agnostic (they route on {@code league.phase()}), so this controller reuses them and
+ * re-renders the DoS view from {@link ViewDirectorOfScoutingHiring} after each mutation.
+ */
+@Controller
+class HiringDirectorOfScoutingController {
+
+  private static final Logger log =
+      LoggerFactory.getLogger(HiringDirectorOfScoutingController.class);
+
+  private final ViewDirectorOfScoutingHiring viewHiring;
+  private final ManageHeadCoachShortlist shortlist;
+  private final StartInterview startInterview;
+  private final MakeOffer makeOffer;
+
+  HiringDirectorOfScoutingController(
+      ViewDirectorOfScoutingHiring viewHiring,
+      ManageHeadCoachShortlist shortlist,
+      StartInterview startInterview,
+      MakeOffer makeOffer) {
+    this.viewHiring = viewHiring;
+    this.shortlist = shortlist;
+    this.startInterview = startInterview;
+    this.makeOffer = makeOffer;
+  }
+
+  @GetMapping("/leagues/{id}/hiring/director-of-scouting")
+  String page(@AuthenticationPrincipal OAuth2User principal, @PathVariable long id, Model model) {
+    var view = resolveView(principal, id);
+    model.addAttribute("view", view);
+    return "league/hiring/director-of-scouting";
+  }
+
+  @GetMapping("/leagues/{id}/hiring/director-of-scouting/pool")
+  String poolFragment(
+      @AuthenticationPrincipal OAuth2User principal, @PathVariable long id, Model model) {
+    model.addAttribute("view", resolveView(principal, id));
+    return "league/hiring/director-of-scouting-fragments :: pool";
+  }
+
+  @GetMapping("/leagues/{id}/hiring/director-of-scouting/interviews")
+  String interviewsFragment(
+      @AuthenticationPrincipal OAuth2User principal, @PathVariable long id, Model model) {
+    model.addAttribute("view", resolveView(principal, id));
+    return "league/hiring/director-of-scouting-fragments :: interviews";
+  }
+
+  @PostMapping("/leagues/{id}/hiring/director-of-scouting/interview/{candidateId}")
+  String startInterview(
+      @AuthenticationPrincipal OAuth2User principal,
+      @PathVariable long id,
+      @PathVariable long candidateId,
+      Model model) {
+    var result = startInterview.start(id, candidateId, principal.getAttribute("sub"));
+    return switch (result) {
+      case InterviewResult.Started ignored -> {
+        log.info("dos interview started leagueId={} candidateId={}", id, candidateId);
+        model.addAttribute("view", resolveView(principal, id));
+        yield "league/hiring/director-of-scouting-fragments :: combined";
+      }
+      case InterviewResult.NotFound ignored ->
+          throw new ResponseStatusException(HttpStatus.NOT_FOUND);
+      case InterviewResult.UnknownCandidate ignored ->
+          throw new ResponseStatusException(HttpStatus.NOT_FOUND);
+      case InterviewResult.CapacityReached capacity ->
+          throw new ResponseStatusException(
+              HttpStatus.CONFLICT,
+              "Weekly interview capacity of %d already reached".formatted(capacity.capacity()));
+    };
+  }
+
+  @GetMapping("/leagues/{id}/hiring/director-of-scouting/shortlist")
+  String shortlistFragment(
+      @AuthenticationPrincipal OAuth2User principal, @PathVariable long id, Model model) {
+    model.addAttribute("view", resolveView(principal, id));
+    return "league/hiring/director-of-scouting-fragments :: shortlist";
+  }
+
+  @PostMapping("/leagues/{id}/hiring/director-of-scouting/shortlist/{candidateId}")
+  String addToShortlist(
+      @AuthenticationPrincipal OAuth2User principal,
+      @PathVariable long id,
+      @PathVariable long candidateId,
+      Model model) {
+    var result = shortlist.add(id, candidateId, principal.getAttribute("sub"));
+    return renderMutation(result, principal, id, model);
+  }
+
+  @DeleteMapping("/leagues/{id}/hiring/director-of-scouting/shortlist/{candidateId}")
+  String removeFromShortlist(
+      @AuthenticationPrincipal OAuth2User principal,
+      @PathVariable long id,
+      @PathVariable long candidateId,
+      Model model) {
+    var result = shortlist.remove(id, candidateId, principal.getAttribute("sub"));
+    return renderMutation(result, principal, id, model);
+  }
+
+  @PostMapping("/leagues/{id}/hiring/director-of-scouting/offer/{candidateId}")
+  String submitOffer(
+      @AuthenticationPrincipal OAuth2User principal,
+      @PathVariable long id,
+      @PathVariable long candidateId,
+      @ModelAttribute MakeOfferForm form,
+      Model model) {
+    var result = makeOffer.offer(id, candidateId, principal.getAttribute("sub"), form.toTerms());
+    return switch (result) {
+      case MakeOfferResult.Created created -> {
+        log.info(
+            "dos offer submitted leagueId={} candidateId={} offerId={}",
+            id,
+            candidateId,
+            created.offer().id());
+        model.addAttribute("view", resolveView(principal, id));
+        yield "league/hiring/director-of-scouting-fragments :: combined";
+      }
+      case MakeOfferResult.NotFound ignored ->
+          throw new ResponseStatusException(HttpStatus.NOT_FOUND);
+      case MakeOfferResult.UnknownCandidate ignored ->
+          throw new ResponseStatusException(HttpStatus.NOT_FOUND);
+      case MakeOfferResult.AlreadyHired ignored ->
+          throw new ResponseStatusException(HttpStatus.CONFLICT);
+      case MakeOfferResult.ActiveOfferExists ignored ->
+          throw new ResponseStatusException(HttpStatus.CONFLICT);
+    };
+  }
+
+  private DirectorOfScoutingHiringView resolveView(OAuth2User principal, long id) {
+    return viewHiring
+        .view(id, principal.getAttribute("sub"))
+        .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND));
+  }
+
+  private String renderMutation(
+      ShortlistResult result, OAuth2User principal, long leagueId, Model model) {
+    return switch (result) {
+      case ShortlistResult.Updated updated -> {
+        log.info("dos shortlist updated leagueId={}", updated.view().league().leagueId());
+        model.addAttribute("view", resolveView(principal, leagueId));
+        yield "league/hiring/director-of-scouting-fragments :: combined";
+      }
+      case ShortlistResult.NotFound ignored ->
+          throw new ResponseStatusException(HttpStatus.NOT_FOUND);
+      case ShortlistResult.UnknownCandidate ignored ->
+          throw new ResponseStatusException(HttpStatus.NOT_FOUND);
+    };
+  }
+}

--- a/src/main/java/app/zoneblitz/league/HiringDirectorOfScoutingTransitionHandler.java
+++ b/src/main/java/app/zoneblitz/league/HiringDirectorOfScoutingTransitionHandler.java
@@ -1,0 +1,107 @@
+package app.zoneblitz.league;
+
+import java.util.List;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+/**
+ * Phase-entry hook for {@link LeaguePhase#HIRING_DIRECTOR_OF_SCOUTING}. Mirrors {@link
+ * HiringHeadCoachTransitionHandler}: generate the league-wide DoS candidate pool (if not already
+ * present), persist candidates + preferences, and initialize each franchise's hiring sub-state to
+ * {@link HiringStep#SEARCHING} with empty shortlist/interview lists.
+ *
+ * <p>Idempotent: re-entry of a phase that already has a pool is a no-op.
+ */
+@Component
+class HiringDirectorOfScoutingTransitionHandler implements PhaseTransitionHandler {
+
+  private static final Logger log =
+      LoggerFactory.getLogger(HiringDirectorOfScoutingTransitionHandler.class);
+
+  /** Per {@code docs/technical/league-phases.md}: pool size is 2–3× franchise count. */
+  private static final int POOL_SIZE_PER_FRANCHISE = 3;
+
+  private final LeagueRepository leagues;
+  private final TeamLookup teams;
+  private final CandidatePoolRepository pools;
+  private final CandidateRepository candidates;
+  private final CandidatePreferencesRepository preferences;
+  private final FranchiseHiringStateRepository hiringStates;
+  private final DirectorOfScoutingGenerator generator;
+  private final CandidateRandomSources rngs;
+
+  HiringDirectorOfScoutingTransitionHandler(
+      LeagueRepository leagues,
+      TeamLookup teams,
+      CandidatePoolRepository pools,
+      CandidateRepository candidates,
+      CandidatePreferencesRepository preferences,
+      FranchiseHiringStateRepository hiringStates,
+      DirectorOfScoutingGenerator generator,
+      CandidateRandomSources rngs) {
+    this.leagues = leagues;
+    this.teams = teams;
+    this.pools = pools;
+    this.candidates = candidates;
+    this.preferences = preferences;
+    this.hiringStates = hiringStates;
+    this.generator = generator;
+    this.rngs = rngs;
+  }
+
+  @Override
+  public LeaguePhase phase() {
+    return LeaguePhase.HIRING_DIRECTOR_OF_SCOUTING;
+  }
+
+  @Override
+  public void onEntry(long leagueId) {
+    if (pools
+        .findByLeaguePhaseAndType(leagueId, phase(), CandidatePoolType.DIRECTOR_OF_SCOUTING)
+        .isPresent()) {
+      log.debug("DoS pool already present for league={}; entry is a no-op", leagueId);
+      return;
+    }
+    var league =
+        leagues
+            .findById(leagueId)
+            .orElseThrow(() -> new IllegalStateException("league missing: " + leagueId));
+    var franchiseIds = teams.franchiseIdsForLeague(leagueId);
+    var poolSize = Math.max(1, franchiseIds.size() * POOL_SIZE_PER_FRANCHISE);
+
+    var pool = pools.insert(leagueId, phase(), CandidatePoolType.DIRECTOR_OF_SCOUTING);
+    var rng = rngs.forLeaguePhase(leagueId, phase());
+    var generated = generator.generate(poolSize, rng);
+    for (var g : generated) {
+      var withPool = attachPool(g.candidate(), pool.id());
+      var saved = candidates.insert(withPool);
+      preferences.insert(g.preferences().withCandidateId(saved.id()));
+    }
+    for (var franchiseId : franchiseIds) {
+      hiringStates.upsert(
+          new FranchiseHiringState(
+              0L, leagueId, franchiseId, phase(), HiringStep.SEARCHING, List.of(), List.of()));
+    }
+    log.info(
+        "hiring director-of-scouting pool generated leagueId={} poolId={} size={} franchises={}",
+        league.id(),
+        pool.id(),
+        generated.size(),
+        franchiseIds.size());
+  }
+
+  private static NewCandidate attachPool(NewCandidate candidate, long poolId) {
+    return new NewCandidate(
+        poolId,
+        candidate.kind(),
+        candidate.specialtyPosition(),
+        candidate.archetype(),
+        candidate.age(),
+        candidate.totalExperienceYears(),
+        candidate.experienceByRole(),
+        candidate.hiddenAttrs(),
+        candidate.scoutedAttrs(),
+        candidate.scoutBranch());
+  }
+}

--- a/src/main/java/app/zoneblitz/league/HiringHeadCoachController.java
+++ b/src/main/java/app/zoneblitz/league/HiringHeadCoachController.java
@@ -1,0 +1,173 @@
+package app.zoneblitz.league;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.server.ResponseStatusException;
+
+/**
+ * Web controller for the HIRING_HEAD_COACH page and its HTMX fragment endpoints. Follows project
+ * convention: separate URLs for full pages vs fragments; fragments return {@code text/html}; page
+ * template composes the same fragments returned by the fragment endpoints.
+ */
+@Controller
+class HiringHeadCoachController {
+
+  private static final Logger log = LoggerFactory.getLogger(HiringHeadCoachController.class);
+
+  private final ViewHeadCoachHiring viewHiring;
+  private final ManageHeadCoachShortlist shortlist;
+  private final StartInterview startInterview;
+  private final MakeOffer makeOffer;
+
+  HiringHeadCoachController(
+      ViewHeadCoachHiring viewHiring,
+      ManageHeadCoachShortlist shortlist,
+      StartInterview startInterview,
+      MakeOffer makeOffer) {
+    this.viewHiring = viewHiring;
+    this.shortlist = shortlist;
+    this.startInterview = startInterview;
+    this.makeOffer = makeOffer;
+  }
+
+  @GetMapping("/leagues/{id}/hiring/head-coach")
+  String page(@AuthenticationPrincipal OAuth2User principal, @PathVariable long id, Model model) {
+    var view = resolveView(principal, id);
+    model.addAttribute("view", view);
+    return "league/hiring/head-coach";
+  }
+
+  @GetMapping("/leagues/{id}/hiring/head-coach/pool")
+  String poolFragment(
+      @AuthenticationPrincipal OAuth2User principal, @PathVariable long id, Model model) {
+    model.addAttribute("view", resolveView(principal, id));
+    return "league/hiring/head-coach-fragments :: pool";
+  }
+
+  @GetMapping("/leagues/{id}/hiring/head-coach/interviews")
+  String interviewsFragment(
+      @AuthenticationPrincipal OAuth2User principal, @PathVariable long id, Model model) {
+    model.addAttribute("view", resolveView(principal, id));
+    return "league/hiring/head-coach-fragments :: interviews";
+  }
+
+  @PostMapping("/leagues/{id}/hiring/head-coach/interview/{candidateId}")
+  String startInterview(
+      @AuthenticationPrincipal OAuth2User principal,
+      @PathVariable long id,
+      @PathVariable long candidateId,
+      Model model) {
+    var result = startInterview.start(id, candidateId, principal.getAttribute("sub"));
+    return renderInterview(result, model);
+  }
+
+  @GetMapping("/leagues/{id}/hiring/head-coach/shortlist")
+  String shortlistFragment(
+      @AuthenticationPrincipal OAuth2User principal, @PathVariable long id, Model model) {
+    model.addAttribute("view", resolveView(principal, id));
+    return "league/hiring/head-coach-fragments :: shortlist";
+  }
+
+  @PostMapping("/leagues/{id}/hiring/head-coach/shortlist/{candidateId}")
+  String addToShortlist(
+      @AuthenticationPrincipal OAuth2User principal,
+      @PathVariable long id,
+      @PathVariable long candidateId,
+      Model model) {
+    var result = shortlist.add(id, candidateId, principal.getAttribute("sub"));
+    return renderMutation(result, model);
+  }
+
+  @DeleteMapping("/leagues/{id}/hiring/head-coach/shortlist/{candidateId}")
+  String removeFromShortlist(
+      @AuthenticationPrincipal OAuth2User principal,
+      @PathVariable long id,
+      @PathVariable long candidateId,
+      Model model) {
+    var result = shortlist.remove(id, candidateId, principal.getAttribute("sub"));
+    return renderMutation(result, model);
+  }
+
+  @PostMapping("/leagues/{id}/hiring/head-coach/offer/{candidateId}")
+  String submitOffer(
+      @AuthenticationPrincipal OAuth2User principal,
+      @PathVariable long id,
+      @PathVariable long candidateId,
+      @ModelAttribute MakeOfferForm form,
+      Model model) {
+    var result = makeOffer.offer(id, candidateId, principal.getAttribute("sub"), form.toTerms());
+    return switch (result) {
+      case MakeOfferResult.Created created -> {
+        log.info(
+            "offer submitted leagueId={} candidateId={} offerId={}",
+            id,
+            candidateId,
+            created.offer().id());
+        model.addAttribute("view", resolveView(principal, id));
+        yield "league/hiring/head-coach-fragments :: combined";
+      }
+      case MakeOfferResult.NotFound ignored ->
+          throw new ResponseStatusException(HttpStatus.NOT_FOUND);
+      case MakeOfferResult.UnknownCandidate ignored ->
+          throw new ResponseStatusException(HttpStatus.NOT_FOUND);
+      case MakeOfferResult.AlreadyHired ignored ->
+          throw new ResponseStatusException(HttpStatus.CONFLICT);
+      case MakeOfferResult.ActiveOfferExists ignored ->
+          throw new ResponseStatusException(HttpStatus.CONFLICT);
+    };
+  }
+
+  private HeadCoachHiringView resolveView(OAuth2User principal, long id) {
+    return viewHiring
+        .view(id, principal.getAttribute("sub"))
+        .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND));
+  }
+
+  private String renderInterview(InterviewResult result, Model model) {
+    return switch (result) {
+      case InterviewResult.Started started -> {
+        model.addAttribute("view", started.view());
+        log.info(
+            "interview started leagueId={} interviewsThisWeek={}",
+            started.view().league().leagueId(),
+            started.view().interviewsThisWeek());
+        yield "league/hiring/head-coach-fragments :: combined";
+      }
+      case InterviewResult.NotFound ignored ->
+          throw new ResponseStatusException(HttpStatus.NOT_FOUND);
+      case InterviewResult.UnknownCandidate ignored ->
+          throw new ResponseStatusException(HttpStatus.NOT_FOUND);
+      case InterviewResult.CapacityReached capacity ->
+          throw new ResponseStatusException(
+              HttpStatus.CONFLICT,
+              "Weekly interview capacity of %d already reached".formatted(capacity.capacity()));
+    };
+  }
+
+  private String renderMutation(ShortlistResult result, Model model) {
+    return switch (result) {
+      case ShortlistResult.Updated updated -> {
+        model.addAttribute("view", updated.view());
+        log.info(
+            "shortlist updated leagueId={} size={}",
+            updated.view().league().leagueId(),
+            updated.view().shortlist().size());
+        yield "league/hiring/head-coach-fragments :: combined";
+      }
+      case ShortlistResult.NotFound ignored ->
+          throw new ResponseStatusException(HttpStatus.NOT_FOUND);
+      case ShortlistResult.UnknownCandidate ignored ->
+          throw new ResponseStatusException(HttpStatus.NOT_FOUND);
+    };
+  }
+}

--- a/src/main/java/app/zoneblitz/league/HiringHeadCoachTransitionHandler.java
+++ b/src/main/java/app/zoneblitz/league/HiringHeadCoachTransitionHandler.java
@@ -1,0 +1,107 @@
+package app.zoneblitz.league;
+
+import java.util.List;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+/**
+ * Phase-entry hook for {@link LeaguePhase#HIRING_HEAD_COACH}. On entry: generate the league-wide HC
+ * candidate pool (if not already present), persist candidates + preferences, and initialize each
+ * franchise's hiring sub-state to {@link HiringStep#SEARCHING} with empty shortlist/interview
+ * lists.
+ *
+ * <p>Idempotent: re-entry of a phase that already has a pool is a no-op so autofill/recovery paths
+ * do not duplicate data.
+ */
+@Component
+class HiringHeadCoachTransitionHandler implements PhaseTransitionHandler {
+
+  private static final Logger log = LoggerFactory.getLogger(HiringHeadCoachTransitionHandler.class);
+
+  /** Per {@code docs/technical/league-phases.md}: pool size is 2–3× franchise count. */
+  private static final int POOL_SIZE_PER_FRANCHISE = 3;
+
+  private final LeagueRepository leagues;
+  private final TeamLookup teams;
+  private final CandidatePoolRepository pools;
+  private final CandidateRepository candidates;
+  private final CandidatePreferencesRepository preferences;
+  private final FranchiseHiringStateRepository hiringStates;
+  private final HeadCoachGenerator generator;
+  private final CandidateRandomSources rngs;
+
+  HiringHeadCoachTransitionHandler(
+      LeagueRepository leagues,
+      TeamLookup teams,
+      CandidatePoolRepository pools,
+      CandidateRepository candidates,
+      CandidatePreferencesRepository preferences,
+      FranchiseHiringStateRepository hiringStates,
+      HeadCoachGenerator generator,
+      CandidateRandomSources rngs) {
+    this.leagues = leagues;
+    this.teams = teams;
+    this.pools = pools;
+    this.candidates = candidates;
+    this.preferences = preferences;
+    this.hiringStates = hiringStates;
+    this.generator = generator;
+    this.rngs = rngs;
+  }
+
+  @Override
+  public LeaguePhase phase() {
+    return LeaguePhase.HIRING_HEAD_COACH;
+  }
+
+  @Override
+  public void onEntry(long leagueId) {
+    if (pools
+        .findByLeaguePhaseAndType(leagueId, phase(), CandidatePoolType.HEAD_COACH)
+        .isPresent()) {
+      log.debug("HC pool already present for league={}; entry is a no-op", leagueId);
+      return;
+    }
+    var league =
+        leagues
+            .findById(leagueId)
+            .orElseThrow(() -> new IllegalStateException("league missing: " + leagueId));
+    var franchiseIds = teams.franchiseIdsForLeague(leagueId);
+    var poolSize = Math.max(1, franchiseIds.size() * POOL_SIZE_PER_FRANCHISE);
+
+    var pool = pools.insert(leagueId, phase(), CandidatePoolType.HEAD_COACH);
+    var rng = rngs.forLeaguePhase(leagueId, phase());
+    var generated = generator.generate(poolSize, rng);
+    for (var g : generated) {
+      var withPool = attachPool(g.candidate(), pool.id());
+      var saved = candidates.insert(withPool);
+      preferences.insert(g.preferences().withCandidateId(saved.id()));
+    }
+    for (var franchiseId : franchiseIds) {
+      hiringStates.upsert(
+          new FranchiseHiringState(
+              0L, leagueId, franchiseId, phase(), HiringStep.SEARCHING, List.of(), List.of()));
+    }
+    log.info(
+        "hiring head-coach pool generated leagueId={} poolId={} size={} franchises={}",
+        league.id(),
+        pool.id(),
+        generated.size(),
+        franchiseIds.size());
+  }
+
+  private static NewCandidate attachPool(NewCandidate candidate, long poolId) {
+    return new NewCandidate(
+        poolId,
+        candidate.kind(),
+        candidate.specialtyPosition(),
+        candidate.archetype(),
+        candidate.age(),
+        candidate.totalExperienceYears(),
+        candidate.experienceByRole(),
+        candidate.hiddenAttrs(),
+        candidate.scoutedAttrs(),
+        candidate.scoutBranch());
+  }
+}

--- a/src/main/java/app/zoneblitz/league/HiringPhaseAutofill.java
+++ b/src/main/java/app/zoneblitz/league/HiringPhaseAutofill.java
@@ -1,0 +1,31 @@
+package app.zoneblitz.league;
+
+/**
+ * Seam invoked when a hiring phase hits its week cap before every franchise has reached {@link
+ * HiringStep#HIRED}. Auto-assigns the best remaining candidate (by scouted overall, deterministic
+ * tie-break) to each unresolved franchise, creates an {@link OfferStatus#ACCEPTED} offer with
+ * default terms, marks the candidate hired, transitions the franchise's {@link
+ * FranchiseHiringState} to {@link HiringStep#HIRED}, and inserts the corresponding {@link
+ * FranchiseStaffMember} row.
+ *
+ * <p>Never surfaces the candidate's {@code hiddenAttrs} (true rating) — the ranking is driven by
+ * {@code scoutedAttrs} only, preserving the hidden-info guarantee from {@code
+ * docs/technical/league-phases.md} (Market dynamics & hidden ratings).
+ *
+ * <p>Idempotent: running twice on a phase where every franchise is already {@link HiringStep#HIRED}
+ * is a no-op.
+ */
+interface HiringPhaseAutofill {
+
+  /**
+   * Auto-assign hires to any franchise that is not already {@link HiringStep#HIRED} in the given
+   * phase.
+   *
+   * @param leagueId the league whose hiring phase is being capped off.
+   * @param phase the hiring phase to autofill. Phases without a candidate pool (e.g. {@link
+   *     LeaguePhase#INITIAL_SETUP}, {@link LeaguePhase#ASSEMBLING_STAFF}) are a no-op.
+   * @param phaseWeek the {@code phase_week} value the autofill is running at; stored on the
+   *     resulting {@link FranchiseStaffMember#hiredAtWeek()} and the synthetic offer row.
+   */
+  void autofill(long leagueId, LeaguePhase phase, int phaseWeek);
+}

--- a/src/main/java/app/zoneblitz/league/HiringPhases.java
+++ b/src/main/java/app/zoneblitz/league/HiringPhases.java
@@ -1,0 +1,39 @@
+package app.zoneblitz.league;
+
+import java.util.Optional;
+
+/**
+ * Utility mapping for hiring-phase concerns shared between the HC and DoS phases: the candidate
+ * pool type to look up, and the terminal staff role the phase produces. Keeps the gate on "is this
+ * a hiring phase?" centralized so services can accept either hiring phase without sprinkling {@code
+ * switch} ladders through every use case.
+ */
+final class HiringPhases {
+
+  private HiringPhases() {}
+
+  /**
+   * Candidate pool type the given phase draws from, or empty if the phase is not a hiring phase.
+   */
+  static Optional<CandidatePoolType> poolTypeFor(LeaguePhase phase) {
+    return switch (phase) {
+      case HIRING_HEAD_COACH -> Optional.of(CandidatePoolType.HEAD_COACH);
+      case HIRING_DIRECTOR_OF_SCOUTING -> Optional.of(CandidatePoolType.DIRECTOR_OF_SCOUTING);
+      case INITIAL_SETUP, ASSEMBLING_STAFF, COMPLETE -> Optional.empty();
+    };
+  }
+
+  /** Terminal staff role produced by a hire in this phase. */
+  static StaffRole staffRoleFor(LeaguePhase phase) {
+    return switch (phase) {
+      case HIRING_HEAD_COACH -> StaffRole.HEAD_COACH;
+      case HIRING_DIRECTOR_OF_SCOUTING -> StaffRole.DIRECTOR_OF_SCOUTING;
+      case INITIAL_SETUP, ASSEMBLING_STAFF, COMPLETE ->
+          throw new IllegalArgumentException("no staff role for non-hiring phase " + phase);
+    };
+  }
+
+  static boolean isHiring(LeaguePhase phase) {
+    return poolTypeFor(phase).isPresent();
+  }
+}

--- a/src/main/java/app/zoneblitz/league/InterviewNoiseModel.java
+++ b/src/main/java/app/zoneblitz/league/InterviewNoiseModel.java
@@ -1,0 +1,31 @@
+package app.zoneblitz.league;
+
+/**
+ * Interview noise-reduction function. Each completed interview multiplies the remaining noise above
+ * the tier floor by {@code (1 - REDUCTION)} — geometric decay with diminishing returns. The
+ * tier-dependent {@code FLOOR_STD} guarantees σ never reaches zero regardless of interview count,
+ * preserving the hidden-info pillar from {@code busts-and-gems.md}.
+ *
+ * <p>σ(n) = FLOOR_STD + (INITIAL_STD − FLOOR_STD) · (1 − REDUCTION)^n
+ */
+final class InterviewNoiseModel {
+
+  static final double HC_INITIAL_STD = 8.0;
+  static final double HC_FLOOR_STD = 2.0;
+  static final double REDUCTION_PER_INTERVIEW = 0.4;
+
+  private InterviewNoiseModel() {}
+
+  /**
+   * Scouted-signal σ after {@code interviewCount} interviews, for the HC tier. Monotonically
+   * non-increasing in {@code interviewCount}; strictly decreasing until it approaches {@link
+   * #HC_FLOOR_STD}; never reaches zero.
+   */
+  static double headCoachSigma(int interviewCount) {
+    if (interviewCount < 0) {
+      throw new IllegalArgumentException("interviewCount must be >= 0, was: " + interviewCount);
+    }
+    var residual = HC_INITIAL_STD - HC_FLOOR_STD;
+    return HC_FLOOR_STD + residual * Math.pow(1.0 - REDUCTION_PER_INTERVIEW, interviewCount);
+  }
+}

--- a/src/main/java/app/zoneblitz/league/InterviewResult.java
+++ b/src/main/java/app/zoneblitz/league/InterviewResult.java
@@ -1,0 +1,17 @@
+package app.zoneblitz.league;
+
+/** Sealed outcomes for {@link StartInterview#start}. */
+public sealed interface InterviewResult {
+
+  /** Interview recorded; the refreshed view-model is returned for fragment rendering. */
+  record Started(HeadCoachHiringView view) implements InterviewResult {}
+
+  /** League not found for the requesting user, or not in the HC hiring phase. */
+  record NotFound(long leagueId) implements InterviewResult {}
+
+  /** Candidate does not exist in this league's HC pool. */
+  record UnknownCandidate(long candidateId) implements InterviewResult {}
+
+  /** Franchise has already hit its per-week interview cap. */
+  record CapacityReached(int capacity) implements InterviewResult {}
+}

--- a/src/main/java/app/zoneblitz/league/JooqFranchiseInterviewRepository.java
+++ b/src/main/java/app/zoneblitz/league/JooqFranchiseInterviewRepository.java
@@ -1,0 +1,82 @@
+package app.zoneblitz.league;
+
+import static app.zoneblitz.jooq.Tables.FRANCHISE_INTERVIEWS;
+
+import java.util.List;
+import java.util.Objects;
+import org.jooq.DSLContext;
+import org.springframework.stereotype.Repository;
+
+@Repository
+class JooqFranchiseInterviewRepository implements FranchiseInterviewRepository {
+
+  private final DSLContext dsl;
+
+  JooqFranchiseInterviewRepository(DSLContext dsl) {
+    this.dsl = dsl;
+  }
+
+  @Override
+  public FranchiseInterview insert(NewFranchiseInterview interview) {
+    Objects.requireNonNull(interview, "interview");
+    var record =
+        dsl.insertInto(FRANCHISE_INTERVIEWS)
+            .set(FRANCHISE_INTERVIEWS.LEAGUE_ID, interview.leagueId())
+            .set(FRANCHISE_INTERVIEWS.FRANCHISE_ID, interview.franchiseId())
+            .set(FRANCHISE_INTERVIEWS.CANDIDATE_ID, interview.candidateId())
+            .set(FRANCHISE_INTERVIEWS.PHASE, interview.phase().name())
+            .set(FRANCHISE_INTERVIEWS.PHASE_WEEK, interview.phaseWeek())
+            .set(FRANCHISE_INTERVIEWS.INTERVIEW_INDEX, interview.interviewIndex())
+            .set(FRANCHISE_INTERVIEWS.SCOUTED_OVERALL, interview.scoutedOverall())
+            .returning(FRANCHISE_INTERVIEWS.fields())
+            .fetchOne();
+    return map(record);
+  }
+
+  @Override
+  public int countForCandidate(
+      long leagueId, long franchiseId, long candidateId, LeaguePhase phase) {
+    return dsl.fetchCount(
+        FRANCHISE_INTERVIEWS,
+        FRANCHISE_INTERVIEWS
+            .LEAGUE_ID
+            .eq(leagueId)
+            .and(FRANCHISE_INTERVIEWS.FRANCHISE_ID.eq(franchiseId))
+            .and(FRANCHISE_INTERVIEWS.CANDIDATE_ID.eq(candidateId))
+            .and(FRANCHISE_INTERVIEWS.PHASE.eq(phase.name())));
+  }
+
+  @Override
+  public int countForWeek(long leagueId, long franchiseId, LeaguePhase phase, int phaseWeek) {
+    return dsl.fetchCount(
+        FRANCHISE_INTERVIEWS,
+        FRANCHISE_INTERVIEWS
+            .LEAGUE_ID
+            .eq(leagueId)
+            .and(FRANCHISE_INTERVIEWS.FRANCHISE_ID.eq(franchiseId))
+            .and(FRANCHISE_INTERVIEWS.PHASE.eq(phase.name()))
+            .and(FRANCHISE_INTERVIEWS.PHASE_WEEK.eq(phaseWeek)));
+  }
+
+  @Override
+  public List<FranchiseInterview> findAllFor(long leagueId, long franchiseId, LeaguePhase phase) {
+    return dsl.selectFrom(FRANCHISE_INTERVIEWS)
+        .where(FRANCHISE_INTERVIEWS.LEAGUE_ID.eq(leagueId))
+        .and(FRANCHISE_INTERVIEWS.FRANCHISE_ID.eq(franchiseId))
+        .and(FRANCHISE_INTERVIEWS.PHASE.eq(phase.name()))
+        .orderBy(FRANCHISE_INTERVIEWS.ID.asc())
+        .fetch(this::map);
+  }
+
+  private FranchiseInterview map(org.jooq.Record r) {
+    return new FranchiseInterview(
+        r.get(FRANCHISE_INTERVIEWS.ID),
+        r.get(FRANCHISE_INTERVIEWS.LEAGUE_ID),
+        r.get(FRANCHISE_INTERVIEWS.FRANCHISE_ID),
+        r.get(FRANCHISE_INTERVIEWS.CANDIDATE_ID),
+        LeaguePhase.valueOf(r.get(FRANCHISE_INTERVIEWS.PHASE)),
+        r.get(FRANCHISE_INTERVIEWS.PHASE_WEEK),
+        r.get(FRANCHISE_INTERVIEWS.INTERVIEW_INDEX),
+        r.get(FRANCHISE_INTERVIEWS.SCOUTED_OVERALL));
+  }
+}

--- a/src/main/java/app/zoneblitz/league/JooqTeamLookup.java
+++ b/src/main/java/app/zoneblitz/league/JooqTeamLookup.java
@@ -1,0 +1,36 @@
+package app.zoneblitz.league;
+
+import static app.zoneblitz.jooq.Tables.TEAMS;
+
+import java.util.List;
+import org.jooq.DSLContext;
+import org.springframework.stereotype.Repository;
+
+@Repository
+class JooqTeamLookup implements TeamLookup {
+
+  private final DSLContext dsl;
+
+  JooqTeamLookup(DSLContext dsl) {
+    this.dsl = dsl;
+  }
+
+  @Override
+  public List<Long> franchiseIdsForLeague(long leagueId) {
+    return dsl.select(TEAMS.FRANCHISE_ID)
+        .from(TEAMS)
+        .where(TEAMS.LEAGUE_ID.eq(leagueId))
+        .orderBy(TEAMS.FRANCHISE_ID.asc())
+        .fetch(TEAMS.FRANCHISE_ID);
+  }
+
+  @Override
+  public List<Long> cpuFranchiseIdsForLeague(long leagueId) {
+    return dsl.select(TEAMS.FRANCHISE_ID)
+        .from(TEAMS)
+        .where(TEAMS.LEAGUE_ID.eq(leagueId))
+        .and(TEAMS.OWNER_SUBJECT.isNull())
+        .orderBy(TEAMS.FRANCHISE_ID.asc())
+        .fetch(TEAMS.FRANCHISE_ID);
+  }
+}

--- a/src/main/java/app/zoneblitz/league/LeagueBeans.java
+++ b/src/main/java/app/zoneblitz/league/LeagueBeans.java
@@ -1,0 +1,76 @@
+package app.zoneblitz.league;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/** Wiring for league-feature beans that are not themselves {@code @Component}-annotated. */
+@Configuration
+class LeagueBeans {
+
+  @Bean
+  HeadCoachGenerator headCoachGenerator() {
+    return new HeadCoachGenerator();
+  }
+
+  @Bean
+  DirectorOfScoutingGenerator directorOfScoutingGenerator() {
+    return new DirectorOfScoutingGenerator();
+  }
+
+  @Bean
+  CoordinatorGenerator coordinatorGenerator() {
+    return new CoordinatorGenerator();
+  }
+
+  @Bean
+  PositionCoachGenerator positionCoachGenerator() {
+    return new PositionCoachGenerator();
+  }
+
+  @Bean
+  ScoutCandidateGenerator scoutCandidateGenerator() {
+    return new ScoutCandidateGenerator();
+  }
+
+  @Bean
+  CpuFranchiseStrategy headCoachCpuHiringStrategy(
+      CandidatePoolRepository pools,
+      CandidateRepository candidates,
+      CandidatePreferencesRepository preferences,
+      CandidateOfferRepository offers,
+      FranchiseHiringStateRepository hiringStates,
+      FranchiseInterviewRepository interviews,
+      CandidateRandomSources rngs) {
+    return new CpuHiringStrategy(
+        LeaguePhase.HIRING_HEAD_COACH,
+        CandidatePoolType.HEAD_COACH,
+        pools,
+        candidates,
+        preferences,
+        offers,
+        hiringStates,
+        interviews,
+        rngs);
+  }
+
+  @Bean
+  CpuFranchiseStrategy directorOfScoutingCpuHiringStrategy(
+      CandidatePoolRepository pools,
+      CandidateRepository candidates,
+      CandidatePreferencesRepository preferences,
+      CandidateOfferRepository offers,
+      FranchiseHiringStateRepository hiringStates,
+      FranchiseInterviewRepository interviews,
+      CandidateRandomSources rngs) {
+    return new CpuHiringStrategy(
+        LeaguePhase.HIRING_DIRECTOR_OF_SCOUTING,
+        CandidatePoolType.DIRECTOR_OF_SCOUTING,
+        pools,
+        candidates,
+        preferences,
+        offers,
+        hiringStates,
+        interviews,
+        rngs);
+  }
+}

--- a/src/main/java/app/zoneblitz/league/LeagueController.java
+++ b/src/main/java/app/zoneblitz/league/LeagueController.java
@@ -58,6 +58,15 @@ class LeagueController {
         getLeague
             .get(id, principal.getAttribute("sub"))
             .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND));
+    if (league.phase() == LeaguePhase.HIRING_HEAD_COACH) {
+      return "redirect:/leagues/" + id + "/hiring/head-coach";
+    }
+    if (league.phase() == LeaguePhase.HIRING_DIRECTOR_OF_SCOUTING) {
+      return "redirect:/leagues/" + id + "/hiring/director-of-scouting";
+    }
+    if (league.phase() == LeaguePhase.ASSEMBLING_STAFF) {
+      return "redirect:/leagues/" + id + "/staff-recap";
+    }
     model.addAttribute("league", league);
     return "league/dashboard";
   }

--- a/src/main/java/app/zoneblitz/league/LeaguePhase.java
+++ b/src/main/java/app/zoneblitz/league/LeaguePhase.java
@@ -4,5 +4,11 @@ public enum LeaguePhase {
   INITIAL_SETUP,
   HIRING_HEAD_COACH,
   HIRING_DIRECTOR_OF_SCOUTING,
-  ASSEMBLING_STAFF
+  ASSEMBLING_STAFF,
+  /**
+   * Placeholder terminal phase reached after {@link #ASSEMBLING_STAFF} completes. Subsequent phases
+   * (inaugural draft prep, season, etc.) are out of scope for v1; this phase exists so the phase
+   * state machine has somewhere to land and the dashboard has a stable post-staff state.
+   */
+  COMPLETE
 }

--- a/src/main/java/app/zoneblitz/league/LeaguePhases.java
+++ b/src/main/java/app/zoneblitz/league/LeaguePhases.java
@@ -4,17 +4,45 @@ import java.util.Map;
 import java.util.Optional;
 
 /**
- * Phase ordering and next-phase lookup. Centralizes the linear sequence so {@link
- * AdvancePhaseUseCase} and tests agree on "what comes next".
+ * Phase ordering, next-phase lookup, and per-phase week caps. Centralizes the linear sequence so
+ * {@link AdvancePhaseUseCase}, {@link AdvanceWeekUseCase}, and tests agree on "what comes next" and
+ * "when does the phase end by cap".
+ *
+ * <p>Per {@code docs/technical/league-phases.md} (Hiring sub-state machine):
+ *
+ * <ul>
+ *   <li>{@link LeaguePhase#HIRING_HEAD_COACH} — max 3 weeks.
+ *   <li>{@link LeaguePhase#HIRING_DIRECTOR_OF_SCOUTING} — max 3 weeks.
+ *   <li>{@link LeaguePhase#ASSEMBLING_STAFF} — max 1 week.
+ *   <li>{@link LeaguePhase#INITIAL_SETUP} — no cap; user-advanced explicitly.
+ * </ul>
  */
 final class LeaguePhases {
 
   private static final Map<LeaguePhase, LeaguePhase> NEXT =
-      Map.of(LeaguePhase.INITIAL_SETUP, LeaguePhase.HIRING_HEAD_COACH);
+      Map.of(
+          LeaguePhase.INITIAL_SETUP, LeaguePhase.HIRING_HEAD_COACH,
+          LeaguePhase.HIRING_HEAD_COACH, LeaguePhase.HIRING_DIRECTOR_OF_SCOUTING,
+          LeaguePhase.HIRING_DIRECTOR_OF_SCOUTING, LeaguePhase.ASSEMBLING_STAFF,
+          LeaguePhase.ASSEMBLING_STAFF, LeaguePhase.COMPLETE);
+
+  private static final Map<LeaguePhase, Integer> MAX_WEEKS =
+      Map.of(
+          LeaguePhase.HIRING_HEAD_COACH, 3,
+          LeaguePhase.HIRING_DIRECTOR_OF_SCOUTING, 3,
+          LeaguePhase.ASSEMBLING_STAFF, 1);
 
   private LeaguePhases() {}
 
   static Optional<LeaguePhase> next(LeaguePhase phase) {
     return Optional.ofNullable(NEXT.get(phase));
+  }
+
+  /**
+   * Returns the phase's week cap, or {@link Optional#empty()} if the phase has no cap (e.g. {@link
+   * LeaguePhase#INITIAL_SETUP}, which is user-advanced).
+   */
+  static Optional<Integer> maxWeeks(LeaguePhase phase) {
+    return Optional.ofNullable(MAX_WEEKS.get(phase));
   }
 }

--- a/src/main/java/app/zoneblitz/league/MakeOffer.java
+++ b/src/main/java/app/zoneblitz/league/MakeOffer.java
@@ -1,0 +1,31 @@
+package app.zoneblitz.league;
+
+/**
+ * Use case: a franchise submits an offer to a Head Coach candidate. One offer per (franchise,
+ * candidate) at a time — re-submitting while an {@link OfferStatus#ACTIVE} offer exists returns
+ * {@link MakeOfferResult.ActiveOfferExists}. Offer is resolved at the next week tick by {@link
+ * OfferResolver}.
+ */
+interface MakeOffer {
+
+  /**
+   * Submit an offer on behalf of the requester's franchise.
+   *
+   * @param leagueId the league.
+   * @param candidateId the candidate being pursued.
+   * @param ownerSubject OAuth subject of the user owning the franchise submitting the offer.
+   * @param terms offer terms; must be valid per {@link OfferTerms} invariants.
+   * @return one of:
+   *     <ul>
+   *       <li>{@link MakeOfferResult.Created} — offer persisted as ACTIVE.
+   *       <li>{@link MakeOfferResult.NotFound} — league not found for the caller.
+   *       <li>{@link MakeOfferResult.UnknownCandidate} — candidate missing, not in HC pool, or
+   *           already hired by any franchise.
+   *       <li>{@link MakeOfferResult.AlreadyHired} — caller's franchise has already hired a HC in
+   *           this league.
+   *       <li>{@link MakeOfferResult.ActiveOfferExists} — caller already has an active offer on
+   *           this candidate.
+   *     </ul>
+   */
+  MakeOfferResult offer(long leagueId, long candidateId, String ownerSubject, OfferTerms terms);
+}

--- a/src/main/java/app/zoneblitz/league/MakeOfferForm.java
+++ b/src/main/java/app/zoneblitz/league/MakeOfferForm.java
@@ -1,0 +1,24 @@
+package app.zoneblitz.league;
+
+import jakarta.validation.constraints.DecimalMax;
+import jakarta.validation.constraints.DecimalMin;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+import java.math.BigDecimal;
+
+/**
+ * HTMX form record bound by {@link HiringHeadCoachController#submitOffer} when a franchise submits
+ * a HC offer. All fields map directly onto the typed {@link OfferTerms} payload.
+ */
+record MakeOfferForm(
+    @NotNull @DecimalMin("0.0") BigDecimal compensation,
+    @Min(1) int contractLengthYears,
+    @NotNull @DecimalMin("0.0") @DecimalMax("1.0") BigDecimal guaranteedMoneyPct,
+    @NotNull RoleScope roleScope,
+    @NotNull StaffContinuity staffContinuity) {
+
+  OfferTerms toTerms() {
+    return new OfferTerms(
+        compensation, contractLengthYears, guaranteedMoneyPct, roleScope, staffContinuity);
+  }
+}

--- a/src/main/java/app/zoneblitz/league/MakeOfferResult.java
+++ b/src/main/java/app/zoneblitz/league/MakeOfferResult.java
@@ -1,0 +1,14 @@
+package app.zoneblitz.league;
+
+public sealed interface MakeOfferResult {
+
+  record Created(CandidateOffer offer) implements MakeOfferResult {}
+
+  record NotFound(long leagueId) implements MakeOfferResult {}
+
+  record UnknownCandidate(long candidateId) implements MakeOfferResult {}
+
+  record AlreadyHired(long franchiseId) implements MakeOfferResult {}
+
+  record ActiveOfferExists(long candidateId, long franchiseId) implements MakeOfferResult {}
+}

--- a/src/main/java/app/zoneblitz/league/MakeOfferUseCase.java
+++ b/src/main/java/app/zoneblitz/league/MakeOfferUseCase.java
@@ -1,0 +1,85 @@
+package app.zoneblitz.league;
+
+import java.util.Objects;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+class MakeOfferUseCase implements MakeOffer {
+
+  private static final Logger log = LoggerFactory.getLogger(MakeOfferUseCase.class);
+
+  private final LeagueRepository leagues;
+  private final CandidatePoolRepository pools;
+  private final CandidateRepository candidates;
+  private final CandidateOfferRepository offers;
+  private final FranchiseHiringStateRepository hiringStates;
+
+  MakeOfferUseCase(
+      LeagueRepository leagues,
+      CandidatePoolRepository pools,
+      CandidateRepository candidates,
+      CandidateOfferRepository offers,
+      FranchiseHiringStateRepository hiringStates) {
+    this.leagues = leagues;
+    this.pools = pools;
+    this.candidates = candidates;
+    this.offers = offers;
+    this.hiringStates = hiringStates;
+  }
+
+  @Override
+  @Transactional
+  public MakeOfferResult offer(
+      long leagueId, long candidateId, String ownerSubject, OfferTerms terms) {
+    Objects.requireNonNull(ownerSubject, "ownerSubject");
+    Objects.requireNonNull(terms, "terms");
+
+    var maybeLeague = leagues.findSummaryByIdAndOwner(leagueId, ownerSubject);
+    if (maybeLeague.isEmpty()) {
+      return new MakeOfferResult.NotFound(leagueId);
+    }
+    var league = maybeLeague.get();
+    var phase = league.phase();
+    var poolType = HiringPhases.poolTypeFor(phase);
+    if (poolType.isEmpty()) {
+      return new MakeOfferResult.NotFound(leagueId);
+    }
+    var maybePool = pools.findByLeaguePhaseAndType(leagueId, phase, poolType.get());
+    if (maybePool.isEmpty()) {
+      return new MakeOfferResult.UnknownCandidate(candidateId);
+    }
+    var candidate = candidates.findById(candidateId);
+    if (candidate.isEmpty() || candidate.get().poolId() != maybePool.get().id()) {
+      return new MakeOfferResult.UnknownCandidate(candidateId);
+    }
+    if (candidate.get().hiredByFranchiseId().isPresent()) {
+      return new MakeOfferResult.UnknownCandidate(candidateId);
+    }
+
+    var franchiseId = league.userFranchise().id();
+    var hiringState = hiringStates.find(leagueId, franchiseId, phase);
+    if (hiringState.isPresent() && hiringState.get().step() == HiringStep.HIRED) {
+      return new MakeOfferResult.AlreadyHired(franchiseId);
+    }
+
+    var existing = offers.findActiveForFranchise(franchiseId);
+    if (existing.stream().anyMatch(o -> o.candidateId() == candidateId)) {
+      return new MakeOfferResult.ActiveOfferExists(candidateId, franchiseId);
+    }
+
+    var phaseWeek = league.phaseWeek();
+    var saved =
+        offers.insertActive(candidateId, franchiseId, OfferTermsJson.toJson(terms), phaseWeek);
+    log.info(
+        "offer submitted leagueId={} franchiseId={} candidateId={} offerId={} week={}",
+        leagueId,
+        franchiseId,
+        candidateId,
+        saved.id(),
+        phaseWeek);
+    return new MakeOfferResult.Created(saved);
+  }
+}

--- a/src/main/java/app/zoneblitz/league/ManageHeadCoachShortlist.java
+++ b/src/main/java/app/zoneblitz/league/ManageHeadCoachShortlist.java
@@ -1,0 +1,14 @@
+package app.zoneblitz.league;
+
+/**
+ * Feature-public use case for adding or removing a candidate on the requesting franchise's
+ * HIRING_HEAD_COACH shortlist. Both operations are idempotent — adding an already-shortlisted
+ * candidate is a no-op that still returns {@link ShortlistResult.Updated}; same for removing one
+ * that isn't on the list.
+ */
+public interface ManageHeadCoachShortlist {
+
+  ShortlistResult add(long leagueId, long candidateId, String ownerSubject);
+
+  ShortlistResult remove(long leagueId, long candidateId, String ownerSubject);
+}

--- a/src/main/java/app/zoneblitz/league/ManageHeadCoachShortlistUseCase.java
+++ b/src/main/java/app/zoneblitz/league/ManageHeadCoachShortlistUseCase.java
@@ -1,0 +1,116 @@
+package app.zoneblitz.league;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+class ManageHeadCoachShortlistUseCase implements ManageHeadCoachShortlist {
+
+  private final LeagueRepository leagues;
+  private final CandidatePoolRepository pools;
+  private final CandidateRepository candidates;
+  private final CandidatePreferencesRepository preferences;
+  private final FranchiseHiringStateRepository hiringStates;
+  private final FranchiseInterviewRepository interviews;
+
+  ManageHeadCoachShortlistUseCase(
+      LeagueRepository leagues,
+      CandidatePoolRepository pools,
+      CandidateRepository candidates,
+      CandidatePreferencesRepository preferences,
+      FranchiseHiringStateRepository hiringStates,
+      FranchiseInterviewRepository interviews) {
+    this.leagues = leagues;
+    this.pools = pools;
+    this.candidates = candidates;
+    this.preferences = preferences;
+    this.hiringStates = hiringStates;
+    this.interviews = interviews;
+  }
+
+  @Override
+  @Transactional
+  public ShortlistResult add(long leagueId, long candidateId, String ownerSubject) {
+    return mutate(leagueId, candidateId, ownerSubject, ids -> addUnique(ids, candidateId));
+  }
+
+  @Override
+  @Transactional
+  public ShortlistResult remove(long leagueId, long candidateId, String ownerSubject) {
+    return mutate(
+        leagueId,
+        candidateId,
+        ownerSubject,
+        ids -> ids.stream().filter(id -> id != candidateId).toList());
+  }
+
+  private ShortlistResult mutate(
+      long leagueId,
+      long candidateId,
+      String ownerSubject,
+      java.util.function.UnaryOperator<List<Long>> transform) {
+    Objects.requireNonNull(ownerSubject, "ownerSubject");
+    var maybeLeague = leagues.findSummaryByIdAndOwner(leagueId, ownerSubject);
+    if (maybeLeague.isEmpty()) {
+      return new ShortlistResult.NotFound(leagueId);
+    }
+    var league = maybeLeague.get();
+    var phase = league.phase();
+    var poolType = HiringPhases.poolTypeFor(phase);
+    if (poolType.isEmpty()) {
+      return new ShortlistResult.NotFound(leagueId);
+    }
+    var maybePool = pools.findByLeaguePhaseAndType(leagueId, phase, poolType.get());
+    if (maybePool.isEmpty()) {
+      return new ShortlistResult.NotFound(leagueId);
+    }
+    var candidate = candidates.findById(candidateId);
+    if (candidate.isEmpty() || candidate.get().poolId() != maybePool.get().id()) {
+      return new ShortlistResult.UnknownCandidate(candidateId);
+    }
+    var franchiseId = league.userFranchise().id();
+    var existing = hiringStates.find(leagueId, franchiseId, phase);
+    var currentIds = existing.map(FranchiseHiringState::shortlist).orElse(List.of());
+    var interviewingIds =
+        existing.map(FranchiseHiringState::interviewingCandidateIds).orElse(List.of());
+    var updatedIds = transform.apply(currentIds);
+    hiringStates.upsert(
+        new FranchiseHiringState(
+            existing.map(FranchiseHiringState::id).orElse(0L),
+            leagueId,
+            franchiseId,
+            phase,
+            HiringStep.SEARCHING,
+            updatedIds,
+            interviewingIds));
+    var pool = candidates.findAllByPoolId(maybePool.get().id());
+    var prefs =
+        pool.stream()
+            .map(c -> preferences.findByCandidateId(c.id()))
+            .flatMap(java.util.Optional::stream)
+            .toList();
+    var interviewHistory = interviews.findAllFor(leagueId, franchiseId, phase);
+    var view =
+        HeadCoachHiringViewModel.assemble(
+            league,
+            pool,
+            prefs,
+            updatedIds,
+            interviewHistory,
+            StartInterview.DEFAULT_WEEKLY_CAPACITY);
+    return new ShortlistResult.Updated(view);
+  }
+
+  private static List<Long> addUnique(List<Long> ids, long candidateId) {
+    if (ids.contains(candidateId)) {
+      return ids;
+    }
+    var updated = new ArrayList<Long>(ids.size() + 1);
+    updated.addAll(ids);
+    updated.add(candidateId);
+    return List.copyOf(updated);
+  }
+}

--- a/src/main/java/app/zoneblitz/league/NewFranchiseInterview.java
+++ b/src/main/java/app/zoneblitz/league/NewFranchiseInterview.java
@@ -1,0 +1,20 @@
+package app.zoneblitz.league;
+
+import java.math.BigDecimal;
+import java.util.Objects;
+
+/** Insert payload for {@link FranchiseInterviewRepository#insert}. */
+record NewFranchiseInterview(
+    long leagueId,
+    long franchiseId,
+    long candidateId,
+    LeaguePhase phase,
+    int phaseWeek,
+    int interviewIndex,
+    BigDecimal scoutedOverall) {
+
+  NewFranchiseInterview {
+    Objects.requireNonNull(phase, "phase");
+    Objects.requireNonNull(scoutedOverall, "scoutedOverall");
+  }
+}

--- a/src/main/java/app/zoneblitz/league/OfferResolver.java
+++ b/src/main/java/app/zoneblitz/league/OfferResolver.java
@@ -1,0 +1,25 @@
+package app.zoneblitz.league;
+
+/**
+ * Seam invoked on each week tick — before {@code phase_week} is incremented — to resolve every
+ * candidate's active offers against their preferences. Each candidate with one or more {@link
+ * OfferStatus#ACTIVE} offers accepts the highest-scoring offer; losing offers are marked {@link
+ * OfferStatus#REJECTED}. When the accepted offer's franchise is signing, the candidate is marked
+ * hired, the franchise's {@link FranchiseHiringState} transitions to {@link HiringStep#HIRED}, and
+ * a {@link FranchiseStaffMember} row is inserted.
+ *
+ * <p>Ties are broken deterministically using the candidate's seeded RNG (see {@code
+ * docs/technical/league-phases.md} "Offer resolution").
+ *
+ * <p>Idempotent: running twice on the same week is safe — there will be no remaining active offers
+ * after the first run.
+ */
+interface OfferResolver {
+
+  /**
+   * Resolve all active offers in the given league for the given hiring phase. {@code weekAtResolve}
+   * is recorded on the resulting {@link FranchiseStaffMember#hiredAtWeek()} — it's the phase week
+   * the offers were in when they resolved, i.e. <em>before</em> the week tick increments.
+   */
+  void resolve(long leagueId, LeaguePhase phase, int weekAtResolve);
+}

--- a/src/main/java/app/zoneblitz/league/OfferScoring.java
+++ b/src/main/java/app/zoneblitz/league/OfferScoring.java
@@ -1,0 +1,119 @@
+package app.zoneblitz.league;
+
+import java.math.BigDecimal;
+
+/**
+ * Pure, stateless preference-scoring functions. The per-dimension fit {@code fit_d} is normalized
+ * to {@code [0, 1]} and combined as a weighted sum:
+ *
+ * <pre>
+ *   score = Σ over dimensions d of: weight_d * fit_d(target_d, franchise_or_offer_value_d)
+ * </pre>
+ *
+ * See {@code docs/technical/league-phases.md} — "Candidate preferences" and "Dimensions" tables.
+ * Numeric targets use a saturating asymmetric ramp (floor-style) for compensation /
+ * guaranteed-money and a symmetric bell for contract length. Categorical fits are exact-match.
+ */
+final class OfferScoring {
+
+  private OfferScoring() {}
+
+  /**
+   * Compute the composite preference score for an offer from a franchise against a candidate's
+   * preferences.
+   */
+  static double score(OfferTerms offer, FranchiseProfile franchise, CandidatePreferences prefs) {
+    double total = 0.0;
+    total += weighted(prefs.compensationWeight(), compensationFit(prefs, offer));
+    total += weighted(prefs.contractLengthWeight(), contractLengthFit(prefs, offer));
+    total += weighted(prefs.guaranteedMoneyWeight(), guaranteedMoneyFit(prefs, offer));
+    total +=
+        weighted(
+            prefs.marketSizeWeight(),
+            categoricalFit(prefs.marketSizeTarget(), franchise.marketSize()));
+    total +=
+        weighted(
+            prefs.geographyWeight(),
+            categoricalFit(prefs.geographyTarget(), franchise.geography()));
+    total +=
+        weighted(prefs.climateWeight(), categoricalFit(prefs.climateTarget(), franchise.climate()));
+    total +=
+        weighted(
+            prefs.franchisePrestigeWeight(),
+            numericFloorFit(prefs.franchisePrestigeTarget(), franchise.prestige(), 100.0));
+    total +=
+        weighted(
+            prefs.competitiveWindowWeight(),
+            categoricalFit(prefs.competitiveWindowTarget(), franchise.window()));
+    total +=
+        weighted(
+            prefs.roleScopeWeight(), categoricalFit(prefs.roleScopeTarget(), offer.roleScope()));
+    total +=
+        weighted(
+            prefs.staffContinuityWeight(),
+            categoricalFit(prefs.staffContinuityTarget(), offer.staffContinuity()));
+    total +=
+        weighted(
+            prefs.schemeAlignmentWeight(),
+            categoricalFit(prefs.schemeAlignmentTarget(), franchise.schemeAlignment()));
+    total +=
+        weighted(
+            prefs.ownerStabilityWeight(),
+            numericFloorFit(prefs.ownerStabilityTarget(), franchise.ownerStability(), 100.0));
+    total +=
+        weighted(
+            prefs.facilityQualityWeight(),
+            numericFloorFit(prefs.facilityQualityTarget(), franchise.facilityQuality(), 100.0));
+    return total;
+  }
+
+  private static double weighted(BigDecimal weight, double fit) {
+    return weight.doubleValue() * fit;
+  }
+
+  private static double categoricalFit(Object target, Object actual) {
+    return target.equals(actual) ? 1.0 : 0.0;
+  }
+
+  /**
+   * Floor-style fit: meets-or-exceeds target → 1.0; below target drops linearly; full zero at 50%
+   * of target. Used for compensation, guaranteed money, and 0..{@code scale} ratings.
+   */
+  private static double numericFloorFit(BigDecimal target, BigDecimal actual, double scale) {
+    var t = target.doubleValue();
+    var a = actual.doubleValue();
+    if (t <= 0.0) {
+      return 1.0;
+    }
+    if (a >= t) {
+      return 1.0;
+    }
+    var floor = Math.max(0.0, t * 0.5);
+    if (a <= floor) {
+      return 0.0;
+    }
+    return (a - floor) / (t - floor);
+  }
+
+  private static double compensationFit(CandidatePreferences prefs, OfferTerms offer) {
+    return numericFloorFit(prefs.compensationTarget(), offer.compensation(), 0.0);
+  }
+
+  private static double guaranteedMoneyFit(CandidatePreferences prefs, OfferTerms offer) {
+    return numericFloorFit(prefs.guaranteedMoneyTarget(), offer.guaranteedMoneyPct(), 1.0);
+  }
+
+  /**
+   * Symmetric bell around contract-length target. 1.0 at target; linearly drops to 0.0 at ±3 years.
+   */
+  private static double contractLengthFit(CandidatePreferences prefs, OfferTerms offer) {
+    var diff = Math.abs(offer.contractLengthYears() - prefs.contractLengthTarget());
+    if (diff == 0) {
+      return 1.0;
+    }
+    if (diff >= 3) {
+      return 0.0;
+    }
+    return 1.0 - (diff / 3.0);
+  }
+}

--- a/src/main/java/app/zoneblitz/league/OfferTerms.java
+++ b/src/main/java/app/zoneblitz/league/OfferTerms.java
@@ -1,0 +1,34 @@
+package app.zoneblitz.league;
+
+import java.math.BigDecimal;
+import java.util.Objects;
+
+/**
+ * Typed offer terms a franchise presents to a candidate. Serialized to the {@code terms} JSONB
+ * column on {@code candidate_offers}. Matches the offer-sourced dimensions in the preference
+ * scoring function ({@code compensation}, {@code contract_length}, {@code guaranteed_money}, {@code
+ * role_scope}, {@code staff_continuity}).
+ */
+public record OfferTerms(
+    BigDecimal compensation,
+    int contractLengthYears,
+    BigDecimal guaranteedMoneyPct,
+    RoleScope roleScope,
+    StaffContinuity staffContinuity) {
+
+  public OfferTerms {
+    Objects.requireNonNull(compensation, "compensation");
+    Objects.requireNonNull(guaranteedMoneyPct, "guaranteedMoneyPct");
+    Objects.requireNonNull(roleScope, "roleScope");
+    Objects.requireNonNull(staffContinuity, "staffContinuity");
+    if (compensation.signum() < 0) {
+      throw new IllegalArgumentException("compensation must be >= 0");
+    }
+    if (contractLengthYears <= 0) {
+      throw new IllegalArgumentException("contractLengthYears must be > 0");
+    }
+    if (guaranteedMoneyPct.signum() < 0 || guaranteedMoneyPct.compareTo(BigDecimal.ONE) > 0) {
+      throw new IllegalArgumentException("guaranteedMoneyPct must be in [0,1]");
+    }
+  }
+}

--- a/src/main/java/app/zoneblitz/league/OfferTermsJson.java
+++ b/src/main/java/app/zoneblitz/league/OfferTermsJson.java
@@ -1,0 +1,50 @@
+package app.zoneblitz.league;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import java.io.IOException;
+import java.math.BigDecimal;
+
+/**
+ * JSON codec for {@link OfferTerms}. Used by repositories and use cases to round-trip the {@code
+ * candidate_offers.terms} JSONB payload.
+ */
+final class OfferTermsJson {
+
+  private static final ObjectMapper MAPPER = new ObjectMapper();
+
+  private OfferTermsJson() {}
+
+  static String toJson(OfferTerms terms) {
+    var node = MAPPER.createObjectNode();
+    node.put("compensation", terms.compensation());
+    node.put("contract_length_years", terms.contractLengthYears());
+    node.put("guaranteed_money_pct", terms.guaranteedMoneyPct());
+    node.put("role_scope", terms.roleScope().name());
+    node.put("staff_continuity", terms.staffContinuity().name());
+    return node.toString();
+  }
+
+  static OfferTerms fromJson(String json) {
+    try {
+      JsonNode node = MAPPER.readTree(json);
+      return new OfferTerms(
+          bigDecimalField(node, "compensation"),
+          node.get("contract_length_years").asInt(),
+          bigDecimalField(node, "guaranteed_money_pct"),
+          RoleScope.valueOf(node.get("role_scope").asText()),
+          StaffContinuity.valueOf(node.get("staff_continuity").asText()));
+    } catch (IOException e) {
+      throw new IllegalStateException("malformed offer terms JSON", e);
+    }
+  }
+
+  private static BigDecimal bigDecimalField(JsonNode node, String field) {
+    var n = node.get(field);
+    if (n instanceof ObjectNode) {
+      throw new IllegalStateException("expected scalar for " + field);
+    }
+    return new BigDecimal(n.asText());
+  }
+}

--- a/src/main/java/app/zoneblitz/league/PositionCoachGenerator.java
+++ b/src/main/java/app/zoneblitz/league/PositionCoachGenerator.java
@@ -1,0 +1,100 @@
+package app.zoneblitz.league;
+
+import app.zoneblitz.gamesimulator.rng.RandomSource;
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.stream.IntStream;
+
+/**
+ * Lightweight placeholder generator for position-coach candidates. Specialty matches the coached
+ * position by construction (a QB coach has {@link SpecialtyPosition#QB} specialty). Reuses the HC
+ * band file as a pricing anchor — position coaches earn a fraction of HC salaries — per {@code
+ * docs/technical/league-phases.md} v1.
+ */
+public final class PositionCoachGenerator {
+
+  private static final double POSITION_COACH_SALARY_FRACTION = 0.10;
+  private static final double TRUE_RATING_MEAN = 58.0;
+  private static final double TRUE_RATING_STD = 10.0;
+  private static final double SCOUTED_NOISE_STD = 8.0;
+  private static final double GUARANTEED_MONEY_FLOOR = 0.50;
+  private static final double GUARANTEED_MONEY_CEIL = 0.85;
+
+  private final HeadCoachMarketBands bands;
+
+  public PositionCoachGenerator() {
+    this(HeadCoachMarketBands.loadFromClasspath());
+  }
+
+  PositionCoachGenerator(HeadCoachMarketBands bands) {
+    this.bands = Objects.requireNonNull(bands, "bands");
+  }
+
+  /**
+   * Generate {@code poolSize} position coach candidates specialized in {@code specialty}. All
+   * returned candidates have {@link CandidateKind#POSITION_COACH} and matching specialty.
+   */
+  public List<GeneratedCandidate> generate(
+      int poolSize, SpecialtyPosition specialty, RandomSource rng) {
+    Objects.requireNonNull(specialty, "specialty");
+    Objects.requireNonNull(rng, "rng");
+    if (poolSize <= 0) {
+      throw new IllegalArgumentException("poolSize must be > 0, was: " + poolSize);
+    }
+    return IntStream.range(0, poolSize).mapToObj(i -> generateOne(specialty, rng)).toList();
+  }
+
+  private GeneratedCandidate generateOne(SpecialtyPosition specialty, RandomSource rng) {
+    var archetype =
+        rng.nextDouble() < 0.7 ? CandidateArchetype.TEACHER : CandidateArchetype.TACTICIAN;
+    var age = 30 + (int) Math.round(rng.nextDouble() * 22);
+    var totalExperience = 3 + (int) Math.round(rng.nextDouble() * Math.min(15, age - 22));
+    var experienceByRole =
+        """
+        {"POSITION_COACH": %d}"""
+            .formatted(totalExperience);
+
+    var trueRating = clamp(TRUE_RATING_MEAN + TRUE_RATING_STD * rng.nextGaussian(), 20.0, 99.0);
+    var scoutedRating = clamp(trueRating + SCOUTED_NOISE_STD * rng.nextGaussian(), 20.0, 99.0);
+
+    var hcBase = bands.salaryP10() + rng.nextDouble() * (bands.salaryP50() - bands.salaryP10());
+    var compensation =
+        BigDecimal.valueOf(
+                Math.max(
+                    250_000,
+                    hcBase * POSITION_COACH_SALARY_FRACTION * (0.85 + rng.nextDouble() * 0.3)))
+            .setScale(2, RoundingMode.HALF_UP);
+    var contractLength = 1 + (int) Math.round(rng.nextDouble() * 2);
+    var guaranteedMoney =
+        BigDecimal.valueOf(
+                GUARANTEED_MONEY_FLOOR
+                    + rng.nextDouble() * (GUARANTEED_MONEY_CEIL - GUARANTEED_MONEY_FLOOR))
+            .setScale(3, RoundingMode.HALF_UP);
+
+    var candidate =
+        new NewCandidate(
+            /* poolId= */ 0L,
+            CandidateKind.POSITION_COACH,
+            specialty,
+            archetype,
+            age,
+            totalExperience,
+            experienceByRole,
+            "{\"overall\": %.2f}".formatted(trueRating),
+            "{\"overall\": %.2f}".formatted(scoutedRating),
+            Optional.empty());
+    var preferences =
+        StaffPreferencesFactory.uniform(compensation, contractLength, guaranteedMoney, rng);
+    return new GeneratedCandidate(candidate, preferences);
+  }
+
+  @SuppressWarnings("unused")
+  private static final List<SpecialtyPosition> ALL_POSITIONS = List.of(SpecialtyPosition.values());
+
+  private static double clamp(double v, double lo, double hi) {
+    return Math.max(lo, Math.min(hi, v));
+  }
+}

--- a/src/main/java/app/zoneblitz/league/PreferenceScoringOfferResolver.java
+++ b/src/main/java/app/zoneblitz/league/PreferenceScoringOfferResolver.java
@@ -1,0 +1,199 @@
+package app.zoneblitz.league;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Optional;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+/**
+ * Default {@link OfferResolver}: scores every candidate's active offers against their {@link
+ * CandidatePreferences}, accepts the highest-scoring offer, rejects the rest.
+ *
+ * <p>Ties on composite score are broken deterministically by the candidate's seeded RNG (see {@code
+ * docs/technical/league-phases.md}), falling back to offer id for total order safety.
+ */
+@Component
+class PreferenceScoringOfferResolver implements OfferResolver {
+
+  private static final Logger log = LoggerFactory.getLogger(PreferenceScoringOfferResolver.class);
+
+  private final CandidateOfferRepository offers;
+  private final CandidateRepository candidates;
+  private final CandidatePoolRepository pools;
+  private final CandidatePreferencesRepository preferences;
+  private final FranchiseProfiles franchiseProfiles;
+  private final FranchiseHiringStateRepository hiringStates;
+  private final FranchiseStaffRepository staff;
+  private final CandidateRandomSources rngs;
+
+  PreferenceScoringOfferResolver(
+      CandidateOfferRepository offers,
+      CandidateRepository candidates,
+      CandidatePoolRepository pools,
+      CandidatePreferencesRepository preferences,
+      FranchiseProfiles franchiseProfiles,
+      FranchiseHiringStateRepository hiringStates,
+      FranchiseStaffRepository staff,
+      CandidateRandomSources rngs) {
+    this.offers = offers;
+    this.candidates = candidates;
+    this.pools = pools;
+    this.preferences = preferences;
+    this.franchiseProfiles = franchiseProfiles;
+    this.hiringStates = hiringStates;
+    this.staff = staff;
+    this.rngs = rngs;
+  }
+
+  @Override
+  public void resolve(long leagueId, LeaguePhase phase, int weekAtResolve) {
+    var poolType = poolTypeFor(phase);
+    if (poolType.isEmpty()) {
+      return;
+    }
+    var pool = pools.findByLeaguePhaseAndType(leagueId, phase, poolType.get());
+    if (pool.isEmpty()) {
+      return;
+    }
+
+    var candidateRows = candidates.findAllByPoolId(pool.get().id());
+    for (var candidate : candidateRows) {
+      if (candidate.hiredByFranchiseId().isPresent()) {
+        continue;
+      }
+      var activeOffers = offers.findActiveForCandidate(candidate.id());
+      if (activeOffers.isEmpty()) {
+        continue;
+      }
+      resolveForCandidate(leagueId, phase, weekAtResolve, candidate, activeOffers);
+    }
+  }
+
+  private void resolveForCandidate(
+      long leagueId,
+      LeaguePhase phase,
+      int weekAtResolve,
+      Candidate candidate,
+      List<CandidateOffer> activeOffers) {
+    var maybePrefs = preferences.findByCandidateId(candidate.id());
+    if (maybePrefs.isEmpty()) {
+      log.warn("offer resolution skipped — no preferences for candidateId={}", candidate.id());
+      return;
+    }
+    var prefs = maybePrefs.get();
+
+    var scored = new ArrayList<ScoredOffer>(activeOffers.size());
+    for (var offer : activeOffers) {
+      var profile = franchiseProfiles.forFranchise(offer.franchiseId());
+      if (profile.isEmpty()) {
+        log.warn(
+            "offer resolution skipped offerId={} — no profile for franchiseId={}",
+            offer.id(),
+            offer.franchiseId());
+        continue;
+      }
+      var terms = OfferTermsJson.fromJson(offer.terms());
+      var score = OfferScoring.score(terms, profile.get(), prefs);
+      scored.add(new ScoredOffer(offer, score));
+    }
+    if (scored.isEmpty()) {
+      return;
+    }
+
+    var winner = chooseWinner(leagueId, phase, candidate.id(), scored);
+
+    candidates.markHired(candidate.id(), winner.offer().franchiseId());
+    offers.resolve(winner.offer().id(), OfferStatus.ACCEPTED);
+    upsertHired(leagueId, phase, winner.offer().franchiseId(), weekAtResolve, candidate.id());
+
+    var winningFranchise = winner.offer().franchiseId();
+    for (var other : scored) {
+      if (other.offer().id() != winner.offer().id()) {
+        offers.resolve(other.offer().id(), OfferStatus.REJECTED);
+      }
+    }
+    // Auto-reject any of this candidate's active offers from franchises that did not win — the
+    // candidate is off the market. `findActiveForCandidate` above captured the scored set, but a
+    // candidate may have active offers from franchises whose profiles are missing; reject those too
+    // so the lifecycle is clean.
+    for (var stray : offers.findActiveForCandidate(candidate.id())) {
+      if (stray.franchiseId() != winningFranchise) {
+        offers.resolve(stray.id(), OfferStatus.REJECTED);
+      }
+    }
+
+    log.info(
+        "offer accepted leagueId={} candidateId={} franchiseId={} offerId={} score={} week={}",
+        leagueId,
+        candidate.id(),
+        winner.offer().franchiseId(),
+        winner.offer().id(),
+        winner.score(),
+        weekAtResolve);
+  }
+
+  private ScoredOffer chooseWinner(
+      long leagueId, LeaguePhase phase, long candidateId, List<ScoredOffer> scored) {
+    scored.sort(
+        Comparator.comparingDouble(ScoredOffer::score)
+            .reversed()
+            .thenComparingLong(s -> s.offer().id()));
+    var topScore = scored.getFirst().score();
+    var tied = scored.stream().filter(s -> s.score() == topScore).toList();
+    if (tied.size() == 1) {
+      return tied.getFirst();
+    }
+    // Ties broken with the candidate's seeded RNG, split per-candidate so results are deterministic
+    // regardless of the order in which candidates are resolved.
+    var rng = rngs.forLeaguePhase(leagueId, phase).split(candidateId);
+    var sortedTied = new ArrayList<>(tied);
+    sortedTied.sort(Comparator.comparingLong(s -> s.offer().id()));
+    var pick = (int) ((rng.nextLong() & Long.MAX_VALUE) % sortedTied.size());
+    return sortedTied.get(pick);
+  }
+
+  private void upsertHired(
+      long leagueId, LeaguePhase phase, long franchiseId, int weekAtResolve, long candidateId) {
+    var existing = hiringStates.find(leagueId, franchiseId, phase);
+    hiringStates.upsert(
+        new FranchiseHiringState(
+            existing.map(FranchiseHiringState::id).orElse(0L),
+            leagueId,
+            franchiseId,
+            phase,
+            HiringStep.HIRED,
+            existing.map(FranchiseHiringState::shortlist).orElse(List.of()),
+            existing.map(FranchiseHiringState::interviewingCandidateIds).orElse(List.of())));
+    staff.insert(
+        new NewFranchiseStaffMember(
+            leagueId,
+            franchiseId,
+            candidateId,
+            staffRoleFor(phase),
+            Optional.empty(),
+            phase,
+            weekAtResolve));
+  }
+
+  private static StaffRole staffRoleFor(LeaguePhase phase) {
+    return switch (phase) {
+      case HIRING_HEAD_COACH -> StaffRole.HEAD_COACH;
+      case HIRING_DIRECTOR_OF_SCOUTING -> StaffRole.DIRECTOR_OF_SCOUTING;
+      case INITIAL_SETUP, ASSEMBLING_STAFF, COMPLETE ->
+          throw new IllegalStateException("no staff role for non-hiring phase " + phase);
+    };
+  }
+
+  private static Optional<CandidatePoolType> poolTypeFor(LeaguePhase phase) {
+    return switch (phase) {
+      case HIRING_HEAD_COACH -> Optional.of(CandidatePoolType.HEAD_COACH);
+      case HIRING_DIRECTOR_OF_SCOUTING -> Optional.of(CandidatePoolType.DIRECTOR_OF_SCOUTING);
+      case INITIAL_SETUP, ASSEMBLING_STAFF, COMPLETE -> Optional.empty();
+    };
+  }
+
+  private record ScoredOffer(CandidateOffer offer, double score) {}
+}

--- a/src/main/java/app/zoneblitz/league/ScoutCandidateGenerator.java
+++ b/src/main/java/app/zoneblitz/league/ScoutCandidateGenerator.java
@@ -1,0 +1,98 @@
+package app.zoneblitz.league;
+
+import app.zoneblitz.gamesimulator.rng.RandomSource;
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.stream.IntStream;
+
+/**
+ * Lightweight placeholder generator for subordinate scout candidates (not DoS). Each generated
+ * candidate has {@link CandidateKind#SCOUT} and a {@link ScoutBranch} reflecting college/pro
+ * operation. Reuses the scout-market bands as a pricing anchor; a subordinate scout earns a
+ * fraction of the DoS salary.
+ */
+public final class ScoutCandidateGenerator {
+
+  private static final double SCOUT_SALARY_FRACTION = 0.18;
+  private static final double TRUE_RATING_MEAN = 55.0;
+  private static final double TRUE_RATING_STD = 10.0;
+  private static final double SCOUTED_NOISE_STD = 9.0;
+  private static final double GUARANTEED_MONEY_FLOOR = 0.30;
+  private static final double GUARANTEED_MONEY_CEIL = 0.70;
+
+  private final ScoutMarketBands bands;
+
+  public ScoutCandidateGenerator() {
+    this(ScoutMarketBands.loadFromClasspath());
+  }
+
+  ScoutCandidateGenerator(ScoutMarketBands bands) {
+    this.bands = Objects.requireNonNull(bands, "bands");
+  }
+
+  /** Generate {@code poolSize} subordinate scouts operating in the given {@code branch}. */
+  public List<GeneratedCandidate> generate(int poolSize, ScoutBranch branch, RandomSource rng) {
+    Objects.requireNonNull(branch, "branch");
+    Objects.requireNonNull(rng, "rng");
+    if (poolSize <= 0) {
+      throw new IllegalArgumentException("poolSize must be > 0, was: " + poolSize);
+    }
+    return IntStream.range(0, poolSize).mapToObj(i -> generateOne(branch, rng)).toList();
+  }
+
+  private GeneratedCandidate generateOne(ScoutBranch branch, RandomSource rng) {
+    var archetype =
+        branch == ScoutBranch.COLLEGE
+            ? CandidateArchetype.COLLEGE_EVALUATOR
+            : CandidateArchetype.PRO_EVALUATOR;
+    var specialty =
+        SpecialtyPosition.values()[(int) (rng.nextDouble() * SpecialtyPosition.values().length)];
+    var age = 28 + (int) Math.round(rng.nextDouble() * 22);
+    var totalExperience = 3 + (int) Math.round(rng.nextDouble() * Math.min(18, age - 22));
+    var experienceByRole =
+        """
+        {"SCOUT": %d, "AREA_SCOUT": %d}"""
+            .formatted(totalExperience, Math.max(0, totalExperience - 2));
+
+    var trueRating = clamp(TRUE_RATING_MEAN + TRUE_RATING_STD * rng.nextGaussian(), 20.0, 99.0);
+    var scoutedRating = clamp(trueRating + SCOUTED_NOISE_STD * rng.nextGaussian(), 20.0, 99.0);
+
+    var dosBase = bands.salaryP10() + rng.nextDouble() * (bands.salaryP50() - bands.salaryP10());
+    var compensation =
+        BigDecimal.valueOf(
+                Math.max(90_000, dosBase * SCOUT_SALARY_FRACTION * (0.85 + rng.nextDouble() * 0.3)))
+            .setScale(2, RoundingMode.HALF_UP);
+    var contractLength = 1 + (int) Math.round(rng.nextDouble() * 2);
+    var guaranteedMoney =
+        BigDecimal.valueOf(
+                GUARANTEED_MONEY_FLOOR
+                    + rng.nextDouble() * (GUARANTEED_MONEY_CEIL - GUARANTEED_MONEY_FLOOR))
+            .setScale(3, RoundingMode.HALF_UP);
+
+    var candidate =
+        new NewCandidate(
+            /* poolId= */ 0L,
+            CandidateKind.SCOUT,
+            specialty,
+            archetype,
+            age,
+            totalExperience,
+            experienceByRole,
+            "{\"overall\": %.2f}".formatted(trueRating),
+            "{\"overall\": %.2f}".formatted(scoutedRating),
+            Optional.of(branch));
+    var preferences =
+        StaffPreferencesFactory.uniform(compensation, contractLength, guaranteedMoney, rng);
+    return new GeneratedCandidate(candidate, preferences);
+  }
+
+  @SuppressWarnings("unused")
+  private static final List<ScoutBranch> BRANCHES = List.of(ScoutBranch.values());
+
+  private static double clamp(double v, double lo, double hi) {
+    return Math.max(lo, Math.min(hi, v));
+  }
+}

--- a/src/main/java/app/zoneblitz/league/ScoutMarketBands.java
+++ b/src/main/java/app/zoneblitz/league/ScoutMarketBands.java
@@ -1,0 +1,76 @@
+package app.zoneblitz.league;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Objects;
+
+/**
+ * Typed view over the {@code tiers.DIRECTOR} section of {@code data/bands/scout-market.json}.
+ * Parsed once at construction so no I/O happens mid-generation. Mirrors {@link
+ * HeadCoachMarketBands} for the DoS candidate tier.
+ */
+record ScoutMarketBands(
+    int salaryP10,
+    int salaryP50,
+    int salaryP90,
+    int salaryCeiling,
+    int contractModeYears,
+    int contractP10Years,
+    int contractP50Years,
+    int contractP90Years,
+    double experienceP10Years,
+    double experienceMeanYears,
+    double experienceP90Years,
+    int ageMin,
+    int ageMode,
+    int ageMax,
+    double generalistShare) {
+
+  static ScoutMarketBands loadFromClasspath() {
+    return loadFromClasspath("/bands/scout-market.json");
+  }
+
+  static ScoutMarketBands loadFromClasspath(String resource) {
+    Objects.requireNonNull(resource, "resource");
+    try (InputStream in = ScoutMarketBands.class.getResourceAsStream(resource)) {
+      if (in == null) {
+        throw new IllegalStateException("Band resource not found on classpath: " + resource);
+      }
+      var root = new ObjectMapper().readTree(in);
+      return fromJson(root.at("/tiers/DIRECTOR"));
+    } catch (IOException e) {
+      throw new IllegalStateException("Failed to read " + resource, e);
+    }
+  }
+
+  private static ScoutMarketBands fromJson(JsonNode director) {
+    if (director == null || director.isMissingNode()) {
+      throw new IllegalStateException("scout-market.json missing tiers.DIRECTOR");
+    }
+    var salary = director.get("salary_annual_usd");
+    var contract = director.get("contract_length_years");
+    var focusSplit = director.get("position_focus_split");
+    return new ScoutMarketBands(
+        salary.get("p10").asInt(),
+        salary.get("p50").asInt(),
+        salary.get("p90").asInt(),
+        salary.get("ceiling").asInt(),
+        contract.get("mode").asInt(),
+        contract.get("p10").asInt(),
+        contract.get("p50").asInt(),
+        contract.get("p90").asInt(),
+        // scout-market.json does not publish an experience block for DIRECTOR; anchor on the band
+        // notes ("15+ years to crack the ceiling") and the career arc to DoS — rising via area
+        // scout
+        // → cross-checker typically spans 10-20+ years before reaching director.
+        10.0,
+        16.0,
+        24.0,
+        32,
+        46,
+        68,
+        focusSplit.get("generalist").asDouble());
+  }
+}

--- a/src/main/java/app/zoneblitz/league/ShortlistResult.java
+++ b/src/main/java/app/zoneblitz/league/ShortlistResult.java
@@ -1,0 +1,14 @@
+package app.zoneblitz.league;
+
+/** Sealed outcomes for adding/removing a candidate on the user's hiring shortlist. */
+public sealed interface ShortlistResult {
+
+  /** Shortlist updated; the refreshed view-model is returned for fragment rendering. */
+  record Updated(HeadCoachHiringView view) implements ShortlistResult {}
+
+  /** League not found for the requesting user, or not in the HC hiring phase. */
+  record NotFound(long leagueId) implements ShortlistResult {}
+
+  /** Candidate does not exist in this league's HC pool. */
+  record UnknownCandidate(long candidateId) implements ShortlistResult {}
+}

--- a/src/main/java/app/zoneblitz/league/SplittableCandidateRandomSources.java
+++ b/src/main/java/app/zoneblitz/league/SplittableCandidateRandomSources.java
@@ -1,0 +1,20 @@
+package app.zoneblitz.league;
+
+import app.zoneblitz.gamesimulator.rng.RandomSource;
+import app.zoneblitz.gamesimulator.rng.SplittableRandomSource;
+import org.springframework.stereotype.Component;
+
+/**
+ * Production {@link CandidateRandomSources}. Derives a deterministic seed from {@code leagueId}
+ * mixed with the phase ordinal so the same league re-entering the same phase produces the same pool
+ * — useful for reproducibility and tests.
+ */
+@Component
+class SplittableCandidateRandomSources implements CandidateRandomSources {
+
+  @Override
+  public RandomSource forLeaguePhase(long leagueId, LeaguePhase phase) {
+    var seed = leagueId * 0x9E3779B97F4A7C15L ^ (long) phase.ordinal();
+    return new SplittableRandomSource(seed);
+  }
+}

--- a/src/main/java/app/zoneblitz/league/StaffPreferencesFactory.java
+++ b/src/main/java/app/zoneblitz/league/StaffPreferencesFactory.java
@@ -1,0 +1,72 @@
+package app.zoneblitz.league;
+
+import app.zoneblitz.gamesimulator.rng.RandomSource;
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.util.List;
+
+/**
+ * Shared preferences-draft builder for subordinate staff generators (coordinators, position
+ * coaches, scouts). Produces a uniform-ish weight profile so these lightweight placeholder
+ * candidates can be persisted and scored by {@link OfferScoring} without special casing. Extracted
+ * so each generator doesn't reimplement the same weight-normalization math.
+ */
+final class StaffPreferencesFactory {
+
+  private static final List<String> SCHEMES =
+      List.of("SPREAD", "WEST_COAST", "AIR_RAID", "SMASHMOUTH", "COVER_2", "COVER_3");
+
+  private StaffPreferencesFactory() {}
+
+  static CandidatePreferencesDraft uniform(
+      BigDecimal compensation, int contractLength, BigDecimal guaranteedMoney, RandomSource rng) {
+    var rawWeights = new double[13];
+    for (var i = 0; i < rawWeights.length; i++) {
+      rawWeights[i] = 0.25 + rng.nextDouble();
+    }
+    var sum = 0.0;
+    for (var w : rawWeights) sum += w;
+    var w = new BigDecimal[13];
+    for (var i = 0; i < rawWeights.length; i++) {
+      w[i] = BigDecimal.valueOf(rawWeights[i] / sum).setScale(3, RoundingMode.HALF_UP);
+    }
+
+    var marketSize = MarketSize.values()[(int) (rng.nextDouble() * MarketSize.values().length)];
+    var geography = Geography.values()[(int) (rng.nextDouble() * Geography.values().length)];
+    var climate = Climate.values()[(int) (rng.nextDouble() * Climate.values().length)];
+    var roleScope = RoleScope.values()[(int) (rng.nextDouble() * RoleScope.values().length)];
+    var staffContinuity =
+        StaffContinuity.values()[(int) (rng.nextDouble() * StaffContinuity.values().length)];
+    var competitiveWindow =
+        CompetitiveWindow.values()[(int) (rng.nextDouble() * CompetitiveWindow.values().length)];
+    var schemeAlignment = SCHEMES.get((int) (rng.nextDouble() * SCHEMES.size()));
+
+    return new CandidatePreferencesDraft(
+        compensation,
+        w[0],
+        contractLength,
+        w[1],
+        guaranteedMoney,
+        w[2],
+        marketSize,
+        w[3],
+        geography,
+        w[4],
+        climate,
+        w[5],
+        BigDecimal.valueOf(50 + rng.nextDouble() * 30).setScale(2, RoundingMode.HALF_UP),
+        w[6],
+        competitiveWindow,
+        w[7],
+        roleScope,
+        w[8],
+        staffContinuity,
+        w[9],
+        schemeAlignment,
+        w[10],
+        BigDecimal.valueOf(50 + rng.nextDouble() * 30).setScale(2, RoundingMode.HALF_UP),
+        w[11],
+        BigDecimal.valueOf(50 + rng.nextDouble() * 30).setScale(2, RoundingMode.HALF_UP),
+        w[12]);
+  }
+}

--- a/src/main/java/app/zoneblitz/league/StaffRecapController.java
+++ b/src/main/java/app/zoneblitz/league/StaffRecapController.java
@@ -1,0 +1,35 @@
+package app.zoneblitz.league;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.server.ResponseStatusException;
+
+/**
+ * Web entry for the {@link LeaguePhase#ASSEMBLING_STAFF} recap page. The page is read-only; the
+ * single user action — advance to the next phase — is wired through {@link
+ * LeagueController#advancePhase} which every phase dashboard shares.
+ */
+@Controller
+class StaffRecapController {
+
+  private final ViewStaffRecap viewStaffRecap;
+
+  StaffRecapController(ViewStaffRecap viewStaffRecap) {
+    this.viewStaffRecap = viewStaffRecap;
+  }
+
+  @GetMapping("/leagues/{id}/staff-recap")
+  String page(@AuthenticationPrincipal OAuth2User principal, @PathVariable long id, Model model) {
+    var view =
+        viewStaffRecap
+            .view(id, principal.getAttribute("sub"))
+            .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND));
+    model.addAttribute("view", view);
+    return "league/staff-recap";
+  }
+}

--- a/src/main/java/app/zoneblitz/league/StaffRecapView.java
+++ b/src/main/java/app/zoneblitz/league/StaffRecapView.java
@@ -1,0 +1,38 @@
+package app.zoneblitz.league;
+
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * View model for the {@link LeaguePhase#ASSEMBLING_STAFF} recap page. {@code franchises} is ordered
+ * with the viewer's franchise first (flagged via {@link FranchiseStaffTree#isViewerFranchise()}),
+ * so the template can render it expanded and the rest collapsed without extra logic.
+ */
+public record StaffRecapView(LeagueSummary league, List<FranchiseStaffTree> franchises) {
+
+  public StaffRecapView {
+    Objects.requireNonNull(league, "league");
+    Objects.requireNonNull(franchises, "franchises");
+    franchises = List.copyOf(franchises);
+  }
+
+  /** Full staff org chart for a franchise, paired with the candidate row per hired seat. */
+  public record FranchiseStaffTree(
+      Franchise franchise, boolean isViewerFranchise, List<StaffSeat> seats) {
+
+    public FranchiseStaffTree {
+      Objects.requireNonNull(franchise, "franchise");
+      Objects.requireNonNull(seats, "seats");
+      seats = List.copyOf(seats);
+    }
+  }
+
+  /** A single filled seat — role, candidate snapshot, scout branch (when applicable). */
+  public record StaffSeat(FranchiseStaffMember hire, Candidate candidate) {
+
+    public StaffSeat {
+      Objects.requireNonNull(hire, "hire");
+      Objects.requireNonNull(candidate, "candidate");
+    }
+  }
+}

--- a/src/main/java/app/zoneblitz/league/StartInterview.java
+++ b/src/main/java/app/zoneblitz/league/StartInterview.java
@@ -1,0 +1,30 @@
+package app.zoneblitz.league;
+
+/**
+ * Feature-public use case for conducting an interview against a shortlisted Head Coach candidate.
+ *
+ * <p>Each completed interview:
+ *
+ * <ul>
+ *   <li>Increments the franchise's interview count against that candidate; each step reduces the
+ *       scouted-signal σ per {@link InterviewNoiseModel}, with diminishing returns and a hard
+ *       tier-dependent floor (σ never reaches 0).
+ *   <li>Counts against the franchise's weekly interview capacity (default 3/week).
+ *   <li>Persists a new scouted-overall estimate derived from the candidate's hidden true rating
+ *       plus noise at the current σ. The shared {@code candidates.scouted_attrs} column is never
+ *       written to — the hidden true rating never leaks into the shared column.
+ *   <li>Appends the candidate id to {@code franchise_hiring_states.interviewing_candidate_ids},
+ *       which records the per-franchise interview history (one entry per interview event).
+ * </ul>
+ *
+ * Returns {@link InterviewResult.Started} on success, {@link InterviewResult.CapacityReached} when
+ * the franchise has already hit the weekly cap, {@link InterviewResult.NotFound} when the league is
+ * not owned or not in HC hiring, and {@link InterviewResult.UnknownCandidate} when the candidate id
+ * does not map to this league's HC pool.
+ */
+public interface StartInterview {
+
+  int DEFAULT_WEEKLY_CAPACITY = 3;
+
+  InterviewResult start(long leagueId, long candidateId, String ownerSubject);
+}

--- a/src/main/java/app/zoneblitz/league/StartInterviewUseCase.java
+++ b/src/main/java/app/zoneblitz/league/StartInterviewUseCase.java
@@ -1,0 +1,150 @@
+package app.zoneblitz.league;
+
+import app.zoneblitz.gamesimulator.rng.SplittableRandomSource;
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.util.ArrayList;
+import java.util.Objects;
+import java.util.regex.Pattern;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+class StartInterviewUseCase implements StartInterview {
+
+  private static final Logger log = LoggerFactory.getLogger(StartInterviewUseCase.class);
+  private static final Pattern HIDDEN_OVERALL =
+      Pattern.compile("\"overall\"\\s*:\\s*(-?[0-9]+(?:\\.[0-9]+)?)");
+  private static final double SCOUTED_LOWER = 20.0;
+  private static final double SCOUTED_UPPER = 99.0;
+
+  private final LeagueRepository leagues;
+  private final CandidatePoolRepository pools;
+  private final CandidateRepository candidates;
+  private final CandidatePreferencesRepository preferences;
+  private final FranchiseHiringStateRepository hiringStates;
+  private final FranchiseInterviewRepository interviews;
+
+  StartInterviewUseCase(
+      LeagueRepository leagues,
+      CandidatePoolRepository pools,
+      CandidateRepository candidates,
+      CandidatePreferencesRepository preferences,
+      FranchiseHiringStateRepository hiringStates,
+      FranchiseInterviewRepository interviews) {
+    this.leagues = leagues;
+    this.pools = pools;
+    this.candidates = candidates;
+    this.preferences = preferences;
+    this.hiringStates = hiringStates;
+    this.interviews = interviews;
+  }
+
+  @Override
+  @Transactional
+  public InterviewResult start(long leagueId, long candidateId, String ownerSubject) {
+    Objects.requireNonNull(ownerSubject, "ownerSubject");
+    var maybeLeague = leagues.findSummaryByIdAndOwner(leagueId, ownerSubject);
+    if (maybeLeague.isEmpty()) {
+      return new InterviewResult.NotFound(leagueId);
+    }
+    var league = maybeLeague.get();
+    var phase = league.phase();
+    var poolType = HiringPhases.poolTypeFor(phase);
+    if (poolType.isEmpty()) {
+      return new InterviewResult.NotFound(leagueId);
+    }
+    var maybePool = pools.findByLeaguePhaseAndType(leagueId, phase, poolType.get());
+    if (maybePool.isEmpty()) {
+      return new InterviewResult.NotFound(leagueId);
+    }
+    var maybeCandidate = candidates.findById(candidateId);
+    if (maybeCandidate.isEmpty() || maybeCandidate.get().poolId() != maybePool.get().id()) {
+      return new InterviewResult.UnknownCandidate(candidateId);
+    }
+    var franchiseId = league.userFranchise().id();
+    var phaseWeek = league.phaseWeek();
+    var weekCount = interviews.countForWeek(leagueId, franchiseId, phase, phaseWeek);
+    if (weekCount >= DEFAULT_WEEKLY_CAPACITY) {
+      return new InterviewResult.CapacityReached(DEFAULT_WEEKLY_CAPACITY);
+    }
+
+    var candidate = maybeCandidate.get();
+    var priorCount = interviews.countForCandidate(leagueId, franchiseId, candidateId, phase);
+    var newIndex = priorCount + 1;
+    var trueRating = extractOverall(candidate.hiddenAttrs());
+    var sigma = InterviewNoiseModel.headCoachSigma(newIndex);
+    var rng = new SplittableRandomSource(seedFor(leagueId, franchiseId, candidateId, newIndex));
+    var sample = trueRating + sigma * rng.nextGaussian();
+    var clamped = Math.max(SCOUTED_LOWER, Math.min(SCOUTED_UPPER, sample));
+    var scoutedOverall = BigDecimal.valueOf(clamped).setScale(2, RoundingMode.HALF_UP);
+
+    interviews.insert(
+        new NewFranchiseInterview(
+            leagueId, franchiseId, candidateId, phase, phaseWeek, newIndex, scoutedOverall));
+    appendToHiringState(leagueId, franchiseId, candidateId, phase);
+
+    var pool = candidates.findAllByPoolId(maybePool.get().id());
+    var prefs =
+        pool.stream()
+            .map(c -> preferences.findByCandidateId(c.id()))
+            .flatMap(java.util.Optional::stream)
+            .toList();
+    var state = hiringStates.find(leagueId, franchiseId, phase);
+    var shortlistIds = state.map(FranchiseHiringState::shortlist).orElse(java.util.List.of());
+    var history = interviews.findAllFor(leagueId, franchiseId, phase);
+    var view =
+        HeadCoachHiringViewModel.assemble(
+            league, pool, prefs, shortlistIds, history, DEFAULT_WEEKLY_CAPACITY);
+    log.info(
+        "interview recorded leagueId={} franchiseId={} candidateId={} index={} sigma={}",
+        leagueId,
+        franchiseId,
+        candidateId,
+        newIndex,
+        sigma);
+    return new InterviewResult.Started(view);
+  }
+
+  private void appendToHiringState(
+      long leagueId, long franchiseId, long candidateId, LeaguePhase phase) {
+    var existing = hiringStates.find(leagueId, franchiseId, phase);
+    var shortlistIds = existing.map(FranchiseHiringState::shortlist).orElse(java.util.List.of());
+    var interviewingIds =
+        existing.map(FranchiseHiringState::interviewingCandidateIds).orElse(java.util.List.of());
+    var updated = new ArrayList<Long>(interviewingIds.size() + 1);
+    updated.addAll(interviewingIds);
+    updated.add(candidateId);
+    hiringStates.upsert(
+        new FranchiseHiringState(
+            existing.map(FranchiseHiringState::id).orElse(0L),
+            leagueId,
+            franchiseId,
+            phase,
+            HiringStep.SEARCHING,
+            shortlistIds,
+            java.util.List.copyOf(updated)));
+  }
+
+  private static double extractOverall(String hiddenAttrsJson) {
+    var m = HIDDEN_OVERALL.matcher(hiddenAttrsJson);
+    if (m.find()) {
+      try {
+        return Double.parseDouble(m.group(1));
+      } catch (NumberFormatException ignored) {
+        return 50.0;
+      }
+    }
+    return 50.0;
+  }
+
+  private static long seedFor(long leagueId, long franchiseId, long candidateId, int index) {
+    var seed = leagueId * 0x9E3779B97F4A7C15L;
+    seed ^= Long.rotateLeft(franchiseId, 17) * 0xBF58476D1CE4E5B9L;
+    seed ^= Long.rotateLeft(candidateId, 31) * 0x94D049BB133111EBL;
+    seed ^= (long) index * 0xD1B54A32D192ED03L;
+    return seed;
+  }
+}

--- a/src/main/java/app/zoneblitz/league/TeamLookup.java
+++ b/src/main/java/app/zoneblitz/league/TeamLookup.java
@@ -1,0 +1,20 @@
+package app.zoneblitz.league;
+
+import java.util.List;
+
+/**
+ * Read-side companion to {@link TeamRepository} for features that need to know which franchises
+ * belong to a league. Kept separate so the write-side repository stays insert-only.
+ */
+interface TeamLookup {
+
+  /** Return the franchise ids participating in the given league, ordered by franchise id. */
+  List<Long> franchiseIdsForLeague(long leagueId);
+
+  /**
+   * Return the franchise ids participating in the given league whose {@code owner_subject} is null
+   * — i.e. the CPU-controlled franchises. Ordered by franchise id. Used by {@link AdvanceWeek} to
+   * dispatch {@code CpuFranchiseStrategy} per non-user franchise.
+   */
+  List<Long> cpuFranchiseIdsForLeague(long leagueId);
+}

--- a/src/main/java/app/zoneblitz/league/ViewDirectorOfScoutingHiring.java
+++ b/src/main/java/app/zoneblitz/league/ViewDirectorOfScoutingHiring.java
@@ -1,0 +1,18 @@
+package app.zoneblitz.league;
+
+import java.util.Optional;
+
+/**
+ * Feature-public use case: load the HIRING_DIRECTOR_OF_SCOUTING page view-model for the user's
+ * franchise. Empty when the league does not exist, is not owned by the user, or is not in the DoS
+ * hiring phase.
+ */
+public interface ViewDirectorOfScoutingHiring {
+
+  /**
+   * @param leagueId the target league.
+   * @param ownerSubject the OAuth subject of the requesting user.
+   * @return the view-model, or empty if the league is missing / not owned / not in the DoS phase.
+   */
+  Optional<DirectorOfScoutingHiringView> view(long leagueId, String ownerSubject);
+}

--- a/src/main/java/app/zoneblitz/league/ViewDirectorOfScoutingHiringUseCase.java
+++ b/src/main/java/app/zoneblitz/league/ViewDirectorOfScoutingHiringUseCase.java
@@ -1,0 +1,76 @@
+package app.zoneblitz.league;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+class ViewDirectorOfScoutingHiringUseCase implements ViewDirectorOfScoutingHiring {
+
+  private final LeagueRepository leagues;
+  private final CandidatePoolRepository pools;
+  private final CandidateRepository candidates;
+  private final CandidatePreferencesRepository preferences;
+  private final FranchiseHiringStateRepository hiringStates;
+  private final FranchiseInterviewRepository interviews;
+
+  ViewDirectorOfScoutingHiringUseCase(
+      LeagueRepository leagues,
+      CandidatePoolRepository pools,
+      CandidateRepository candidates,
+      CandidatePreferencesRepository preferences,
+      FranchiseHiringStateRepository hiringStates,
+      FranchiseInterviewRepository interviews) {
+    this.leagues = leagues;
+    this.pools = pools;
+    this.candidates = candidates;
+    this.preferences = preferences;
+    this.hiringStates = hiringStates;
+    this.interviews = interviews;
+  }
+
+  @Override
+  @Transactional(readOnly = true)
+  public Optional<DirectorOfScoutingHiringView> view(long leagueId, String ownerSubject) {
+    Objects.requireNonNull(ownerSubject, "ownerSubject");
+    var maybeLeague = leagues.findSummaryByIdAndOwner(leagueId, ownerSubject);
+    if (maybeLeague.isEmpty()) {
+      return Optional.empty();
+    }
+    var league = maybeLeague.get();
+    if (league.phase() != LeaguePhase.HIRING_DIRECTOR_OF_SCOUTING) {
+      return Optional.empty();
+    }
+    var franchiseId = league.userFranchise().id();
+    var phase = LeaguePhase.HIRING_DIRECTOR_OF_SCOUTING;
+    var pool =
+        pools.findByLeaguePhaseAndType(leagueId, phase, CandidatePoolType.DIRECTOR_OF_SCOUTING);
+    if (pool.isEmpty()) {
+      return Optional.of(
+          new DirectorOfScoutingHiringView(
+              league, List.of(), List.of(), List.of(), 0, StartInterview.DEFAULT_WEEKLY_CAPACITY));
+    }
+    var rows = candidates.findAllByPoolId(pool.get().id());
+    var prefs =
+        rows.stream()
+            .map(c -> preferences.findByCandidateId(c.id()))
+            .flatMap(Optional::stream)
+            .toList();
+    var shortlist =
+        hiringStates
+            .find(leagueId, franchiseId, phase)
+            .map(FranchiseHiringState::shortlist)
+            .orElse(List.of());
+    var interviewHistory = interviews.findAllFor(leagueId, franchiseId, phase);
+    return Optional.of(
+        DirectorOfScoutingHiringViewModel.assemble(
+            league,
+            rows,
+            prefs,
+            shortlist,
+            interviewHistory,
+            StartInterview.DEFAULT_WEEKLY_CAPACITY));
+  }
+}

--- a/src/main/java/app/zoneblitz/league/ViewHeadCoachHiring.java
+++ b/src/main/java/app/zoneblitz/league/ViewHeadCoachHiring.java
@@ -1,0 +1,17 @@
+package app.zoneblitz.league;
+
+import java.util.Optional;
+
+/**
+ * Feature-public use case: load the HIRING_HEAD_COACH page view-model for the user's franchise.
+ * Empty when the league does not exist, is not owned by the user, or is not in the HC hiring phase.
+ */
+public interface ViewHeadCoachHiring {
+
+  /**
+   * @param leagueId the target league.
+   * @param ownerSubject the OAuth subject of the requesting user.
+   * @return the view-model, or empty if the league is missing / not owned / not in the HC phase.
+   */
+  Optional<HeadCoachHiringView> view(long leagueId, String ownerSubject);
+}

--- a/src/main/java/app/zoneblitz/league/ViewHeadCoachHiringUseCase.java
+++ b/src/main/java/app/zoneblitz/league/ViewHeadCoachHiringUseCase.java
@@ -1,0 +1,75 @@
+package app.zoneblitz.league;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+class ViewHeadCoachHiringUseCase implements ViewHeadCoachHiring {
+
+  private final LeagueRepository leagues;
+  private final CandidatePoolRepository pools;
+  private final CandidateRepository candidates;
+  private final CandidatePreferencesRepository preferences;
+  private final FranchiseHiringStateRepository hiringStates;
+  private final FranchiseInterviewRepository interviews;
+
+  ViewHeadCoachHiringUseCase(
+      LeagueRepository leagues,
+      CandidatePoolRepository pools,
+      CandidateRepository candidates,
+      CandidatePreferencesRepository preferences,
+      FranchiseHiringStateRepository hiringStates,
+      FranchiseInterviewRepository interviews) {
+    this.leagues = leagues;
+    this.pools = pools;
+    this.candidates = candidates;
+    this.preferences = preferences;
+    this.hiringStates = hiringStates;
+    this.interviews = interviews;
+  }
+
+  @Override
+  @Transactional(readOnly = true)
+  public Optional<HeadCoachHiringView> view(long leagueId, String ownerSubject) {
+    Objects.requireNonNull(ownerSubject, "ownerSubject");
+    var maybeLeague = leagues.findSummaryByIdAndOwner(leagueId, ownerSubject);
+    if (maybeLeague.isEmpty()) {
+      return Optional.empty();
+    }
+    var league = maybeLeague.get();
+    if (league.phase() != LeaguePhase.HIRING_HEAD_COACH) {
+      return Optional.empty();
+    }
+    var franchiseId = league.userFranchise().id();
+    var phase = LeaguePhase.HIRING_HEAD_COACH;
+    var pool = pools.findByLeaguePhaseAndType(leagueId, phase, CandidatePoolType.HEAD_COACH);
+    if (pool.isEmpty()) {
+      return Optional.of(
+          new HeadCoachHiringView(
+              league, List.of(), List.of(), List.of(), 0, StartInterview.DEFAULT_WEEKLY_CAPACITY));
+    }
+    var rows = candidates.findAllByPoolId(pool.get().id());
+    var prefs =
+        rows.stream()
+            .map(c -> preferences.findByCandidateId(c.id()))
+            .flatMap(Optional::stream)
+            .toList();
+    var shortlist =
+        hiringStates
+            .find(leagueId, franchiseId, phase)
+            .map(FranchiseHiringState::shortlist)
+            .orElse(List.of());
+    var interviewHistory = interviews.findAllFor(leagueId, franchiseId, phase);
+    return Optional.of(
+        HeadCoachHiringViewModel.assemble(
+            league,
+            rows,
+            prefs,
+            shortlist,
+            interviewHistory,
+            StartInterview.DEFAULT_WEEKLY_CAPACITY));
+  }
+}

--- a/src/main/java/app/zoneblitz/league/ViewStaffRecap.java
+++ b/src/main/java/app/zoneblitz/league/ViewStaffRecap.java
@@ -1,0 +1,19 @@
+package app.zoneblitz.league;
+
+import java.util.Optional;
+
+/**
+ * Read-only use case backing the {@link LeaguePhase#ASSEMBLING_STAFF} recap page. Returns the
+ * league-wide staff tree for every franchise with the requesting user's franchise hoisted to the
+ * top of the returned list.
+ */
+public interface ViewStaffRecap {
+
+  /**
+   * Build the recap view for the given league.
+   *
+   * @return {@link Optional#empty()} when the league does not exist or is not owned by {@code
+   *     ownerSubject}.
+   */
+  Optional<StaffRecapView> view(long leagueId, String ownerSubject);
+}

--- a/src/main/java/app/zoneblitz/league/ViewStaffRecapUseCase.java
+++ b/src/main/java/app/zoneblitz/league/ViewStaffRecapUseCase.java
@@ -1,0 +1,67 @@
+package app.zoneblitz.league;
+
+import java.util.ArrayList;
+import java.util.Objects;
+import java.util.Optional;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+class ViewStaffRecapUseCase implements ViewStaffRecap {
+
+  private final LeagueRepository leagues;
+  private final TeamLookup teams;
+  private final FranchiseRepository franchises;
+  private final FranchiseStaffRepository staff;
+  private final CandidateRepository candidates;
+
+  ViewStaffRecapUseCase(
+      LeagueRepository leagues,
+      TeamLookup teams,
+      FranchiseRepository franchises,
+      FranchiseStaffRepository staff,
+      CandidateRepository candidates) {
+    this.leagues = leagues;
+    this.teams = teams;
+    this.franchises = franchises;
+    this.staff = staff;
+    this.candidates = candidates;
+  }
+
+  @Override
+  @Transactional(readOnly = true)
+  public Optional<StaffRecapView> view(long leagueId, String ownerSubject) {
+    Objects.requireNonNull(ownerSubject, "ownerSubject");
+    var maybeLeague = leagues.findSummaryByIdAndOwner(leagueId, ownerSubject);
+    if (maybeLeague.isEmpty()) {
+      return Optional.empty();
+    }
+    var league = maybeLeague.get();
+    var userFranchiseId = league.userFranchise().id();
+
+    var trees = new ArrayList<StaffRecapView.FranchiseStaffTree>();
+    for (var franchiseId : teams.franchiseIdsForLeague(leagueId)) {
+      var franchise = franchises.findById(franchiseId);
+      if (franchise.isEmpty()) {
+        continue;
+      }
+      var hires = staff.findAllForFranchise(leagueId, franchiseId);
+      var seats = new ArrayList<StaffRecapView.StaffSeat>();
+      for (var hire : hires) {
+        candidates
+            .findById(hire.candidateId())
+            .ifPresent(c -> seats.add(new StaffRecapView.StaffSeat(hire, c)));
+      }
+      trees.add(
+          new StaffRecapView.FranchiseStaffTree(
+              franchise.get(), franchiseId == userFranchiseId, seats));
+    }
+    trees.sort(
+        (a, b) -> {
+          if (a.isViewerFranchise() && !b.isViewerFranchise()) return -1;
+          if (!a.isViewerFranchise() && b.isViewerFranchise()) return 1;
+          return a.franchise().name().compareToIgnoreCase(b.franchise().name());
+        });
+    return Optional.of(new StaffRecapView(league, trees));
+  }
+}

--- a/src/main/resources/db/migration/V6__franchise_interviews.sql
+++ b/src/main/resources/db/migration/V6__franchise_interviews.sql
@@ -1,0 +1,25 @@
+-- Per-franchise interview events against pool candidates. Each row represents
+-- one completed interview. interview_index is the 1-based count for that
+-- (franchise, candidate) pair and drives the noise-reduction function. Weekly
+-- capacity is enforced by counting rows per (franchise, phase, phase_week).
+CREATE TABLE franchise_interviews (
+    id BIGSERIAL PRIMARY KEY,
+    league_id BIGINT NOT NULL REFERENCES leagues(id) ON DELETE CASCADE,
+    franchise_id BIGINT NOT NULL REFERENCES franchises(id),
+    candidate_id BIGINT NOT NULL REFERENCES candidates(id) ON DELETE CASCADE,
+    phase TEXT NOT NULL,
+    phase_week INTEGER NOT NULL,
+    interview_index INTEGER NOT NULL,
+    scouted_overall NUMERIC(5, 2) NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    CHECK (phase_week > 0),
+    CHECK (interview_index > 0),
+    UNIQUE (league_id, franchise_id, candidate_id, interview_index)
+);
+
+CREATE INDEX franchise_interviews_league_franchise_phase_idx
+    ON franchise_interviews (league_id, franchise_id, phase);
+CREATE INDEX franchise_interviews_league_franchise_week_idx
+    ON franchise_interviews (league_id, franchise_id, phase, phase_week);
+CREATE INDEX franchise_interviews_candidate_idx
+    ON franchise_interviews (candidate_id);

--- a/src/main/resources/templates/league/hiring/director-of-scouting-fragments.html
+++ b/src/main/resources/templates/league/hiring/director-of-scouting-fragments.html
@@ -1,0 +1,141 @@
+<!DOCTYPE html>
+<html lang="en" xmlns:th="http://www.thymeleaf.org">
+<body>
+	<!-- Combined swap target: pool + shortlist + interviews updated together after mutations. -->
+	<div th:fragment="combined" id="hiring-regions" class="grid grid-cols-1 lg:grid-cols-3 gap-4">
+		<div class="lg:col-span-2">
+			<div th:insert="~{league/hiring/director-of-scouting-fragments :: pool}"></div>
+		</div>
+		<div class="space-y-4">
+			<div th:insert="~{league/hiring/director-of-scouting-fragments :: shortlist}"></div>
+			<div th:insert="~{league/hiring/director-of-scouting-fragments :: interviews}"></div>
+		</div>
+	</div>
+
+	<section th:fragment="pool"
+	         id="dos-pool"
+	         class="bg-white border border-slate-200 rounded p-4 shadow-sm">
+		<h2 class="text-lg font-semibold text-slate-900">Director of Scouting candidate pool</h2>
+		<p class="text-sm text-slate-500 mb-3">Scouted attributes only. True ratings are hidden.</p>
+		<div th:if="${view.pool().isEmpty()}" class="text-slate-500 italic text-sm">
+			No candidates available yet.
+		</div>
+		<table th:unless="${view.pool().isEmpty()}"
+		       class="w-full text-sm border-collapse">
+			<thead>
+				<tr class="text-left text-slate-600 border-b border-slate-200">
+					<th class="py-2 pr-2">Archetype</th>
+					<th class="py-2 pr-2">Specialty</th>
+					<th class="py-2 pr-2">Age</th>
+					<th class="py-2 pr-2">Exp (DoS / Scout / Area)</th>
+					<th class="py-2 pr-2">Scouted</th>
+					<th class="py-2 pr-2">Comp target</th>
+					<th class="py-2 pr-2">Length</th>
+					<th class="py-2 pr-2">Guaranteed</th>
+					<th class="py-2 pr-2"></th>
+				</tr>
+			</thead>
+			<tbody>
+				<tr th:each="row : ${view.pool()}"
+				    th:attr="data-candidate-id=${row.id()}"
+				    class="border-b border-slate-100">
+					<td class="py-2 pr-2" th:text="${row.archetype()}"></td>
+					<td class="py-2 pr-2" th:text="${row.specialty()}"></td>
+					<td class="py-2 pr-2" th:text="${row.age()}"></td>
+					<td class="py-2 pr-2">
+						<span th:text="${row.dosYears()} + ' / ' + ${row.scoutYears()} + ' / ' + ${row.areaScoutYears()}"></span>
+						<span class="text-slate-400 text-xs" th:text="'(' + ${row.totalExperienceYears()} + ' yrs total)'"></span>
+					</td>
+					<td class="py-2 pr-2" th:text="${row.scoutedOverall()}"></td>
+					<td class="py-2 pr-2" th:text="'$' + ${#numbers.formatDecimal(row.compensationTarget(), 0, 'COMMA', 0, 'POINT')}"></td>
+					<td class="py-2 pr-2" th:text="${row.contractLengthTarget()} + ' yr'"></td>
+					<td class="py-2 pr-2" th:text="${#numbers.formatPercent(row.guaranteedMoneyTarget(), 1, 0)}"></td>
+					<td class="py-2 pr-2 space-x-1">
+						<button type="button"
+						        th:unless="${row.shortlisted()}"
+						        th:attr="hx-post=@{'/leagues/' + ${view.league().leagueId()} + '/hiring/director-of-scouting/shortlist/' + ${row.id()}}"
+						        hx-target="#hiring-regions"
+						        hx-swap="outerHTML"
+						        class="px-2 py-1 text-xs rounded bg-slate-900 text-white hover:bg-slate-800 cursor-pointer">
+							Shortlist
+						</button>
+						<button type="button"
+						        th:if="${row.shortlisted()}"
+						        th:attr="hx-delete=@{'/leagues/' + ${view.league().leagueId()} + '/hiring/director-of-scouting/shortlist/' + ${row.id()}}"
+						        hx-target="#hiring-regions"
+						        hx-swap="outerHTML"
+						        class="px-2 py-1 text-xs rounded bg-slate-200 text-slate-700 hover:bg-slate-300 cursor-pointer">
+							Shortlisted
+						</button>
+						<button type="button"
+						        th:attr="hx-post=@{'/leagues/' + ${view.league().leagueId()} + '/hiring/director-of-scouting/interview/' + ${row.id()}},
+						                 disabled=${view.interviewsThisWeek() >= view.interviewCapacity()} ? 'disabled' : null"
+						        hx-target="#hiring-regions"
+						        hx-swap="outerHTML"
+						        th:classappend="${view.interviewsThisWeek() >= view.interviewCapacity()} ? ' opacity-50 cursor-not-allowed' : ' cursor-pointer'"
+						        class="px-2 py-1 text-xs rounded bg-indigo-600 text-white hover:bg-indigo-500">
+							<span th:if="${row.interviewCount() == 0}">Interview</span>
+							<span th:if="${row.interviewCount() > 0}"
+							      th:text="'Re-interview (' + ${row.interviewCount()} + ')'">Re-interview</span>
+						</button>
+					</td>
+				</tr>
+			</tbody>
+		</table>
+	</section>
+
+	<aside th:fragment="shortlist"
+	       id="dos-shortlist"
+	       class="bg-white border border-slate-200 rounded p-4 shadow-sm">
+		<h2 class="text-lg font-semibold text-slate-900">Your shortlist</h2>
+		<p class="text-sm text-slate-500 mb-3"
+		   th:text="'(' + ${view.shortlist().size()} + ' candidates)'"></p>
+		<div th:if="${view.shortlist().isEmpty()}" class="text-slate-500 italic text-sm">
+			No candidates shortlisted yet.
+		</div>
+		<ul th:unless="${view.shortlist().isEmpty()}" class="space-y-2">
+			<li th:each="row : ${view.shortlist()}"
+			    class="flex items-center justify-between gap-2 border-b border-slate-100 pb-2">
+				<div class="min-w-0">
+					<div class="text-sm font-medium text-slate-900"
+					     th:text="${row.archetype()} + ' · ' + ${row.specialty()}"></div>
+					<div class="text-xs text-slate-500"
+					     th:text="'age ' + ${row.age()} + ' · scouted ' + ${row.scoutedOverall()}"></div>
+				</div>
+				<button type="button"
+				        th:attr="hx-delete=@{'/leagues/' + ${view.league().leagueId()} + '/hiring/director-of-scouting/shortlist/' + ${row.id()}}"
+				        hx-target="#hiring-regions"
+				        hx-swap="outerHTML"
+				        class="px-2 py-1 text-xs rounded border border-slate-300 text-slate-600 hover:bg-slate-100 cursor-pointer">
+					Remove
+				</button>
+			</li>
+		</ul>
+	</aside>
+
+	<aside th:fragment="interviews"
+	       id="dos-interviews"
+	       class="bg-white border border-slate-200 rounded p-4 shadow-sm">
+		<div class="flex items-center justify-between mb-2">
+			<h2 class="text-lg font-semibold text-slate-900">Active interviews</h2>
+			<span class="text-xs text-slate-500"
+			      th:text="${view.interviewsThisWeek()} + ' / ' + ${view.interviewCapacity()} + ' this week'"></span>
+		</div>
+		<p class="text-sm text-slate-500 mb-3">Each interview tightens the scouted signal; true rating is never revealed.</p>
+		<div th:if="${view.activeInterviews().isEmpty()}" class="text-slate-500 italic text-sm">
+			No interviews conducted yet.
+		</div>
+		<ul th:unless="${view.activeInterviews().isEmpty()}" class="space-y-2">
+			<li th:each="row : ${view.activeInterviews()}"
+			    class="flex items-center justify-between gap-2 border-b border-slate-100 pb-2">
+				<div class="min-w-0">
+					<div class="text-sm font-medium text-slate-900"
+					     th:text="${row.archetype()} + ' · ' + ${row.specialty()}"></div>
+					<div class="text-xs text-slate-500"
+					     th:text="${row.interviewCount()} + ' interview(s) · scouted ' + ${row.scoutedOverall()}"></div>
+				</div>
+			</li>
+		</ul>
+	</aside>
+</body>
+</html>

--- a/src/main/resources/templates/league/hiring/director-of-scouting.html
+++ b/src/main/resources/templates/league/hiring/director-of-scouting.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html lang="en" xmlns:th="http://www.thymeleaf.org">
+<head>
+	<meta charset="UTF-8">
+	<title th:text="${view.league().leagueName() + ' — Hire a Director of Scouting — Zone Blitz'}">Hire a Director of Scouting — Zone Blitz</title>
+	<meta name="_csrf" th:content="${_csrf.token}">
+	<meta name="_csrf_header" th:content="${_csrf.headerName}">
+	<link rel="stylesheet" th:href="@{/css/app.css}">
+	<script th:src="@{/webjars/htmx.org/2.0.4/dist/htmx.min.js}" defer></script>
+	<script th:inline="javascript">
+		/*<![CDATA[*/
+		document.addEventListener('htmx:configRequest', function (event) {
+			var header = document.querySelector('meta[name="_csrf_header"]').content;
+			var token = document.querySelector('meta[name="_csrf"]').content;
+			event.detail.headers[header] = token;
+		});
+		/*]]>*/
+	</script>
+</head>
+<body class="bg-slate-50 text-slate-900 min-h-screen">
+	<main class="max-w-6xl mx-auto p-6 space-y-4">
+		<header class="flex items-center justify-between">
+			<div>
+				<h1 class="text-2xl font-bold" th:text="${view.league().leagueName()}">League</h1>
+				<p class="text-sm text-slate-500">
+					Phase: Hire Director of Scouting · Week
+					<span th:text="${view.league().phaseWeek()}">1</span>
+				</p>
+			</div>
+			<a th:href="@{'/leagues/' + ${view.league().leagueId()}}"
+			   class="text-sm text-slate-600 hover:underline">Back to dashboard</a>
+		</header>
+
+		<div th:insert="~{league/hiring/director-of-scouting-fragments :: combined}"></div>
+	</main>
+</body>
+</html>

--- a/src/main/resources/templates/league/hiring/head-coach-fragments.html
+++ b/src/main/resources/templates/league/hiring/head-coach-fragments.html
@@ -1,0 +1,141 @@
+<!DOCTYPE html>
+<html lang="en" xmlns:th="http://www.thymeleaf.org">
+<body>
+	<!-- Combined swap target: pool + shortlist + interviews updated together after mutations. -->
+	<div th:fragment="combined" id="hiring-regions" class="grid grid-cols-1 lg:grid-cols-3 gap-4">
+		<div class="lg:col-span-2">
+			<div th:insert="~{league/hiring/head-coach-fragments :: pool}"></div>
+		</div>
+		<div class="space-y-4">
+			<div th:insert="~{league/hiring/head-coach-fragments :: shortlist}"></div>
+			<div th:insert="~{league/hiring/head-coach-fragments :: interviews}"></div>
+		</div>
+	</div>
+
+	<section th:fragment="pool"
+	         id="hc-pool"
+	         class="bg-white border border-slate-200 rounded p-4 shadow-sm">
+		<h2 class="text-lg font-semibold text-slate-900">Head Coach candidate pool</h2>
+		<p class="text-sm text-slate-500 mb-3">Scouted attributes only. True ratings are hidden.</p>
+		<div th:if="${view.pool().isEmpty()}" class="text-slate-500 italic text-sm">
+			No candidates available yet.
+		</div>
+		<table th:unless="${view.pool().isEmpty()}"
+		       class="w-full text-sm border-collapse">
+			<thead>
+				<tr class="text-left text-slate-600 border-b border-slate-200">
+					<th class="py-2 pr-2">Archetype</th>
+					<th class="py-2 pr-2">Specialty</th>
+					<th class="py-2 pr-2">Age</th>
+					<th class="py-2 pr-2">Exp (HC / OC / PC)</th>
+					<th class="py-2 pr-2">Scouted</th>
+					<th class="py-2 pr-2">Comp target</th>
+					<th class="py-2 pr-2">Length</th>
+					<th class="py-2 pr-2">Guaranteed</th>
+					<th class="py-2 pr-2"></th>
+				</tr>
+			</thead>
+			<tbody>
+				<tr th:each="row : ${view.pool()}"
+				    th:attr="data-candidate-id=${row.id()}"
+				    class="border-b border-slate-100">
+					<td class="py-2 pr-2" th:text="${row.archetype()}"></td>
+					<td class="py-2 pr-2" th:text="${row.specialty()}"></td>
+					<td class="py-2 pr-2" th:text="${row.age()}"></td>
+					<td class="py-2 pr-2">
+						<span th:text="${row.hcYears()} + ' / ' + ${row.ocYears()} + ' / ' + ${row.positionCoachYears()}"></span>
+						<span class="text-slate-400 text-xs" th:text="'(' + ${row.totalExperienceYears()} + ' yrs total)'"></span>
+					</td>
+					<td class="py-2 pr-2" th:text="${row.scoutedOverall()}"></td>
+					<td class="py-2 pr-2" th:text="'$' + ${#numbers.formatDecimal(row.compensationTarget(), 0, 'COMMA', 0, 'POINT')}"></td>
+					<td class="py-2 pr-2" th:text="${row.contractLengthTarget()} + ' yr'"></td>
+					<td class="py-2 pr-2" th:text="${#numbers.formatPercent(row.guaranteedMoneyTarget(), 1, 0)}"></td>
+					<td class="py-2 pr-2 space-x-1">
+						<button type="button"
+						        th:unless="${row.shortlisted()}"
+						        th:attr="hx-post=@{'/leagues/' + ${view.league().leagueId()} + '/hiring/head-coach/shortlist/' + ${row.id()}}"
+						        hx-target="#hiring-regions"
+						        hx-swap="outerHTML"
+						        class="px-2 py-1 text-xs rounded bg-slate-900 text-white hover:bg-slate-800 cursor-pointer">
+							Shortlist
+						</button>
+						<button type="button"
+						        th:if="${row.shortlisted()}"
+						        th:attr="hx-delete=@{'/leagues/' + ${view.league().leagueId()} + '/hiring/head-coach/shortlist/' + ${row.id()}}"
+						        hx-target="#hiring-regions"
+						        hx-swap="outerHTML"
+						        class="px-2 py-1 text-xs rounded bg-slate-200 text-slate-700 hover:bg-slate-300 cursor-pointer">
+							Shortlisted
+						</button>
+						<button type="button"
+						        th:attr="hx-post=@{'/leagues/' + ${view.league().leagueId()} + '/hiring/head-coach/interview/' + ${row.id()}},
+						                 disabled=${view.interviewsThisWeek() >= view.interviewCapacity()} ? 'disabled' : null"
+						        hx-target="#hiring-regions"
+						        hx-swap="outerHTML"
+						        th:classappend="${view.interviewsThisWeek() >= view.interviewCapacity()} ? ' opacity-50 cursor-not-allowed' : ' cursor-pointer'"
+						        class="px-2 py-1 text-xs rounded bg-indigo-600 text-white hover:bg-indigo-500">
+							<span th:if="${row.interviewCount() == 0}">Interview</span>
+							<span th:if="${row.interviewCount() > 0}"
+							      th:text="'Re-interview (' + ${row.interviewCount()} + ')'">Re-interview</span>
+						</button>
+					</td>
+				</tr>
+			</tbody>
+		</table>
+	</section>
+
+	<aside th:fragment="shortlist"
+	       id="hc-shortlist"
+	       class="bg-white border border-slate-200 rounded p-4 shadow-sm">
+		<h2 class="text-lg font-semibold text-slate-900">Your shortlist</h2>
+		<p class="text-sm text-slate-500 mb-3"
+		   th:text="'(' + ${view.shortlist().size()} + ' candidates)'"></p>
+		<div th:if="${view.shortlist().isEmpty()}" class="text-slate-500 italic text-sm">
+			No candidates shortlisted yet.
+		</div>
+		<ul th:unless="${view.shortlist().isEmpty()}" class="space-y-2">
+			<li th:each="row : ${view.shortlist()}"
+			    class="flex items-center justify-between gap-2 border-b border-slate-100 pb-2">
+				<div class="min-w-0">
+					<div class="text-sm font-medium text-slate-900"
+					     th:text="${row.archetype()} + ' · ' + ${row.specialty()}"></div>
+					<div class="text-xs text-slate-500"
+					     th:text="'age ' + ${row.age()} + ' · scouted ' + ${row.scoutedOverall()}"></div>
+				</div>
+				<button type="button"
+				        th:attr="hx-delete=@{'/leagues/' + ${view.league().leagueId()} + '/hiring/head-coach/shortlist/' + ${row.id()}}"
+				        hx-target="#hiring-regions"
+				        hx-swap="outerHTML"
+				        class="px-2 py-1 text-xs rounded border border-slate-300 text-slate-600 hover:bg-slate-100 cursor-pointer">
+					Remove
+				</button>
+			</li>
+		</ul>
+	</aside>
+
+	<aside th:fragment="interviews"
+	       id="hc-interviews"
+	       class="bg-white border border-slate-200 rounded p-4 shadow-sm">
+		<div class="flex items-center justify-between mb-2">
+			<h2 class="text-lg font-semibold text-slate-900">Active interviews</h2>
+			<span class="text-xs text-slate-500"
+			      th:text="${view.interviewsThisWeek()} + ' / ' + ${view.interviewCapacity()} + ' this week'"></span>
+		</div>
+		<p class="text-sm text-slate-500 mb-3">Each interview tightens the scouted signal; true rating is never revealed.</p>
+		<div th:if="${view.activeInterviews().isEmpty()}" class="text-slate-500 italic text-sm">
+			No interviews conducted yet.
+		</div>
+		<ul th:unless="${view.activeInterviews().isEmpty()}" class="space-y-2">
+			<li th:each="row : ${view.activeInterviews()}"
+			    class="flex items-center justify-between gap-2 border-b border-slate-100 pb-2">
+				<div class="min-w-0">
+					<div class="text-sm font-medium text-slate-900"
+					     th:text="${row.archetype()} + ' · ' + ${row.specialty()}"></div>
+					<div class="text-xs text-slate-500"
+					     th:text="${row.interviewCount()} + ' interview(s) · scouted ' + ${row.scoutedOverall()}"></div>
+				</div>
+			</li>
+		</ul>
+	</aside>
+</body>
+</html>

--- a/src/main/resources/templates/league/hiring/head-coach.html
+++ b/src/main/resources/templates/league/hiring/head-coach.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html lang="en" xmlns:th="http://www.thymeleaf.org">
+<head>
+	<meta charset="UTF-8">
+	<title th:text="${view.league().leagueName() + ' — Hire a Head Coach — Zone Blitz'}">Hire a Head Coach — Zone Blitz</title>
+	<meta name="_csrf" th:content="${_csrf.token}">
+	<meta name="_csrf_header" th:content="${_csrf.headerName}">
+	<link rel="stylesheet" th:href="@{/css/app.css}">
+	<script th:src="@{/webjars/htmx.org/2.0.4/dist/htmx.min.js}" defer></script>
+	<script th:inline="javascript">
+		/*<![CDATA[*/
+		document.addEventListener('htmx:configRequest', function (event) {
+			var header = document.querySelector('meta[name="_csrf_header"]').content;
+			var token = document.querySelector('meta[name="_csrf"]').content;
+			event.detail.headers[header] = token;
+		});
+		/*]]>*/
+	</script>
+</head>
+<body class="bg-slate-50 text-slate-900 min-h-screen">
+	<main class="max-w-6xl mx-auto p-6 space-y-4">
+		<header class="flex items-center justify-between">
+			<div>
+				<h1 class="text-2xl font-bold" th:text="${view.league().leagueName()}">League</h1>
+				<p class="text-sm text-slate-500">
+					Phase: Hire Head Coach · Week
+					<span th:text="${view.league().phaseWeek()}">1</span>
+				</p>
+			</div>
+			<a th:href="@{'/leagues/' + ${view.league().leagueId()}}"
+			   class="text-sm text-slate-600 hover:underline">Back to dashboard</a>
+		</header>
+
+		<div th:insert="~{league/hiring/head-coach-fragments :: combined}"></div>
+	</main>
+</body>
+</html>

--- a/src/main/resources/templates/league/staff-recap.html
+++ b/src/main/resources/templates/league/staff-recap.html
@@ -1,0 +1,63 @@
+<!DOCTYPE html>
+<html lang="en" xmlns:th="http://www.thymeleaf.org">
+<head>
+	<meta charset="UTF-8">
+	<title th:text="${view.league().leagueName() + ' — Staff Recap — Zone Blitz'}">Staff Recap — Zone Blitz</title>
+	<meta name="_csrf" th:content="${_csrf.token}">
+	<meta name="_csrf_header" th:content="${_csrf.headerName}">
+	<link rel="stylesheet" th:href="@{/css/app.css}">
+</head>
+<body class="bg-slate-50 text-slate-900 min-h-screen">
+	<main class="max-w-5xl mx-auto p-6 space-y-4">
+		<header class="flex items-center justify-between">
+			<div>
+				<h1 class="text-2xl font-bold" th:text="${view.league().leagueName()}">League</h1>
+				<p class="text-sm text-slate-500">Phase: Assembling Staff</p>
+			</div>
+			<form th:action="@{'/leagues/' + ${view.league().leagueId()} + '/phase/advance'}"
+			      method="post">
+				<button type="submit"
+				        class="inline-flex items-center gap-2 px-4 py-2 rounded bg-slate-900 text-white font-medium hover:bg-slate-800 cursor-pointer">
+					Advance to next phase
+				</button>
+			</form>
+		</header>
+
+		<p class="text-sm text-slate-600">
+			Coordinators, position coaches and scouts have been hired for every franchise. Your staff is
+			shown expanded; other franchises are collapsed — click to expand.
+		</p>
+
+		<section class="space-y-3">
+			<details th:each="tree : ${view.franchises()}"
+			         th:open="${tree.isViewerFranchise()}"
+			         class="bg-white border border-slate-200 rounded shadow-sm">
+				<summary class="cursor-pointer px-4 py-3 flex items-center justify-between">
+					<span class="font-medium" th:text="${tree.franchise().name()}">Franchise</span>
+					<span class="text-xs text-slate-500"
+					      th:text="${tree.seats().size() + ' staff'}">staff</span>
+				</summary>
+				<ul class="divide-y divide-slate-100">
+					<li th:each="seat : ${tree.seats()}"
+					    class="px-4 py-2 flex items-center justify-between text-sm">
+						<span>
+							<span class="font-mono text-xs text-slate-500"
+							      th:text="${seat.hire().role().name()}">ROLE</span>
+							<span th:if="${seat.hire().scoutBranch().isPresent()}"
+							      class="ml-2 inline-block px-2 py-0.5 rounded bg-slate-100 text-slate-700 text-xs"
+							      th:text="${seat.hire().scoutBranch().get().name()}">BRANCH</span>
+						</span>
+						<span class="text-slate-500 text-xs">
+							<span th:text="${seat.candidate().specialtyPosition().name()}">SPEC</span>
+							·
+							<span th:text="${seat.candidate().archetype().name()}">ARCH</span>
+							·
+							age <span th:text="${seat.candidate().age()}">0</span>
+						</span>
+					</li>
+				</ul>
+			</details>
+		</section>
+	</main>
+</body>
+</html>

--- a/src/test/java/app/zoneblitz/gamesimulator/DriveOutcomeCalibrationTests.java
+++ b/src/test/java/app/zoneblitz/gamesimulator/DriveOutcomeCalibrationTests.java
@@ -40,6 +40,8 @@ import java.util.Random;
 import java.util.UUID;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
 
 /**
  * Drive-outcome calibration harness for issue #615.

--- a/src/test/java/app/zoneblitz/gamesimulator/FullGameCalibrationTests.java
+++ b/src/test/java/app/zoneblitz/gamesimulator/FullGameCalibrationTests.java
@@ -41,6 +41,8 @@ import java.util.Random;
 import java.util.UUID;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
 
 /**
  * Calibration harness: simulates 10k games with the real dependency graph wired to the classpath
@@ -48,6 +50,7 @@ import org.junit.jupiter.api.Test;
  * pass yards, rush yards, plays, sacks, interceptions, and fumbles.
  */
 @Tag("calibration")
+@Execution(ExecutionMode.CONCURRENT)
 class FullGameCalibrationTests {
 
   private static final int GAMES = 10_000;

--- a/src/test/java/app/zoneblitz/league/AdvancePhaseUseCaseTests.java
+++ b/src/test/java/app/zoneblitz/league/AdvancePhaseUseCaseTests.java
@@ -83,14 +83,43 @@ class AdvancePhaseUseCaseTests {
   @Test
   void advance_whenAlreadyInTerminalPhase_returnsNoNextPhase() {
     var league = createLeagueFor("sub-1");
+    leagues.updatePhaseAndResetWeek(league.id(), LeaguePhase.COMPLETE);
+
+    var result = advancePhase.advance(league.id(), "sub-1");
+
+    assertThat(result)
+        .isEqualTo(new AdvancePhaseResult.NoNextPhase(league.id(), LeaguePhase.COMPLETE));
+    assertThat(leagues.findById(league.id()).orElseThrow().phase()).isEqualTo(LeaguePhase.COMPLETE);
+  }
+
+  @Test
+  void advance_fromHiringHeadCoach_transitionsToHiringDirectorOfScouting() {
+    var league = createLeagueFor("sub-1");
     leagues.updatePhaseAndResetWeek(league.id(), LeaguePhase.HIRING_HEAD_COACH);
 
     var result = advancePhase.advance(league.id(), "sub-1");
 
     assertThat(result)
-        .isEqualTo(new AdvancePhaseResult.NoNextPhase(league.id(), LeaguePhase.HIRING_HEAD_COACH));
-    assertThat(leagues.findById(league.id()).orElseThrow().phase())
-        .isEqualTo(LeaguePhase.HIRING_HEAD_COACH);
+        .isEqualTo(
+            new AdvancePhaseResult.Advanced(
+                league.id(),
+                LeaguePhase.HIRING_HEAD_COACH,
+                LeaguePhase.HIRING_DIRECTOR_OF_SCOUTING));
+  }
+
+  @Test
+  void advance_fromHiringDirectorOfScouting_transitionsToAssemblingStaff() {
+    var league = createLeagueFor("sub-1");
+    leagues.updatePhaseAndResetWeek(league.id(), LeaguePhase.HIRING_DIRECTOR_OF_SCOUTING);
+
+    var result = advancePhase.advance(league.id(), "sub-1");
+
+    assertThat(result)
+        .isEqualTo(
+            new AdvancePhaseResult.Advanced(
+                league.id(),
+                LeaguePhase.HIRING_DIRECTOR_OF_SCOUTING,
+                LeaguePhase.ASSEMBLING_STAFF));
   }
 
   @Test

--- a/src/test/java/app/zoneblitz/league/AdvanceWeekUseCaseTests.java
+++ b/src/test/java/app/zoneblitz/league/AdvanceWeekUseCaseTests.java
@@ -3,6 +3,7 @@ package app.zoneblitz.league;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import app.zoneblitz.support.PostgresTestcontainer;
+import java.util.List;
 import java.util.Optional;
 import org.jooq.DSLContext;
 import org.junit.jupiter.api.BeforeEach;
@@ -18,16 +19,57 @@ class AdvanceWeekUseCaseTests {
   @Autowired DSLContext dsl;
 
   private LeagueRepository leagues;
+  private JooqFranchiseHiringStateRepository hiringStates;
+  private JooqCandidatePoolRepository pools;
+  private JooqCandidateRepository candidates;
+  private JooqCandidatePreferencesRepository preferences;
+  private JooqCandidateOfferRepository offers;
+  private JooqFranchiseStaffRepository staff;
+  private JooqTeamLookup teamLookup;
   private CreateLeague createLeague;
   private AdvanceWeek advanceWeek;
+  private HiringHeadCoachTransitionHandler hcEntryHandler;
+  private AdvancePhase advancePhase;
+  private HiringPhaseAutofill autofill;
+  private CandidateRandomSources rngs;
+  private OfferResolver noopResolver;
+  private RecordingAutofill recordingAutofill;
+  private RecordingAdvancePhase recordingAdvancePhase;
 
   @BeforeEach
   void setUp() {
     leagues = new JooqLeagueRepository(dsl);
+    hiringStates = new JooqFranchiseHiringStateRepository(dsl);
+    pools = new JooqCandidatePoolRepository(dsl);
+    candidates = new JooqCandidateRepository(dsl);
+    preferences = new JooqCandidatePreferencesRepository(dsl);
+    offers = new JooqCandidateOfferRepository(dsl);
+    staff = new JooqFranchiseStaffRepository(dsl);
+    teamLookup = new JooqTeamLookup(dsl);
     var franchises = new JooqFranchiseRepository(dsl);
-    var teams = new JooqTeamRepository(dsl);
-    createLeague = new CreateLeagueUseCase(leagues, franchises, teams);
-    advanceWeek = new AdvanceWeekUseCase(leagues);
+    var teamRepo = new JooqTeamRepository(dsl);
+    createLeague = new CreateLeagueUseCase(leagues, franchises, teamRepo);
+    rngs = (leagueId, phase) -> new FakeRandomSource(leagueId + phase.ordinal());
+    hcEntryHandler =
+        new HiringHeadCoachTransitionHandler(
+            leagues,
+            teamLookup,
+            pools,
+            candidates,
+            preferences,
+            hiringStates,
+            new HeadCoachGenerator(),
+            rngs);
+    autofill =
+        new BestScoutedHiringAutofill(
+            pools, candidates, preferences, offers, hiringStates, staff, teamLookup, rngs);
+    advancePhase = new AdvancePhaseUseCase(leagues, List.of());
+    noopResolver = (leagueId, phase, week) -> {};
+    recordingAutofill = new RecordingAutofill();
+    recordingAdvancePhase = new RecordingAdvancePhase(leagues);
+    advanceWeek =
+        new AdvanceWeekUseCase(
+            leagues, noopResolver, teamLookup, autofill, hiringStates, advancePhase, List.of());
   }
 
   @Test
@@ -62,12 +104,208 @@ class AdvanceWeekUseCaseTests {
   }
 
   @Test
+  void advance_invokesOfferResolverBeforeIncrementingWeek() {
+    var league = createLeagueFor("sub-1");
+    var seen = new java.util.concurrent.atomic.AtomicInteger(-1);
+    OfferResolver capturingResolver = (leagueId, phase, weekAtResolve) -> seen.set(weekAtResolve);
+    var useCase =
+        new AdvanceWeekUseCase(
+            leagues,
+            capturingResolver,
+            teamLookup,
+            autofill,
+            hiringStates,
+            advancePhase,
+            List.of());
+
+    useCase.advance(league.id(), "sub-1");
+
+    assertThat(seen.get()).isEqualTo(1);
+    assertThat(leagues.findById(league.id()).orElseThrow().phaseWeek()).isEqualTo(2);
+  }
+
+  @Test
+  void advance_invokesCpuStrategy_onceForEachCpuFranchiseOfMatchingPhase() {
+    var league = createLeagueFor("sub-1");
+    leagues.updatePhaseAndResetWeek(league.id(), LeaguePhase.HIRING_HEAD_COACH);
+    var calls = new java.util.ArrayList<Long>();
+    CpuFranchiseStrategy cpu =
+        new CpuFranchiseStrategy() {
+          @Override
+          public LeaguePhase phase() {
+            return LeaguePhase.HIRING_HEAD_COACH;
+          }
+
+          @Override
+          public void execute(long leagueId, long franchiseId, int phaseWeek) {
+            calls.add(franchiseId);
+          }
+        };
+    var useCase =
+        new AdvanceWeekUseCase(
+            leagues, noopResolver, teamLookup, autofill, hiringStates, advancePhase, List.of(cpu));
+
+    useCase.advance(league.id(), "sub-1");
+
+    var expectedCpuIds = teamLookup.cpuFranchiseIdsForLeague(league.id());
+    assertThat(calls).containsExactlyElementsOf(expectedCpuIds);
+  }
+
+  @Test
+  void advance_doesNotInvokeCpuStrategy_whenPhaseDoesNotMatch() {
+    var league = createLeagueFor("sub-1");
+    var calls = new java.util.ArrayList<Long>();
+    CpuFranchiseStrategy cpu =
+        new CpuFranchiseStrategy() {
+          @Override
+          public LeaguePhase phase() {
+            return LeaguePhase.HIRING_HEAD_COACH;
+          }
+
+          @Override
+          public void execute(long leagueId, long franchiseId, int phaseWeek) {
+            calls.add(franchiseId);
+          }
+        };
+    var useCase =
+        new AdvanceWeekUseCase(
+            leagues, noopResolver, teamLookup, autofill, hiringStates, advancePhase, List.of(cpu));
+
+    useCase.advance(league.id(), "sub-1");
+
+    assertThat(calls).isEmpty();
+  }
+
+  @Test
   void advance_whenNotOwnedByCaller_returnsNotFound() {
     var league = createLeagueFor("owner");
 
     var result = advanceWeek.advance(league.id(), "someone-else");
 
     assertThat(result).isEqualTo(new AdvanceWeekResult.NotFound(league.id()));
+  }
+
+  @Test
+  void advance_whenAllFranchisesHired_transitionsToNextPhaseEarly() {
+    var league = createLeagueFor("sub-1");
+    leagues.updatePhaseAndResetWeek(league.id(), LeaguePhase.HIRING_HEAD_COACH);
+    markAllFranchisesHired(league.id(), LeaguePhase.HIRING_HEAD_COACH);
+    var useCase =
+        new AdvanceWeekUseCase(
+            leagues,
+            noopResolver,
+            teamLookup,
+            recordingAutofill,
+            hiringStates,
+            recordingAdvancePhase,
+            List.of());
+
+    var result = useCase.advance(league.id(), "sub-1");
+
+    assertThat(recordingAdvancePhase.calls).isEqualTo(1);
+    assertThat(recordingAutofill.calls).isEmpty();
+    var ticked = (AdvanceWeekResult.Ticked) result;
+    assertThat(ticked.transitionedTo()).contains(LeaguePhase.HIRING_DIRECTOR_OF_SCOUTING);
+    assertThat(ticked.phase()).isEqualTo(LeaguePhase.HIRING_DIRECTOR_OF_SCOUTING);
+    assertThat(ticked.phaseWeek()).isEqualTo(1);
+  }
+
+  @Test
+  void advance_whenWeekCapExceededWithPendingFranchise_runsAutofillAndTransitions() {
+    var league = createLeagueFor("sub-1");
+    leagues.updatePhaseAndResetWeek(league.id(), LeaguePhase.HIRING_HEAD_COACH);
+    hcEntryHandler.onEntry(league.id());
+    // Burn weeks 1 and 2 so the third tick is the capped one.
+    leagues.incrementPhaseWeek(league.id());
+    leagues.incrementPhaseWeek(league.id());
+    var useCase =
+        new AdvanceWeekUseCase(
+            leagues,
+            noopResolver,
+            teamLookup,
+            recordingAutofill,
+            hiringStates,
+            recordingAdvancePhase,
+            List.of());
+
+    var result = useCase.advance(league.id(), "sub-1");
+
+    assertThat(recordingAutofill.calls)
+        .containsExactly(new AutofillCall(league.id(), LeaguePhase.HIRING_HEAD_COACH, 3));
+    assertThat(recordingAdvancePhase.calls).isEqualTo(1);
+    var ticked = (AdvanceWeekResult.Ticked) result;
+    assertThat(ticked.transitionedTo()).contains(LeaguePhase.HIRING_DIRECTOR_OF_SCOUTING);
+  }
+
+  @Test
+  void advance_whenWeekCapExceededWithAllHired_transitionsAndAutofillIsNoOp() {
+    var league = createLeagueFor("sub-1");
+    leagues.updatePhaseAndResetWeek(league.id(), LeaguePhase.HIRING_HEAD_COACH);
+    markAllFranchisesHired(league.id(), LeaguePhase.HIRING_HEAD_COACH);
+    leagues.incrementPhaseWeek(league.id());
+    leagues.incrementPhaseWeek(league.id());
+    var useCase =
+        new AdvanceWeekUseCase(
+            leagues,
+            noopResolver,
+            teamLookup,
+            autofill,
+            hiringStates,
+            recordingAdvancePhase,
+            List.of());
+
+    var result = useCase.advance(league.id(), "sub-1");
+
+    // Cap triggers the autofill branch, but with every franchise already HIRED it is a no-op —
+    // no new staff rows, no new offers. Transition still happens.
+    for (var franchiseId : teamLookup.franchiseIdsForLeague(league.id())) {
+      assertThat(staff.findAllForFranchise(league.id(), franchiseId)).isEmpty();
+    }
+    assertThat(recordingAdvancePhase.calls).isEqualTo(1);
+    var ticked = (AdvanceWeekResult.Ticked) result;
+    assertThat(ticked.transitionedTo()).contains(LeaguePhase.HIRING_DIRECTOR_OF_SCOUTING);
+  }
+
+  @Test
+  void advance_whenBelowCapAndSomeFranchisesSearching_doesNotTransition() {
+    var league = createLeagueFor("sub-1");
+    leagues.updatePhaseAndResetWeek(league.id(), LeaguePhase.HIRING_HEAD_COACH);
+    // Only initialize a handful of SEARCHING states; leave others untouched.
+    hiringStates.upsert(
+        new FranchiseHiringState(
+            0L,
+            league.id(),
+            teamLookup.franchiseIdsForLeague(league.id()).getFirst(),
+            LeaguePhase.HIRING_HEAD_COACH,
+            HiringStep.SEARCHING,
+            List.of(),
+            List.of()));
+    var useCase =
+        new AdvanceWeekUseCase(
+            leagues,
+            noopResolver,
+            teamLookup,
+            recordingAutofill,
+            hiringStates,
+            recordingAdvancePhase,
+            List.of());
+
+    var result = useCase.advance(league.id(), "sub-1");
+
+    assertThat(recordingAutofill.calls).isEmpty();
+    assertThat(recordingAdvancePhase.calls).isZero();
+    var ticked = (AdvanceWeekResult.Ticked) result;
+    assertThat(ticked.transitionedTo()).isEmpty();
+    assertThat(ticked.phase()).isEqualTo(LeaguePhase.HIRING_HEAD_COACH);
+    assertThat(ticked.phaseWeek()).isEqualTo(2);
+  }
+
+  private void markAllFranchisesHired(long leagueId, LeaguePhase phase) {
+    for (var franchiseId : teamLookup.franchiseIdsForLeague(leagueId)) {
+      hiringStates.upsert(
+          new FranchiseHiringState(
+              0L, leagueId, franchiseId, phase, HiringStep.HIRED, List.of(), List.of()));
+    }
   }
 
   private League createLeagueFor(String ownerSubject) {
@@ -77,5 +315,44 @@ class AdvanceWeekUseCaseTests {
 
   private long firstFranchiseId() {
     return new JooqFranchiseRepository(dsl).listAll().getFirst().id();
+  }
+
+  private record AutofillCall(long leagueId, LeaguePhase phase, int phaseWeek) {}
+
+  private static final class RecordingAutofill implements HiringPhaseAutofill {
+    final List<AutofillCall> calls = new java.util.ArrayList<>();
+
+    @Override
+    public void autofill(long leagueId, LeaguePhase phase, int phaseWeek) {
+      calls.add(new AutofillCall(leagueId, phase, phaseWeek));
+    }
+  }
+
+  private static final class RecordingAdvancePhase implements AdvancePhase {
+    private final LeagueRepository leagues;
+    int calls;
+
+    RecordingAdvancePhase(LeagueRepository leagues) {
+      this.leagues = leagues;
+    }
+
+    @Override
+    public AdvancePhaseResult advance(long leagueId, String ownerSubject) {
+      calls++;
+      var league = leagues.findSummaryByIdAndOwner(leagueId, ownerSubject).orElseThrow();
+      var next = next(league.phase());
+      leagues.updatePhaseAndResetWeek(leagueId, next);
+      return new AdvancePhaseResult.Advanced(leagueId, league.phase(), next);
+    }
+
+    private static LeaguePhase next(LeaguePhase phase) {
+      return switch (phase) {
+        case INITIAL_SETUP -> LeaguePhase.HIRING_HEAD_COACH;
+        case HIRING_HEAD_COACH -> LeaguePhase.HIRING_DIRECTOR_OF_SCOUTING;
+        case HIRING_DIRECTOR_OF_SCOUTING -> LeaguePhase.ASSEMBLING_STAFF;
+        case ASSEMBLING_STAFF -> LeaguePhase.COMPLETE;
+        case COMPLETE -> LeaguePhase.COMPLETE;
+      };
+    }
   }
 }

--- a/src/test/java/app/zoneblitz/league/BestScoutedHiringAutofillTests.java
+++ b/src/test/java/app/zoneblitz/league/BestScoutedHiringAutofillTests.java
@@ -1,0 +1,225 @@
+package app.zoneblitz.league;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import app.zoneblitz.support.PostgresTestcontainer;
+import java.util.List;
+import java.util.Optional;
+import org.jooq.DSLContext;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.jooq.test.autoconfigure.JooqTest;
+import org.springframework.context.annotation.Import;
+
+@JooqTest
+@Import(PostgresTestcontainer.class)
+class BestScoutedHiringAutofillTests {
+
+  @Autowired DSLContext dsl;
+
+  private LeagueRepository leagues;
+  private JooqCandidatePoolRepository pools;
+  private JooqCandidateRepository candidates;
+  private JooqCandidatePreferencesRepository preferences;
+  private JooqCandidateOfferRepository offers;
+  private JooqFranchiseHiringStateRepository hiringStates;
+  private JooqFranchiseStaffRepository staff;
+  private JooqTeamLookup teamLookup;
+  private CreateLeague createLeague;
+  private HiringPhaseAutofill autofill;
+  private CandidateRandomSources rngs;
+
+  @BeforeEach
+  void setUp() {
+    leagues = new JooqLeagueRepository(dsl);
+    var franchises = new JooqFranchiseRepository(dsl);
+    var teamRepo = new JooqTeamRepository(dsl);
+    pools = new JooqCandidatePoolRepository(dsl);
+    candidates = new JooqCandidateRepository(dsl);
+    preferences = new JooqCandidatePreferencesRepository(dsl);
+    offers = new JooqCandidateOfferRepository(dsl);
+    hiringStates = new JooqFranchiseHiringStateRepository(dsl);
+    staff = new JooqFranchiseStaffRepository(dsl);
+    teamLookup = new JooqTeamLookup(dsl);
+    rngs = (leagueId, phase) -> new FakeRandomSource(leagueId + phase.ordinal());
+    createLeague = new CreateLeagueUseCase(leagues, franchises, teamRepo);
+    autofill =
+        new BestScoutedHiringAutofill(
+            pools, candidates, preferences, offers, hiringStates, staff, teamLookup, rngs);
+  }
+
+  @Test
+  void autofill_whenPhaseHasNoPool_isNoOp() {
+    var league = createLeagueFor("sub-1");
+
+    autofill.autofill(league.id(), LeaguePhase.HIRING_HEAD_COACH, 3);
+
+    assertThat(hiringStates.findAllForLeaguePhase(league.id(), LeaguePhase.HIRING_HEAD_COACH))
+        .isEmpty();
+  }
+
+  @Test
+  void autofill_assignsUnresolvedFranchise_withBestScoutedCandidate() {
+    var league = createLeagueFor("sub-1");
+    leagues.updatePhaseAndResetWeek(league.id(), LeaguePhase.HIRING_HEAD_COACH);
+    var pool =
+        pools.insert(league.id(), LeaguePhase.HIRING_HEAD_COACH, CandidatePoolType.HEAD_COACH);
+    // Top candidate: highest scouted overall; ranking should pick this regardless of hidden rating.
+    var topScouted = insertCandidate(pool.id(), "{\"overall\": 55.00}", "{\"overall\": 95.00}");
+    var strongHidden = insertCandidate(pool.id(), "{\"overall\": 80.00}", "{\"overall\": 60.00}");
+    // Fill out enough candidates so every franchise gets hired without running out.
+    seedFillerCandidates(pool.id(), 20, 40.00);
+
+    var franchiseIds = teamLookup.franchiseIdsForLeague(league.id());
+    var targetFranchise = franchiseIds.getFirst();
+    markSearching(league.id(), targetFranchise, LeaguePhase.HIRING_HEAD_COACH);
+
+    autofill.autofill(league.id(), LeaguePhase.HIRING_HEAD_COACH, 3);
+
+    // The first-iterated franchise gets the highest scouted pick. Ranking is by SCOUTED only.
+    assertThat(candidates.findById(topScouted.id()).orElseThrow().hiredByFranchiseId())
+        .contains(targetFranchise);
+    assertThat(candidates.findById(strongHidden.id()).orElseThrow().hiredByFranchiseId())
+        .isPresent()
+        .hasValueSatisfying(id -> assertThat(id).isNotEqualTo(targetFranchise));
+    var state =
+        hiringStates
+            .find(league.id(), targetFranchise, LeaguePhase.HIRING_HEAD_COACH)
+            .orElseThrow();
+    assertThat(state.step()).isEqualTo(HiringStep.HIRED);
+    assertThat(staff.findAllForFranchise(league.id(), targetFranchise))
+        .extracting(FranchiseStaffMember::role, FranchiseStaffMember::candidateId)
+        .containsExactly(
+            org.assertj.core.api.Assertions.tuple(StaffRole.HEAD_COACH, topScouted.id()));
+    assertThat(offers.findAllForCandidate(topScouted.id()))
+        .extracting(CandidateOffer::status)
+        .containsExactly(OfferStatus.ACCEPTED);
+  }
+
+  @Test
+  void autofill_skipsFranchisesAlreadyHired() {
+    var league = createLeagueFor("sub-1");
+    leagues.updatePhaseAndResetWeek(league.id(), LeaguePhase.HIRING_HEAD_COACH);
+    var pool =
+        pools.insert(league.id(), LeaguePhase.HIRING_HEAD_COACH, CandidatePoolType.HEAD_COACH);
+    insertCandidate(pool.id(), "{\"overall\": 70.00}", "{\"overall\": 70.00}");
+
+    // Seed additional candidates so every pending franchise in the league gets filled.
+    seedFillerCandidates(pool.id(), 20, 60.00);
+
+    var franchiseIds = teamLookup.franchiseIdsForLeague(league.id());
+    var alreadyHired = franchiseIds.get(0);
+    var pending = franchiseIds.get(1);
+    hiringStates.upsert(
+        new FranchiseHiringState(
+            0L,
+            league.id(),
+            alreadyHired,
+            LeaguePhase.HIRING_HEAD_COACH,
+            HiringStep.HIRED,
+            List.of(),
+            List.of()));
+    markSearching(league.id(), pending, LeaguePhase.HIRING_HEAD_COACH);
+
+    autofill.autofill(league.id(), LeaguePhase.HIRING_HEAD_COACH, 3);
+
+    assertThat(staff.findAllForFranchise(league.id(), alreadyHired)).isEmpty();
+    assertThat(staff.findAllForFranchise(league.id(), pending))
+        .extracting(FranchiseStaffMember::role)
+        .containsExactly(StaffRole.HEAD_COACH);
+  }
+
+  @Test
+  void autofill_neverReadsHiddenAttrs_picksByScoutedOnly() {
+    // Regression guard: two candidates with inverted hidden vs scouted ratings — autofill must
+    // pick the one with the higher scouted rating, proving hidden attrs never leak into the
+    // decision. Aligns with the hidden-info guarantee in docs/technical/league-phases.md.
+    var league = createLeagueFor("sub-1");
+    leagues.updatePhaseAndResetWeek(league.id(), LeaguePhase.HIRING_HEAD_COACH);
+    var pool =
+        pools.insert(league.id(), LeaguePhase.HIRING_HEAD_COACH, CandidatePoolType.HEAD_COACH);
+    var hiddenGem = insertCandidate(pool.id(), "{\"overall\": 95.00}", "{\"overall\": 40.00}");
+    var publicFavorite = insertCandidate(pool.id(), "{\"overall\": 55.00}", "{\"overall\": 85.00}");
+    // Fillers keep the hidden gem out of the top-1 by-scouted pick across other franchises so the
+    // first-iterated franchise is the only one that could conceivably pick it up.
+    seedFillerCandidates(pool.id(), 20, 70.00);
+
+    var franchiseIds = teamLookup.franchiseIdsForLeague(league.id());
+    var targetFranchise = franchiseIds.getFirst();
+    markSearching(league.id(), targetFranchise, LeaguePhase.HIRING_HEAD_COACH);
+
+    autofill.autofill(league.id(), LeaguePhase.HIRING_HEAD_COACH, 3);
+
+    assertThat(candidates.findById(publicFavorite.id()).orElseThrow().hiredByFranchiseId())
+        .contains(targetFranchise);
+    // Hidden gem's scouted is below the filler band, so it stays unhired for this run — the
+    // key invariant is that the target (highest scouted) franchise never received it.
+    var hiddenGemOwner = candidates.findById(hiddenGem.id()).orElseThrow().hiredByFranchiseId();
+    assertThat(hiddenGemOwner).isNotEqualTo(Optional.of(targetFranchise));
+  }
+
+  @Test
+  void autofill_multipleFranchises_getsDistinctCandidates() {
+    var league = createLeagueFor("sub-1");
+    leagues.updatePhaseAndResetWeek(league.id(), LeaguePhase.HIRING_HEAD_COACH);
+    var pool =
+        pools.insert(league.id(), LeaguePhase.HIRING_HEAD_COACH, CandidatePoolType.HEAD_COACH);
+    var topCandidate = insertCandidate(pool.id(), "{\"overall\": 80.00}", "{\"overall\": 85.00}");
+    var secondCandidate =
+        insertCandidate(pool.id(), "{\"overall\": 70.00}", "{\"overall\": 75.00}");
+    seedFillerCandidates(pool.id(), 20, 50.00);
+
+    var franchiseIds = teamLookup.franchiseIdsForLeague(league.id());
+    for (var franchiseId : franchiseIds) {
+      markSearching(league.id(), franchiseId, LeaguePhase.HIRING_HEAD_COACH);
+    }
+
+    autofill.autofill(league.id(), LeaguePhase.HIRING_HEAD_COACH, 3);
+
+    var firstHire = candidates.findById(topCandidate.id()).orElseThrow().hiredByFranchiseId();
+    var secondHire = candidates.findById(secondCandidate.id()).orElseThrow().hiredByFranchiseId();
+    assertThat(firstHire).isPresent();
+    assertThat(secondHire).isPresent();
+    assertThat(firstHire.get()).isNotEqualTo(secondHire.get());
+  }
+
+  private void seedFillerCandidates(long poolId, int count, double scoutedOverall) {
+    for (int i = 0; i < count; i++) {
+      insertCandidate(
+          poolId,
+          "{\"overall\": 50.00}",
+          "{\"overall\": " + String.format(java.util.Locale.ROOT, "%.2f", scoutedOverall) + "}");
+    }
+  }
+
+  private Candidate insertCandidate(long poolId, String hiddenAttrs, String scoutedAttrs) {
+    var saved =
+        candidates.insert(
+            new NewCandidate(
+                poolId,
+                CandidateKind.HEAD_COACH,
+                SpecialtyPosition.QB,
+                CandidateArchetype.OFFENSIVE_PLAY_CALLER,
+                43,
+                18,
+                "{\"HC\":0}",
+                hiddenAttrs,
+                scoutedAttrs,
+                Optional.empty()));
+    preferences.insert(CandidateTestData.preferencesFor(saved.id()));
+    return saved;
+  }
+
+  private void markSearching(long leagueId, long franchiseId, LeaguePhase phase) {
+    hiringStates.upsert(
+        new FranchiseHiringState(
+            0L, leagueId, franchiseId, phase, HiringStep.SEARCHING, List.of(), List.of()));
+  }
+
+  private League createLeagueFor(String ownerSubject) {
+    var franchiseId = new JooqFranchiseRepository(dsl).listAll().getFirst().id();
+    var result = createLeague.create(ownerSubject, "Dynasty-" + ownerSubject, franchiseId);
+    return ((CreateLeagueResult.Created) result).league();
+  }
+}

--- a/src/test/java/app/zoneblitz/league/CpuHiringStrategyTests.java
+++ b/src/test/java/app/zoneblitz/league/CpuHiringStrategyTests.java
@@ -1,0 +1,286 @@
+package app.zoneblitz.league;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import app.zoneblitz.support.PostgresTestcontainer;
+import java.math.BigDecimal;
+import java.util.List;
+import org.jooq.DSLContext;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.jooq.test.autoconfigure.JooqTest;
+import org.springframework.context.annotation.Import;
+
+@JooqTest
+@Import(PostgresTestcontainer.class)
+class CpuHiringStrategyTests {
+
+  @Autowired DSLContext dsl;
+
+  private LeagueRepository leagues;
+  private JooqCandidatePoolRepository pools;
+  private JooqCandidateRepository candidates;
+  private JooqCandidatePreferencesRepository preferences;
+  private JooqCandidateOfferRepository offers;
+  private JooqFranchiseHiringStateRepository hiringStates;
+  private JooqFranchiseInterviewRepository interviews;
+  private JooqFranchiseStaffRepository staff;
+  private FranchiseProfiles profiles;
+  private TeamLookup teamLookup;
+  private CreateLeague createLeague;
+  private HiringHeadCoachTransitionHandler entryHandler;
+  private CandidateRandomSources rngs;
+  private CpuHiringStrategy strategy;
+  private PreferenceScoringOfferResolver resolver;
+
+  @BeforeEach
+  void setUp() {
+    leagues = new JooqLeagueRepository(dsl);
+    var franchiseRepo = new JooqFranchiseRepository(dsl);
+    var teamRepo = new JooqTeamRepository(dsl);
+    teamLookup = new JooqTeamLookup(dsl);
+    pools = new JooqCandidatePoolRepository(dsl);
+    candidates = new JooqCandidateRepository(dsl);
+    preferences = new JooqCandidatePreferencesRepository(dsl);
+    offers = new JooqCandidateOfferRepository(dsl);
+    hiringStates = new JooqFranchiseHiringStateRepository(dsl);
+    interviews = new JooqFranchiseInterviewRepository(dsl);
+    staff = new JooqFranchiseStaffRepository(dsl);
+    profiles = new CityFranchiseProfiles(franchiseRepo);
+    rngs = (leagueId, phase) -> new FakeRandomSource(leagueId * 31 + phase.ordinal());
+    createLeague = new CreateLeagueUseCase(leagues, franchiseRepo, teamRepo);
+    entryHandler =
+        new HiringHeadCoachTransitionHandler(
+            leagues,
+            teamLookup,
+            pools,
+            candidates,
+            preferences,
+            hiringStates,
+            new HeadCoachGenerator(),
+            rngs);
+    strategy =
+        new CpuHiringStrategy(
+            LeaguePhase.HIRING_HEAD_COACH,
+            CandidatePoolType.HEAD_COACH,
+            pools,
+            candidates,
+            preferences,
+            offers,
+            hiringStates,
+            interviews,
+            rngs);
+    resolver =
+        new PreferenceScoringOfferResolver(
+            offers, candidates, pools, preferences, profiles, hiringStates, staff, rngs);
+  }
+
+  @Test
+  void execute_week1_buildsShortlistAndRunsInterviews() {
+    var ctx = seedLeague("sub-1");
+    var cpuFranchiseId = ctx.cpuFranchises().getFirst();
+
+    strategy.execute(ctx.leagueId(), cpuFranchiseId, 1);
+
+    var state =
+        hiringStates
+            .find(ctx.leagueId(), cpuFranchiseId, LeaguePhase.HIRING_HEAD_COACH)
+            .orElseThrow();
+    assertThat(state.shortlist()).hasSize(CpuHiringStrategy.SHORTLIST_SIZE);
+    assertThat(state.step()).isEqualTo(HiringStep.SEARCHING);
+
+    var history =
+        interviews.findAllFor(ctx.leagueId(), cpuFranchiseId, LeaguePhase.HIRING_HEAD_COACH);
+    assertThat(history).hasSize(StartInterview.DEFAULT_WEEKLY_CAPACITY);
+    assertThat(history).allSatisfy(h -> assertThat(state.shortlist()).contains(h.candidateId()));
+  }
+
+  @Test
+  void execute_submitsExactlyOneActiveOfferOnShortlistedCandidate() {
+    var ctx = seedLeague("sub-1");
+    var cpuFranchiseId = ctx.cpuFranchises().getFirst();
+
+    strategy.execute(ctx.leagueId(), cpuFranchiseId, 1);
+
+    var active = offers.findActiveForFranchise(cpuFranchiseId);
+    assertThat(active).hasSize(1);
+    var state =
+        hiringStates
+            .find(ctx.leagueId(), cpuFranchiseId, LeaguePhase.HIRING_HEAD_COACH)
+            .orElseThrow();
+    assertThat(state.shortlist()).contains(active.getFirst().candidateId());
+  }
+
+  @Test
+  void execute_nextWeek_doesNotSubmitSecondOfferWhilePriorIsActive() {
+    var ctx = seedLeague("sub-1");
+    var cpuFranchiseId = ctx.cpuFranchises().getFirst();
+    strategy.execute(ctx.leagueId(), cpuFranchiseId, 1);
+    var week1Offers = offers.findActiveForFranchise(cpuFranchiseId);
+
+    strategy.execute(ctx.leagueId(), cpuFranchiseId, 2);
+
+    var week2Offers = offers.findActiveForFranchise(cpuFranchiseId);
+    assertThat(week2Offers)
+        .describedAs("still one active offer; no duplicate submitted")
+        .hasSize(1)
+        .extracting(CandidateOffer::id)
+        .containsExactlyElementsOf(week1Offers.stream().map(CandidateOffer::id).toList());
+  }
+
+  @Test
+  void execute_advancesThroughStepsEachWeek_interviewCountGrows() {
+    var ctx = seedLeague("sub-1");
+    var cpuFranchiseId = ctx.cpuFranchises().getFirst();
+
+    strategy.execute(ctx.leagueId(), cpuFranchiseId, 1);
+    var week1Count =
+        interviews.findAllFor(ctx.leagueId(), cpuFranchiseId, LeaguePhase.HIRING_HEAD_COACH).size();
+    strategy.execute(ctx.leagueId(), cpuFranchiseId, 2);
+    var week2Count =
+        interviews.findAllFor(ctx.leagueId(), cpuFranchiseId, LeaguePhase.HIRING_HEAD_COACH).size();
+
+    assertThat(week1Count).isEqualTo(StartInterview.DEFAULT_WEEKLY_CAPACITY);
+    assertThat(week2Count).isGreaterThan(week1Count);
+  }
+
+  @Test
+  void execute_whenAlreadyHired_skipsAllWork() {
+    var ctx = seedLeague("sub-1");
+    var cpuFranchiseId = ctx.cpuFranchises().getFirst();
+    hiringStates.upsert(
+        new FranchiseHiringState(
+            0L,
+            ctx.leagueId(),
+            cpuFranchiseId,
+            LeaguePhase.HIRING_HEAD_COACH,
+            HiringStep.HIRED,
+            List.of(),
+            List.of()));
+
+    strategy.execute(ctx.leagueId(), cpuFranchiseId, 1);
+
+    assertThat(offers.findActiveForFranchise(cpuFranchiseId)).isEmpty();
+    assertThat(interviews.findAllFor(ctx.leagueId(), cpuFranchiseId, LeaguePhase.HIRING_HEAD_COACH))
+        .isEmpty();
+  }
+
+  @Test
+  void execute_isDeterministicAcrossRuns_givenSameSeed() {
+    var ctxA = seedLeague("sub-A");
+    var cpuA = ctxA.cpuFranchises().getFirst();
+    strategy.execute(ctxA.leagueId(), cpuA, 1);
+    var stateA =
+        hiringStates.find(ctxA.leagueId(), cpuA, LeaguePhase.HIRING_HEAD_COACH).orElseThrow();
+    var offersA = offers.findActiveForFranchise(cpuA);
+
+    var ctxB = seedLeague("sub-B");
+    var cpuB = ctxB.cpuFranchises().getFirst();
+    strategy.execute(ctxB.leagueId(), cpuB, 1);
+    var stateB =
+        hiringStates.find(ctxB.leagueId(), cpuB, LeaguePhase.HIRING_HEAD_COACH).orElseThrow();
+    var offersB = offers.findActiveForFranchise(cpuB);
+
+    assertThat(stateB.shortlist().size()).isEqualTo(stateA.shortlist().size());
+    assertThat(offersB).hasSameSizeAs(offersA);
+  }
+
+  @Test
+  void execute_cpuOutbidsUserOnTopCandidate_winsResolution() {
+    var ctx = seedLeague("sub-1");
+    var cpuFranchiseId = ctx.cpuFranchises().getFirst();
+
+    // Precompute the candidate CPU will pick (top scouted overall) so user can pre-empt with a
+    // deliberately weak offer on the same candidate.
+    var topCandidate = topCandidateByScouted(ctx.leagueId());
+    var userFranchiseId = ctx.userFranchiseId();
+    // Initialize user's hiring state so resolver can flip loser back to SEARCHING cleanly.
+    hiringStates.upsert(
+        new FranchiseHiringState(
+            0L,
+            ctx.leagueId(),
+            userFranchiseId,
+            LeaguePhase.HIRING_HEAD_COACH,
+            HiringStep.SEARCHING,
+            List.of(),
+            List.of()));
+    offers.insertActive(topCandidate.id(), userFranchiseId, OfferTermsJson.toJson(weakOffer()), 1);
+
+    strategy.execute(ctx.leagueId(), cpuFranchiseId, 1);
+    resolver.resolve(ctx.leagueId(), LeaguePhase.HIRING_HEAD_COACH, 1);
+
+    assertThat(candidates.findById(topCandidate.id()).orElseThrow().hiredByFranchiseId())
+        .contains(cpuFranchiseId);
+    var cpuState =
+        hiringStates
+            .find(ctx.leagueId(), cpuFranchiseId, LeaguePhase.HIRING_HEAD_COACH)
+            .orElseThrow();
+    assertThat(cpuState.step()).isEqualTo(HiringStep.HIRED);
+  }
+
+  @Test
+  void execute_snipesShortlistedCandidateWhenUserHasNotOffered() {
+    var ctx = seedLeague("sub-1");
+    var cpuFranchiseId = ctx.cpuFranchises().getFirst();
+    var topCandidate = topCandidateByScouted(ctx.leagueId());
+
+    // User shortlists the candidate but submits no offer.
+    hiringStates.upsert(
+        new FranchiseHiringState(
+            0L,
+            ctx.leagueId(),
+            ctx.userFranchiseId(),
+            LeaguePhase.HIRING_HEAD_COACH,
+            HiringStep.SEARCHING,
+            List.of(topCandidate.id()),
+            List.of()));
+
+    strategy.execute(ctx.leagueId(), cpuFranchiseId, 1);
+    resolver.resolve(ctx.leagueId(), LeaguePhase.HIRING_HEAD_COACH, 1);
+
+    assertThat(candidates.findById(topCandidate.id()).orElseThrow().hiredByFranchiseId())
+        .contains(cpuFranchiseId);
+  }
+
+  private Candidate topCandidateByScouted(long leagueId) {
+    var pool =
+        pools
+            .findByLeaguePhaseAndType(
+                leagueId, LeaguePhase.HIRING_HEAD_COACH, CandidatePoolType.HEAD_COACH)
+            .orElseThrow();
+    return candidates.findAllByPoolId(pool.id()).stream()
+        .filter(c -> c.hiredByFranchiseId().isEmpty())
+        .max(java.util.Comparator.comparingDouble(c -> extractScouted(c.scoutedAttrs())))
+        .orElseThrow();
+  }
+
+  private static double extractScouted(String json) {
+    var m =
+        java.util.regex.Pattern.compile("\"overall\"\\s*:\\s*(-?[0-9]+(?:\\.[0-9]+)?)")
+            .matcher(json);
+    return m.find() ? Double.parseDouble(m.group(1)) : 0.0;
+  }
+
+  private static OfferTerms weakOffer() {
+    return new OfferTerms(
+        new BigDecimal("100000.00"),
+        1,
+        new BigDecimal("0.01"),
+        RoleScope.LOW,
+        StaffContinuity.KEEP_EXISTING);
+  }
+
+  private Ctx seedLeague(String subject) {
+    var franchises = new JooqFranchiseRepository(dsl).listAll();
+    var userFranchiseId = franchises.getFirst().id();
+    var result = createLeague.create(subject, "Dynasty-" + subject, userFranchiseId);
+    var league = ((CreateLeagueResult.Created) result).league();
+    leagues.updatePhaseAndResetWeek(league.id(), LeaguePhase.HIRING_HEAD_COACH);
+    entryHandler.onEntry(league.id());
+    var cpuFranchises = teamLookup.cpuFranchiseIdsForLeague(league.id());
+    return new Ctx(league.id(), userFranchiseId, cpuFranchises);
+  }
+
+  private record Ctx(long leagueId, long userFranchiseId, List<Long> cpuFranchises) {}
+}

--- a/src/test/java/app/zoneblitz/league/DirectorOfScoutingGeneratorTests.java
+++ b/src/test/java/app/zoneblitz/league/DirectorOfScoutingGeneratorTests.java
@@ -1,0 +1,177 @@
+package app.zoneblitz.league;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.math.BigDecimal;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class DirectorOfScoutingGeneratorTests {
+
+  private CandidateGenerator generator;
+
+  @BeforeEach
+  void setUp() {
+    generator = new DirectorOfScoutingGenerator();
+  }
+
+  @Test
+  void generate_whenPoolSizeIsZeroOrNegative_throws() {
+    var rng = new FakeRandomSource(42L);
+    assertThatThrownBy(() -> generator.generate(0, rng))
+        .isInstanceOf(IllegalArgumentException.class);
+    assertThatThrownBy(() -> generator.generate(-1, rng))
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
+  void generate_producesRequestedPoolSizeWithAllRequiredFields() {
+    var rng = new FakeRandomSource(7L);
+
+    var candidates = generator.generate(20, rng);
+
+    assertThat(candidates).hasSize(20);
+    for (var generated : candidates) {
+      var candidate = generated.candidate();
+      assertThat(candidate.kind()).isEqualTo(CandidateKind.DIRECTOR_OF_SCOUTING);
+      assertThat(candidate.archetype())
+          .isIn(
+              CandidateArchetype.COLLEGE_EVALUATOR,
+              CandidateArchetype.PRO_EVALUATOR,
+              CandidateArchetype.GENERALIST);
+      assertThat(candidate.age()).isBetween(32, 68);
+      assertThat(candidate.totalExperienceYears()).isGreaterThanOrEqualTo(0);
+      assertThat(candidate.experienceByRole()).contains("\"DOS\"", "\"SCOUT\"", "\"AREA_SCOUT\"");
+      assertThat(candidate.hiddenAttrs()).contains("overall");
+      assertThat(candidate.scoutedAttrs()).contains("overall");
+      assertThat(candidate.scoutBranch()).isEmpty();
+
+      var prefs = generated.preferences();
+      assertThat(prefs.compensationTarget()).isGreaterThan(BigDecimal.ZERO);
+      assertThat(prefs.contractLengthTarget()).isGreaterThan(0);
+      assertThat(prefs.guaranteedMoneyTarget()).isBetween(BigDecimal.ZERO, BigDecimal.ONE);
+
+      var weightSum =
+          prefs
+              .compensationWeight()
+              .add(prefs.contractLengthWeight())
+              .add(prefs.guaranteedMoneyWeight())
+              .add(prefs.marketSizeWeight())
+              .add(prefs.geographyWeight())
+              .add(prefs.climateWeight())
+              .add(prefs.franchisePrestigeWeight())
+              .add(prefs.competitiveWindowWeight())
+              .add(prefs.roleScopeWeight())
+              .add(prefs.staffContinuityWeight())
+              .add(prefs.schemeAlignmentWeight())
+              .add(prefs.ownerStabilityWeight())
+              .add(prefs.facilityQualityWeight());
+      assertThat(weightSum.doubleValue()).isBetween(0.95, 1.05);
+    }
+  }
+
+  @Test
+  void generate_isDeterministicForSameSeed() {
+    var candidatesA = generator.generate(50, new FakeRandomSource(1234L));
+    var candidatesB = generator.generate(50, new FakeRandomSource(1234L));
+
+    assertThat(candidatesA).isEqualTo(candidatesB);
+  }
+
+  @Test
+  void generate_salaryDistributionHonorsScoutMarketBands() {
+    var salaries =
+        generator.generate(2_000, new FakeRandomSource(99L)).stream()
+            .map(c -> c.preferences().compensationTarget().doubleValue())
+            .sorted()
+            .toList();
+
+    var p10 = percentile(salaries, 0.10);
+    var p50 = percentile(salaries, 0.50);
+    var p90 = percentile(salaries, 0.90);
+
+    // scout-market.json DIRECTOR salary bands: p10 300K, p50 475K, p90 800K, ceiling 1.2M.
+    // The generator overlays age/experience/archetype multipliers, so tolerance is loose. Ordering
+    // must hold and each quantile must fall within a reasonable window of the band value.
+    assertThat(p10).isBetween(150_000.0, 500_000.0);
+    assertThat(p50).isBetween(300_000.0, 700_000.0);
+    assertThat(p90).isBetween(500_000.0, 1_400_000.0);
+    assertThat(p10).isLessThan(p50);
+    assertThat(p50).isLessThan(p90);
+  }
+
+  @Test
+  void generate_generalistShareMatchesBandSplit() {
+    var sample = generator.generate(3_000, new FakeRandomSource(17L));
+
+    var generalists =
+        sample.stream()
+                .filter(c -> c.candidate().archetype() == CandidateArchetype.GENERALIST)
+                .count()
+            / (double) sample.size();
+
+    // Band: position_focus_split.generalist = 0.70 for DIRECTOR tier.
+    assertThat(generalists).isBetween(0.62, 0.78);
+  }
+
+  @Test
+  void generate_trueRatingIsStatisticallyIndependentOfPrice() {
+    var sample = generator.generate(2_000, new FakeRandomSource(5150L));
+
+    var ratings = sample.stream().map(c -> parseOverall(c.candidate().hiddenAttrs())).toList();
+    var prices =
+        sample.stream().map(c -> c.preferences().compensationTarget().doubleValue()).toList();
+
+    var correlation = pearsonCorrelation(ratings, prices);
+    assertThat(Math.abs(correlation)).isLessThan(0.12);
+  }
+
+  @Test
+  void generate_contractLengthsFallWithinBandRange() {
+    var lengths =
+        generator.generate(500, new FakeRandomSource(42L)).stream()
+            .mapToInt(c -> c.preferences().contractLengthTarget())
+            .toArray();
+
+    // scout-market.json DIRECTOR contract_length_years: p10 3, p90 5.
+    for (var length : lengths) {
+      assertThat(length).isBetween(2, 7);
+    }
+  }
+
+  private static double parseOverall(String attrsJson) {
+    var idx = attrsJson.indexOf(':');
+    var end = attrsJson.indexOf('}', idx);
+    return Double.parseDouble(attrsJson.substring(idx + 1, end).trim());
+  }
+
+  private static double percentile(List<Double> sortedValues, double p) {
+    var idx = (int) Math.floor(p * (sortedValues.size() - 1));
+    return sortedValues.get(idx);
+  }
+
+  private static double pearsonCorrelation(List<Double> xs, List<Double> ys) {
+    var n = xs.size();
+    var sumX = 0.0;
+    var sumY = 0.0;
+    for (var i = 0; i < n; i++) {
+      sumX += xs.get(i);
+      sumY += ys.get(i);
+    }
+    var meanX = sumX / n;
+    var meanY = sumY / n;
+    var covariance = 0.0;
+    var varX = 0.0;
+    var varY = 0.0;
+    for (var i = 0; i < n; i++) {
+      var dx = xs.get(i) - meanX;
+      var dy = ys.get(i) - meanY;
+      covariance += dx * dy;
+      varX += dx * dx;
+      varY += dy * dy;
+    }
+    return covariance / Math.sqrt(varX * varY);
+  }
+}

--- a/src/test/java/app/zoneblitz/league/HiringAssemblingStaffTransitionHandlerTests.java
+++ b/src/test/java/app/zoneblitz/league/HiringAssemblingStaffTransitionHandlerTests.java
@@ -1,0 +1,248 @@
+package app.zoneblitz.league;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import app.zoneblitz.gamesimulator.rng.RandomSource;
+import app.zoneblitz.support.PostgresTestcontainer;
+import java.util.Optional;
+import org.jooq.DSLContext;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.jooq.test.autoconfigure.JooqTest;
+import org.springframework.context.annotation.Import;
+
+@JooqTest
+@Import(PostgresTestcontainer.class)
+class HiringAssemblingStaffTransitionHandlerTests {
+
+  @Autowired DSLContext dsl;
+
+  private LeagueRepository leagues;
+  private CreateLeague createLeague;
+  private CandidatePoolRepository pools;
+  private CandidateRepository candidates;
+  private CandidatePreferencesRepository preferences;
+  private FranchiseStaffRepository staffRepo;
+  private TeamLookup teams;
+  private HiringAssemblingStaffTransitionHandler handler;
+
+  @BeforeEach
+  void setUp() {
+    leagues = new JooqLeagueRepository(dsl);
+    var franchises = new JooqFranchiseRepository(dsl);
+    var teamRepo = new JooqTeamRepository(dsl);
+    teams = new JooqTeamLookup(dsl);
+    pools = new JooqCandidatePoolRepository(dsl);
+    candidates = new JooqCandidateRepository(dsl);
+    preferences = new JooqCandidatePreferencesRepository(dsl);
+    staffRepo = new JooqFranchiseStaffRepository(dsl);
+    createLeague = new CreateLeagueUseCase(leagues, franchises, teamRepo);
+    handler =
+        new HiringAssemblingStaffTransitionHandler(
+            teams,
+            pools,
+            candidates,
+            preferences,
+            staffRepo,
+            new CoordinatorGenerator(),
+            new PositionCoachGenerator(),
+            new ScoutCandidateGenerator(),
+            new SeededRandomSources());
+  }
+
+  @Test
+  void phase_isAssemblingStaff() {
+    assertThat(handler.phase()).isEqualTo(LeaguePhase.ASSEMBLING_STAFF);
+  }
+
+  @Test
+  void onEntry_everyFranchiseHasTwelveCoachesAndEightScouts() {
+    var league = createLeagueFor("sub-1");
+    seedHcAndDosForEveryFranchise(league.id());
+
+    handler.onEntry(league.id());
+
+    for (var franchiseId : teams.franchiseIdsForLeague(league.id())) {
+      var hires = staffRepo.findAllForFranchise(league.id(), franchiseId);
+      var coachCount =
+          hires.stream()
+              .filter(
+                  h ->
+                      h.role() != StaffRole.COLLEGE_SCOUT
+                          && h.role() != StaffRole.PRO_SCOUT
+                          && h.role() != StaffRole.DIRECTOR_OF_SCOUTING)
+              .count();
+      var scoutCount =
+          hires.stream()
+              .filter(h -> h.role() == StaffRole.COLLEGE_SCOUT || h.role() == StaffRole.PRO_SCOUT)
+              .count();
+      // coaches: HC (already seeded) + 12 subordinates = 13
+      assertThat(coachCount).as("franchise %s coaches", franchiseId).isEqualTo(13L);
+      assertThat(scoutCount).as("franchise %s scouts", franchiseId).isEqualTo(8L);
+    }
+  }
+
+  @Test
+  void onEntry_coversEveryNonScoutRole() {
+    var league = createLeagueFor("sub-1");
+    seedHcAndDosForEveryFranchise(league.id());
+
+    handler.onEntry(league.id());
+
+    for (var franchiseId : teams.franchiseIdsForLeague(league.id())) {
+      var roles =
+          staffRepo.findAllForFranchise(league.id(), franchiseId).stream()
+              .map(FranchiseStaffMember::role)
+              .toList();
+      assertThat(roles)
+          .contains(
+              StaffRole.HEAD_COACH,
+              StaffRole.OFFENSIVE_COORDINATOR,
+              StaffRole.DEFENSIVE_COORDINATOR,
+              StaffRole.SPECIAL_TEAMS_COORDINATOR,
+              StaffRole.QB_COACH,
+              StaffRole.RB_COACH,
+              StaffRole.WR_COACH,
+              StaffRole.TE_COACH,
+              StaffRole.OL_COACH,
+              StaffRole.DL_COACH,
+              StaffRole.EDGE_COACH,
+              StaffRole.LB_COACH,
+              StaffRole.DB_COACH,
+              StaffRole.DIRECTOR_OF_SCOUTING);
+    }
+  }
+
+  @Test
+  void onEntry_scoutBranchIsSetForScoutsAndUnsetForCoaches() {
+    var league = createLeagueFor("sub-1");
+    seedHcAndDosForEveryFranchise(league.id());
+
+    handler.onEntry(league.id());
+
+    var franchiseId = teams.franchiseIdsForLeague(league.id()).getFirst();
+    var hires = staffRepo.findAllForFranchise(league.id(), franchiseId);
+
+    var collegeScouts = hires.stream().filter(h -> h.role() == StaffRole.COLLEGE_SCOUT).toList();
+    var proScouts = hires.stream().filter(h -> h.role() == StaffRole.PRO_SCOUT).toList();
+    assertThat(collegeScouts).hasSize(5);
+    assertThat(proScouts).hasSize(3);
+    assertThat(collegeScouts)
+        .allSatisfy(h -> assertThat(h.scoutBranch()).hasValue(ScoutBranch.COLLEGE));
+    assertThat(proScouts).allSatisfy(h -> assertThat(h.scoutBranch()).hasValue(ScoutBranch.PRO));
+    assertThat(
+            hires.stream()
+                .filter(
+                    h -> h.role() != StaffRole.COLLEGE_SCOUT && h.role() != StaffRole.PRO_SCOUT))
+        .allSatisfy(h -> assertThat(h.scoutBranch()).isEmpty());
+  }
+
+  @Test
+  void onEntry_candidatesAreMarkedHiredAndInCorrectPools() {
+    var league = createLeagueFor("sub-1");
+    seedHcAndDosForEveryFranchise(league.id());
+
+    handler.onEntry(league.id());
+
+    var coordinatorPool =
+        pools
+            .findByLeaguePhaseAndType(
+                league.id(), LeaguePhase.ASSEMBLING_STAFF, CandidatePoolType.COORDINATOR)
+            .orElseThrow();
+    var positionCoachPool =
+        pools
+            .findByLeaguePhaseAndType(
+                league.id(), LeaguePhase.ASSEMBLING_STAFF, CandidatePoolType.POSITION_COACH)
+            .orElseThrow();
+    var scoutPool =
+        pools
+            .findByLeaguePhaseAndType(
+                league.id(), LeaguePhase.ASSEMBLING_STAFF, CandidatePoolType.SCOUT)
+            .orElseThrow();
+
+    var franchiseCount = teams.franchiseIdsForLeague(league.id()).size();
+    assertThat(candidates.findAllByPoolId(coordinatorPool.id())).hasSize(franchiseCount * 3);
+    assertThat(candidates.findAllByPoolId(positionCoachPool.id())).hasSize(franchiseCount * 9);
+    assertThat(candidates.findAllByPoolId(scoutPool.id())).hasSize(franchiseCount * 8);
+
+    assertThat(candidates.findAllByPoolId(coordinatorPool.id()))
+        .allSatisfy(c -> assertThat(c.hiredByFranchiseId()).isPresent());
+  }
+
+  @Test
+  void onEntry_isIdempotentPerFranchise() {
+    var league = createLeagueFor("sub-1");
+    seedHcAndDosForEveryFranchise(league.id());
+
+    handler.onEntry(league.id());
+    var firstFranchiseId = teams.franchiseIdsForLeague(league.id()).getFirst();
+    var firstRunSize = staffRepo.findAllForFranchise(league.id(), firstFranchiseId).size();
+
+    handler.onEntry(league.id());
+
+    var secondRunSize = staffRepo.findAllForFranchise(league.id(), firstFranchiseId).size();
+    assertThat(secondRunSize).isEqualTo(firstRunSize);
+  }
+
+  private League createLeagueFor(String ownerSubject) {
+    var franchiseId = new JooqFranchiseRepository(dsl).listAll().getFirst().id();
+    var result = createLeague.create(ownerSubject, "Dynasty", franchiseId);
+    return ((CreateLeagueResult.Created) result).league();
+  }
+
+  private void seedHcAndDosForEveryFranchise(long leagueId) {
+    var hcPool =
+        pools.insert(leagueId, LeaguePhase.HIRING_HEAD_COACH, CandidatePoolType.HEAD_COACH);
+    var dosPool =
+        pools.insert(
+            leagueId,
+            LeaguePhase.HIRING_DIRECTOR_OF_SCOUTING,
+            CandidatePoolType.DIRECTOR_OF_SCOUTING);
+    for (var franchiseId : teams.franchiseIdsForLeague(leagueId)) {
+      var hc = candidates.insert(CandidateTestData.newHeadCoach(hcPool.id()));
+      preferences.insert(CandidateTestData.preferencesFor(hc.id()));
+      candidates.markHired(hc.id(), franchiseId);
+      staffRepo.insert(
+          new NewFranchiseStaffMember(
+              leagueId,
+              franchiseId,
+              hc.id(),
+              StaffRole.HEAD_COACH,
+              Optional.empty(),
+              LeaguePhase.HIRING_HEAD_COACH,
+              1));
+      var dos =
+          candidates.insert(
+              new NewCandidate(
+                  dosPool.id(),
+                  CandidateKind.DIRECTOR_OF_SCOUTING,
+                  SpecialtyPosition.CB,
+                  CandidateArchetype.GENERALIST,
+                  45,
+                  15,
+                  "{\"DOS\":2,\"SCOUT\":10}",
+                  "{\"overall\": 70.0}",
+                  "{\"overall\": 68.0}",
+                  Optional.empty()));
+      preferences.insert(CandidateTestData.preferencesFor(dos.id()));
+      candidates.markHired(dos.id(), franchiseId);
+      staffRepo.insert(
+          new NewFranchiseStaffMember(
+              leagueId,
+              franchiseId,
+              dos.id(),
+              StaffRole.DIRECTOR_OF_SCOUTING,
+              Optional.empty(),
+              LeaguePhase.HIRING_DIRECTOR_OF_SCOUTING,
+              1));
+    }
+  }
+
+  private static final class SeededRandomSources implements CandidateRandomSources {
+    @Override
+    public RandomSource forLeaguePhase(long leagueId, LeaguePhase phase) {
+      return new FakeRandomSource(leagueId * 131 + phase.ordinal());
+    }
+  }
+}

--- a/src/test/java/app/zoneblitz/league/HiringDirectorOfScoutingControllerTests.java
+++ b/src/test/java/app/zoneblitz/league/HiringDirectorOfScoutingControllerTests.java
@@ -1,0 +1,96 @@
+package app.zoneblitz.league;
+
+import static org.mockito.BDDMockito.given;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.oauth2Login;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.view;
+
+import app.zoneblitz.config.SecurityConfig;
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
+import org.springframework.boot.security.autoconfigure.SecurityAutoConfiguration;
+import org.springframework.boot.security.autoconfigure.web.servlet.ServletWebSecurityAutoConfiguration;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(HiringDirectorOfScoutingController.class)
+@Import(SecurityConfig.class)
+@ImportAutoConfiguration({
+  SecurityAutoConfiguration.class,
+  ServletWebSecurityAutoConfiguration.class
+})
+class HiringDirectorOfScoutingControllerTests {
+
+  @Autowired MockMvc mvc;
+
+  @MockitoBean ViewDirectorOfScoutingHiring viewHiring;
+  @MockitoBean ManageHeadCoachShortlist shortlist;
+  @MockitoBean StartInterview startInterview;
+  @MockitoBean MakeOffer makeOffer;
+  @MockitoBean ClientRegistrationRepository clientRegistrationRepository;
+
+  @Test
+  void page_whenFound_rendersPageTemplate() throws Exception {
+    given(viewHiring.view(42L, "sub-1")).willReturn(Optional.of(sampleView()));
+
+    mvc.perform(
+            get("/leagues/42/hiring/director-of-scouting")
+                .with(oauth2Login().attributes(a -> a.put("sub", "sub-1"))))
+        .andExpect(status().isOk())
+        .andExpect(view().name("league/hiring/director-of-scouting"));
+  }
+
+  @Test
+  void page_whenMissing_returns404() throws Exception {
+    given(viewHiring.view(42L, "sub-1")).willReturn(Optional.empty());
+
+    mvc.perform(
+            get("/leagues/42/hiring/director-of-scouting")
+                .with(oauth2Login().attributes(a -> a.put("sub", "sub-1"))))
+        .andExpect(status().isNotFound());
+  }
+
+  @Test
+  void poolFragment_returnsFragment() throws Exception {
+    given(viewHiring.view(42L, "sub-1")).willReturn(Optional.of(sampleView()));
+
+    mvc.perform(
+            get("/leagues/42/hiring/director-of-scouting/pool")
+                .with(oauth2Login().attributes(a -> a.put("sub", "sub-1"))))
+        .andExpect(status().isOk())
+        .andExpect(view().name("league/hiring/director-of-scouting-fragments :: pool"));
+  }
+
+  @Test
+  void shortlistFragment_returnsFragment() throws Exception {
+    given(viewHiring.view(42L, "sub-1")).willReturn(Optional.of(sampleView()));
+
+    mvc.perform(
+            get("/leagues/42/hiring/director-of-scouting/shortlist")
+                .with(oauth2Login().attributes(a -> a.put("sub", "sub-1"))))
+        .andExpect(status().isOk())
+        .andExpect(view().name("league/hiring/director-of-scouting-fragments :: shortlist"));
+  }
+
+  private DirectorOfScoutingHiringView sampleView() {
+    var franchise =
+        new Franchise(
+            1L,
+            "Minutemen",
+            new City(1L, "Boston", new State(1L, "MA", "Massachusetts")),
+            "#000000",
+            "#ffffff");
+    var league =
+        new LeagueSummary(
+            42L, "Dynasty", LeaguePhase.HIRING_DIRECTOR_OF_SCOUTING, 1, Instant.now(), franchise);
+    return new DirectorOfScoutingHiringView(league, List.of(), List.of(), List.of(), 0, 3);
+  }
+}

--- a/src/test/java/app/zoneblitz/league/HiringDirectorOfScoutingPhaseProgressionTests.java
+++ b/src/test/java/app/zoneblitz/league/HiringDirectorOfScoutingPhaseProgressionTests.java
@@ -1,0 +1,168 @@
+package app.zoneblitz.league;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import app.zoneblitz.support.PostgresTestcontainer;
+import java.util.List;
+import org.jooq.DSLContext;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.jooq.test.autoconfigure.JooqTest;
+import org.springframework.context.annotation.Import;
+
+/**
+ * End-to-end phase progression through HIRING_DIRECTOR_OF_SCOUTING. Verifies that after the DoS
+ * pool is generated via {@link HiringDirectorOfScoutingTransitionHandler}, CPU franchises (and, via
+ * autofill, any remaining unresolved franchises) progress through the phase and eventually advance
+ * into {@link LeaguePhase#ASSEMBLING_STAFF}.
+ */
+@JooqTest
+@Import(PostgresTestcontainer.class)
+class HiringDirectorOfScoutingPhaseProgressionTests {
+
+  @Autowired DSLContext dsl;
+
+  private LeagueRepository leagues;
+  private CreateLeague createLeague;
+  private AdvanceWeek advanceWeek;
+  private AdvancePhase advancePhase;
+  private TeamLookup teamLookup;
+  private CandidatePoolRepository pools;
+  private CandidateRepository candidates;
+  private FranchiseHiringStateRepository hiringStates;
+
+  @BeforeEach
+  void setUp() {
+    leagues = new JooqLeagueRepository(dsl);
+    var franchises = new JooqFranchiseRepository(dsl);
+    var teamRepo = new JooqTeamRepository(dsl);
+    teamLookup = new JooqTeamLookup(dsl);
+    pools = new JooqCandidatePoolRepository(dsl);
+    candidates = new JooqCandidateRepository(dsl);
+    var preferences = new JooqCandidatePreferencesRepository(dsl);
+    var offers = new JooqCandidateOfferRepository(dsl);
+    var staff = new JooqFranchiseStaffRepository(dsl);
+    hiringStates = new JooqFranchiseHiringStateRepository(dsl);
+    var interviews = new JooqFranchiseInterviewRepository(dsl);
+    var profiles = new CityFranchiseProfiles(franchises);
+    CandidateRandomSources rngs =
+        (leagueId, phase) -> new FakeRandomSource(leagueId * 31 + phase.ordinal());
+
+    createLeague = new CreateLeagueUseCase(leagues, franchises, teamRepo);
+
+    var hcHandler =
+        new HiringHeadCoachTransitionHandler(
+            leagues,
+            teamLookup,
+            pools,
+            candidates,
+            preferences,
+            hiringStates,
+            new HeadCoachGenerator(),
+            rngs);
+    var dosHandler =
+        new HiringDirectorOfScoutingTransitionHandler(
+            leagues,
+            teamLookup,
+            pools,
+            candidates,
+            preferences,
+            hiringStates,
+            new DirectorOfScoutingGenerator(),
+            rngs);
+
+    advancePhase = new AdvancePhaseUseCase(leagues, List.of(hcHandler, dosHandler));
+
+    var autofill =
+        new BestScoutedHiringAutofill(
+            pools, candidates, preferences, offers, hiringStates, staff, teamLookup, rngs);
+    var resolver =
+        new PreferenceScoringOfferResolver(
+            offers, candidates, pools, preferences, profiles, hiringStates, staff, rngs);
+    var hcCpu =
+        new CpuHiringStrategy(
+            LeaguePhase.HIRING_HEAD_COACH,
+            CandidatePoolType.HEAD_COACH,
+            pools,
+            candidates,
+            preferences,
+            offers,
+            hiringStates,
+            interviews,
+            rngs);
+    var dosCpu =
+        new CpuHiringStrategy(
+            LeaguePhase.HIRING_DIRECTOR_OF_SCOUTING,
+            CandidatePoolType.DIRECTOR_OF_SCOUTING,
+            pools,
+            candidates,
+            preferences,
+            offers,
+            hiringStates,
+            interviews,
+            rngs);
+
+    advanceWeek =
+        new AdvanceWeekUseCase(
+            leagues,
+            resolver,
+            teamLookup,
+            autofill,
+            hiringStates,
+            advancePhase,
+            List.of(hcCpu, dosCpu));
+  }
+
+  @Test
+  void fullHiringProgression_exitsHcThenEntersDosThenExitsDosIntoAssembling() {
+    var league = createLeagueFor("sub-1");
+
+    // Enter HC phase.
+    advancePhase.advance(league.id(), "sub-1");
+    assertThat(leagues.findById(league.id()).orElseThrow().phase())
+        .isEqualTo(LeaguePhase.HIRING_HEAD_COACH);
+
+    // Tick HC phase until it caps out; autofill + advance move us into DoS.
+    tickUntilPhaseLeaves(league.id(), LeaguePhase.HIRING_HEAD_COACH, 10);
+
+    assertThat(leagues.findById(league.id()).orElseThrow().phase())
+        .isEqualTo(LeaguePhase.HIRING_DIRECTOR_OF_SCOUTING);
+    // DoS pool has been generated on phase entry.
+    var dosPool =
+        pools
+            .findByLeaguePhaseAndType(
+                league.id(),
+                LeaguePhase.HIRING_DIRECTOR_OF_SCOUTING,
+                CandidatePoolType.DIRECTOR_OF_SCOUTING)
+            .orElseThrow();
+    assertThat(candidates.findAllByPoolId(dosPool.id())).isNotEmpty();
+
+    // Tick DoS until it caps out and advances to ASSEMBLING_STAFF.
+    tickUntilPhaseLeaves(league.id(), LeaguePhase.HIRING_DIRECTOR_OF_SCOUTING, 10);
+
+    assertThat(leagues.findById(league.id()).orElseThrow().phase())
+        .isEqualTo(LeaguePhase.ASSEMBLING_STAFF);
+    // Every franchise has a DoS hire recorded.
+    var statesAfter =
+        hiringStates.findAllForLeaguePhase(league.id(), LeaguePhase.HIRING_DIRECTOR_OF_SCOUTING);
+    assertThat(statesAfter).isNotEmpty();
+    assertThat(statesAfter).allSatisfy(s -> assertThat(s.step()).isEqualTo(HiringStep.HIRED));
+  }
+
+  private void tickUntilPhaseLeaves(long leagueId, LeaguePhase phase, int maxTicks) {
+    for (var i = 0; i < maxTicks; i++) {
+      var current = leagues.findById(leagueId).orElseThrow().phase();
+      if (current != phase) {
+        return;
+      }
+      advanceWeek.advance(leagueId, "sub-1");
+    }
+  }
+
+  private League createLeagueFor(String ownerSubject) {
+    var franchiseId = new JooqFranchiseRepository(dsl).listAll().getFirst().id();
+    var result = createLeague.create(ownerSubject, "Dynasty", franchiseId);
+    return ((CreateLeagueResult.Created) result).league();
+  }
+}

--- a/src/test/java/app/zoneblitz/league/HiringDirectorOfScoutingTransitionHandlerTests.java
+++ b/src/test/java/app/zoneblitz/league/HiringDirectorOfScoutingTransitionHandlerTests.java
@@ -1,0 +1,121 @@
+package app.zoneblitz.league;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import app.zoneblitz.gamesimulator.rng.RandomSource;
+import app.zoneblitz.support.PostgresTestcontainer;
+import org.jooq.DSLContext;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.jooq.test.autoconfigure.JooqTest;
+import org.springframework.context.annotation.Import;
+
+@JooqTest
+@Import(PostgresTestcontainer.class)
+class HiringDirectorOfScoutingTransitionHandlerTests {
+
+  @Autowired DSLContext dsl;
+
+  private LeagueRepository leagues;
+  private CreateLeague createLeague;
+  private CandidatePoolRepository pools;
+  private CandidateRepository candidates;
+  private CandidatePreferencesRepository preferences;
+  private FranchiseHiringStateRepository hiringStates;
+  private TeamLookup teams;
+  private HiringDirectorOfScoutingTransitionHandler handler;
+
+  @BeforeEach
+  void setUp() {
+    leagues = new JooqLeagueRepository(dsl);
+    var franchises = new JooqFranchiseRepository(dsl);
+    var teamRepo = new JooqTeamRepository(dsl);
+    teams = new JooqTeamLookup(dsl);
+    pools = new JooqCandidatePoolRepository(dsl);
+    candidates = new JooqCandidateRepository(dsl);
+    preferences = new JooqCandidatePreferencesRepository(dsl);
+    hiringStates = new JooqFranchiseHiringStateRepository(dsl);
+    createLeague = new CreateLeagueUseCase(leagues, franchises, teamRepo);
+    handler =
+        new HiringDirectorOfScoutingTransitionHandler(
+            leagues,
+            teams,
+            pools,
+            candidates,
+            preferences,
+            hiringStates,
+            new DirectorOfScoutingGenerator(),
+            new SeededRandomSources());
+  }
+
+  @Test
+  void phase_isHiringDirectorOfScouting() {
+    assertThat(handler.phase()).isEqualTo(LeaguePhase.HIRING_DIRECTOR_OF_SCOUTING);
+  }
+
+  @Test
+  void onEntry_generatesPoolCandidatesAndPreferencesAndInitialHiringStates() {
+    var league = createLeagueFor("sub-1");
+
+    handler.onEntry(league.id());
+
+    var pool =
+        pools
+            .findByLeaguePhaseAndType(
+                league.id(),
+                LeaguePhase.HIRING_DIRECTOR_OF_SCOUTING,
+                CandidatePoolType.DIRECTOR_OF_SCOUTING)
+            .orElseThrow();
+    var generated = candidates.findAllByPoolId(pool.id());
+    var franchiseCount = teams.franchiseIdsForLeague(league.id()).size();
+    assertThat(generated).hasSize(franchiseCount * 3);
+    assertThat(generated)
+        .allSatisfy(c -> assertThat(c.kind()).isEqualTo(CandidateKind.DIRECTOR_OF_SCOUTING));
+    assertThat(generated)
+        .allSatisfy(c -> assertThat(preferences.findByCandidateId(c.id())).isPresent());
+
+    var states =
+        hiringStates.findAllForLeaguePhase(league.id(), LeaguePhase.HIRING_DIRECTOR_OF_SCOUTING);
+    assertThat(states).hasSize(franchiseCount);
+    assertThat(states)
+        .allSatisfy(
+            s -> {
+              assertThat(s.step()).isEqualTo(HiringStep.SEARCHING);
+              assertThat(s.shortlist()).isEmpty();
+              assertThat(s.interviewingCandidateIds()).isEmpty();
+            });
+  }
+
+  @Test
+  void onEntry_isIdempotent_whenPoolAlreadyExists() {
+    var league = createLeagueFor("sub-1");
+    handler.onEntry(league.id());
+    var firstPool =
+        pools
+            .findByLeaguePhaseAndType(
+                league.id(),
+                LeaguePhase.HIRING_DIRECTOR_OF_SCOUTING,
+                CandidatePoolType.DIRECTOR_OF_SCOUTING)
+            .orElseThrow();
+    var firstCount = candidates.findAllByPoolId(firstPool.id()).size();
+
+    handler.onEntry(league.id());
+
+    var secondCount = candidates.findAllByPoolId(firstPool.id()).size();
+    assertThat(secondCount).isEqualTo(firstCount);
+  }
+
+  private League createLeagueFor(String ownerSubject) {
+    var franchiseId = new JooqFranchiseRepository(dsl).listAll().getFirst().id();
+    var result = createLeague.create(ownerSubject, "Dynasty", franchiseId);
+    return ((CreateLeagueResult.Created) result).league();
+  }
+
+  private static final class SeededRandomSources implements CandidateRandomSources {
+    @Override
+    public RandomSource forLeaguePhase(long leagueId, LeaguePhase phase) {
+      return new FakeRandomSource(leagueId * 31 + phase.ordinal());
+    }
+  }
+}

--- a/src/test/java/app/zoneblitz/league/HiringHeadCoachControllerTests.java
+++ b/src/test/java/app/zoneblitz/league/HiringHeadCoachControllerTests.java
@@ -1,0 +1,297 @@
+package app.zoneblitz.league;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.oauth2Login;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.view;
+
+import app.zoneblitz.config.SecurityConfig;
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
+import org.springframework.boot.security.autoconfigure.SecurityAutoConfiguration;
+import org.springframework.boot.security.autoconfigure.web.servlet.ServletWebSecurityAutoConfiguration;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(HiringHeadCoachController.class)
+@Import(SecurityConfig.class)
+@ImportAutoConfiguration({
+  SecurityAutoConfiguration.class,
+  ServletWebSecurityAutoConfiguration.class
+})
+class HiringHeadCoachControllerTests {
+
+  @Autowired MockMvc mvc;
+
+  @MockitoBean ViewHeadCoachHiring viewHiring;
+  @MockitoBean ManageHeadCoachShortlist shortlist;
+  @MockitoBean StartInterview startInterview;
+  @MockitoBean MakeOffer makeOffer;
+  @MockitoBean ClientRegistrationRepository clientRegistrationRepository;
+
+  @Test
+  void page_whenFound_rendersPageTemplate() throws Exception {
+    given(viewHiring.view(42L, "sub-1")).willReturn(Optional.of(sampleView()));
+
+    mvc.perform(
+            get("/leagues/42/hiring/head-coach")
+                .with(oauth2Login().attributes(a -> a.put("sub", "sub-1"))))
+        .andExpect(status().isOk())
+        .andExpect(view().name("league/hiring/head-coach"));
+  }
+
+  @Test
+  void page_whenMissing_returns404() throws Exception {
+    given(viewHiring.view(42L, "sub-1")).willReturn(Optional.empty());
+
+    mvc.perform(
+            get("/leagues/42/hiring/head-coach")
+                .with(oauth2Login().attributes(a -> a.put("sub", "sub-1"))))
+        .andExpect(status().isNotFound());
+  }
+
+  @Test
+  void poolFragment_returnsFragment() throws Exception {
+    given(viewHiring.view(42L, "sub-1")).willReturn(Optional.of(sampleView()));
+
+    mvc.perform(
+            get("/leagues/42/hiring/head-coach/pool")
+                .with(oauth2Login().attributes(a -> a.put("sub", "sub-1"))))
+        .andExpect(status().isOk())
+        .andExpect(view().name("league/hiring/head-coach-fragments :: pool"));
+  }
+
+  @Test
+  void shortlistFragment_returnsFragment() throws Exception {
+    given(viewHiring.view(42L, "sub-1")).willReturn(Optional.of(sampleView()));
+
+    mvc.perform(
+            get("/leagues/42/hiring/head-coach/shortlist")
+                .with(oauth2Login().attributes(a -> a.put("sub", "sub-1"))))
+        .andExpect(status().isOk())
+        .andExpect(view().name("league/hiring/head-coach-fragments :: shortlist"));
+  }
+
+  @Test
+  void addToShortlist_whenUpdated_rendersCombinedFragment() throws Exception {
+    given(shortlist.add(42L, 7L, "sub-1")).willReturn(new ShortlistResult.Updated(sampleView()));
+
+    mvc.perform(
+            post("/leagues/42/hiring/head-coach/shortlist/7")
+                .with(oauth2Login().attributes(a -> a.put("sub", "sub-1")))
+                .with(csrf()))
+        .andExpect(status().isOk())
+        .andExpect(view().name("league/hiring/head-coach-fragments :: combined"));
+
+    verify(shortlist).add(42L, 7L, "sub-1");
+  }
+
+  @Test
+  void addToShortlist_whenNotFound_returns404() throws Exception {
+    given(shortlist.add(42L, 7L, "sub-1")).willReturn(new ShortlistResult.NotFound(42L));
+
+    mvc.perform(
+            post("/leagues/42/hiring/head-coach/shortlist/7")
+                .with(oauth2Login().attributes(a -> a.put("sub", "sub-1")))
+                .with(csrf()))
+        .andExpect(status().isNotFound());
+  }
+
+  @Test
+  void addToShortlist_whenUnknownCandidate_returns404() throws Exception {
+    given(shortlist.add(42L, 7L, "sub-1")).willReturn(new ShortlistResult.UnknownCandidate(7L));
+
+    mvc.perform(
+            post("/leagues/42/hiring/head-coach/shortlist/7")
+                .with(oauth2Login().attributes(a -> a.put("sub", "sub-1")))
+                .with(csrf()))
+        .andExpect(status().isNotFound());
+  }
+
+  @Test
+  void removeFromShortlist_whenUpdated_rendersCombinedFragment() throws Exception {
+    given(shortlist.remove(42L, 7L, "sub-1")).willReturn(new ShortlistResult.Updated(sampleView()));
+
+    mvc.perform(
+            delete("/leagues/42/hiring/head-coach/shortlist/7")
+                .with(oauth2Login().attributes(a -> a.put("sub", "sub-1")))
+                .with(csrf()))
+        .andExpect(status().isOk())
+        .andExpect(view().name("league/hiring/head-coach-fragments :: combined"));
+
+    verify(shortlist).remove(42L, 7L, "sub-1");
+  }
+
+  @Test
+  void startInterview_whenStarted_rendersCombinedFragment() throws Exception {
+    given(startInterview.start(42L, 7L, "sub-1"))
+        .willReturn(new InterviewResult.Started(sampleView()));
+
+    mvc.perform(
+            post("/leagues/42/hiring/head-coach/interview/7")
+                .with(oauth2Login().attributes(a -> a.put("sub", "sub-1")))
+                .with(csrf()))
+        .andExpect(status().isOk())
+        .andExpect(view().name("league/hiring/head-coach-fragments :: combined"));
+
+    verify(startInterview).start(42L, 7L, "sub-1");
+  }
+
+  @Test
+  void startInterview_whenCapacityReached_returns409() throws Exception {
+    given(startInterview.start(42L, 7L, "sub-1"))
+        .willReturn(new InterviewResult.CapacityReached(3));
+
+    mvc.perform(
+            post("/leagues/42/hiring/head-coach/interview/7")
+                .with(oauth2Login().attributes(a -> a.put("sub", "sub-1")))
+                .with(csrf()))
+        .andExpect(status().isConflict());
+  }
+
+  @Test
+  void startInterview_whenNotFound_returns404() throws Exception {
+    given(startInterview.start(42L, 7L, "sub-1")).willReturn(new InterviewResult.NotFound(42L));
+
+    mvc.perform(
+            post("/leagues/42/hiring/head-coach/interview/7")
+                .with(oauth2Login().attributes(a -> a.put("sub", "sub-1")))
+                .with(csrf()))
+        .andExpect(status().isNotFound());
+  }
+
+  @Test
+  void startInterview_whenUnknownCandidate_returns404() throws Exception {
+    given(startInterview.start(42L, 7L, "sub-1"))
+        .willReturn(new InterviewResult.UnknownCandidate(7L));
+
+    mvc.perform(
+            post("/leagues/42/hiring/head-coach/interview/7")
+                .with(oauth2Login().attributes(a -> a.put("sub", "sub-1")))
+                .with(csrf()))
+        .andExpect(status().isNotFound());
+  }
+
+  @Test
+  void startInterview_requiresCsrf() throws Exception {
+    mvc.perform(
+            post("/leagues/42/hiring/head-coach/interview/7")
+                .with(oauth2Login().attributes(a -> a.put("sub", "sub-1"))))
+        .andExpect(status().isForbidden());
+  }
+
+  @Test
+  void interviewsFragment_returnsFragment() throws Exception {
+    given(viewHiring.view(42L, "sub-1")).willReturn(Optional.of(sampleView()));
+
+    mvc.perform(
+            get("/leagues/42/hiring/head-coach/interviews")
+                .with(oauth2Login().attributes(a -> a.put("sub", "sub-1"))))
+        .andExpect(status().isOk())
+        .andExpect(view().name("league/hiring/head-coach-fragments :: interviews"));
+  }
+
+  @Test
+  void submitOffer_whenCreated_rendersCombinedFragment() throws Exception {
+    given(viewHiring.view(42L, "sub-1")).willReturn(Optional.of(sampleView()));
+    given(makeOffer.offer(eq(42L), eq(7L), eq("sub-1"), any()))
+        .willReturn(
+            new MakeOfferResult.Created(
+                new CandidateOffer(1L, 7L, 99L, "{}", 1, OfferStatus.ACTIVE)));
+
+    mvc.perform(
+            post("/leagues/42/hiring/head-coach/offer/7")
+                .param("compensation", "8500000")
+                .param("contractLengthYears", "5")
+                .param("guaranteedMoneyPct", "0.85")
+                .param("roleScope", "HIGH")
+                .param("staffContinuity", "BRING_OWN")
+                .with(oauth2Login().attributes(a -> a.put("sub", "sub-1")))
+                .with(csrf()))
+        .andExpect(status().isOk())
+        .andExpect(view().name("league/hiring/head-coach-fragments :: combined"));
+  }
+
+  @Test
+  void submitOffer_whenActiveOfferExists_returns409() throws Exception {
+    given(makeOffer.offer(eq(42L), eq(7L), eq("sub-1"), any()))
+        .willReturn(new MakeOfferResult.ActiveOfferExists(7L, 1L));
+
+    mvc.perform(
+            post("/leagues/42/hiring/head-coach/offer/7")
+                .param("compensation", "8500000")
+                .param("contractLengthYears", "5")
+                .param("guaranteedMoneyPct", "0.85")
+                .param("roleScope", "HIGH")
+                .param("staffContinuity", "BRING_OWN")
+                .with(oauth2Login().attributes(a -> a.put("sub", "sub-1")))
+                .with(csrf()))
+        .andExpect(status().isConflict());
+  }
+
+  @Test
+  void submitOffer_whenUnknownCandidate_returns404() throws Exception {
+    given(makeOffer.offer(eq(42L), eq(7L), eq("sub-1"), any()))
+        .willReturn(new MakeOfferResult.UnknownCandidate(7L));
+
+    mvc.perform(
+            post("/leagues/42/hiring/head-coach/offer/7")
+                .param("compensation", "8500000")
+                .param("contractLengthYears", "5")
+                .param("guaranteedMoneyPct", "0.85")
+                .param("roleScope", "HIGH")
+                .param("staffContinuity", "BRING_OWN")
+                .with(oauth2Login().attributes(a -> a.put("sub", "sub-1")))
+                .with(csrf()))
+        .andExpect(status().isNotFound());
+  }
+
+  @Test
+  void submitOffer_requiresCsrf() throws Exception {
+    mvc.perform(
+            post("/leagues/42/hiring/head-coach/offer/7")
+                .param("compensation", "8500000")
+                .param("contractLengthYears", "5")
+                .param("guaranteedMoneyPct", "0.85")
+                .param("roleScope", "HIGH")
+                .param("staffContinuity", "BRING_OWN")
+                .with(oauth2Login().attributes(a -> a.put("sub", "sub-1"))))
+        .andExpect(status().isForbidden());
+  }
+
+  @Test
+  void addToShortlist_requiresCsrf() throws Exception {
+    mvc.perform(
+            post("/leagues/42/hiring/head-coach/shortlist/7")
+                .with(oauth2Login().attributes(a -> a.put("sub", "sub-1"))))
+        .andExpect(status().isForbidden());
+  }
+
+  private static HeadCoachHiringView sampleView() {
+    var franchise =
+        new Franchise(
+            1L,
+            "Minutemen",
+            new City(1L, "Boston", new State(1L, "MA", "Massachusetts")),
+            "#000000",
+            "#ffffff");
+    var league =
+        new LeagueSummary(
+            42L, "Dynasty", LeaguePhase.HIRING_HEAD_COACH, 1, Instant.now(), franchise);
+    return new HeadCoachHiringView(league, List.of(), List.of(), List.of(), 0, 3);
+  }
+}

--- a/src/test/java/app/zoneblitz/league/HiringHeadCoachTransitionHandlerTests.java
+++ b/src/test/java/app/zoneblitz/league/HiringHeadCoachTransitionHandlerTests.java
@@ -1,0 +1,115 @@
+package app.zoneblitz.league;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import app.zoneblitz.gamesimulator.rng.RandomSource;
+import app.zoneblitz.support.PostgresTestcontainer;
+import org.jooq.DSLContext;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.jooq.test.autoconfigure.JooqTest;
+import org.springframework.context.annotation.Import;
+
+@JooqTest
+@Import(PostgresTestcontainer.class)
+class HiringHeadCoachTransitionHandlerTests {
+
+  @Autowired DSLContext dsl;
+
+  private LeagueRepository leagues;
+  private CreateLeague createLeague;
+  private CandidatePoolRepository pools;
+  private CandidateRepository candidates;
+  private CandidatePreferencesRepository preferences;
+  private FranchiseHiringStateRepository hiringStates;
+  private TeamLookup teams;
+  private HiringHeadCoachTransitionHandler handler;
+
+  @BeforeEach
+  void setUp() {
+    leagues = new JooqLeagueRepository(dsl);
+    var franchises = new JooqFranchiseRepository(dsl);
+    var teamRepo = new JooqTeamRepository(dsl);
+    teams = new JooqTeamLookup(dsl);
+    pools = new JooqCandidatePoolRepository(dsl);
+    candidates = new JooqCandidateRepository(dsl);
+    preferences = new JooqCandidatePreferencesRepository(dsl);
+    hiringStates = new JooqFranchiseHiringStateRepository(dsl);
+    createLeague = new CreateLeagueUseCase(leagues, franchises, teamRepo);
+    handler =
+        new HiringHeadCoachTransitionHandler(
+            leagues,
+            teams,
+            pools,
+            candidates,
+            preferences,
+            hiringStates,
+            new HeadCoachGenerator(),
+            new SeededRandomSources());
+  }
+
+  @Test
+  void phase_isHiringHeadCoach() {
+    assertThat(handler.phase()).isEqualTo(LeaguePhase.HIRING_HEAD_COACH);
+  }
+
+  @Test
+  void onEntry_generatesPoolCandidatesAndPreferencesAndInitialHiringStates() {
+    var league = createLeagueFor("sub-1");
+
+    handler.onEntry(league.id());
+
+    var pool =
+        pools
+            .findByLeaguePhaseAndType(
+                league.id(), LeaguePhase.HIRING_HEAD_COACH, CandidatePoolType.HEAD_COACH)
+            .orElseThrow();
+    var generated = candidates.findAllByPoolId(pool.id());
+    var franchiseCount = teams.franchiseIdsForLeague(league.id()).size();
+    assertThat(generated).hasSize(franchiseCount * 3);
+    assertThat(generated).allSatisfy(c -> assertThat(c.kind()).isEqualTo(CandidateKind.HEAD_COACH));
+    assertThat(generated)
+        .allSatisfy(c -> assertThat(preferences.findByCandidateId(c.id())).isPresent());
+
+    var states = hiringStates.findAllForLeaguePhase(league.id(), LeaguePhase.HIRING_HEAD_COACH);
+    assertThat(states).hasSize(franchiseCount);
+    assertThat(states)
+        .allSatisfy(
+            s -> {
+              assertThat(s.step()).isEqualTo(HiringStep.SEARCHING);
+              assertThat(s.shortlist()).isEmpty();
+              assertThat(s.interviewingCandidateIds()).isEmpty();
+            });
+  }
+
+  @Test
+  void onEntry_isIdempotent_whenPoolAlreadyExists() {
+    var league = createLeagueFor("sub-1");
+    handler.onEntry(league.id());
+    var firstPool =
+        pools
+            .findByLeaguePhaseAndType(
+                league.id(), LeaguePhase.HIRING_HEAD_COACH, CandidatePoolType.HEAD_COACH)
+            .orElseThrow();
+    var firstCount = candidates.findAllByPoolId(firstPool.id()).size();
+
+    handler.onEntry(league.id());
+
+    var secondCount = candidates.findAllByPoolId(firstPool.id()).size();
+    assertThat(secondCount).isEqualTo(firstCount);
+  }
+
+  private League createLeagueFor(String ownerSubject) {
+    var franchiseId = new JooqFranchiseRepository(dsl).listAll().getFirst().id();
+    var result = createLeague.create(ownerSubject, "Dynasty", franchiseId);
+    return ((CreateLeagueResult.Created) result).league();
+  }
+
+  private static final class SeededRandomSources implements CandidateRandomSources {
+    @Override
+    public RandomSource forLeaguePhase(long leagueId, LeaguePhase phase) {
+      return new FakeRandomSource(leagueId * 31 + phase.ordinal());
+    }
+  }
+}

--- a/src/test/java/app/zoneblitz/league/InterviewNoiseModelTests.java
+++ b/src/test/java/app/zoneblitz/league/InterviewNoiseModelTests.java
@@ -1,0 +1,48 @@
+package app.zoneblitz.league;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.Test;
+
+class InterviewNoiseModelTests {
+
+  @Test
+  void headCoachSigma_atZero_equalsInitial() {
+    assertThat(InterviewNoiseModel.headCoachSigma(0)).isEqualTo(InterviewNoiseModel.HC_INITIAL_STD);
+  }
+
+  @Test
+  void headCoachSigma_monotonicallyDecreasesAcrossInterviews() {
+    var previous = InterviewNoiseModel.headCoachSigma(0);
+    for (var i = 1; i <= 20; i++) {
+      var current = InterviewNoiseModel.headCoachSigma(i);
+      assertThat(current)
+          .as("sigma must strictly decrease at interview %d", i)
+          .isLessThan(previous);
+      previous = current;
+    }
+  }
+
+  @Test
+  void headCoachSigma_neverReachesZero_evenAtLargeCounts() {
+    for (var n : new int[] {10, 50, 100, 1_000, 10_000}) {
+      assertThat(InterviewNoiseModel.headCoachSigma(n))
+          .as("sigma at n=%d", n)
+          .isGreaterThan(0.0)
+          .isGreaterThanOrEqualTo(InterviewNoiseModel.HC_FLOOR_STD);
+    }
+  }
+
+  @Test
+  void headCoachSigma_asymptoticallyApproachesFloor() {
+    assertThat(InterviewNoiseModel.headCoachSigma(100_000))
+        .isCloseTo(InterviewNoiseModel.HC_FLOOR_STD, org.assertj.core.data.Offset.offset(1e-6));
+  }
+
+  @Test
+  void headCoachSigma_negative_throws() {
+    assertThatThrownBy(() -> InterviewNoiseModel.headCoachSigma(-1))
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+}

--- a/src/test/java/app/zoneblitz/league/JooqFranchiseInterviewRepositoryTests.java
+++ b/src/test/java/app/zoneblitz/league/JooqFranchiseInterviewRepositoryTests.java
@@ -1,0 +1,117 @@
+package app.zoneblitz.league;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import app.zoneblitz.support.PostgresTestcontainer;
+import java.math.BigDecimal;
+import org.jooq.DSLContext;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.jooq.test.autoconfigure.JooqTest;
+import org.springframework.context.annotation.Import;
+
+@JooqTest
+@Import(PostgresTestcontainer.class)
+class JooqFranchiseInterviewRepositoryTests {
+
+  @Autowired DSLContext dsl;
+
+  private FranchiseInterviewRepository interviews;
+  private long leagueId;
+  private long franchiseId;
+  private long otherFranchiseId;
+  private long candidateId;
+
+  @BeforeEach
+  void setUp() {
+    interviews = new JooqFranchiseInterviewRepository(dsl);
+    var leagues = new JooqLeagueRepository(dsl);
+    var franchises = new JooqFranchiseRepository(dsl);
+    var pools = new JooqCandidatePoolRepository(dsl);
+    var candidates = new JooqCandidateRepository(dsl);
+    var league =
+        leagues.insert("sub-1", "Dynasty", LeaguePhase.INITIAL_SETUP, LeagueSettings.defaults());
+    leagueId = league.id();
+    var listed = franchises.listAll();
+    franchiseId = listed.get(0).id();
+    otherFranchiseId = listed.get(1).id();
+    var pool = pools.insert(leagueId, LeaguePhase.HIRING_HEAD_COACH, CandidatePoolType.HEAD_COACH);
+    candidateId = candidates.insert(CandidateTestData.newHeadCoach(pool.id())).id();
+  }
+
+  @Test
+  void insert_roundTripsAllFields() {
+    var inserted =
+        interviews.insert(
+            new NewFranchiseInterview(
+                leagueId,
+                franchiseId,
+                candidateId,
+                LeaguePhase.HIRING_HEAD_COACH,
+                1,
+                1,
+                new BigDecimal("76.50")));
+
+    assertThat(inserted.id()).isPositive();
+    assertThat(inserted.leagueId()).isEqualTo(leagueId);
+    assertThat(inserted.franchiseId()).isEqualTo(franchiseId);
+    assertThat(inserted.candidateId()).isEqualTo(candidateId);
+    assertThat(inserted.phase()).isEqualTo(LeaguePhase.HIRING_HEAD_COACH);
+    assertThat(inserted.phaseWeek()).isEqualTo(1);
+    assertThat(inserted.interviewIndex()).isEqualTo(1);
+    assertThat(inserted.scoutedOverall()).isEqualByComparingTo("76.50");
+  }
+
+  @Test
+  void countForCandidate_returnsPerFranchisePerCandidateTotal() {
+    interviews.insert(interview(franchiseId, candidateId, 1, 1));
+    interviews.insert(interview(franchiseId, candidateId, 1, 2));
+    interviews.insert(interview(otherFranchiseId, candidateId, 1, 1));
+
+    assertThat(
+            interviews.countForCandidate(
+                leagueId, franchiseId, candidateId, LeaguePhase.HIRING_HEAD_COACH))
+        .isEqualTo(2);
+    assertThat(
+            interviews.countForCandidate(
+                leagueId, otherFranchiseId, candidateId, LeaguePhase.HIRING_HEAD_COACH))
+        .isEqualTo(1);
+  }
+
+  @Test
+  void countForWeek_isScopedToWeek() {
+    interviews.insert(interview(franchiseId, candidateId, 1, 1));
+    interviews.insert(interview(franchiseId, candidateId, 1, 2));
+    interviews.insert(interview(franchiseId, candidateId, 2, 3));
+
+    assertThat(interviews.countForWeek(leagueId, franchiseId, LeaguePhase.HIRING_HEAD_COACH, 1))
+        .isEqualTo(2);
+    assertThat(interviews.countForWeek(leagueId, franchiseId, LeaguePhase.HIRING_HEAD_COACH, 2))
+        .isEqualTo(1);
+    assertThat(interviews.countForWeek(leagueId, franchiseId, LeaguePhase.HIRING_HEAD_COACH, 3))
+        .isZero();
+  }
+
+  @Test
+  void findAllFor_orderedByIdAscending() {
+    interviews.insert(interview(franchiseId, candidateId, 1, 1));
+    interviews.insert(interview(franchiseId, candidateId, 1, 2));
+    interviews.insert(interview(otherFranchiseId, candidateId, 1, 1));
+
+    var mine = interviews.findAllFor(leagueId, franchiseId, LeaguePhase.HIRING_HEAD_COACH);
+
+    assertThat(mine).extracting(FranchiseInterview::interviewIndex).containsExactly(1, 2);
+  }
+
+  private NewFranchiseInterview interview(long franchise, long candidate, int week, int index) {
+    return new NewFranchiseInterview(
+        leagueId,
+        franchise,
+        candidate,
+        LeaguePhase.HIRING_HEAD_COACH,
+        week,
+        index,
+        new BigDecimal("70.00"));
+  }
+}

--- a/src/test/java/app/zoneblitz/league/MakeOfferUseCaseTests.java
+++ b/src/test/java/app/zoneblitz/league/MakeOfferUseCaseTests.java
@@ -1,0 +1,172 @@
+package app.zoneblitz.league;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import app.zoneblitz.support.PostgresTestcontainer;
+import java.math.BigDecimal;
+import java.util.List;
+import org.jooq.DSLContext;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.jooq.test.autoconfigure.JooqTest;
+import org.springframework.context.annotation.Import;
+
+@JooqTest
+@Import(PostgresTestcontainer.class)
+class MakeOfferUseCaseTests {
+
+  @Autowired DSLContext dsl;
+
+  private LeagueRepository leagues;
+  private JooqCandidateRepository candidates;
+  private JooqCandidateOfferRepository offers;
+  private JooqFranchiseHiringStateRepository hiringStates;
+  private CreateLeague createLeague;
+  private HiringHeadCoachTransitionHandler entryHandler;
+  private MakeOffer makeOffer;
+
+  @BeforeEach
+  void setUp() {
+    leagues = new JooqLeagueRepository(dsl);
+    var franchises = new JooqFranchiseRepository(dsl);
+    var teamRepo = new JooqTeamRepository(dsl);
+    var teams = new JooqTeamLookup(dsl);
+    var pools = new JooqCandidatePoolRepository(dsl);
+    candidates = new JooqCandidateRepository(dsl);
+    var preferences = new JooqCandidatePreferencesRepository(dsl);
+    hiringStates = new JooqFranchiseHiringStateRepository(dsl);
+    offers = new JooqCandidateOfferRepository(dsl);
+    createLeague = new CreateLeagueUseCase(leagues, franchises, teamRepo);
+    entryHandler =
+        new HiringHeadCoachTransitionHandler(
+            leagues,
+            teams,
+            pools,
+            candidates,
+            preferences,
+            hiringStates,
+            new HeadCoachGenerator(),
+            (leagueId, phase) -> new FakeRandomSource(leagueId + phase.ordinal()));
+    makeOffer = new MakeOfferUseCase(leagues, pools, candidates, offers, hiringStates);
+  }
+
+  @Test
+  void offer_whenValid_persistsActiveOffer() {
+    var ctx = seedLeagueInPhase("sub-1");
+
+    var result = makeOffer.offer(ctx.leagueId, ctx.firstCandidateId, "sub-1", terms());
+
+    assertThat(result).isInstanceOf(MakeOfferResult.Created.class);
+    var created = ((MakeOfferResult.Created) result).offer();
+    assertThat(created.status()).isEqualTo(OfferStatus.ACTIVE);
+    assertThat(created.candidateId()).isEqualTo(ctx.firstCandidateId);
+    assertThat(created.submittedAtWeek()).isEqualTo(1);
+    assertThat(offers.findActiveForCandidate(ctx.firstCandidateId)).hasSize(1);
+  }
+
+  @Test
+  void offer_whenLeagueNotOwned_returnsNotFound() {
+    var ctx = seedLeagueInPhase("owner");
+
+    var result = makeOffer.offer(ctx.leagueId, ctx.firstCandidateId, "someone-else", terms());
+
+    assertThat(result).isInstanceOf(MakeOfferResult.NotFound.class);
+  }
+
+  @Test
+  void offer_whenCandidateUnknown_returnsUnknownCandidate() {
+    var ctx = seedLeagueInPhase("sub-1");
+
+    var result = makeOffer.offer(ctx.leagueId, 999_999L, "sub-1", terms());
+
+    assertThat(result).isInstanceOf(MakeOfferResult.UnknownCandidate.class);
+  }
+
+  @Test
+  void offer_whenCandidateAlreadyHired_returnsUnknownCandidate() {
+    var ctx = seedLeagueInPhase("sub-1");
+    candidates.markHired(ctx.firstCandidateId, ctx.otherFranchiseId);
+
+    var result = makeOffer.offer(ctx.leagueId, ctx.firstCandidateId, "sub-1", terms());
+
+    assertThat(result).isInstanceOf(MakeOfferResult.UnknownCandidate.class);
+  }
+
+  @Test
+  void offer_whenFranchiseAlreadyHired_returnsAlreadyHired() {
+    var ctx = seedLeagueInPhase("sub-1");
+    hiringStates.upsert(
+        new FranchiseHiringState(
+            0L,
+            ctx.leagueId,
+            ctx.franchiseId,
+            LeaguePhase.HIRING_HEAD_COACH,
+            HiringStep.HIRED,
+            List.of(),
+            List.of()));
+
+    var result = makeOffer.offer(ctx.leagueId, ctx.firstCandidateId, "sub-1", terms());
+
+    assertThat(result).isInstanceOf(MakeOfferResult.AlreadyHired.class);
+  }
+
+  @Test
+  void offer_whenActiveOfferExists_returnsActiveOfferExists() {
+    var ctx = seedLeagueInPhase("sub-1");
+    makeOffer.offer(ctx.leagueId, ctx.firstCandidateId, "sub-1", terms());
+
+    var second = makeOffer.offer(ctx.leagueId, ctx.firstCandidateId, "sub-1", terms());
+
+    assertThat(second).isInstanceOf(MakeOfferResult.ActiveOfferExists.class);
+  }
+
+  @Test
+  void offer_whenPhaseNotHiringHeadCoach_returnsNotFound() {
+    var league = createLeagueFor("sub-1");
+
+    var result = makeOffer.offer(league.id(), 1L, "sub-1", terms());
+
+    assertThat(result).isInstanceOf(MakeOfferResult.NotFound.class);
+  }
+
+  private Ctx seedLeagueInPhase(String subject) {
+    var league = createLeagueFor(subject);
+    leagues.updatePhaseAndResetWeek(league.id(), LeaguePhase.HIRING_HEAD_COACH);
+    entryHandler.onEntry(league.id());
+    var pool =
+        new JooqCandidatePoolRepository(dsl)
+            .findByLeaguePhaseAndType(
+                league.id(), LeaguePhase.HIRING_HEAD_COACH, CandidatePoolType.HEAD_COACH)
+            .orElseThrow();
+    var first = candidates.findAllByPoolId(pool.id()).getFirst();
+    var franchises = new JooqFranchiseRepository(dsl).listAll();
+    var userFranchiseId =
+        leagues.findSummaryByIdAndOwner(league.id(), subject).orElseThrow().userFranchise().id();
+    var otherFranchiseId =
+        franchises.stream()
+            .mapToLong(Franchise::id)
+            .filter(id -> id != userFranchiseId)
+            .findFirst()
+            .orElseThrow();
+    return new Ctx(league.id(), first.id(), userFranchiseId, otherFranchiseId);
+  }
+
+  private League createLeagueFor(String ownerSubject) {
+    var franchiseId = new JooqFranchiseRepository(dsl).listAll().getFirst().id();
+    var result = createLeague.create(ownerSubject, "Dynasty", franchiseId);
+    return ((CreateLeagueResult.Created) result).league();
+  }
+
+  private static OfferTerms terms() {
+    return new OfferTerms(
+        new BigDecimal("8500000.00"),
+        5,
+        new BigDecimal("0.85"),
+        RoleScope.HIGH,
+        StaffContinuity.BRING_OWN);
+  }
+
+  private record Ctx(
+      long leagueId, long firstCandidateId, long franchiseId, long otherFranchiseId) {}
+}

--- a/src/test/java/app/zoneblitz/league/ManageHeadCoachShortlistUseCaseTests.java
+++ b/src/test/java/app/zoneblitz/league/ManageHeadCoachShortlistUseCaseTests.java
@@ -1,0 +1,149 @@
+package app.zoneblitz.league;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import app.zoneblitz.support.PostgresTestcontainer;
+import org.jooq.DSLContext;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.jooq.test.autoconfigure.JooqTest;
+import org.springframework.context.annotation.Import;
+
+@JooqTest
+@Import(PostgresTestcontainer.class)
+class ManageHeadCoachShortlistUseCaseTests {
+
+  @Autowired DSLContext dsl;
+
+  private LeagueRepository leagues;
+  private CreateLeague createLeague;
+  private JooqCandidateRepository candidates;
+  private HiringHeadCoachTransitionHandler entryHandler;
+  private ManageHeadCoachShortlist useCase;
+
+  @BeforeEach
+  void setUp() {
+    leagues = new JooqLeagueRepository(dsl);
+    var franchises = new JooqFranchiseRepository(dsl);
+    var teamRepo = new JooqTeamRepository(dsl);
+    var teams = new JooqTeamLookup(dsl);
+    var pools = new JooqCandidatePoolRepository(dsl);
+    candidates = new JooqCandidateRepository(dsl);
+    var preferences = new JooqCandidatePreferencesRepository(dsl);
+    var hiringStates = new JooqFranchiseHiringStateRepository(dsl);
+    createLeague = new CreateLeagueUseCase(leagues, franchises, teamRepo);
+    entryHandler =
+        new HiringHeadCoachTransitionHandler(
+            leagues,
+            teams,
+            pools,
+            candidates,
+            preferences,
+            hiringStates,
+            new HeadCoachGenerator(),
+            (leagueId, phase) -> new FakeRandomSource(leagueId + phase.ordinal()));
+    var interviews = new JooqFranchiseInterviewRepository(dsl);
+    useCase =
+        new ManageHeadCoachShortlistUseCase(
+            leagues, pools, candidates, preferences, hiringStates, interviews);
+  }
+
+  @Test
+  void add_whenValid_putsCandidateOnShortlistAndFlagsRow() {
+    var ctx = seedLeagueInPhase("sub-1");
+
+    var result = useCase.add(ctx.leagueId, ctx.firstCandidateId, "sub-1");
+
+    assertThat(result).isInstanceOf(ShortlistResult.Updated.class);
+    var view = ((ShortlistResult.Updated) result).view();
+    assertThat(view.shortlist()).hasSize(1);
+    assertThat(view.shortlist().getFirst().id()).isEqualTo(ctx.firstCandidateId);
+    assertThat(view.pool())
+        .anySatisfy(
+            row -> {
+              if (row.id() == ctx.firstCandidateId) {
+                assertThat(row.shortlisted()).isTrue();
+              }
+            });
+  }
+
+  @Test
+  void add_isIdempotent() {
+    var ctx = seedLeagueInPhase("sub-1");
+    useCase.add(ctx.leagueId, ctx.firstCandidateId, "sub-1");
+    var second = useCase.add(ctx.leagueId, ctx.firstCandidateId, "sub-1");
+
+    assertThat(second).isInstanceOf(ShortlistResult.Updated.class);
+    assertThat(((ShortlistResult.Updated) second).view().shortlist()).hasSize(1);
+  }
+
+  @Test
+  void remove_whenPresent_clearsIt() {
+    var ctx = seedLeagueInPhase("sub-1");
+    useCase.add(ctx.leagueId, ctx.firstCandidateId, "sub-1");
+
+    var result = useCase.remove(ctx.leagueId, ctx.firstCandidateId, "sub-1");
+
+    assertThat(result).isInstanceOf(ShortlistResult.Updated.class);
+    assertThat(((ShortlistResult.Updated) result).view().shortlist()).isEmpty();
+  }
+
+  @Test
+  void remove_isIdempotent_whenCandidateAbsent() {
+    var ctx = seedLeagueInPhase("sub-1");
+
+    var result = useCase.remove(ctx.leagueId, ctx.firstCandidateId, "sub-1");
+
+    assertThat(result).isInstanceOf(ShortlistResult.Updated.class);
+    assertThat(((ShortlistResult.Updated) result).view().shortlist()).isEmpty();
+  }
+
+  @Test
+  void add_whenLeagueNotOwned_returnsNotFound() {
+    var ctx = seedLeagueInPhase("owner");
+
+    var result = useCase.add(ctx.leagueId, ctx.firstCandidateId, "someone-else");
+
+    assertThat(result).isInstanceOf(ShortlistResult.NotFound.class);
+  }
+
+  @Test
+  void add_whenPhaseNotHiringHeadCoach_returnsNotFound() {
+    var league = createLeagueFor("sub-1");
+
+    var result = useCase.add(league.id(), 1L, "sub-1");
+
+    assertThat(result).isInstanceOf(ShortlistResult.NotFound.class);
+  }
+
+  @Test
+  void add_whenCandidateUnknown_returnsUnknownCandidate() {
+    var ctx = seedLeagueInPhase("sub-1");
+
+    var result = useCase.add(ctx.leagueId, 999_999L, "sub-1");
+
+    assertThat(result).isInstanceOf(ShortlistResult.UnknownCandidate.class);
+  }
+
+  private Ctx seedLeagueInPhase(String subject) {
+    var league = createLeagueFor(subject);
+    leagues.updatePhaseAndResetWeek(league.id(), LeaguePhase.HIRING_HEAD_COACH);
+    entryHandler.onEntry(league.id());
+    var pool =
+        new JooqCandidatePoolRepository(dsl)
+            .findByLeaguePhaseAndType(
+                league.id(), LeaguePhase.HIRING_HEAD_COACH, CandidatePoolType.HEAD_COACH)
+            .orElseThrow();
+    var firstCandidate = candidates.findAllByPoolId(pool.id()).getFirst();
+    return new Ctx(league.id(), firstCandidate.id());
+  }
+
+  private League createLeagueFor(String ownerSubject) {
+    var franchiseId = new JooqFranchiseRepository(dsl).listAll().getFirst().id();
+    var result = createLeague.create(ownerSubject, "Dynasty", franchiseId);
+    return ((CreateLeagueResult.Created) result).league();
+  }
+
+  private record Ctx(long leagueId, long firstCandidateId) {}
+}

--- a/src/test/java/app/zoneblitz/league/OfferScoringTests.java
+++ b/src/test/java/app/zoneblitz/league/OfferScoringTests.java
@@ -1,0 +1,138 @@
+package app.zoneblitz.league;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.math.BigDecimal;
+import org.junit.jupiter.api.Test;
+
+class OfferScoringTests {
+
+  private static final FranchiseProfile NE_LARGE_COLD =
+      new FranchiseProfile(
+          1L,
+          MarketSize.LARGE,
+          Geography.NE,
+          Climate.COLD,
+          new BigDecimal("50.00"),
+          CompetitiveWindow.NEUTRAL,
+          new BigDecimal("50.00"),
+          new BigDecimal("50.00"),
+          "WEST_COAST");
+
+  private static final FranchiseProfile SE_LARGE_WARM =
+      new FranchiseProfile(
+          2L,
+          MarketSize.LARGE,
+          Geography.SE,
+          Climate.WARM,
+          new BigDecimal("50.00"),
+          CompetitiveWindow.NEUTRAL,
+          new BigDecimal("50.00"),
+          new BigDecimal("50.00"),
+          "WEST_COAST");
+
+  @Test
+  void score_isDeterministic() {
+    var prefs = CandidateTestData.preferencesFor(1L);
+    var offer = fullyMatchingOffer();
+
+    var first = OfferScoring.score(offer, NE_LARGE_COLD, prefs);
+    var second = OfferScoring.score(offer, NE_LARGE_COLD, prefs);
+
+    assertThat(first).isEqualTo(second);
+  }
+
+  @Test
+  void score_preferredGeographyOutscoresUnpreferred() {
+    // Candidate prefs NE + cold. NE_LARGE_COLD matches on geography+climate, SE_LARGE_WARM misses.
+    var prefs = CandidateTestData.preferencesFor(1L);
+    var offer = fullyMatchingOffer();
+
+    var neScore = OfferScoring.score(offer, NE_LARGE_COLD, prefs);
+    var seScore = OfferScoring.score(offer, SE_LARGE_WARM, prefs);
+
+    assertThat(neScore).isGreaterThan(seScore);
+  }
+
+  @Test
+  void score_offerAtOrAboveCompensationTarget_hitsFullCompensationFit() {
+    var prefs = CandidateTestData.preferencesFor(1L);
+    var atTarget =
+        new OfferTerms(
+            prefs.compensationTarget(),
+            prefs.contractLengthTarget(),
+            prefs.guaranteedMoneyTarget(),
+            prefs.roleScopeTarget(),
+            prefs.staffContinuityTarget());
+    var below =
+        new OfferTerms(
+            new BigDecimal("1"),
+            prefs.contractLengthTarget(),
+            prefs.guaranteedMoneyTarget(),
+            prefs.roleScopeTarget(),
+            prefs.staffContinuityTarget());
+
+    var atScore = OfferScoring.score(atTarget, NE_LARGE_COLD, prefs);
+    var belowScore = OfferScoring.score(below, NE_LARGE_COLD, prefs);
+
+    assertThat(atScore).isGreaterThan(belowScore);
+  }
+
+  @Test
+  void score_contractLengthAtTarget_beatsOffBy3() {
+    var prefs = CandidateTestData.preferencesFor(1L);
+    var matching = fullyMatchingOffer();
+    var offBy3 =
+        new OfferTerms(
+            prefs.compensationTarget(),
+            prefs.contractLengthTarget() + 3,
+            prefs.guaranteedMoneyTarget(),
+            prefs.roleScopeTarget(),
+            prefs.staffContinuityTarget());
+
+    assertThat(OfferScoring.score(matching, NE_LARGE_COLD, prefs))
+        .isGreaterThan(OfferScoring.score(offBy3, NE_LARGE_COLD, prefs));
+  }
+
+  @Test
+  void score_equalFootingDynamicDimensions_doNotDifferentiateFranchises() {
+    // Two profiles identical in static fields; dynamic fields are equal-footing constants by
+    // construction. Same prefs + same offer must score identically.
+    var prefs = CandidateTestData.preferencesFor(1L);
+    var offer = fullyMatchingOffer();
+    var a =
+        new FranchiseProfile(
+            10L,
+            MarketSize.LARGE,
+            Geography.NE,
+            Climate.COLD,
+            new BigDecimal("50.00"),
+            CompetitiveWindow.NEUTRAL,
+            new BigDecimal("50.00"),
+            new BigDecimal("50.00"),
+            "BALANCED");
+    var b =
+        new FranchiseProfile(
+            11L,
+            MarketSize.LARGE,
+            Geography.NE,
+            Climate.COLD,
+            new BigDecimal("50.00"),
+            CompetitiveWindow.NEUTRAL,
+            new BigDecimal("50.00"),
+            new BigDecimal("50.00"),
+            "BALANCED");
+
+    assertThat(OfferScoring.score(offer, a, prefs)).isEqualTo(OfferScoring.score(offer, b, prefs));
+  }
+
+  private static OfferTerms fullyMatchingOffer() {
+    var prefs = CandidateTestData.preferencesFor(1L);
+    return new OfferTerms(
+        prefs.compensationTarget(),
+        prefs.contractLengthTarget(),
+        prefs.guaranteedMoneyTarget(),
+        prefs.roleScopeTarget(),
+        prefs.staffContinuityTarget());
+  }
+}

--- a/src/test/java/app/zoneblitz/league/PreferenceScoringOfferResolverTests.java
+++ b/src/test/java/app/zoneblitz/league/PreferenceScoringOfferResolverTests.java
@@ -1,0 +1,312 @@
+package app.zoneblitz.league;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import app.zoneblitz.support.PostgresTestcontainer;
+import java.math.BigDecimal;
+import java.util.List;
+import org.jooq.DSLContext;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.jooq.test.autoconfigure.JooqTest;
+import org.springframework.context.annotation.Import;
+
+@JooqTest
+@Import(PostgresTestcontainer.class)
+class PreferenceScoringOfferResolverTests {
+
+  @Autowired DSLContext dsl;
+
+  private LeagueRepository leagues;
+  private JooqCandidatePoolRepository pools;
+  private JooqCandidateRepository candidates;
+  private JooqCandidatePreferencesRepository preferences;
+  private JooqCandidateOfferRepository offers;
+  private JooqFranchiseHiringStateRepository hiringStates;
+  private JooqFranchiseStaffRepository staff;
+  private FranchiseProfiles profiles;
+  private CandidateRandomSources rngs;
+  private OfferResolver resolver;
+  private CreateLeague createLeague;
+  private HiringHeadCoachTransitionHandler entryHandler;
+
+  @BeforeEach
+  void setUp() {
+    leagues = new JooqLeagueRepository(dsl);
+    var franchises = new JooqFranchiseRepository(dsl);
+    var teamRepo = new JooqTeamRepository(dsl);
+    var teams = new JooqTeamLookup(dsl);
+    pools = new JooqCandidatePoolRepository(dsl);
+    candidates = new JooqCandidateRepository(dsl);
+    preferences = new JooqCandidatePreferencesRepository(dsl);
+    offers = new JooqCandidateOfferRepository(dsl);
+    hiringStates = new JooqFranchiseHiringStateRepository(dsl);
+    staff = new JooqFranchiseStaffRepository(dsl);
+    profiles = new CityFranchiseProfiles(franchises);
+    rngs = (leagueId, phase) -> new FakeRandomSource(leagueId + phase.ordinal());
+    resolver =
+        new PreferenceScoringOfferResolver(
+            offers, candidates, pools, preferences, profiles, hiringStates, staff, rngs);
+    createLeague = new CreateLeagueUseCase(leagues, franchises, teamRepo);
+    entryHandler =
+        new HiringHeadCoachTransitionHandler(
+            leagues,
+            teams,
+            pools,
+            candidates,
+            preferences,
+            hiringStates,
+            new HeadCoachGenerator(),
+            rngs);
+  }
+
+  @Test
+  void resolve_singleOffer_acceptsAndHires() {
+    var ctx = seedLeague();
+    var offer =
+        offers.insertActive(
+            ctx.candidateId, ctx.franchiseId, OfferTermsJson.toJson(goodTerms()), 1);
+
+    resolver.resolve(ctx.leagueId, LeaguePhase.HIRING_HEAD_COACH, 1);
+
+    assertThat(offers.findById(offer.id()).orElseThrow().status()).isEqualTo(OfferStatus.ACCEPTED);
+    assertThat(candidates.findById(ctx.candidateId).orElseThrow().hiredByFranchiseId())
+        .contains(ctx.franchiseId);
+    assertThat(
+            hiringStates
+                .find(ctx.leagueId, ctx.franchiseId, LeaguePhase.HIRING_HEAD_COACH)
+                .orElseThrow()
+                .step())
+        .isEqualTo(HiringStep.HIRED);
+    assertThat(staff.findAllForFranchise(ctx.leagueId, ctx.franchiseId))
+        .extracting(FranchiseStaffMember::role)
+        .containsExactly(StaffRole.HEAD_COACH);
+  }
+
+  @Test
+  void resolve_multipleOffers_acceptsHighestAndRejectsOthers() {
+    var ctx = seedLeague();
+    // Lower offer from other franchise
+    var loser =
+        offers.insertActive(
+            ctx.candidateId, ctx.otherFranchiseId, OfferTermsJson.toJson(lowCompOffer()), 1);
+    var winner =
+        offers.insertActive(
+            ctx.candidateId, ctx.franchiseId, OfferTermsJson.toJson(goodTerms()), 1);
+
+    resolver.resolve(ctx.leagueId, LeaguePhase.HIRING_HEAD_COACH, 1);
+
+    assertThat(offers.findById(winner.id()).orElseThrow().status()).isEqualTo(OfferStatus.ACCEPTED);
+    assertThat(offers.findById(loser.id()).orElseThrow().status()).isEqualTo(OfferStatus.REJECTED);
+    assertThat(candidates.findById(ctx.candidateId).orElseThrow().hiredByFranchiseId())
+        .contains(ctx.franchiseId);
+  }
+
+  @Test
+  void resolve_withNoActiveOffers_noChange() {
+    var ctx = seedLeague();
+
+    resolver.resolve(ctx.leagueId, LeaguePhase.HIRING_HEAD_COACH, 1);
+
+    assertThat(candidates.findById(ctx.candidateId).orElseThrow().hiredByFranchiseId()).isEmpty();
+    assertThat(staff.findAllForFranchise(ctx.leagueId, ctx.franchiseId)).isEmpty();
+  }
+
+  @Test
+  void resolve_equalFootingV1_identicalStaticProfilesScoreEqually() {
+    // When two franchises share the same static city triple (market/geo/climate), v1
+    // equal-footing constants on dynamic dimensions guarantee identical composite scores.
+    var allFranchises = new JooqFranchiseRepository(dsl).listAll();
+    // Find two franchises whose static city triples match.
+    FranchiseProfile a = null;
+    FranchiseProfile b = null;
+    for (var fa : allFranchises) {
+      var pa = profiles.forFranchise(fa.id()).orElseThrow();
+      for (var fb : allFranchises) {
+        if (fa.id() == fb.id()) {
+          continue;
+        }
+        var pb = profiles.forFranchise(fb.id()).orElseThrow();
+        if (pa.marketSize() == pb.marketSize()
+            && pa.geography() == pb.geography()
+            && pa.climate() == pb.climate()) {
+          a = pa;
+          b = pb;
+          break;
+        }
+      }
+      if (a != null) {
+        break;
+      }
+    }
+    assertThat(a).describedAs("expected at least one matching city pair in seed data").isNotNull();
+
+    var prefs = CandidateTestData.preferencesFor(1L);
+    var terms = goodTerms();
+    assertThat(OfferScoring.score(terms, a, prefs)).isEqualTo(OfferScoring.score(terms, b, prefs));
+  }
+
+  @Test
+  void resolve_tieBrokenDeterministically_onlyOneWinner() {
+    // Two franchises make byte-identical offers on the same candidate. Exactly one must be
+    // accepted and one rejected — tie-break driven by the candidate's seeded RNG.
+    var ctx = seedLeague();
+    var offerA =
+        offers.insertActive(
+            ctx.candidateId, ctx.franchiseId, OfferTermsJson.toJson(goodTerms()), 1);
+    var offerB =
+        offers.insertActive(
+            ctx.candidateId, ctx.otherFranchiseId, OfferTermsJson.toJson(goodTerms()), 1);
+
+    resolver.resolve(ctx.leagueId, LeaguePhase.HIRING_HEAD_COACH, 1);
+
+    var statuses =
+        List.of(
+            offers.findById(offerA.id()).orElseThrow().status(),
+            offers.findById(offerB.id()).orElseThrow().status());
+    assertThat(statuses).containsExactlyInAnyOrder(OfferStatus.ACCEPTED, OfferStatus.REJECTED);
+    assertThat(candidates.findById(ctx.candidateId).orElseThrow().hiredByFranchiseId()).isPresent();
+  }
+
+  @Test
+  void resolve_losingFranchise_remainsSearchingAndCanRebid() {
+    var ctx = seedLeague();
+    // Force the candidate's compensation to dominate the composite score so the good-offer
+    // franchise always wins regardless of the random preferences the generator produced for this
+    // specific seed. Without this the test is seed-sensitive — at some leagueId values the
+    // candidate's random dimension weights make a low-comp offer competitive with good terms, and
+    // the outcome flips.
+    overwritePreferencesToDominateComp(ctx.candidateId);
+    // Winner franchise has high offer; loser has low offer on same candidate.
+    offers.insertActive(ctx.candidateId, ctx.franchiseId, OfferTermsJson.toJson(goodTerms()), 1);
+    offers.insertActive(
+        ctx.candidateId, ctx.otherFranchiseId, OfferTermsJson.toJson(lowCompOffer()), 1);
+
+    resolver.resolve(ctx.leagueId, LeaguePhase.HIRING_HEAD_COACH, 1);
+
+    // Loser still SEARCHING (never transitioned to HIRED).
+    var loserState =
+        hiringStates
+            .find(ctx.leagueId, ctx.otherFranchiseId, LeaguePhase.HIRING_HEAD_COACH)
+            .orElseThrow();
+    assertThat(loserState.step()).isEqualTo(HiringStep.SEARCHING);
+
+    // Loser can submit a new offer on a different candidate.
+    var otherCandidate = candidates.findAllByPoolId(poolIdFor(ctx.leagueId)).get(1);
+    var rebid =
+        offers.insertActive(
+            otherCandidate.id(), ctx.otherFranchiseId, OfferTermsJson.toJson(goodTerms()), 2);
+    assertThat(rebid.status()).isEqualTo(OfferStatus.ACTIVE);
+  }
+
+  private void overwritePreferencesToDominateComp(long candidateId) {
+    // Zero all non-comp weights, saturate the comp weight. Composite score then reduces to
+    // numericFloorFit on compensation — good terms ($20M vs any target) = 1.0, low ($500k) = 0.0.
+    dsl.update(app.zoneblitz.jooq.Tables.CANDIDATE_PREFERENCES)
+        .set(
+            app.zoneblitz.jooq.Tables.CANDIDATE_PREFERENCES.COMPENSATION_WEIGHT,
+            new BigDecimal("1.000"))
+        .set(
+            app.zoneblitz.jooq.Tables.CANDIDATE_PREFERENCES.CONTRACT_LENGTH_WEIGHT,
+            new BigDecimal("0.000"))
+        .set(
+            app.zoneblitz.jooq.Tables.CANDIDATE_PREFERENCES.GUARANTEED_MONEY_WEIGHT,
+            new BigDecimal("0.000"))
+        .set(
+            app.zoneblitz.jooq.Tables.CANDIDATE_PREFERENCES.MARKET_SIZE_WEIGHT,
+            new BigDecimal("0.000"))
+        .set(
+            app.zoneblitz.jooq.Tables.CANDIDATE_PREFERENCES.GEOGRAPHY_WEIGHT,
+            new BigDecimal("0.000"))
+        .set(
+            app.zoneblitz.jooq.Tables.CANDIDATE_PREFERENCES.CLIMATE_WEIGHT, new BigDecimal("0.000"))
+        .set(
+            app.zoneblitz.jooq.Tables.CANDIDATE_PREFERENCES.FRANCHISE_PRESTIGE_WEIGHT,
+            new BigDecimal("0.000"))
+        .set(
+            app.zoneblitz.jooq.Tables.CANDIDATE_PREFERENCES.COMPETITIVE_WINDOW_WEIGHT,
+            new BigDecimal("0.000"))
+        .set(
+            app.zoneblitz.jooq.Tables.CANDIDATE_PREFERENCES.ROLE_SCOPE_WEIGHT,
+            new BigDecimal("0.000"))
+        .set(
+            app.zoneblitz.jooq.Tables.CANDIDATE_PREFERENCES.STAFF_CONTINUITY_WEIGHT,
+            new BigDecimal("0.000"))
+        .set(
+            app.zoneblitz.jooq.Tables.CANDIDATE_PREFERENCES.SCHEME_ALIGNMENT_WEIGHT,
+            new BigDecimal("0.000"))
+        .set(
+            app.zoneblitz.jooq.Tables.CANDIDATE_PREFERENCES.OWNER_STABILITY_WEIGHT,
+            new BigDecimal("0.000"))
+        .set(
+            app.zoneblitz.jooq.Tables.CANDIDATE_PREFERENCES.FACILITY_QUALITY_WEIGHT,
+            new BigDecimal("0.000"))
+        .set(
+            app.zoneblitz.jooq.Tables.CANDIDATE_PREFERENCES.COMPENSATION_TARGET,
+            new BigDecimal("10000000.00"))
+        .where(app.zoneblitz.jooq.Tables.CANDIDATE_PREFERENCES.CANDIDATE_ID.eq(candidateId))
+        .execute();
+  }
+
+  private long poolIdFor(long leagueId) {
+    return pools
+        .findByLeaguePhaseAndType(
+            leagueId, LeaguePhase.HIRING_HEAD_COACH, CandidatePoolType.HEAD_COACH)
+        .orElseThrow()
+        .id();
+  }
+
+  private Ctx seedLeague() {
+    var league = createLeagueFor("sub-" + System.nanoTime());
+    leagues.updatePhaseAndResetWeek(league.id(), LeaguePhase.HIRING_HEAD_COACH);
+    entryHandler.onEntry(league.id());
+    var pool =
+        pools
+            .findByLeaguePhaseAndType(
+                league.id(), LeaguePhase.HIRING_HEAD_COACH, CandidatePoolType.HEAD_COACH)
+            .orElseThrow();
+    var firstCandidate = candidates.findAllByPoolId(pool.id()).getFirst();
+    var allFranchises = new JooqFranchiseRepository(dsl).listAll();
+    // League creation picks the first franchise; pick two arbitrary franchise ids for offers.
+    var franchiseA = allFranchises.get(0).id();
+    var franchiseB = allFranchises.get(1).id();
+    // Initialize hiring states for both so the loser can be inspected.
+    hiringStates.upsert(
+        new FranchiseHiringState(
+            0L,
+            league.id(),
+            franchiseB,
+            LeaguePhase.HIRING_HEAD_COACH,
+            HiringStep.SEARCHING,
+            List.of(),
+            List.of()));
+    return new Ctx(league.id(), firstCandidate.id(), franchiseA, franchiseB);
+  }
+
+  private League createLeagueFor(String ownerSubject) {
+    var franchiseId = new JooqFranchiseRepository(dsl).listAll().getFirst().id();
+    var result = createLeague.create(ownerSubject, "Dynasty-" + ownerSubject, franchiseId);
+    return ((CreateLeagueResult.Created) result).league();
+  }
+
+  private static OfferTerms goodTerms() {
+    return new OfferTerms(
+        new BigDecimal("20000000.00"),
+        6,
+        new BigDecimal("0.95"),
+        RoleScope.HIGH,
+        StaffContinuity.BRING_OWN);
+  }
+
+  private static OfferTerms lowCompOffer() {
+    return new OfferTerms(
+        new BigDecimal("500000.00"),
+        1,
+        new BigDecimal("0.01"),
+        RoleScope.LOW,
+        StaffContinuity.KEEP_EXISTING);
+  }
+
+  private record Ctx(long leagueId, long candidateId, long franchiseId, long otherFranchiseId) {}
+}

--- a/src/test/java/app/zoneblitz/league/StaffAssemblyE2ETest.java
+++ b/src/test/java/app/zoneblitz/league/StaffAssemblyE2ETest.java
@@ -1,0 +1,270 @@
+package app.zoneblitz.league;
+
+import static com.microsoft.playwright.assertions.PlaywrightAssertions.assertThat;
+
+import app.zoneblitz.support.E2ETestAuth;
+import app.zoneblitz.support.PostgresTestcontainer;
+import com.microsoft.playwright.Browser;
+import com.microsoft.playwright.BrowserContext;
+import com.microsoft.playwright.Locator;
+import com.microsoft.playwright.Page;
+import com.microsoft.playwright.Playwright;
+import com.microsoft.playwright.options.AriaRole;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.util.regex.Pattern;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.context.annotation.Import;
+
+/**
+ * End-to-end happy-path journey from league creation through the staff-assembly phase. Exercises
+ * the full phase ladder: {@code INITIAL_SETUP → HIRING_HEAD_COACH → HIRING_DIRECTOR_OF_SCOUTING →
+ * ASSEMBLING_STAFF → COMPLETE}.
+ *
+ * <p>Each hiring phase is driven through the real UI for the actions it currently exposes
+ * (shortlist, interview, offer) and then ticked to completion via {@link AdvanceWeek}. The
+ * week-tick affordance does not yet live on any page; injecting the use case keeps this test
+ * UI-driven wherever UI exists and server-driven exactly where the UI does not, without smuggling
+ * in new production surface for a test-only PR.
+ *
+ * <p>Determinism is inherited from {@link SplittableCandidateRandomSources}, the production {@link
+ * CandidateRandomSources} bean: per-league seeds derived from {@code (leagueId, phase)} so
+ * candidate pools, CPU decisions, and autofill tie-breaks are reproducible run-to-run.
+ */
+@Tag("e2e")
+@SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
+@Import({PostgresTestcontainer.class, E2ETestAuth.class})
+class StaffAssemblyE2ETest {
+
+  private static Playwright playwright;
+  private static Browser browser;
+
+  @LocalServerPort int port;
+  @Autowired AdvanceWeek advanceWeek;
+  @Autowired LeagueRepository leagues;
+  @Autowired FranchiseStaffRepository staff;
+  @Autowired TeamLookup teams;
+
+  private BrowserContext context;
+  private Page page;
+
+  @BeforeAll
+  static void launchBrowser() {
+    playwright = Playwright.create();
+    browser = playwright.chromium().launch();
+  }
+
+  @AfterAll
+  static void closeBrowser() {
+    if (browser != null) browser.close();
+    if (playwright != null) playwright.close();
+  }
+
+  @BeforeEach
+  void openContext() {
+    context =
+        browser.newContext(new Browser.NewContextOptions().setBaseURL("http://localhost:" + port));
+    page = context.newPage();
+  }
+
+  @AfterEach
+  void closeContext() {
+    if (context != null) context.close();
+  }
+
+  @Test
+  void userWalksStaffAssemblyJourney_fromInitialSetupToCompleteWithFullyPopulatedStaff() {
+    var subject = "e2e-staff-" + System.nanoTime();
+    signIn(subject);
+
+    var leagueName = "Dynasty " + System.nanoTime();
+    var leagueUrl = createLeague(leagueName);
+    var leagueId = extractLeagueId(leagueUrl);
+
+    // INITIAL_SETUP: dashboard intro card; advance into HIRING_HEAD_COACH via the rendered form.
+    assertThat(page.getByRole(AriaRole.HEADING, new Page.GetByRoleOptions().setName(leagueName)))
+        .isVisible();
+    page.getByRole(AriaRole.BUTTON, new Page.GetByRoleOptions().setName("Advance to staff hiring"))
+        .click();
+
+    // HIRING_HEAD_COACH: shortlist, interview, offer on the first candidate, then tick to hire.
+    assertThat(page).hasURL(Pattern.compile(".*/leagues/\\d+/hiring/head-coach$"));
+    assertThat(page.getByRole(AriaRole.HEADING, new Page.GetByRoleOptions().setName(leagueName)))
+        .isVisible();
+
+    var hcRow = firstCandidateRow();
+    var hcCandidateId = hcRow.getAttribute("data-candidate-id");
+    // htmx attaches listeners on DOMContentLoaded; wait until it is ready before clicking, so the
+    // first click is processed as an hx-post rather than a no-op plain button.
+    waitForHtmxReady();
+    hcRow.getByRole(AriaRole.BUTTON, new Locator.GetByRoleOptions().setName("Shortlist")).click();
+    assertThat(buttonInRow(hcCandidateId, "Shortlisted")).isVisible();
+    buttonInRow(hcCandidateId, "Interview").click();
+    assertThat(reInterviewButton(hcCandidateId)).isVisible();
+
+    submitOfferForm(leagueUrl + "/hiring/head-coach/offer/" + hcCandidateId, headCoachOfferBody());
+
+    tickUntilPhaseLeaves(leagueId, subject, LeaguePhase.HIRING_HEAD_COACH);
+
+    // HIRING_DIRECTOR_OF_SCOUTING: same UI-driven shortlist/interview/offer, then tick.
+    page.navigate(leagueUrl);
+    assertThat(page).hasURL(Pattern.compile(".*/leagues/\\d+/hiring/director-of-scouting$"));
+
+    var dosRow = firstCandidateRow();
+    var dosCandidateId = dosRow.getAttribute("data-candidate-id");
+    waitForHtmxReady();
+    dosRow.getByRole(AriaRole.BUTTON, new Locator.GetByRoleOptions().setName("Shortlist")).click();
+    assertThat(buttonInRow(dosCandidateId, "Shortlisted")).isVisible();
+    buttonInRow(dosCandidateId, "Interview").click();
+    assertThat(reInterviewButton(dosCandidateId)).isVisible();
+
+    submitOfferForm(
+        leagueUrl + "/hiring/director-of-scouting/offer/" + dosCandidateId,
+        directorOfScoutingOfferBody());
+
+    tickUntilPhaseLeaves(leagueId, subject, LeaguePhase.HIRING_DIRECTOR_OF_SCOUTING);
+
+    // ASSEMBLING_STAFF: the recap page lists the viewer franchise expanded with a full staff tree.
+    page.navigate(leagueUrl);
+    assertThat(page).hasURL(Pattern.compile(".*/leagues/\\d+/staff-recap$"));
+    assertThat(page.getByText("Phase: Assembling Staff")).isVisible();
+    assertThat(page.locator("details[open]").locator("li")).hasCount(EXPECTED_SEATS_PER_FRANCHISE);
+    assertThat(page.locator("details[open] summary").getByText("22 staff")).isVisible();
+
+    // Advance out of ASSEMBLING_STAFF into COMPLETE through the on-page form.
+    page.getByRole(AriaRole.BUTTON, new Page.GetByRoleOptions().setName("Advance to next phase"))
+        .click();
+
+    assertThat(page).hasURL(Pattern.compile(".*/leagues/\\d+$"));
+    assertThat(
+            page.getByRole(
+                AriaRole.BUTTON, new Page.GetByRoleOptions().setName("Advance to staff hiring")))
+        .hasCount(0);
+
+    // Assert franchise staff is fully populated for every franchise in the league.
+    for (var franchiseId : teams.franchiseIdsForLeague(leagueId)) {
+      org.assertj.core.api.Assertions.assertThat(staff.findAllForFranchise(leagueId, franchiseId))
+          .as(
+              "franchise %d in league %d should have all %d seats filled",
+              franchiseId, leagueId, EXPECTED_SEATS_PER_FRANCHISE)
+          .hasSize(EXPECTED_SEATS_PER_FRANCHISE);
+    }
+  }
+
+  /** 1 HC + 1 DoS + 3 coordinators + 9 position coaches + 5 college + 3 pro scouts. */
+  private static final int EXPECTED_SEATS_PER_FRANCHISE = 22;
+
+  /**
+   * Waits for htmx to load, then forces a process pass over the document body so that any {@code
+   * hx-*} attributes on pre-navigation elements have bound click handlers before the test issues
+   * its first click.
+   */
+  private void waitForHtmxReady() {
+    page.waitForLoadState();
+    page.waitForFunction("() => typeof window.htmx !== 'undefined'");
+    page.evaluate("() => window.htmx.process(document.body)");
+  }
+
+  private Locator firstCandidateRow() {
+    return page.locator("tr[data-candidate-id]").first();
+  }
+
+  private Locator buttonInRow(String candidateId, String name) {
+    return page.locator("tr[data-candidate-id='" + candidateId + "']")
+        .getByRole(AriaRole.BUTTON, new Locator.GetByRoleOptions().setName(name));
+  }
+
+  private Locator reInterviewButton(String candidateId) {
+    return page.locator("tr[data-candidate-id='" + candidateId + "']")
+        .getByRole(
+            AriaRole.BUTTON,
+            new Locator.GetByRoleOptions().setName(Pattern.compile("^Re-interview.*")));
+  }
+
+  private static String headCoachOfferBody() {
+    return "compensation=8500000&contractLengthYears=5&guaranteedMoneyPct=0.85"
+        + "&roleScope=HIGH&staffContinuity=BRING_OWN";
+  }
+
+  private static String directorOfScoutingOfferBody() {
+    return "compensation=1200000&contractLengthYears=4&guaranteedMoneyPct=0.5"
+        + "&roleScope=MEDIUM&staffContinuity=HYBRID";
+  }
+
+  /**
+   * Submits a classic form POST from the current page using the rendered {@code _csrf} meta token.
+   * Offer endpoints return an HTMX fragment (not a full page shell) so callers must navigate back
+   * to a page-rendering URL before the next CSRF-dependent step.
+   */
+  private void submitOfferForm(String action, String formBody) {
+    page.evaluate(
+        """
+        ({ action, formBody }) => {
+          const form = document.createElement('form');
+          form.method = 'POST';
+          form.action = action;
+          const csrf = document.querySelector('meta[name="_csrf"]').content;
+          const addField = (name, value) => {
+            const input = document.createElement('input');
+            input.type = 'hidden';
+            input.name = name;
+            input.value = value;
+            form.appendChild(input);
+          };
+          addField('_csrf', csrf);
+          for (const pair of formBody.split('&')) {
+            const [k, v] = pair.split('=');
+            addField(decodeURIComponent(k), decodeURIComponent(v));
+          }
+          document.body.appendChild(form);
+          form.submit();
+        }
+        """,
+        java.util.Map.of("action", action, "formBody", formBody));
+    page.waitForLoadState();
+  }
+
+  private void tickUntilPhaseLeaves(long leagueId, String subject, LeaguePhase phase) {
+    for (var i = 0; i < 10; i++) {
+      var current = leagues.findById(leagueId).orElseThrow().phase();
+      if (current != phase) {
+        return;
+      }
+      advanceWeek.advance(leagueId, subject);
+    }
+    throw new IllegalStateException(
+        "phase %s did not complete within 10 ticks for league %d".formatted(phase, leagueId));
+  }
+
+  private static long extractLeagueId(String leagueUrl) {
+    var matcher = Pattern.compile(".*/leagues/(\\d+)$").matcher(leagueUrl);
+    if (!matcher.matches()) {
+      throw new IllegalStateException("unexpected league url: " + leagueUrl);
+    }
+    return Long.parseLong(matcher.group(1));
+  }
+
+  private String createLeague(String leagueName) {
+    page.navigate("/leagues/new");
+    page.getByLabel("League name").fill(leagueName);
+    page.locator("input[name='franchiseId']")
+        .first()
+        .check(new Locator.CheckOptions().setForce(true));
+    page.getByRole(AriaRole.BUTTON, new Page.GetByRoleOptions().setName("Create league")).click();
+    assertThat(page).hasURL(Pattern.compile(".*/leagues/\\d+$"));
+    return page.url();
+  }
+
+  private void signIn(String subject) {
+    page.navigate("/test-auth/login?sub=" + URLEncoder.encode(subject, StandardCharsets.UTF_8));
+  }
+}

--- a/src/test/java/app/zoneblitz/league/StaffRecapControllerTests.java
+++ b/src/test/java/app/zoneblitz/league/StaffRecapControllerTests.java
@@ -1,0 +1,66 @@
+package app.zoneblitz.league;
+
+import static org.mockito.BDDMockito.given;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.oauth2Login;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.view;
+
+import app.zoneblitz.config.SecurityConfig;
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
+import org.springframework.boot.security.autoconfigure.SecurityAutoConfiguration;
+import org.springframework.boot.security.autoconfigure.web.servlet.ServletWebSecurityAutoConfiguration;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(StaffRecapController.class)
+@Import(SecurityConfig.class)
+@ImportAutoConfiguration({
+  SecurityAutoConfiguration.class,
+  ServletWebSecurityAutoConfiguration.class
+})
+class StaffRecapControllerTests {
+
+  @Autowired MockMvc mvc;
+
+  @MockitoBean ViewStaffRecap viewStaffRecap;
+  @MockitoBean ClientRegistrationRepository clientRegistrationRepository;
+
+  @Test
+  void page_whenFound_rendersStaffRecapTemplate() throws Exception {
+    given(viewStaffRecap.view(42L, "sub-1")).willReturn(Optional.of(sampleView()));
+
+    mvc.perform(
+            get("/leagues/42/staff-recap")
+                .with(oauth2Login().attributes(a -> a.put("sub", "sub-1"))))
+        .andExpect(status().isOk())
+        .andExpect(view().name("league/staff-recap"));
+  }
+
+  @Test
+  void page_whenMissing_returns404() throws Exception {
+    given(viewStaffRecap.view(42L, "sub-1")).willReturn(Optional.empty());
+
+    mvc.perform(
+            get("/leagues/42/staff-recap")
+                .with(oauth2Login().attributes(a -> a.put("sub", "sub-1"))))
+        .andExpect(status().isNotFound());
+  }
+
+  private static StaffRecapView sampleView() {
+    var franchise = new Franchise(1L, "Patriots", null, "#000", "#FFF");
+    var summary =
+        new LeagueSummary(
+            42L, "Dynasty", LeaguePhase.ASSEMBLING_STAFF, 1, Instant.EPOCH, franchise);
+    return new StaffRecapView(
+        summary, List.of(new StaffRecapView.FranchiseStaffTree(franchise, true, List.of())));
+  }
+}

--- a/src/test/java/app/zoneblitz/league/StartInterviewUseCaseTests.java
+++ b/src/test/java/app/zoneblitz/league/StartInterviewUseCaseTests.java
@@ -1,0 +1,215 @@
+package app.zoneblitz.league;
+
+import static app.zoneblitz.jooq.Tables.CANDIDATES;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import app.zoneblitz.support.PostgresTestcontainer;
+import java.util.regex.Pattern;
+import org.jooq.DSLContext;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.jooq.test.autoconfigure.JooqTest;
+import org.springframework.context.annotation.Import;
+
+@JooqTest
+@Import(PostgresTestcontainer.class)
+class StartInterviewUseCaseTests {
+
+  private static final Pattern HIDDEN_OVERALL =
+      Pattern.compile("\"overall\"\\s*:\\s*(-?[0-9]+(?:\\.[0-9]+)?)");
+
+  @Autowired DSLContext dsl;
+
+  private LeagueRepository leagues;
+  private CreateLeague createLeague;
+  private JooqCandidateRepository candidates;
+  private FranchiseInterviewRepository interviews;
+  private FranchiseHiringStateRepository hiringStates;
+  private HiringHeadCoachTransitionHandler entryHandler;
+  private StartInterview useCase;
+
+  @BeforeEach
+  void setUp() {
+    leagues = new JooqLeagueRepository(dsl);
+    var franchises = new JooqFranchiseRepository(dsl);
+    var teamRepo = new JooqTeamRepository(dsl);
+    var teams = new JooqTeamLookup(dsl);
+    var pools = new JooqCandidatePoolRepository(dsl);
+    candidates = new JooqCandidateRepository(dsl);
+    var preferences = new JooqCandidatePreferencesRepository(dsl);
+    hiringStates = new JooqFranchiseHiringStateRepository(dsl);
+    interviews = new JooqFranchiseInterviewRepository(dsl);
+    createLeague = new CreateLeagueUseCase(leagues, franchises, teamRepo);
+    entryHandler =
+        new HiringHeadCoachTransitionHandler(
+            leagues,
+            teams,
+            pools,
+            candidates,
+            preferences,
+            hiringStates,
+            new HeadCoachGenerator(),
+            (leagueId, phase) -> new FakeRandomSource(leagueId + phase.ordinal()));
+    useCase =
+        new StartInterviewUseCase(
+            leagues, pools, candidates, preferences, hiringStates, interviews);
+  }
+
+  @Test
+  void start_firstInterview_recordsEventAndAppendsCandidateToHiringState() {
+    var ctx = seedLeagueInPhase("sub-1");
+
+    var result = useCase.start(ctx.leagueId, ctx.firstCandidateId, "sub-1");
+
+    assertThat(result).isInstanceOf(InterviewResult.Started.class);
+    var view = ((InterviewResult.Started) result).view();
+    assertThat(view.activeInterviews()).hasSize(1);
+    assertThat(view.activeInterviews().getFirst().id()).isEqualTo(ctx.firstCandidateId);
+    assertThat(view.activeInterviews().getFirst().interviewCount()).isEqualTo(1);
+    assertThat(view.interviewsThisWeek()).isEqualTo(1);
+
+    var state =
+        hiringStates
+            .find(ctx.leagueId, ctx.franchiseId, LeaguePhase.HIRING_HEAD_COACH)
+            .orElseThrow();
+    assertThat(state.interviewingCandidateIds()).containsExactly(ctx.firstCandidateId);
+  }
+
+  @Test
+  void start_multipleInterviewsOnSameCandidate_tightenSigmaMonotonically() {
+    var ctx = seedLeagueInPhase("sub-1");
+
+    for (var i = 0; i < 5; i++) {
+      useCase.start(ctx.leagueId, ctx.firstCandidateId, "sub-1");
+      leagues.incrementPhaseWeek(ctx.leagueId);
+    }
+    var history =
+        interviews.findAllFor(ctx.leagueId, ctx.franchiseId, LeaguePhase.HIRING_HEAD_COACH);
+    assertThat(history).hasSize(5);
+    assertThat(history)
+        .extracting(FranchiseInterview::interviewIndex)
+        .containsExactly(1, 2, 3, 4, 5);
+
+    var sigmas =
+        history.stream().map(h -> InterviewNoiseModel.headCoachSigma(h.interviewIndex())).toList();
+    var previous = InterviewNoiseModel.HC_INITIAL_STD + 1.0;
+    for (var sigma : sigmas) {
+      assertThat(sigma).isLessThan(previous);
+      assertThat(sigma).isGreaterThan(0.0);
+      previous = sigma;
+    }
+  }
+
+  @Test
+  void start_hittingWeeklyCap_returnsCapacityReached() {
+    var ctx = seedLeagueInPhase("sub-1");
+    var secondId = secondCandidateId(ctx);
+    var thirdId = thirdCandidateId(ctx);
+
+    useCase.start(ctx.leagueId, ctx.firstCandidateId, "sub-1");
+    useCase.start(ctx.leagueId, secondId, "sub-1");
+    useCase.start(ctx.leagueId, thirdId, "sub-1");
+
+    var capped = useCase.start(ctx.leagueId, ctx.firstCandidateId, "sub-1");
+
+    assertThat(capped).isInstanceOf(InterviewResult.CapacityReached.class);
+    assertThat(((InterviewResult.CapacityReached) capped).capacity())
+        .isEqualTo(StartInterview.DEFAULT_WEEKLY_CAPACITY);
+  }
+
+  @Test
+  void start_doesNotWriteTrueRatingIntoScoutedAttrs() {
+    var ctx = seedLeagueInPhase("sub-1");
+    var before =
+        dsl.select(CANDIDATES.SCOUTED_ATTRS, CANDIDATES.HIDDEN_ATTRS)
+            .from(CANDIDATES)
+            .where(CANDIDATES.ID.eq(ctx.firstCandidateId))
+            .fetchOne();
+    var hiddenBefore = before.get(CANDIDATES.HIDDEN_ATTRS).data();
+    var scoutedBefore = before.get(CANDIDATES.SCOUTED_ATTRS).data();
+    var trueRating = extractOverall(hiddenBefore);
+
+    for (var i = 0; i < 10; i++) {
+      useCase.start(ctx.leagueId, ctx.firstCandidateId, "sub-1");
+      // ensure we don't blow past weekly cap across multiple weeks
+      leagues.incrementPhaseWeek(ctx.leagueId);
+    }
+
+    var after =
+        dsl.select(CANDIDATES.SCOUTED_ATTRS, CANDIDATES.HIDDEN_ATTRS)
+            .from(CANDIDATES)
+            .where(CANDIDATES.ID.eq(ctx.firstCandidateId))
+            .fetchOne();
+    assertThat(after.get(CANDIDATES.SCOUTED_ATTRS).data()).isEqualTo(scoutedBefore);
+    assertThat(after.get(CANDIDATES.HIDDEN_ATTRS).data()).isEqualTo(hiddenBefore);
+
+    var perInterview =
+        interviews.findAllFor(ctx.leagueId, ctx.franchiseId, LeaguePhase.HIRING_HEAD_COACH);
+    assertThat(perInterview).isNotEmpty();
+    assertThat(perInterview)
+        .allSatisfy(i -> assertThat(i.scoutedOverall().doubleValue()).isNotEqualTo(trueRating));
+  }
+
+  @Test
+  void start_phaseNotHiringHeadCoach_returnsNotFound() {
+    var league = createLeagueFor("sub-1");
+
+    var result = useCase.start(league.id(), 1L, "sub-1");
+
+    assertThat(result).isInstanceOf(InterviewResult.NotFound.class);
+  }
+
+  @Test
+  void start_unknownCandidate_returnsUnknownCandidate() {
+    var ctx = seedLeagueInPhase("sub-1");
+
+    var result = useCase.start(ctx.leagueId, 999_999L, "sub-1");
+
+    assertThat(result).isInstanceOf(InterviewResult.UnknownCandidate.class);
+  }
+
+  @Test
+  void start_notOwnedByCaller_returnsNotFound() {
+    var ctx = seedLeagueInPhase("owner");
+
+    var result = useCase.start(ctx.leagueId, ctx.firstCandidateId, "someone-else");
+
+    assertThat(result).isInstanceOf(InterviewResult.NotFound.class);
+  }
+
+  private long secondCandidateId(Ctx ctx) {
+    return candidates.findAllByPoolId(ctx.poolId).get(1).id();
+  }
+
+  private long thirdCandidateId(Ctx ctx) {
+    return candidates.findAllByPoolId(ctx.poolId).get(2).id();
+  }
+
+  private Ctx seedLeagueInPhase(String subject) {
+    var league = createLeagueFor(subject);
+    leagues.updatePhaseAndResetWeek(league.id(), LeaguePhase.HIRING_HEAD_COACH);
+    entryHandler.onEntry(league.id());
+    var pool =
+        new JooqCandidatePoolRepository(dsl)
+            .findByLeaguePhaseAndType(
+                league.id(), LeaguePhase.HIRING_HEAD_COACH, CandidatePoolType.HEAD_COACH)
+            .orElseThrow();
+    var summary = leagues.findSummaryByIdAndOwner(league.id(), subject).orElseThrow();
+    var firstCandidate = candidates.findAllByPoolId(pool.id()).getFirst();
+    return new Ctx(league.id(), summary.userFranchise().id(), pool.id(), firstCandidate.id());
+  }
+
+  private League createLeagueFor(String ownerSubject) {
+    var franchiseId = new JooqFranchiseRepository(dsl).listAll().getFirst().id();
+    var result = createLeague.create(ownerSubject, "Dynasty", franchiseId);
+    return ((CreateLeagueResult.Created) result).league();
+  }
+
+  private static double extractOverall(String attrsJson) {
+    var m = HIDDEN_OVERALL.matcher(attrsJson);
+    return m.find() ? Double.parseDouble(m.group(1)) : Double.NaN;
+  }
+
+  private record Ctx(long leagueId, long franchiseId, long poolId, long firstCandidateId) {}
+}

--- a/src/test/java/app/zoneblitz/league/ViewDirectorOfScoutingHiringUseCaseTests.java
+++ b/src/test/java/app/zoneblitz/league/ViewDirectorOfScoutingHiringUseCaseTests.java
@@ -1,0 +1,90 @@
+package app.zoneblitz.league;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import app.zoneblitz.support.PostgresTestcontainer;
+import org.jooq.DSLContext;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.jooq.test.autoconfigure.JooqTest;
+import org.springframework.context.annotation.Import;
+
+@JooqTest
+@Import(PostgresTestcontainer.class)
+class ViewDirectorOfScoutingHiringUseCaseTests {
+
+  @Autowired DSLContext dsl;
+
+  private LeagueRepository leagues;
+  private CreateLeague createLeague;
+  private HiringDirectorOfScoutingTransitionHandler entryHandler;
+  private ViewDirectorOfScoutingHiring useCase;
+
+  @BeforeEach
+  void setUp() {
+    leagues = new JooqLeagueRepository(dsl);
+    var franchises = new JooqFranchiseRepository(dsl);
+    var teamRepo = new JooqTeamRepository(dsl);
+    var teams = new JooqTeamLookup(dsl);
+    var pools = new JooqCandidatePoolRepository(dsl);
+    var candidates = new JooqCandidateRepository(dsl);
+    var preferences = new JooqCandidatePreferencesRepository(dsl);
+    var hiringStates = new JooqFranchiseHiringStateRepository(dsl);
+    createLeague = new CreateLeagueUseCase(leagues, franchises, teamRepo);
+    entryHandler =
+        new HiringDirectorOfScoutingTransitionHandler(
+            leagues,
+            teams,
+            pools,
+            candidates,
+            preferences,
+            hiringStates,
+            new DirectorOfScoutingGenerator(),
+            (leagueId, phase) -> new FakeRandomSource(leagueId + phase.ordinal()));
+    var interviews = new JooqFranchiseInterviewRepository(dsl);
+    useCase =
+        new ViewDirectorOfScoutingHiringUseCase(
+            leagues, pools, candidates, preferences, hiringStates, interviews);
+  }
+
+  @Test
+  void view_whenLeagueMissing_returnsEmpty() {
+    assertThat(useCase.view(999_999L, "sub-1")).isEmpty();
+  }
+
+  @Test
+  void view_whenNotOwnedByCaller_returnsEmpty() {
+    var league = createLeagueFor("owner");
+    leagues.updatePhaseAndResetWeek(league.id(), LeaguePhase.HIRING_DIRECTOR_OF_SCOUTING);
+    entryHandler.onEntry(league.id());
+
+    assertThat(useCase.view(league.id(), "someone-else")).isEmpty();
+  }
+
+  @Test
+  void view_whenPhaseNotHiringDirectorOfScouting_returnsEmpty() {
+    var league = createLeagueFor("sub-1");
+
+    assertThat(useCase.view(league.id(), "sub-1")).isEmpty();
+  }
+
+  @Test
+  void view_whenInPhase_returnsPoolAndEmptyShortlist() {
+    var league = createLeagueFor("sub-1");
+    leagues.updatePhaseAndResetWeek(league.id(), LeaguePhase.HIRING_DIRECTOR_OF_SCOUTING);
+    entryHandler.onEntry(league.id());
+
+    var view = useCase.view(league.id(), "sub-1").orElseThrow();
+
+    assertThat(view.pool()).isNotEmpty();
+    assertThat(view.shortlist()).isEmpty();
+    assertThat(view.pool()).allSatisfy(row -> assertThat(row.shortlisted()).isFalse());
+  }
+
+  private League createLeagueFor(String ownerSubject) {
+    var franchiseId = new JooqFranchiseRepository(dsl).listAll().getFirst().id();
+    var result = createLeague.create(ownerSubject, "Dynasty", franchiseId);
+    return ((CreateLeagueResult.Created) result).league();
+  }
+}

--- a/src/test/java/app/zoneblitz/league/ViewHeadCoachHiringUseCaseTests.java
+++ b/src/test/java/app/zoneblitz/league/ViewHeadCoachHiringUseCaseTests.java
@@ -1,0 +1,90 @@
+package app.zoneblitz.league;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import app.zoneblitz.support.PostgresTestcontainer;
+import org.jooq.DSLContext;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.jooq.test.autoconfigure.JooqTest;
+import org.springframework.context.annotation.Import;
+
+@JooqTest
+@Import(PostgresTestcontainer.class)
+class ViewHeadCoachHiringUseCaseTests {
+
+  @Autowired DSLContext dsl;
+
+  private LeagueRepository leagues;
+  private CreateLeague createLeague;
+  private HiringHeadCoachTransitionHandler entryHandler;
+  private ViewHeadCoachHiring useCase;
+
+  @BeforeEach
+  void setUp() {
+    leagues = new JooqLeagueRepository(dsl);
+    var franchises = new JooqFranchiseRepository(dsl);
+    var teamRepo = new JooqTeamRepository(dsl);
+    var teams = new JooqTeamLookup(dsl);
+    var pools = new JooqCandidatePoolRepository(dsl);
+    var candidates = new JooqCandidateRepository(dsl);
+    var preferences = new JooqCandidatePreferencesRepository(dsl);
+    var hiringStates = new JooqFranchiseHiringStateRepository(dsl);
+    createLeague = new CreateLeagueUseCase(leagues, franchises, teamRepo);
+    entryHandler =
+        new HiringHeadCoachTransitionHandler(
+            leagues,
+            teams,
+            pools,
+            candidates,
+            preferences,
+            hiringStates,
+            new HeadCoachGenerator(),
+            (leagueId, phase) -> new FakeRandomSource(leagueId + phase.ordinal()));
+    var interviews = new JooqFranchiseInterviewRepository(dsl);
+    useCase =
+        new ViewHeadCoachHiringUseCase(
+            leagues, pools, candidates, preferences, hiringStates, interviews);
+  }
+
+  @Test
+  void view_whenLeagueMissing_returnsEmpty() {
+    assertThat(useCase.view(999_999L, "sub-1")).isEmpty();
+  }
+
+  @Test
+  void view_whenNotOwnedByCaller_returnsEmpty() {
+    var league = createLeagueFor("owner");
+    leagues.updatePhaseAndResetWeek(league.id(), LeaguePhase.HIRING_HEAD_COACH);
+    entryHandler.onEntry(league.id());
+
+    assertThat(useCase.view(league.id(), "someone-else")).isEmpty();
+  }
+
+  @Test
+  void view_whenPhaseNotHiringHeadCoach_returnsEmpty() {
+    var league = createLeagueFor("sub-1");
+
+    assertThat(useCase.view(league.id(), "sub-1")).isEmpty();
+  }
+
+  @Test
+  void view_whenInPhase_returnsPoolAndEmptyShortlist() {
+    var league = createLeagueFor("sub-1");
+    leagues.updatePhaseAndResetWeek(league.id(), LeaguePhase.HIRING_HEAD_COACH);
+    entryHandler.onEntry(league.id());
+
+    var view = useCase.view(league.id(), "sub-1").orElseThrow();
+
+    assertThat(view.pool()).isNotEmpty();
+    assertThat(view.shortlist()).isEmpty();
+    assertThat(view.pool()).allSatisfy(row -> assertThat(row.shortlisted()).isFalse());
+  }
+
+  private League createLeagueFor(String ownerSubject) {
+    var franchiseId = new JooqFranchiseRepository(dsl).listAll().getFirst().id();
+    var result = createLeague.create(ownerSubject, "Dynasty", franchiseId);
+    return ((CreateLeagueResult.Created) result).league();
+  }
+}

--- a/src/test/resources/junit-platform.properties
+++ b/src/test/resources/junit-platform.properties
@@ -1,0 +1,5 @@
+junit.jupiter.execution.parallel.enabled=true
+junit.jupiter.execution.parallel.mode.default=same_thread
+junit.jupiter.execution.parallel.mode.classes.default=same_thread
+junit.jupiter.execution.parallel.config.strategy=dynamic
+junit.jupiter.execution.parallel.config.dynamic.factor=1


### PR DESCRIPTION
Closes #611

Stacked on #610.

## Summary

- New `StaffAssemblyE2ETest` drives a viewer franchise through the full phase ladder (`INITIAL_SETUP → HIRING_HEAD_COACH → HIRING_DIRECTOR_OF_SCOUTING → ASSEMBLING_STAFF → COMPLETE`). Shortlist, interview, and offer are driven via the rendered HTMX UI on each hiring phase; weekly ticks run through the injected `AdvanceWeek` use case since no week-advance affordance exists in the UI yet. Staff-recap DOM is asserted for a full tree, and `FranchiseStaffRepository` is checked post-completion to verify every franchise has all 22 seats filled.
- Determinism is inherited from the production `SplittableCandidateRandomSources` bean (seeded per `(leagueId, phase)`), so no test-only RNG override is required.

## Adjacent prod fixes uncovered while wiring the test

- `hiring/head-coach.html` and `hiring/director-of-scouting.html` set `hx-headers` to a single-quoted JSON blob that htmx cannot parse, dropping the CSRF header and forcing every POST to redirect through login. Replaced with a per-page `htmx:configRequest` listener that reads the existing `_csrf` / `_csrf_header` meta tags and attaches the token on each request.
- `PreferenceScoringOfferResolver.chooseWinner` computed its tie-break index as `(int)(long) % size`, truncating the long before the modulo and sometimes yielding a negative index. Fixed by taking the modulo on the long first, then casting.

## Test plan

- [x] `./gradlew spotlessCheck`
- [x] `./gradlew test`
- [x] `./gradlew e2eTest`