### PR TITLE
fix(hiring): clear stale pending offers after hiring HC/SD

### DIFF
--- a/src/main/java/app/zoneblitz/league/hiring/hire/HireCandidateUseCase.java
+++ b/src/main/java/app/zoneblitz/league/hiring/hire/HireCandidateUseCase.java
@@ -109,6 +109,9 @@ class HireCandidateUseCase implements HireCandidate {
     for (var other : offers.findActiveForCandidate(candidateId)) {
       offers.resolve(other.id(), OfferStatus.REJECTED);
     }
+    for (var stale : offers.findOutstandingForTeam(teamId)) {
+      offers.resolve(stale.id(), OfferStatus.REJECTED);
+    }
     upsertHired(teamId, phase, candidateId, league.phaseDay(), offer.get(), league);
     log.info(
         "user hire leagueId={} teamId={} candidateId={} offerId={} day={}",

--- a/src/test/java/app/zoneblitz/league/hiring/hire/HireCandidateUseCaseTests.java
+++ b/src/test/java/app/zoneblitz/league/hiring/hire/HireCandidateUseCaseTests.java
@@ -147,6 +147,43 @@ class HireCandidateUseCaseTests {
   }
 
   @Test
+  void hire_rejectsTeamsOtherOutstandingOffers_soSalaryCapDropsThem() {
+    var ownerSubject = "sub-" + System.nanoTime();
+    var league = createLeagueFor(ownerSubject);
+    leagues.updatePhaseAndResetDay(league.id(), LeaguePhase.HIRING_HEAD_COACH);
+    entryHandler.onEntry(league.id());
+    var pool =
+        pools
+            .findByLeaguePhaseAndType(
+                league.id(), LeaguePhase.HIRING_HEAD_COACH, CandidatePoolType.HEAD_COACH)
+            .orElseThrow();
+    var poolCandidates = candidates.findAllByPoolId(pool.id());
+    var hiredCandidateId = poolCandidates.get(0).id();
+    var otherCandidateId = poolCandidates.get(1).id();
+    var userTeamId = teams.userTeamIdForLeague(league.id()).orElseThrow();
+    var terms =
+        new OfferTerms(
+            new BigDecimal("8500000.00"),
+            4,
+            new BigDecimal("0.95"),
+            RoleScope.HIGH,
+            StaffContinuity.BRING_OWN);
+    var hiredOffer =
+        offers.insertActive(hiredCandidateId, userTeamId, OfferTermsJson.toJson(terms), 1);
+    offers.setStance(hiredOffer.id(), OfferStance.AGREED);
+    var otherOffer =
+        offers.insertActive(otherCandidateId, userTeamId, OfferTermsJson.toJson(terms), 1);
+
+    useCase.hire(league.id(), hiredCandidateId, ownerSubject);
+
+    assertThat(offers.findOutstandingForTeam(userTeamId)).isEmpty();
+    assertThat(offers.findById(otherOffer.id()))
+        .get()
+        .extracting(o -> o.status())
+        .isEqualTo(app.zoneblitz.league.hiring.OfferStatus.REJECTED);
+  }
+
+  @Test
   void hire_createsStaffContract_withCorrectGuaranteeCents() {
     // APY 5,000,000.00 * 5 yrs = 25,000,000.00 * 0.80 guarantee = 20,000,000.00 = 2,000,000,000
     // cents.


### PR DESCRIPTION
## Summary
- After a user hires a Head Coach or Scouting Director, the team's other outstanding offers (e.g. offers extended to other candidates while shopping the role) were left `ACTIVE`, so they continued to appear on the Staff Salary Cap page as "pending offers for a coach they never hired."
- `HireCandidateUseCase.hire` now sweeps `offers.findOutstandingForTeam(teamId)` and rejects the leftovers right after the chosen offer is `ACCEPTED`. The salary cap query reads only `ACTIVE`/`COUNTER_PENDING`, so they drop off the page.
- Added a Testcontainers-backed regression test in `HireCandidateUseCaseTests` that makes two offers (one `AGREED`, one `ACTIVE`) on different HC candidates, hires one, and asserts the team has no outstanding offers remaining.

Note: the analogous CPU path in `PreferenceScoringOfferResolver.finalizeHire` has the same gap but does not surface on the user-facing salary cap; left for a follow-up if we want symmetry.

## Test plan
- [x] `./verify` (spotlessApply + spotlessCheck + full test suite) green
- [x] New test fails before the fix and passes after
- [ ] Manually verify the Staff Salary Cap page no longer lists stale offers after hiring

🤖 Generated with [Claude Code](https://claude.com/claude-code)