### PR TITLE
feat(league): htmx sortable/filterable home leagues table (POC)

### DIFF
--- a/src/main/java/app/zoneblitz/league/LeagueController.java
+++ b/src/main/java/app/zoneblitz/league/LeagueController.java
@@ -16,6 +16,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.server.ResponseStatusException;
 
 @Controller
@@ -46,11 +47,43 @@ public class LeagueController {
   }
 
   @GetMapping("/")
-  String home(@AuthenticationPrincipal OAuth2User principal, Model model) {
+  String home(
+      @AuthenticationPrincipal OAuth2User principal,
+      @RequestParam(name = "q", required = false) String q,
+      @RequestParam(name = "name", required = false) String name,
+      @RequestParam(name = "franchise", required = false) String franchise,
+      @RequestParam(name = "phase", required = false) String phase,
+      @RequestParam(name = "sort", required = false) LeagueTableQuery.SortKey sort,
+      @RequestParam(name = "dir", required = false) LeagueTableQuery.SortDir dir,
+      @RequestParam(name = "page", required = false, defaultValue = "1") int page,
+      @RequestParam(name = "pageSize", required = false, defaultValue = "10") int pageSize,
+      Model model) {
+    var query = new LeagueTableQuery(q, name, franchise, phase, sort, dir, page, pageSize);
+    model.addAttribute("tablePage", resolveTablePage(principal, query));
+    return "index";
+  }
+
+  @GetMapping("/leagues/rows")
+  String leaguesTableFragment(
+      @AuthenticationPrincipal OAuth2User principal,
+      @RequestParam(name = "q", required = false) String q,
+      @RequestParam(name = "name", required = false) String name,
+      @RequestParam(name = "franchise", required = false) String franchise,
+      @RequestParam(name = "phase", required = false) String phase,
+      @RequestParam(name = "sort", required = false) LeagueTableQuery.SortKey sort,
+      @RequestParam(name = "dir", required = false) LeagueTableQuery.SortDir dir,
+      @RequestParam(name = "page", required = false, defaultValue = "1") int page,
+      @RequestParam(name = "pageSize", required = false, defaultValue = "10") int pageSize,
+      Model model) {
+    var query = new LeagueTableQuery(q, name, franchise, phase, sort, dir, page, pageSize);
+    model.addAttribute("tablePage", resolveTablePage(principal, query));
+    return "leagues-table-fragments :: table";
+  }
+
+  private LeagueTablePage resolveTablePage(OAuth2User principal, LeagueTableQuery query) {
     List<LeagueSummary> leagues =
         principal == null ? List.of() : listLeagues.listFor(principal.getAttribute("sub"));
-    model.addAttribute("leagues", leagues);
-    return "index";
+    return LeagueTableFilter.apply(leagues, query);
   }
 
   @GetMapping("/leagues/{id}")

--- a/src/main/java/app/zoneblitz/league/LeagueTableFilter.java
+++ b/src/main/java/app/zoneblitz/league/LeagueTableFilter.java
@@ -1,0 +1,70 @@
+package app.zoneblitz.league;
+
+import java.util.Comparator;
+import java.util.List;
+import java.util.Locale;
+
+/**
+ * Pure, in-memory filter/sort/paginate for the home-page leagues table. Pool sizes per user are
+ * small (tens, low hundreds at the tail), so doing this in-memory over the already-loaded summary
+ * list keeps the query layer untouched while proving the HTMX table pattern.
+ */
+public final class LeagueTableFilter {
+
+  private LeagueTableFilter() {}
+
+  public static LeagueTablePage apply(List<LeagueSummary> all, LeagueTableQuery query) {
+    var filtered =
+        all.stream().filter(row -> matches(row, query)).sorted(comparatorFor(query)).toList();
+    var fromIndex = Math.min((query.page() - 1) * query.pageSize(), filtered.size());
+    var toIndex = Math.min(fromIndex + query.pageSize(), filtered.size());
+    return new LeagueTablePage(
+        filtered.subList(fromIndex, toIndex), all.size(), filtered.size(), query);
+  }
+
+  private static boolean matches(LeagueSummary row, LeagueTableQuery q) {
+    var franchiseDisplay = franchiseDisplay(row);
+    if (!q.q().isEmpty()) {
+      var needle = q.q().toLowerCase(Locale.ROOT);
+      var nameHit = row.leagueName().toLowerCase(Locale.ROOT).contains(needle);
+      var franchiseHit = franchiseDisplay.toLowerCase(Locale.ROOT).contains(needle);
+      var phaseHit = row.phase().name().toLowerCase(Locale.ROOT).contains(needle);
+      if (!(nameHit || franchiseHit || phaseHit)) {
+        return false;
+      }
+    }
+    if (!q.name().isEmpty()
+        && !row.leagueName().toLowerCase(Locale.ROOT).contains(q.name().toLowerCase(Locale.ROOT))) {
+      return false;
+    }
+    if (!q.franchise().isEmpty()
+        && !franchiseDisplay
+            .toLowerCase(Locale.ROOT)
+            .contains(q.franchise().toLowerCase(Locale.ROOT))) {
+      return false;
+    }
+    var phaseFilter = q.phaseFilter();
+    if (phaseFilter.isPresent() && row.phase() != phaseFilter.get()) {
+      return false;
+    }
+    return true;
+  }
+
+  private static Comparator<LeagueSummary> comparatorFor(LeagueTableQuery q) {
+    Comparator<LeagueSummary> base =
+        switch (q.sort()) {
+          case NAME ->
+              Comparator.comparing(LeagueSummary::leagueName, String.CASE_INSENSITIVE_ORDER);
+          case FRANCHISE ->
+              Comparator.comparing(
+                  LeagueTableFilter::franchiseDisplay, String.CASE_INSENSITIVE_ORDER);
+          case PHASE -> Comparator.comparing(row -> row.phase().ordinal());
+          case CREATED_AT -> Comparator.comparing(LeagueSummary::createdAt);
+        };
+    return q.dir() == LeagueTableQuery.SortDir.DESC ? base.reversed() : base;
+  }
+
+  static String franchiseDisplay(LeagueSummary row) {
+    return row.userFranchise().city().name() + " " + row.userFranchise().name();
+  }
+}

--- a/src/main/java/app/zoneblitz/league/LeagueTablePage.java
+++ b/src/main/java/app/zoneblitz/league/LeagueTablePage.java
@@ -1,0 +1,32 @@
+package app.zoneblitz.league;
+
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * A slice of the leagues table for a given {@link LeagueTableQuery}: the filtered, sorted, and
+ * paginated rows plus the totals needed to render pagination controls.
+ */
+public record LeagueTablePage(
+    List<LeagueSummary> rows, int totalRows, int filteredRows, LeagueTableQuery query) {
+
+  public LeagueTablePage {
+    Objects.requireNonNull(query, "query");
+    rows = List.copyOf(rows);
+  }
+
+  public int totalPages() {
+    if (filteredRows == 0) {
+      return 1;
+    }
+    return (filteredRows + query.pageSize() - 1) / query.pageSize();
+  }
+
+  public boolean hasPrev() {
+    return query.page() > 1;
+  }
+
+  public boolean hasNext() {
+    return query.page() < totalPages();
+  }
+}

--- a/src/main/java/app/zoneblitz/league/LeagueTableQuery.java
+++ b/src/main/java/app/zoneblitz/league/LeagueTableQuery.java
@@ -1,0 +1,69 @@
+package app.zoneblitz.league;
+
+import app.zoneblitz.league.phase.LeaguePhase;
+import java.util.Objects;
+
+/**
+ * Querystring-bound parameters for the home-page leagues table. Every field is non-null and
+ * canonicalized in the compact constructor so callers can pass user input as-is. Empty strings
+ * represent "no filter"; {@link #phase()} is empty when no phase filter is active.
+ *
+ * <p>Used by the page endpoint (to render initial state from a bookmarked URL) and the fragment
+ * endpoint (to re-render the table on filter/sort/paginate interactions).
+ */
+public record LeagueTableQuery(
+    String q,
+    String name,
+    String franchise,
+    String phase,
+    SortKey sort,
+    SortDir dir,
+    int page,
+    int pageSize) {
+
+  public static final int DEFAULT_PAGE_SIZE = 10;
+  public static final int MAX_PAGE_SIZE = 100;
+
+  public enum SortKey {
+    NAME,
+    FRANCHISE,
+    PHASE,
+    CREATED_AT
+  }
+
+  public enum SortDir {
+    ASC,
+    DESC
+  }
+
+  public LeagueTableQuery {
+    q = nullToEmpty(q).trim();
+    name = nullToEmpty(name).trim();
+    franchise = nullToEmpty(franchise).trim();
+    phase = nullToEmpty(phase).trim();
+    sort = Objects.requireNonNullElse(sort, SortKey.CREATED_AT);
+    dir = Objects.requireNonNullElse(dir, sort == SortKey.CREATED_AT ? SortDir.DESC : SortDir.ASC);
+    page = Math.max(1, page);
+    pageSize = pageSize <= 0 ? DEFAULT_PAGE_SIZE : Math.min(pageSize, MAX_PAGE_SIZE);
+  }
+
+  public static LeagueTableQuery defaults() {
+    return new LeagueTableQuery(
+        "", "", "", "", SortKey.CREATED_AT, SortDir.DESC, 1, DEFAULT_PAGE_SIZE);
+  }
+
+  public java.util.Optional<LeaguePhase> phaseFilter() {
+    if (phase.isEmpty()) {
+      return java.util.Optional.empty();
+    }
+    try {
+      return java.util.Optional.of(LeaguePhase.valueOf(phase));
+    } catch (IllegalArgumentException ignored) {
+      return java.util.Optional.empty();
+    }
+  }
+
+  private static String nullToEmpty(String s) {
+    return s == null ? "" : s;
+  }
+}

--- a/src/main/resources/templates/index.html
+++ b/src/main/resources/templates/index.html
@@ -47,53 +47,14 @@
 				</a>
 			</div>
 
-			<div th:if="${leagues.isEmpty()}"
+			<div th:if="${tablePage.totalRows() == 0}"
 			     class="border border-dashed border-slate-300 rounded-md p-8 text-center text-slate-600">
 				<p class="mb-2">You haven't created a league yet.</p>
 				<p>Click <span class="font-semibold">Create league</span> to get started.</p>
 			</div>
 
-			<table th:unless="${leagues.isEmpty()}"
-			       class="w-full border border-slate-200 bg-white rounded-md overflow-hidden">
-				<thead class="bg-slate-100 text-left text-sm text-slate-600">
-					<tr>
-						<th class="px-4 py-2">Name</th>
-						<th class="px-4 py-2">Your franchise</th>
-						<th class="px-4 py-2">Phase</th>
-						<th class="px-4 py-2">Created</th>
-						<th class="px-4 py-2 text-right"><span class="sr-only">Actions</span></th>
-					</tr>
-				</thead>
-				<tbody class="text-sm">
-					<tr th:each="league : ${leagues}" class="border-t border-slate-200">
-						<td class="px-4 py-2 font-semibold">
-							<a th:href="@{'/leagues/' + ${league.leagueId()}}"
-							   class="text-slate-900 hover:text-blue-700 hover:underline"
-							   th:text="${league.leagueName()}">League</a>
-						</td>
-						<td class="px-4 py-2">
-							<span class="inline-flex items-center gap-2">
-								<span class="inline-block w-3 h-3 rounded-full border border-slate-300"
-								      th:style="'background-color: ' + ${league.userFranchise().primaryColor()}"></span>
-								<span th:text="${league.userFranchise().city().name() + ' ' + league.userFranchise().name()}">Team</span>
-							</span>
-						</td>
-						<td class="px-4 py-2 text-slate-600" th:text="${league.phase()}">PHASE</td>
-						<td class="px-4 py-2 text-slate-500" th:text="${#temporals.format(league.createdAt(), 'yyyy-MM-dd')}">date</td>
-						<td class="px-4 py-2 text-right">
-							<form th:action="@{'/leagues/' + ${league.leagueId()} + '/delete'}" method="post" class="inline"
-							      th:data-league-name="${league.leagueName()}"
-							      onsubmit="return confirm('Delete league &quot;' + this.dataset.leagueName + '&quot;? This cannot be undone.');">
-								<button type="submit"
-								        th:aria-label="'Delete league ' + ${league.leagueName()}"
-								        class="inline-flex items-center justify-center size-8 rounded text-slate-500 hover:bg-red-50 hover:text-red-600 cursor-pointer">
-									<svg th:replace="~{icons :: trash(cls='size-4')}"></svg>
-								</button>
-							</form>
-						</td>
-					</tr>
-				</tbody>
-			</table>
+			<div th:unless="${tablePage.totalRows() == 0}"
+			     th:insert="~{leagues-table-fragments :: table}"></div>
 		</section>
 	</main>
 </body>

--- a/src/main/resources/templates/leagues-table-fragments.html
+++ b/src/main/resources/templates/leagues-table-fragments.html
@@ -1,0 +1,209 @@
+<!DOCTYPE html>
+<html lang="en" xmlns:th="http://www.thymeleaf.org">
+<body>
+	<div th:fragment="table"
+	     id="leagues-table"
+	     th:with="query=${tablePage.query()}, rows=${tablePage.rows()}"
+	     hx-get="/leagues/rows"
+	     hx-target="this"
+	     hx-swap="outerHTML"
+	     hx-push-url="true"
+	     hx-include="#leagues-table input, #leagues-table select"
+	     hx-trigger="leagues:refresh"
+	     class="space-y-3">
+
+		<input type="hidden" name="sort" th:value="${query.sort().name()}">
+		<input type="hidden" name="dir" th:value="${query.dir().name()}">
+		<input type="hidden" name="page" th:value="${query.page()}">
+		<input type="hidden" name="pageSize" th:value="${query.pageSize()}">
+
+		<div class="flex items-center gap-3 flex-wrap">
+			<label class="flex-1 min-w-[200px]">
+				<span class="sr-only">Search</span>
+				<input type="search" name="q" th:value="${query.q()}"
+				       placeholder="Search name, franchise, phase…"
+				       data-filter-input
+				       class="w-full px-3 py-2 border border-slate-300 rounded text-sm focus:outline-none focus:ring-2 focus:ring-blue-500">
+			</label>
+			<label class="flex items-center gap-2 text-sm">
+				<span class="text-slate-600">Phase</span>
+				<select name="phase" data-filter-input
+				        class="px-3 py-2 border border-slate-300 rounded text-sm bg-white">
+					<option value="">All</option>
+					<option th:each="p : ${T(app.zoneblitz.league.phase.LeaguePhase).values()}"
+					        th:value="${p.name()}"
+					        th:text="${p.name()}"
+					        th:selected="${query.phase() == p.name()}"></option>
+				</select>
+			</label>
+			<span class="text-xs text-slate-500 tabular-nums"
+			      th:text="${tablePage.filteredRows()} + ' of ' + ${tablePage.totalRows()} + ' leagues'"></span>
+		</div>
+
+		<div class="border border-slate-200 bg-white rounded-md overflow-hidden">
+			<table class="w-full">
+				<thead class="bg-slate-100 text-left text-sm text-slate-600">
+					<tr th:with="sortName=${query.sort().name()}, dirName=${query.dir().name()}">
+						<th class="px-4 py-2">
+							<button type="button" data-sort-key="NAME"
+							        class="inline-flex items-center gap-1 font-semibold hover:text-slate-900 cursor-pointer">
+								Name
+								<span th:if="${sortName == 'NAME'}" class="text-xs"
+								      th:text="${dirName == 'ASC'} ? '▲' : '▼'"></span>
+							</button>
+						</th>
+						<th class="px-4 py-2">
+							<button type="button" data-sort-key="FRANCHISE"
+							        class="inline-flex items-center gap-1 font-semibold hover:text-slate-900 cursor-pointer">
+								Your franchise
+								<span th:if="${sortName == 'FRANCHISE'}" class="text-xs"
+								      th:text="${dirName == 'ASC'} ? '▲' : '▼'"></span>
+							</button>
+						</th>
+						<th class="px-4 py-2">
+							<button type="button" data-sort-key="PHASE"
+							        class="inline-flex items-center gap-1 font-semibold hover:text-slate-900 cursor-pointer">
+								Phase
+								<span th:if="${sortName == 'PHASE'}" class="text-xs"
+								      th:text="${dirName == 'ASC'} ? '▲' : '▼'"></span>
+							</button>
+						</th>
+						<th class="px-4 py-2">
+							<button type="button" data-sort-key="CREATED_AT"
+							        class="inline-flex items-center gap-1 font-semibold hover:text-slate-900 cursor-pointer">
+								Created
+								<span th:if="${sortName == 'CREATED_AT'}" class="text-xs"
+								      th:text="${dirName == 'ASC'} ? '▲' : '▼'"></span>
+							</button>
+						</th>
+						<th class="px-4 py-2 text-right"><span class="sr-only">Actions</span></th>
+					</tr>
+					<tr class="bg-white border-t border-slate-200">
+						<th class="px-4 py-1">
+							<input type="text" name="name" th:value="${query.name()}"
+							       placeholder="Filter" data-filter-input
+							       class="w-full px-2 py-1 border border-slate-200 rounded text-xs font-normal focus:outline-none focus:ring-1 focus:ring-blue-500">
+						</th>
+						<th class="px-4 py-1">
+							<input type="text" name="franchise" th:value="${query.franchise()}"
+							       placeholder="Filter" data-filter-input
+							       class="w-full px-2 py-1 border border-slate-200 rounded text-xs font-normal focus:outline-none focus:ring-1 focus:ring-blue-500">
+						</th>
+						<th class="px-4 py-1"></th>
+						<th class="px-4 py-1"></th>
+						<th class="px-4 py-1"></th>
+					</tr>
+				</thead>
+				<tbody class="text-sm">
+					<tr th:if="${rows.isEmpty()}">
+						<td colspan="5" class="px-4 py-8 text-center text-slate-500 italic">
+							No leagues match your filters.
+						</td>
+					</tr>
+					<tr th:each="league : ${rows}" class="border-t border-slate-200">
+						<td class="px-4 py-2 font-semibold">
+							<a th:href="@{'/leagues/' + ${league.leagueId()}}"
+							   class="text-slate-900 hover:text-blue-700 hover:underline"
+							   th:text="${league.leagueName()}">League</a>
+						</td>
+						<td class="px-4 py-2">
+							<span class="inline-flex items-center gap-2">
+								<span class="inline-block w-3 h-3 rounded-full border border-slate-300"
+								      th:style="'background-color: ' + ${league.userFranchise().primaryColor()}"></span>
+								<span th:text="${league.userFranchise().city().name() + ' ' + league.userFranchise().name()}">Team</span>
+							</span>
+						</td>
+						<td class="px-4 py-2 text-slate-600" th:text="${league.phase()}">PHASE</td>
+						<td class="px-4 py-2 text-slate-500"
+						    th:text="${#temporals.format(league.createdAt(), 'yyyy-MM-dd')}">date</td>
+						<td class="px-4 py-2 text-right">
+							<form th:action="@{'/leagues/' + ${league.leagueId()} + '/delete'}" method="post" class="inline"
+							      th:data-league-name="${league.leagueName()}"
+							      onsubmit="return confirm('Delete league &quot;' + this.dataset.leagueName + '&quot;? This cannot be undone.');">
+								<button type="submit"
+								        th:aria-label="'Delete league ' + ${league.leagueName()}"
+								        class="inline-flex items-center justify-center size-8 rounded text-slate-500 hover:bg-red-50 hover:text-red-600 cursor-pointer">
+									<svg th:replace="~{icons :: trash(cls='size-4')}"></svg>
+								</button>
+							</form>
+						</td>
+					</tr>
+				</tbody>
+			</table>
+		</div>
+
+		<div class="flex items-center justify-between text-sm text-slate-600">
+			<span>
+				Page <span class="font-semibold" th:text="${query.page()}">1</span>
+				of <span class="font-semibold" th:text="${tablePage.totalPages()}">1</span>
+			</span>
+			<div class="flex gap-2">
+				<button type="button" data-page-delta="-1" th:disabled="${!tablePage.hasPrev()}"
+				        class="px-3 py-1 border border-slate-300 rounded hover:bg-slate-100 disabled:opacity-40 disabled:cursor-not-allowed cursor-pointer">
+					Prev
+				</button>
+				<button type="button" data-page-delta="1" th:disabled="${!tablePage.hasNext()}"
+				        class="px-3 py-1 border border-slate-300 rounded hover:bg-slate-100 disabled:opacity-40 disabled:cursor-not-allowed cursor-pointer">
+					Next
+				</button>
+			</div>
+		</div>
+
+		<script>
+			(function () {
+				var root = document.getElementById('leagues-table');
+				if (!root || root.dataset.wired) return;
+				root.dataset.wired = '1';
+
+				function refresh() { htmx.trigger(root, 'leagues:refresh'); }
+
+				function resetPage() { root.querySelector('input[name=page]').value = '1'; }
+
+				var debounceTimer;
+				function debouncedRefresh() {
+					clearTimeout(debounceTimer);
+					debounceTimer = setTimeout(refresh, 250);
+				}
+
+				root.addEventListener('input', function (e) {
+					if (e.target.matches('[data-filter-input]') && e.target.type !== 'hidden') {
+						resetPage();
+						debouncedRefresh();
+					}
+				});
+				root.addEventListener('change', function (e) {
+					if (e.target.matches('select[data-filter-input]')) {
+						resetPage();
+						refresh();
+					}
+				});
+
+				root.querySelectorAll('button[data-sort-key]').forEach(function (btn) {
+					btn.addEventListener('click', function () {
+						var sortInput = root.querySelector('input[name=sort]');
+						var dirInput = root.querySelector('input[name=dir]');
+						var key = btn.dataset.sortKey;
+						if (sortInput.value === key) {
+							dirInput.value = dirInput.value === 'ASC' ? 'DESC' : 'ASC';
+						} else {
+							sortInput.value = key;
+							dirInput.value = key === 'CREATED_AT' ? 'DESC' : 'ASC';
+						}
+						resetPage();
+						refresh();
+					});
+				});
+
+				root.querySelectorAll('button[data-page-delta]').forEach(function (btn) {
+					btn.addEventListener('click', function () {
+						if (btn.disabled) return;
+						var pageInput = root.querySelector('input[name=page]');
+						pageInput.value = String(Math.max(1, parseInt(pageInput.value, 10) + parseInt(btn.dataset.pageDelta, 10)));
+						refresh();
+					});
+				});
+			})();
+		</script>
+	</div>
+</body>
+</html>

--- a/src/test/java/app/zoneblitz/league/LeagueControllerTests.java
+++ b/src/test/java/app/zoneblitz/league/LeagueControllerTests.java
@@ -55,11 +55,52 @@ class LeagueControllerTests {
   @MockitoBean ClientRegistrationRepository clientRegistrationRepository;
 
   @Test
-  void home_whenUnauthenticated_rendersIndexWithEmptyLeagues() throws Exception {
+  void home_whenUnauthenticated_rendersIndexWithEmptyTablePage() throws Exception {
     mvc.perform(get("/"))
         .andExpect(status().isOk())
         .andExpect(view().name("index"))
-        .andExpect(model().attribute("leagues", List.of()));
+        .andExpect(model().attributeExists("tablePage"));
+  }
+
+  @Test
+  void leaguesRows_fragmentEndpoint_filtersAndSortsByQuery() throws Exception {
+    given(listLeagues.listFor("sub-1"))
+        .willReturn(
+            List.of(
+                new LeagueSummary(
+                    1L,
+                    "Alpha",
+                    LeaguePhase.INITIAL_SETUP,
+                    1,
+                    Instant.parse("2025-01-01T00:00:00Z"),
+                    100L,
+                    new Franchise(
+                        1L,
+                        "Minutemen",
+                        new City(1L, "Boston", new State(1L, "MA", "Massachusetts")),
+                        "#000000",
+                        "#ffffff")),
+                new LeagueSummary(
+                    2L,
+                    "Zeta",
+                    LeaguePhase.COMPLETE,
+                    1,
+                    Instant.parse("2025-03-01T00:00:00Z"),
+                    200L,
+                    new Franchise(
+                        2L,
+                        "Empires",
+                        new City(2L, "New York", new State(2L, "NY", "New York")),
+                        "#000000",
+                        "#ffffff"))));
+
+    mvc.perform(
+            get("/leagues/rows")
+                .param("phase", "COMPLETE")
+                .with(oauth2Login().attributes(a -> a.put("sub", "sub-1"))))
+        .andExpect(status().isOk())
+        .andExpect(content().string(Matchers.containsString("Zeta")))
+        .andExpect(content().string(Matchers.not(Matchers.containsString(">Alpha<"))));
   }
 
   @Test

--- a/src/test/java/app/zoneblitz/league/LeagueTableFilterTests.java
+++ b/src/test/java/app/zoneblitz/league/LeagueTableFilterTests.java
@@ -1,0 +1,179 @@
+package app.zoneblitz.league;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import app.zoneblitz.league.franchise.Franchise;
+import app.zoneblitz.league.geography.City;
+import app.zoneblitz.league.geography.State;
+import app.zoneblitz.league.phase.LeaguePhase;
+import java.time.Instant;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class LeagueTableFilterTests {
+
+  private static final State MA = new State(1L, "MA", "Massachusetts");
+  private static final State NY = new State(2L, "NY", "New York");
+
+  private final LeagueSummary boston =
+      league(
+          1L,
+          "Alpha",
+          LeaguePhase.INITIAL_SETUP,
+          Instant.parse("2025-01-01T00:00:00Z"),
+          "Boston",
+          "Minutemen",
+          MA);
+  private final LeagueSummary ny =
+      league(
+          2L,
+          "Zeta",
+          LeaguePhase.HIRING_HEAD_COACH,
+          Instant.parse("2025-03-01T00:00:00Z"),
+          "New York",
+          "Empires",
+          NY);
+  private final LeagueSummary second =
+      league(
+          3L,
+          "Bravo",
+          LeaguePhase.COMPLETE,
+          Instant.parse("2025-02-01T00:00:00Z"),
+          "Boston",
+          "Minutemen",
+          MA);
+
+  private final List<LeagueSummary> all = List.of(boston, ny, second);
+
+  @Test
+  void apply_withDefaults_sortsByCreatedAtDescending() {
+    var page = LeagueTableFilter.apply(all, LeagueTableQuery.defaults());
+
+    assertThat(page.rows()).extracting(LeagueSummary::leagueId).containsExactly(2L, 3L, 1L);
+    assertThat(page.totalRows()).isEqualTo(3);
+    assertThat(page.filteredRows()).isEqualTo(3);
+  }
+
+  @Test
+  void apply_globalSearch_matchesNameOrFranchiseCaseInsensitive() {
+    var query = query().withQ("empire").build();
+    var page = LeagueTableFilter.apply(all, query);
+
+    assertThat(page.rows()).extracting(LeagueSummary::leagueId).containsExactly(2L);
+  }
+
+  @Test
+  void apply_phaseFilter_limitsToExactPhase() {
+    var query = query().withPhase(LeaguePhase.COMPLETE.name()).build();
+    var page = LeagueTableFilter.apply(all, query);
+
+    assertThat(page.rows()).extracting(LeagueSummary::leagueId).containsExactly(3L);
+  }
+
+  @Test
+  void apply_sortByName_ascending() {
+    var query =
+        query().withSort(LeagueTableQuery.SortKey.NAME, LeagueTableQuery.SortDir.ASC).build();
+    var page = LeagueTableFilter.apply(all, query);
+
+    assertThat(page.rows())
+        .extracting(LeagueSummary::leagueName)
+        .containsExactly("Alpha", "Bravo", "Zeta");
+  }
+
+  @Test
+  void apply_pagination_returnsRequestedSlice() {
+    var query =
+        query()
+            .withPage(2)
+            .withPageSize(2)
+            .withSort(LeagueTableQuery.SortKey.NAME, LeagueTableQuery.SortDir.ASC)
+            .build();
+    var page = LeagueTableFilter.apply(all, query);
+
+    assertThat(page.rows()).extracting(LeagueSummary::leagueName).containsExactly("Zeta");
+    assertThat(page.totalPages()).isEqualTo(2);
+    assertThat(page.hasPrev()).isTrue();
+    assertThat(page.hasNext()).isFalse();
+  }
+
+  @Test
+  void apply_invalidPhaseString_isIgnored() {
+    var query = query().withPhase("NONSENSE").build();
+    var page = LeagueTableFilter.apply(all, query);
+
+    assertThat(page.rows()).hasSize(3);
+  }
+
+  @Test
+  void apply_filteredToEmpty_totalPagesIsOne() {
+    var query = query().withQ("nomatch").build();
+    var page = LeagueTableFilter.apply(all, query);
+
+    assertThat(page.rows()).isEmpty();
+    assertThat(page.totalPages()).isEqualTo(1);
+  }
+
+  private static QueryBuilder query() {
+    return new QueryBuilder();
+  }
+
+  private static LeagueSummary league(
+      long id,
+      String name,
+      LeaguePhase phase,
+      Instant created,
+      String cityName,
+      String franchiseName,
+      State state) {
+    return new LeagueSummary(
+        id,
+        name,
+        phase,
+        1,
+        created,
+        100L + id,
+        new Franchise(id, franchiseName, new City(id, cityName, state), "#000000", "#ffffff"));
+  }
+
+  private static final class QueryBuilder {
+    private String q = "";
+    private String name = "";
+    private String franchise = "";
+    private String phase = "";
+    private LeagueTableQuery.SortKey sort = LeagueTableQuery.SortKey.CREATED_AT;
+    private LeagueTableQuery.SortDir dir = LeagueTableQuery.SortDir.DESC;
+    private int page = 1;
+    private int pageSize = LeagueTableQuery.DEFAULT_PAGE_SIZE;
+
+    QueryBuilder withQ(String v) {
+      this.q = v;
+      return this;
+    }
+
+    QueryBuilder withPhase(String v) {
+      this.phase = v;
+      return this;
+    }
+
+    QueryBuilder withSort(LeagueTableQuery.SortKey s, LeagueTableQuery.SortDir d) {
+      this.sort = s;
+      this.dir = d;
+      return this;
+    }
+
+    QueryBuilder withPage(int p) {
+      this.page = p;
+      return this;
+    }
+
+    QueryBuilder withPageSize(int s) {
+      this.pageSize = s;
+      return this;
+    }
+
+    LeagueTableQuery build() {
+      return new LeagueTableQuery(q, name, franchise, phase, sort, dir, page, pageSize);
+    }
+  }
+}


### PR DESCRIPTION
## Summary

POC for an MRT-style sortable/filterable/paginated leagues table on the home page, built with pure HTMX — no client-side grid library. Proves the querystring-driven server-fragment pattern we'll reuse for the hiring tables.

- `LeagueTableQuery` + `LeagueTableFilter` — pure in-memory filter/sort/paginate (per-user row counts are small; query layer stays untouched)
- New `GET /leagues/rows` fragment endpoint; the page endpoint reads the same params so a bookmarked URL renders correctly on fresh load
- `hx-push-url="true"` → sort/filter/page state is bookmarkable, back button works
- One small IIFE dispatches a single `leagues:refresh` custom event from sort-header clicks + pagination + debounced filter input; page resets to 1 whenever a filter changes
- Table shell is a `<div>` (not `<form>`) so the per-row delete `<form>` isn't illegally nested; `hx-include` gathers filter inputs by CSS selector

## Not verified

**Tests were not run** — unrelated pre-existing compile failure in `JooqTeamHiringStateRepository` (references `TEAM_HIRING_STATES.SHORTLIST`, which an applied-but-uncommitted DB migration V10 "offer stance drop shortlist" has removed). The POC files compile in isolation and `./gradlew spotlessApply` is clean.

## Explicit follow-ups (out of scope for POC)

- **Delete preserves filter state:** delete is still a full-page POST → redirect to `/`, losing active filters. Convert to `hx-delete` returning just the refreshed table fragment when we productionize.
- **Extract to a shared Thymeleaf fragment** once a second table (hiring pools) adopts the pattern — keep it scoped to leagues for now.
- **Column visibility / density / virtualization** — not needed at current row counts.

## Test plan

- [ ] Sign in, visit `/` — table renders with default sort (createdAt desc)
- [ ] Type in global search → rows filter after 250ms, URL updates
- [ ] Pick a phase from dropdown → rows filter, page resets to 1
- [ ] Click column headers → sort toggles ASC/DESC, arrow indicator updates
- [ ] Click Next → page 2 renders, URL reflects `?page=2`
- [ ] Copy URL with filters active, paste in new tab → same view renders server-side
- [ ] Back button walks through filter history
- [ ] Delete a league → still works (confirm dialog, full-page redirect)

🤖 Generated with [Claude Code](https://claude.com/claude-code)